### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typescript-enforcement.yml
+++ b/.github/workflows/typescript-enforcement.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '20'
 


### PR DESCRIPTION
Potential fix for [https://github.com/rservant/toast-stats/security/code-scanning/29](https://github.com/rservant/toast-stats/security/code-scanning/29)

In general, the fix is to explicitly set `permissions:` for the workflow or for individual jobs so that `GITHUB_TOKEN` has only the minimal scopes required. For this workflow, all jobs (`typescript-check`, `lint-and-format`, `test`, `build`) only need to read repository contents and write to `GITHUB_STEP_SUMMARY`, which does not require any special `permissions` entries. Therefore `contents: read` is a safe, least-privilege default.

The single best fix with minimal functional impact is to add a root-level `permissions:` block right after the `on:` block and before `env:`. This will apply to all jobs that do not override permissions, including the `build` job on line 148 flagged by CodeQL. We will set:
```yaml
permissions:
  contents: read
```
No additional imports or methods are needed since this is a YAML configuration change within `.github/workflows/typescript-enforcement.yml` only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
