### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/backend/src/services/DistrictCacheManager.ts
+++ b/backend/src/services/DistrictCacheManager.ts
@@ -37,6 +37,22 @@ interface ErrnoException extends Error {
   syscall?: string
 }
 
+/**
+ * Sanitize a district identifier before using it in filesystem paths.
+ *
+ * Allows only alphanumeric characters, underscores, and dashes. This prevents
+ * directory traversal and other unsafe path constructions using user-controlled
+ * input while preserving existing valid district ID formats.
+ */
+function sanitizeDistrictId(districtId: string): string {
+  const trimmed = districtId.trim()
+  // Allow only letters, numbers, underscore and dash
+  if (!/^[A-Za-z0-9_-]+$/.test(trimmed)) {
+    throw new Error('Invalid district ID')
+  }
+  return trimmed
+}
+
 export class DistrictCacheManager {
   private cacheDir: string
   /**
@@ -261,7 +277,8 @@ export class DistrictCacheManager {
    */
   async getCachedDatesForDistrict(districtId: string): Promise<string[]> {
     try {
-      const districtDir = path.join(this.cacheDir, 'districts', districtId)
+      const safeDistrictId = sanitizeDistrictId(districtId)
+      const districtDir = path.join(this.cacheDir, 'districts', safeDistrictId)
 
       try {
         const files = await fs.readdir(districtDir)


### PR DESCRIPTION
Potential fix for [https://github.com/rservant/toast-stats/security/code-scanning/6](https://github.com/rservant/toast-stats/security/code-scanning/6)

In general, the fix is to ensure that any user-controlled value used in a filesystem path is either (a) strictly validated to a safe pattern (e.g., digits only) or (b) normalized and constrained to a safe root directory. Here, since district IDs are logical identifiers and not arbitrary paths, the least intrusive and most robust fix is to sanitize/validate `districtId` inside `DistrictCacheManager` before using it as a path component, and to reject dangerous values early.

Concretely, we can add a small helper method in `DistrictCacheManager` that “sanitizes” a district ID by enforcing a simple allow‑list pattern such as `^[A-Za-z0-9_-]+$`. If the provided `districtId` does not match, we throw an error. We then use this sanitized value inside `getCachedDatesForDistrict` (and, for completeness and to address related CodeQL variants, anywhere else in this class that builds paths with `districtId`, like `getDistrictData` via `getDistrictCacheFilePath`). This keeps the external behavior the same for valid inputs but prevents any traversal characters such as `/`, `\`, or `..` from entering the filesystem path. Because we keep the same directory structure under `this.cacheDir` and only constrain what characters are allowed in `districtId`, we do not need to change callers or add new dependencies.

Implementation details:

- In `backend/src/services/DistrictCacheManager.ts`, add a private method, e.g. `sanitizeDistrictId(districtId: string): string`, near the other helper methods. This method:
  - Trims whitespace.
  - Checks the value against a regular expression like `/^[A-Za-z0-9_-]+$/`.
  - Throws an `Error` (or logs and throws) if the value is invalid.
- In `getCachedDatesForDistrict`, before constructing `districtDir`, call this helper and use the sanitized value in the path:  
  `const safeDistrictId = this.sanitizeDistrictId(districtId); const districtDir = path.join(this.cacheDir, 'districts', safeDistrictId)`.
- Optionally (but strongly recommended to comprehensively address all variants in this class), apply the same `sanitizeDistrictId` helper in other methods that build district-specific paths (such as in `getDistrictCacheFilePath` if that method uses `districtId` in a `path.join`). Since we are only allowed to edit shown snippets, we will at least wire it into `getCachedDatesForDistrict`, which is the location flagged.

No new imports are required; we use built‑in TypeScript/JavaScript features only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
