### PR TITLE
fix: exclude new charters from District Club Retention Award (#336)

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -513,6 +513,9 @@ const LandingPage: React.FC = () => {
           </div>
         </div>
 
+        {/* Awards Race — competitive district awards (#331) */}
+        <AwardsRaceSection standings={competitiveAwards ?? null} />
+
         {/* Sort Controls + Region Filter Toolbar — compact (#83) */}
         <div className="bg-white rounded-lg shadow-md p-3 mb-3">
           <div className="flex items-center gap-2 mb-2 overflow-x-auto pb-1 -mx-3 px-3 sm:mx-0 sm:px-0 sm:pb-0 scrollbar-hide">
@@ -899,9 +902,6 @@ const LandingPage: React.FC = () => {
             </table>
           </div>
         </div>
-
-        {/* Awards Race — competitive district awards (#331) */}
-        <AwardsRaceSection standings={competitiveAwards ?? null} />
 
         {/* Historical Rank Progression — collapsed by default (#83) */}
         <details className="bg-white rounded-lg shadow-md mt-4">

--- a/packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts
+++ b/packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts
@@ -41,6 +41,54 @@ const noopLogger: RankingLogger = {
 }
 
 /**
+ * Return the start-of-program-year date (July 1) preceding the given
+ * snapshot date, or null if the snapshot date is unparseable (#336).
+ *
+ * Toastmasters program years run July 1 → June 30.
+ */
+function getProgramYearStartDate(snapshotDate: string): Date | null {
+  const parsed = parseDateFlexible(snapshotDate)
+  if (!parsed) return null
+  const year = parsed.getUTCFullYear()
+  const month = parsed.getUTCMonth() + 1 // 1-indexed
+  const pyStartYear = month >= 7 ? year : year - 1
+  return new Date(Date.UTC(pyStartYear, 6, 1)) // July 1 UTC
+}
+
+/**
+ * Parse a date string in either ISO (YYYY-MM-DD) or US (M/D/YYYY or MM/DD/YYYY)
+ * format and return a UTC-normalized Date. Returns null on failure.
+ */
+function parseDateFlexible(value: string): Date | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  // ISO format: YYYY-MM-DD (optionally with time)
+  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (isoMatch) {
+    const y = Number(isoMatch[1])
+    const m = Number(isoMatch[2])
+    const d = Number(isoMatch[3])
+    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
+      return new Date(Date.UTC(y, m - 1, d))
+    }
+  }
+
+  // US format: M/D/YYYY or MM/DD/YYYY
+  const usMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/)
+  if (usMatch) {
+    const m = Number(usMatch[1])
+    const d = Number(usMatch[2])
+    const y = Number(usMatch[3])
+    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
+      return new Date(Date.UTC(y, m - 1, d))
+    }
+  }
+
+  return null
+}
+
+/**
  * Input district statistics for ranking calculation.
  * This interface matches the backend DistrictStatistics structure.
  */
