### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/backend/src/services/CacheManager.ts
+++ b/backend/src/services/CacheManager.ts
@@ -34,6 +34,15 @@ export class CacheManager {
   }
 
   /**
+   * Validate that a cache key date is in YYYY-MM-DD format.
+   * This constrains the value used in file paths to a simple, safe filename suffix.
+   */
+  private isValidDateKey(date: string): boolean {
+    // Accept only digits and hyphens in strict YYYY-MM-DD format
+    return /^\d{4}-\d{2}-\d{2}$/.test(date)
+  }
+
+  /**
    * Initialize cache directory
    */
   async init(): Promise<void> {
@@ -334,6 +343,14 @@ export class CacheManager {
    */
   async getMetadata(date: string): Promise<CacheMetadata | null> {
     try {
+      // Validate date key format defensively to avoid unsafe path usage
+      if (!this.isValidDateKey(date)) {
+        logger.warn('Rejected cache metadata request with invalid date key', {
+          date,
+        })
+        return null
+      }
+
       // Check in-memory cache first
       if (this.metadataCache.has(date)) {
         return this.metadataCache.get(date)!


### PR DESCRIPTION
Potential fix for [https://github.com/rservant/toast-stats/security/code-scanning/4](https://github.com/rservant/toast-stats/security/code-scanning/4)

In general, to fix uncontrolled data in path expressions you must ensure that any user-derived component used to construct a path is validated or normalized before use, and that it cannot cause the final path to escape an intended root directory. For a parameter that is supposed to be a simple date (not an arbitrary path), the simplest and safest approach is to use a strict allow list: accept only values that match the expected date pattern and reject everything else.

In this codebase, the best minimal fix without changing existing behavior is to add an internal validation step inside `CacheManager.getMetadata` that ensures the `date` parameter has the `YYYY-MM-DD` format before using it to build the filename. If the `date` doesn’t match this pattern, we log a warning/error and return `null`, just as we already do on other errors. This keeps the public API behavior unchanged from the caller’s perspective (they still get `null` for invalid/unavailable metadata) but guarantees that `getMetadataFilePath` is never called with a string containing path metacharacters. Because `getCacheFilePath` and `getIndexFilePath` use similar patterns but don’t directly take HTTP parameters in the shown flow, we can leave them as-is to avoid speculative changes.

Concretely:
- In `backend/src/services/CacheManager.ts`, add a small private helper like `private isValidDateKey(date: string): boolean` that checks `/^\d{4}-\d{2}-\d{2}$/`.
- At the beginning of `getMetadata(date: string)`, call this validator; if it fails, log and return `null` before constructing any paths.
- This requires no new imports beyond what already exists and does not change existing callers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
