### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/backend/src/services/CacheManager.ts
+++ b/backend/src/services/CacheManager.ts
@@ -127,16 +127,22 @@ export class CacheManager {
    */
   private getMetadataFilePath(date: string): string {
     // Validate date format to prevent path traversal
-    if (!this.isValidDateKey(date)) {
+    const datePattern = /^\d{4}-\d{2}-\d{2}$/
+    if (!datePattern.test(date) || !this.isValidDateKey(date)) {
       throw new Error(`Invalid date format for metadata file path: ${date}`)
     }
 
     // Construct the filename using only validated components
     const filename = `metadata_${date}.json`
 
+    // Extra safeguard: ensure no path separators slipped into the filename
+    if (filename.includes('/') || filename.includes('\\')) {
+      throw new Error(`Unsafe characters in metadata filename: ${filename}`)
+    }
+
     // Use path.resolve to get absolute path and ensure it's within cache directory
-    const filePath = path.resolve(this.cacheDir, filename)
     const cacheDir = path.resolve(this.cacheDir)
+    const filePath = path.resolve(cacheDir, filename)
 
     // Ensure the resolved path is within the cache directory (prevent directory traversal)
     if (!filePath.startsWith(cacheDir + path.sep) && filePath !== cacheDir) {


### PR DESCRIPTION
Potential fix for [https://github.com/rservant/toast-stats/security/code-scanning/4](https://github.com/rservant/toast-stats/security/code-scanning/4)

In general terms, to fix uncontrolled data in a path expression you either (1) restrict user input to a safe pattern (for example strict `YYYY-MM-DD` dates), (2) construct filenames only from those validated components (no slashes, no `..`), and (3) resolve the final path relative to a known safe root and verify it is inside that root. The existing code already does most of this; we can strengthen it slightly to make the safety guarantees more explicit and more easily recognized by tools.

The best targeted fix here is to tighten `getMetadataFilePath` in `backend/src/services/CacheManager.ts` so that it:
- Uses a strict, local date regex to validate `date` rather than relying solely on `isValidDateKey` (which the analyzer may not understand).
- Ensures the constructed filename cannot contain path separators, even if the date string were maliciously crafted.
- Keeps the `path.resolve` containment check, but updates it to compare normalized absolute paths more explicitly.

Concretely, in `CacheManager.getMetadataFilePath` (lines 128–149), we will:
- Add an explicit regex `const datePattern = /^\d{4}-\d{2}-\d{2}$/;` and check `date` against it, throwing on mismatch.
- Construct `filename` as before, but also assert that it does not contain `/` or `\` (a defensive double‑check).
- Use `path.resolve` on both the cache directory and the file path and keep the existing containment check.

No changes are needed in `routes/districts.ts` or `RealToastmastersAPIService.ts` beyond this, because they already perform logical validation and simply pass the date down.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