@@ -133,6 +181,11 @@ export interface DistrictRankingData {
 
   // Count of clubs with 20+ paid members — for President's 20-Plus Award (#330)
   clubsWith20PlusMembers: number
+
+  // Count of paid clubs chartered in the current program year (#336).
+  // Subtracted from paidClubs when computing the District Club Retention Award
+  // so the metric reflects base-club survival rather than extension.
+  newCharteredClubs: number
 
   // Payment breakdown (#327)
   newPayments: number
@@ -239,6 +292,8 @@ interface RankingMetrics {
   regionAdvisorVisitMet: boolean
   // Count of clubs with 20+ paid members — for President's 20-Plus Award (#330)
   clubsWith20PlusMembers: number
+  // Count of paid clubs chartered in the current program year (#336)
+  newCharteredClubs: number
   // Payment breakdown (#327)
   newPayments: number
   aprilPayments: number
@@ -511,6 +566,8 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
           regionAdvisorVisitMet: ranking.regionAdvisorVisitMet,
           // Clubs with 20+ paid members for President's 20-Plus Award (#330)
           clubsWith20PlusMembers: ranking.clubsWith20PlusMembers,
+          // New chartered clubs for District Club Retention Award (#336)
+          newCharteredClubs: ranking.newCharteredClubs,
           // Payment breakdown (#327)
           newPayments: ranking.newPayments,
           aprilPayments: ranking.aprilPayments,
@@ -605,6 +662,14 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
           clubsWith20PlusMembers: district.clubPerformance
             ? this.countClubsWith20PlusMembers(district.clubPerformance)
             : 0,
+          // Count paid clubs chartered in the current program year (#336)
+          newCharteredClubs:
+            district.clubPerformance && district.asOfDate
+              ? this.countNewCharteredClubs(
+                  district.clubPerformance,
+                  district.asOfDate
+                )
+              : 0,
           // Payment breakdown (#327)
           newPayments: this.parseNumber(districtPerformance['New Payments']),
           aprilPayments: this.parseNumber(
@@ -699,6 +764,33 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
         club['Active Members'] ?? club['Membership'] ?? club['Paid Members']
       )
       if (members >= 20) count++
+    }
+    return count
+  }
+
+  /**
+   * Count clubs chartered during the current program year (#336).
+   *
+   * The Toastmasters program year runs July 1 → June 30. A club counts as a
+   * "new charter this year" if its Charter Date falls on or after the most
+   * recent July 1 preceding the snapshot.
+   *
+   * Used to exclude new charters from the District Club Retention Award
+   * numerator so retention measures base-club survival rather than extension.
+   */
+  private countNewCharteredClubs(
+    clubPerformance: Array<Record<string, string | number | null>>,
+    snapshotDate: string
+  ): number {
+    const programYearStart = getProgramYearStartDate(snapshotDate)
+    if (!programYearStart) return 0
+
+    let count = 0
+    for (const club of clubPerformance) {
+      const raw = club['Charter Date'] ?? club['Chartered']
+      if (typeof raw !== 'string' || raw.trim() === '') continue
+      const chartered = parseDateFlexible(raw)
+      if (chartered && chartered >= programYearStart) count++
     }
     return count
   }
@@ -907,6 +999,8 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
         regionAdvisorVisitMet: metric.regionAdvisorVisitMet,
         // Clubs with 20+ paid members for President's 20-Plus Award (#330)
         clubsWith20PlusMembers: metric.clubsWith20PlusMembers,
+        // New chartered clubs for District Club Retention Award (#336)
+        newCharteredClubs: metric.newCharteredClubs,
         // Payment breakdown (#327)
         newPayments: metric.newPayments,
         aprilPayments: metric.aprilPayments,

--- a/packages/analytics-core/src/rankings/CompetitiveAwardsCalculator.test.ts
+++ b/packages/analytics-core/src/rankings/CompetitiveAwardsCalculator.test.ts
@@ -208,6 +208,111 @@ describe('CompetitiveAwardsCalculator', () => {
       expect(result.retentionAward[2]?.isWinner).toBe(false) // D3 at 89%
       expect(result.retentionAward[3]?.isWinner).toBe(false)
     })
