### PR TITLE
fix(shell): drop double-v prefix on footer version (#354)

### DIFF
--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -126,6 +126,16 @@ describe('AppShell (#354)', () => {
       expect(footer).toHaveTextContent(/mit license/i)
     })
 
+    it('does not double-prefix the version (deploy.yml already passes v<semver>)', () => {
+      // Regression guard: VITE_APP_VERSION ships as e.g. 'v2.10.0', so the
+      // footer must NOT add another 'v'. The fallback in tests is 'dev', so
+      // we assert no 'vdev'/'vv' substring.
+      renderShell()
+      const footer = screen.getByRole('contentinfo')
+      expect(footer.textContent).not.toMatch(/v\s*v/i)
+      expect(footer.textContent).not.toMatch(/vdev/i)
+    })
+
     it('preserves the theme toggle for manual dark-mode access', () => {
       renderShell()
       const footer = screen.getByRole('contentinfo')

--- a/frontend/src/components/AppShell/AppShellFooter.tsx
+++ b/frontend/src/components/AppShell/AppShellFooter.tsx
@@ -35,7 +35,7 @@ const AppShellFooter: React.FC = () => {
             >
               MIT License
             </a>
-            {' · v'}
+            {' · '}
             {version}
           </span>
           <ThemeToggle />


### PR DESCRIPTION
## Summary

Visual regression caught after #354 deployed: footer rendered `MIT License · vv2.10.0`. Root cause — `deploy.yml` passes `VITE_APP_VERSION` as `v2.10.0` (already has the `v`), but `AppShellFooter` was prepending another `v` literal. Drop the literal.

## Test plan

- [x] AppShell tests pass (14/14)
- [x] Added a regression guard: footer text must not match `/v\s*v/i` or `/vdev/i`. The tests' `__APP_VERSION__` fallback is `'dev'`, so this catches both prod (`vv2.10.0`) and test (`vdev`) failure modes.
- [ ] After deploy: confirm footer reads `· v2.10.0` (or current version) instead of `· vv2.10.0`

## Related

- Cosmetic regression from #354 / PR #378
- Doesn't block Sprint 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)