+
+    it('should exclude newly chartered clubs from retention numerator (#336)', () => {
+      // Two districts with identical paidClubs/paidClubBase ratios, but one
+      // achieved its paid count via new charters (low retention) while the
+      // other retained all its base clubs (100% retention).
+      const rankings: DistrictRanking[] = [
+        // D1: 50 base, 50 retained, 0 new charters → 50/50 = 100%
+        buildRanking({
+          districtId: '1',
+          paidClubs: 50,
+          paidClubBase: 50,
+          newCharteredClubs: 0,
+        }),
+        // D2: 50 base, 46 retained, 4 new charters → 46/50 = 92%
+        // Under the old (buggy) formula, this would score 50/50 = 100% and tie with D1.
+        buildRanking({
+          districtId: '2',
+          paidClubs: 50,
+          paidClubBase: 50,
+          newCharteredClubs: 4,
+        }),
+      ]
+
+      const result = calculator.calculate(rankings)
+
+      expect(result.retentionAward[0]?.districtId).toBe('1')
+      expect(result.retentionAward[0]?.value).toBe(100)
+      expect(result.retentionAward[1]?.districtId).toBe('2')
+      expect(result.retentionAward[1]?.value).toBe(92)
+    })
+
+    it('should not exceed 100% retention when new charters outpace losses (#336)', () => {
+      // D1: Extension-style growth — 50 base, 48 retained, 6 new charters.
+      // paidClubs = 54, paidClubBase = 50. Old formula: 108%. New formula: 96%.
+      const rankings: DistrictRanking[] = [
+        buildRanking({
+          districtId: '1',
+          paidClubs: 54,
+          paidClubBase: 50,
+          newCharteredClubs: 6,
+        }),
+      ]
+
+      const result = calculator.calculate(rankings)
+
+      expect(result.retentionAward[0]?.value).toBe(96)
+    })
+
+    it('should fall back to paidClubs / paidClubBase when newCharteredClubs is missing', () => {
+      // Backward compatibility: older snapshots without the new field continue
+      // to use the legacy formula.
+      const rankings: DistrictRanking[] = [
+        buildRanking({
+          districtId: '1',
+          paidClubs: 95,
+          paidClubBase: 100,
+          // newCharteredClubs intentionally undefined
+        }),
+      ]
+
+      const result = calculator.calculate(rankings)
+
+      expect(result.retentionAward[0]?.value).toBe(95)
+    })
+
+    it('should rank districts correctly when distinguishing retention from extension (#336)', () => {
+      // Scenario from the reported bug: three districts at the top of the
+      // Extension Award should not automatically be the top of the Retention
+      // Award when their new-charter counts differ.
+      const rankings: DistrictRanking[] = [
+        // District with lots of growth but some base losses
+        buildRanking({
+          districtId: 'A',
+          paidClubs: 54,
+          paidClubBase: 50,
+          newCharteredClubs: 6, // 48/50 = 96% retention
+        }),
+        // District with steady base, modest growth
+        buildRanking({
+          districtId: 'B',
+          paidClubs: 52,
+          paidClubBase: 50,
+          newCharteredClubs: 2, // 50/50 = 100% retention
+        }),
+        // District with no growth and no losses
+        buildRanking({
+          districtId: 'C',
+          paidClubs: 50,
+          paidClubBase: 50,
+          newCharteredClubs: 0, // 50/50 = 100% retention
+        }),
+      ]
+
+      const result = calculator.calculate(rankings)
+
+      // Extension ranks A first (net +4), B second (+2), C third (0)
+      expect(result.extensionAward[0]?.districtId).toBe('A')
+
+      // Retention puts B and C tied at 100%, A at 96% — decouples from extension
+      const topRetention = result.retentionAward.filter(r => r.value === 100)
+      expect(topRetention.map(r => r.districtId).sort()).toEqual(['B', 'C'])
+      expect(result.retentionAward.find(r => r.districtId === 'A')?.value).toBe(
+        96
+      )
+    })
   })
 
   describe('Per-district lookup', () => {

--- a/packages/analytics-core/src/rankings/CompetitiveAwardsCalculator.ts
+++ b/packages/analytics-core/src/rankings/CompetitiveAwardsCalculator.ts
@@ -141,15 +141,27 @@ export class CompetitiveAwardsCalculator {
 
   /**
    * District Club Retention Award — top 3 retaining ≥90% paid clubs.
-   * Retention % = paidClubs / paidClubBase * 100
+   *
+   * Retention % = (paidClubs − newCharteredClubs) / paidClubBase * 100
+   *
+   * Subtracting newly chartered clubs is what distinguishes this from the
+   * Extension Award (#336). Without that subtraction the formula collapses to
+   * `1 + netGrowth / paidClubBase`, producing identical rankings to Extension.
+   *
+   * Falls back to the legacy `paidClubs / paidClubBase` formula when
+   * `newCharteredClubs` is missing (older snapshots predating #336).
    * Districts below 90% threshold cannot win even if they're in the top 3.
    */
   private rankByRetention(
     rankings: DistrictRanking[]
   ): CompetitiveAwardRanking[] {
     const scored = rankings.map(r => {
-      const value =
-        r.paidClubBase > 0 ? (r.paidClubs / r.paidClubBase) * 100 : 0
+      if (r.paidClubBase <= 0) return { district: r, value: 0 }
+      const retainedBase =
+        r.newCharteredClubs !== undefined
+          ? r.paidClubs - r.newCharteredClubs
+          : r.paidClubs
+      const value = (retainedBase / r.paidClubBase) * 100
       return { district: r, value }
     })
     return this.assignRanks(scored, RETENTION_WINNER_THRESHOLD)

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -60,6 +60,51 @@ import {
 import { DistrictAwardsHistoryStore } from './DistrictAwardsHistoryStore.js'
 
 /**
+ * Parse a date string in either ISO (YYYY-MM-DD) or US (M/D/YYYY) format
+ * and return a UTC-normalized Date. Returns null on failure. (#336)
+ */
+function parseDateFlexible(value: string): Date | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (isoMatch) {
+    const y = Number(isoMatch[1])
+    const m = Number(isoMatch[2])
+    const d = Number(isoMatch[3])
+    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
+      return new Date(Date.UTC(y, m - 1, d))
+    }
+  }
+
+  const usMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/)
+  if (usMatch) {
+    const m = Number(usMatch[1])
+    const d = Number(usMatch[2])
+    const y = Number(usMatch[3])
+    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
+      return new Date(Date.UTC(y, m - 1, d))
+    }
+  }
+
+  return null
+}
+
+/**
+ * Return the start-of-program-year date (July 1) preceding the given
+ * snapshot date, or null if unparseable. Toastmasters program years run
+ * July 1 → June 30. (#336)
+ */
+function getProgramYearStartDate(snapshotDate: string): Date | null {
+  const parsed = parseDateFlexible(snapshotDate)
+  if (!parsed) return null
+  const year = parsed.getUTCFullYear()
+  const month = parsed.getUTCMonth() + 1
+  const pyStartYear = month >= 7 ? year : year - 1
+  return new Date(Date.UTC(pyStartYear, 6, 1))
+}
+
+/**
  * Internal structure for ranking metrics extraction
  */
 interface RankingMetrics {
@@ -87,6 +132,9 @@ interface RankingMetrics {
   regionAdvisorVisitMet: boolean
   // Clubs with 20+ paid members for President's 20-Plus Award (#330)
   clubsWith20PlusMembers: number
+  // Paid clubs chartered in the current program year (#336) — used to compute
+  // the District Club Retention Award on base-club survival alone.
+  newCharteredClubs: number
   // Payment breakdown (#327)
   newPayments: number
   aprilPayments: number
@@ -622,6 +670,8 @@ export class TransformService {
           ),
           // Default 0; populated later from per-district club-performance.csv (#330)
           clubsWith20PlusMembers: 0,
+          // Default 0; populated later from per-district club-performance.csv (#336)
+          newCharteredClubs: 0,
           // Payment breakdown (#327)
           newPayments: this.parseNumber(record['New Payments']),
           aprilPayments: this.parseNumber(record['April Payments']),
@@ -911,8 +961,10 @@ export class TransformService {
 
     // Aggregate per-district club data from club-performance CSVs:
     // - clubsWith20PlusMembers (#330) — always computed for 20-Plus Award
+    // - newCharteredClubs (#336) — for District Club Retention Award
     // - confirmed Distinguished count (#304) — only when all districts report 0
     const allZeroDistinguished = metrics.every(m => m.distinguishedClubs === 0)
+    const programYearStart = getProgramYearStartDate(date)
     for (const metric of metrics) {
       try {
         const csvPath = path.join(
@@ -928,13 +980,23 @@ export class TransformService {
 
         // Always count clubs with 20+ paid members for President's 20-Plus Award (#330)
         let twentyPlus = 0
+        let newCharters = 0
         for (const club of clubs) {
           const members = this.parseNumber(
             club['Active Members'] ?? club['Membership'] ?? club['Paid Members']
           )
           if (members >= 20) twentyPlus++
+
+          if (programYearStart) {
+            const raw = club['Charter Date'] ?? club['Chartered']
+            if (typeof raw === 'string' && raw.trim() !== '') {
+              const chartered = parseDateFlexible(raw)
+              if (chartered && chartered >= programYearStart) newCharters++
+            }
+          }
         }
         metric.clubsWith20PlusMembers = twentyPlus
+        metric.newCharteredClubs = newCharters
 
         // Compute confirmed Distinguished only when all districts report 0 (#304)
         if (allZeroDistinguished) {
@@ -1030,6 +1092,8 @@ export class TransformService {
         regionAdvisorVisitMet: metric.regionAdvisorVisitMet,
         // Clubs with 20+ paid members for President's 20-Plus Award (#330)
         clubsWith20PlusMembers: metric.clubsWith20PlusMembers,
+        // Paid clubs chartered this program year for District Club Retention Award (#336)
+        newCharteredClubs: metric.newCharteredClubs,
         // Payment breakdown (#327)
         newPayments: metric.newPayments,
         aprilPayments: metric.aprilPayments,

--- a/packages/shared-contracts/src/schemas/all-districts-rankings.schema.ts
+++ b/packages/shared-contracts/src/schemas/all-districts-rankings.schema.ts
@@ -98,6 +98,12 @@ export const DistrictRankingSchema = z.object({
   /** Count of active clubs with 20+ paid members — for President's 20-Plus Award (#330) */
   clubsWith20PlusMembers: z.number().optional(),
 
+  /**
+   * Count of paid clubs chartered during the current program year (#336).
+   * Used by CompetitiveAwardsCalculator to compute true base retention.
+   */
+  newCharteredClubs: z.number().optional(),
+
   /** Payment breakdown from All Districts CSV (#327) */
   newPayments: z.number().optional(),
   aprilPayments: z.number().optional(),

--- a/packages/shared-contracts/src/types/all-districts-rankings.ts
+++ b/packages/shared-contracts/src/types/all-districts-rankings.ts
@@ -88,6 +88,12 @@ export interface DistrictRanking {
   regionAdvisorVisitMet?: boolean
   /** Count of active clubs with 20+ paid members — for President's 20-Plus Award (#330) */
   clubsWith20PlusMembers?: number
+  /**
+   * Count of paid clubs chartered during the current program year (#336).
+   * Subtracted from paidClubs when computing the District Club Retention Award
+   * so retention only reflects base-club survival, not new charters.
+   */
+  newCharteredClubs?: number
   /** Payment breakdown from All Districts CSV (#327) */
   newPayments?: number
   aprilPayments?: number

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -957,3 +957,12 @@
 **Rule**: When adding a new GCS-backed persistent store (R9 pattern), audit ALL workflow paths that touch persistent state. Use `grep -n "club-trends\|time-series" data-pipeline.yml` to find every existing sync point and mirror them for the new store. Every `gsutil rsync` for an existing store needs a corresponding command for the new one.
 **Warning**: The staging and production rebuild paths in data-pipeline.yml are structurally duplicated (not shared). Changes to one must be manually mirrored to the other.
 **rules.md**: R9 (extended — new stores need full sync parity across all workflow paths)
+
+## 🗓️ 2026-04-22 — Lesson 46: Two Awards Collapse When Formula Conflates Retention With Growth (#336)
+
+**Discovery**: The District Club Retention Award and President's Extension Award produced identical top-3 standings. Root cause: retention was computed as `paidClubs / paidClubBase * 100`, which algebraically equals `1 + netGrowth / paidClubBase` when `paidClubs = baseRetained + newCharters`. The two awards measured the same underlying thing (club growth), just on different scales.
+**Proof**: Districts 93, 17, and 110 — the Extension Award top 3 — also topped the Retention Award at 105.8%, 105.2%, and 102.8%. Retention values >100% are a tell that the formula counts new charters as "retained" clubs.
+**Fix**: Added `newCharteredClubs` to `DistrictRanking`, computed by counting `clubPerformance` rows whose `Charter Date` falls within the current program year (July 1 – June 30). Retention now uses `(paidClubs − newCharteredClubs) / paidClubBase * 100`, so it measures only base-club survival.
+**Rule**: When two metrics appear to measure different things but share inputs, check the algebra. If `metric_A(x, y) = f(metric_B(x, y))` for any monotonic `f`, they will rank identically. Design metrics to have independent inputs or explicit differentiators.
+**Warning**: Both `BordaCountRankingCalculator.extractRankingMetrics` (analytics-core) and `TransformService.extractRankingMetrics` (collector-cli) have duplicated ranking-metric extraction logic. A new DistrictRanking field must be populated in BOTH or per-district snapshots will diverge from all-districts-rankings.json.
+**rules.md**: none


### PR DESCRIPTION
The Retention Award was producing identical top-3 standings to the
President's Extension Award because the formula reduced algebraically
to a scaled version of net club growth:

  paidClubs / paidClubBase = 1 + netGrowth / paidClubBase

Add a `newCharteredClubs` field to DistrictRanking populated by counting
clubs whose Charter Date falls within the current program year, and
update the retention formula to `(paidClubs - newCharteredClubs) /
paidClubBase * 100`. Retention now measures base-club survival only.

The field is populated in both ranking pipelines that exist in the
codebase (BordaCountRankingCalculator and TransformService) so the
two must stay in parity.

Falls back to the legacy formula when the field is absent, so older
snapshots continue to work.