### PR TITLE
feat(awards): rebuild AwardsRaceSection as 3-card contender summary (#357)

### DIFF
--- a/frontend/src/components/AwardsRaceSection.tsx
+++ b/frontend/src/components/AwardsRaceSection.tsx
@@ -1,183 +1,147 @@
 import React from 'react'
-import { useNavigate } from 'react-router-dom'
 import type {
   CompetitiveAwardRanking,
   CompetitiveAwardStandings,
 } from '../services/cdn'
+
+/* AwardsRaceSection — 2026 redesign 3-card contender summary (#357).
+   The deeper top-10 leaderboards move to the future Awards page (Epic
+   #370). This panel lives at the top of the Districts leaderboard
+   between the global KPI strip and the rankings table. */
 
 interface AwardsRaceSectionProps {
   /** Competitive award standings; null means no data for this snapshot */
   standings: CompetitiveAwardStandings | null
 }
 
-/**
- * Awards Race Section (#331)
- *
- * Displays leaderboards for the three competitive district awards:
- * - President's Extension Award (top 3 net club growth)
- * - President's 20-Plus Award (top 3 % clubs with 20+ paid members)
- * - District Club Retention Award (top 3 retaining ≥90% paid clubs)
- *
- * Collapsed by default — directors expand to see how close they are to
- * winning each award. Top 3 are highlighted with gold/silver/bronze medals.
- */
+interface AwardCardSpec {
+  title: string
+  description: string
+  /** Format the leader's value for display (e.g. "+14", "94.1%"). */
+  formatValue: (value: number) => string
+}
+
+const AWARD_CARDS: ReadonlyArray<{
+  key: keyof Pick<
+    CompetitiveAwardStandings,
+    'extensionAward' | 'twentyPlusAward' | 'retentionAward'
+  >
+  spec: AwardCardSpec
+}> = [
+  {
+    key: 'extensionAward',
+    spec: {
+      title: "President's Extension Award",
+      description: 'Largest net club growth',
+      formatValue: v => (v >= 0 ? `+${v}` : `${v}`),
+    },
+  },
+  {
+    key: 'twentyPlusAward',
+    spec: {
+      title: "President's 20-Plus Award",
+      description: 'Highest % clubs with 20+ paid members',
+      formatValue: v => `${v.toFixed(1)}%`,
+    },
+  },
+  {
+    key: 'retentionAward',
+    spec: {
+      title: 'District Club Retention Award',
+      description: 'Top retention (≥90% paid clubs)',
+      formatValue: v => `${v.toFixed(1)}%`,
+    },
+  },
+]
+
 export const AwardsRaceSection: React.FC<AwardsRaceSectionProps> = ({
   standings,
 }) => {
   if (!standings) return null
 
-  const extensionEntries = standings.extensionAward ?? []
-  const twentyPlusEntries = standings.twentyPlusAward ?? []
-  const retentionEntries = standings.retentionAward ?? []
+  const cardData = AWARD_CARDS.map(({ key, spec }) => {
+    const entries = standings[key] ?? []
+    return { spec, entries }
+  })
 
-  // Don't render if all leaderboards are empty
-  if (
-    extensionEntries.length === 0 &&
-    twentyPlusEntries.length === 0 &&
-    retentionEntries.length === 0
-  ) {
-    return null
-  }
+  const allEmpty = cardData.every(({ entries }) => entries.length === 0)
+  if (allEmpty) return null
 
   return (
-    <details className="bg-white rounded-lg shadow-md mt-4">
-      <summary className="cursor-pointer select-none text-lg font-bold text-gray-900 p-4 hover:text-tm-loyal-blue transition-colors flex items-center gap-2">
-        <span aria-hidden="true">🏆</span>
-        Awards Race
-        <span className="text-sm font-normal text-gray-500 ml-2">
-          Top 3 districts for each competitive award
-        </span>
-      </summary>
-      <div className="px-4 pb-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <Leaderboard
-            title="President's Extension Award"
-            description="Largest net club growth"
-            valueLabel="Net Clubs"
-            valueFormatter={v => (v >= 0 ? `+${v}` : `${v}`)}
-            entries={extensionEntries.slice(0, 10)}
-          />
-          <Leaderboard
-            title="President's 20-Plus Award"
-            description="Highest % clubs with 20+ paid members"
-            valueLabel="% Clubs"
-            valueFormatter={v => `${v.toFixed(1)}%`}
-            entries={twentyPlusEntries.slice(0, 10)}
-          />
-          <Leaderboard
-            title="District Club Retention Award"
-            description="Top retention (≥90% paid clubs)"
-            valueLabel="Retention"
-            valueFormatter={v => `${v.toFixed(1)}%`}
-            entries={retentionEntries.slice(0, 10)}
-          />
-        </div>
+    <section className="awards-race" aria-labelledby="awards-race-heading">
+      <header className="awards-race__header">
+        <h2 id="awards-race-heading" className="awards-race__title">
+          Awards Race
+        </h2>
+        <p className="awards-race__subtitle">Top contender per award</p>
+      </header>
+      <div className="awards-race__grid">
+        {cardData.map(({ spec, entries }) => (
+          <AwardCard key={spec.title} spec={spec} entries={entries} />
+        ))}
       </div>
-    </details>
+    </section>
   )
 }
 
-interface LeaderboardProps {
-  title: string
-  description: string
-  valueLabel: string
-  valueFormatter: (value: number) => string
+interface AwardCardProps {
+  spec: AwardCardSpec
   entries: CompetitiveAwardRanking[]
 }
 
-const Leaderboard: React.FC<LeaderboardProps> = ({
-  title,
-  description,
-  valueLabel,
-  valueFormatter,
-  entries,
-}) => {
-  const navigate = useNavigate()
+const AwardCard: React.FC<AwardCardProps> = ({ spec, entries }) => {
+  const leader = entries[0]
+  const winners = entries.filter(e => e.isWinner)
+  const isAchieved = leader?.isWinner ?? false
+
+  if (!leader) {
+    return (
+      <article className="awards-race-card">
+        <header className="awards-race-card__header">
+          <h3 className="awards-race-card__title">{spec.title}</h3>
+          <p className="awards-race-card__description">{spec.description}</p>
+        </header>
+        <p className="awards-race-card__empty">No standings yet.</p>
+      </article>
+    )
+  }
 
   return (
-    <div className="border border-gray-200 rounded-lg overflow-hidden">
-      <div className="bg-gray-50 px-3 py-2 border-b border-gray-200">
-        <h3 className="text-sm font-bold text-gray-900 font-tm-headline">
-          {title}
-        </h3>
-        <p className="text-xs text-gray-500 font-tm-body">{description}</p>
+    <article className="awards-race-card">
+      <header className="awards-race-card__header">
+        <h3 className="awards-race-card__title">{spec.title}</h3>
+        <p className="awards-race-card__description">{spec.description}</p>
+      </header>
+      <div className="awards-race-card__leader">
+        <a
+          href={`/district/${leader.districtId}`}
+          className="awards-race-card__leader-link"
+        >
+          D{leader.districtId}
+        </a>
+        <span className="awards-race-card__leader-value">
+          {spec.formatValue(leader.value)}
+        </span>
       </div>
-      <table className="w-full">
-        <thead className="bg-white">
-          <tr>
-            <th className="px-2 py-1 text-left text-xs font-medium text-gray-500 uppercase">
-              Rank
-            </th>
-            <th className="px-2 py-1 text-left text-xs font-medium text-gray-500 uppercase">
-              District
-            </th>
-            <th className="px-2 py-1 text-right text-xs font-medium text-gray-500 uppercase">
-              {valueLabel}
-            </th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-100">
-          {entries.map(entry => (
-            <tr
-              key={entry.districtId}
-              onClick={() => navigate(`/district/${entry.districtId}`)}
-              className={`cursor-pointer hover:bg-tm-loyal-blue-10 transition-colors ${
-                entry.isWinner ? 'bg-yellow-50' : ''
-              }`}
-            >
-              <td className="px-2 py-1.5 whitespace-nowrap">
-                <MedalBadge rank={entry.rank} isWinner={entry.isWinner} />
-              </td>
-              <td className="px-2 py-1.5 whitespace-nowrap text-sm text-gray-900 font-medium">
-                {entry.districtName}
-              </td>
-              <td className="px-2 py-1.5 whitespace-nowrap text-sm text-right text-gray-900 tabular-nums">
-                {valueFormatter(entry.value)}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+      <footer className="awards-race-card__footer">
+        {isAchieved ? (
+          <>
+            <span className="awards-race-card__status awards-race-card__status--achieved">
+              ✓ Achieved
+            </span>
+            {winners.length > 1 && (
+              <span className="awards-race-card__hint">
+                · {winners.length} districts qualifying
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="awards-race-card__status">
+            Leader · next contender at{' '}
+            {entries[1] ? spec.formatValue(entries[1].value) : '—'}
+          </span>
+        )}
+      </footer>
+    </article>
   )
-}
-
-/**
- * Medal badge for top 3 winners. Gold/Silver/Bronze.
- */
-const MedalBadge: React.FC<{ rank: number; isWinner: boolean }> = ({
-  rank,
-  isWinner,
-}) => {
-  if (isWinner && rank === 1) {
-    return (
-      <span
-        aria-label="Award winner — gold medal"
-        className="inline-flex items-center gap-1 text-xs font-semibold text-yellow-700"
-      >
-        <span aria-hidden="true">🥇</span>1
-      </span>
-    )
-  }
-  if (isWinner && rank === 2) {
-    return (
-      <span
-        aria-label="Award winner — silver medal"
-        className="inline-flex items-center gap-1 text-xs font-semibold text-gray-600"
-      >
-        <span aria-hidden="true">🥈</span>2
-      </span>
-    )
-  }
-  if (isWinner && rank === 3) {
-    return (
-      <span
-        aria-label="Award winner — bronze medal"
-        className="inline-flex items-center gap-1 text-xs font-semibold text-amber-700"
-      >
-        <span aria-hidden="true">🥉</span>3
-      </span>
-    )
-  }
-  return <span className="text-xs text-gray-500 tabular-nums">#{rank}</span>
 }

--- a/frontend/src/components/AwardsRaceSection.tsx
+++ b/frontend/src/components/AwardsRaceSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import type {
   CompetitiveAwardRanking,
   CompetitiveAwardStandings,
@@ -113,12 +114,12 @@ const AwardCard: React.FC<AwardCardProps> = ({ spec, entries }) => {
         <p className="awards-race-card__description">{spec.description}</p>
       </header>
       <div className="awards-race-card__leader">
-        <a
-          href={`/district/${leader.districtId}`}
+        <Link
+          to={`/district/${leader.districtId}`}
           className="awards-race-card__leader-link"
         >
           D{leader.districtId}
-        </a>
+        </Link>
         <span className="awards-race-card__leader-value">
           {spec.formatValue(leader.value)}
         </span>

--- a/frontend/src/components/__tests__/AwardsRaceSection.test.tsx
+++ b/frontend/src/components/__tests__/AwardsRaceSection.test.tsx
@@ -1,6 +1,9 @@
+/* AwardsRaceSection — 2026 redesign 3-card contender summary (#357).
+   The detailed top-10 lists move to the future Awards page (Epic #370). */
+
 import React from 'react'
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { AwardsRaceSection } from '../AwardsRaceSection'
 import type { CompetitiveAwardStandings } from '../../services/cdn'
@@ -16,93 +19,151 @@ const mockStandings: CompetitiveAwardStandings = {
   },
   extensionAward: [
     {
-      districtId: '1',
-      districtName: 'District 1',
-      region: '1',
+      districtId: '17',
+      districtName: 'District 17',
+      region: '5',
       rank: 1,
-      value: 15,
-      isWinner: true,
+      value: 14,
+      isWinner: false,
     },
     {
-      districtId: '2',
-      districtName: 'District 2',
-      region: '2',
+      districtId: '60',
+      districtName: 'District 60',
+      region: '8',
       rank: 2,
       value: 10,
-      isWinner: true,
+      isWinner: false,
     },
     {
-      districtId: '3',
-      districtName: 'District 3',
-      region: '3',
+      districtId: '93',
+      districtName: 'District 93',
+      region: '11',
       rank: 3,
-      value: 5,
-      isWinner: true,
-    },
-    {
-      districtId: '4',
-      districtName: 'District 4',
-      region: '4',
-      rank: 4,
-      value: 0,
+      value: 9,
       isWinner: false,
     },
   ],
   twentyPlusAward: [
     {
-      districtId: '1',
-      districtName: 'District 1',
-      region: '1',
+      districtId: '60',
+      districtName: 'District 60',
+      region: '8',
       rank: 1,
-      value: 90,
+      value: 22,
+      isWinner: true,
+    },
+    {
+      districtId: '57',
+      districtName: 'District 57',
+      region: '1',
+      rank: 2,
+      value: 18,
       isWinner: true,
     },
   ],
   retentionAward: [
     {
-      districtId: '1',
-      districtName: 'District 1',
-      region: '1',
+      districtId: '102',
+      districtName: 'District 102',
+      region: '14',
       rank: 1,
-      value: 100,
+      value: 94.1,
       isWinner: true,
     },
   ],
   byDistrict: {},
 }
 
-describe('AwardsRaceSection (#331)', () => {
-  it('should render three competitive award leaderboards', () => {
-    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
+const findCard = (cardTitle: RegExp) => {
+  const heading = screen.getByRole('heading', { name: cardTitle })
+  const card = heading.closest('.awards-race-card') as HTMLElement
+  expect(card).toBeTruthy()
+  return card
+}
 
-    // "Awards Race" is in a <summary> (not a heading element)
-    expect(screen.getByText(/Awards Race/i)).toBeInTheDocument()
+describe('AwardsRaceSection — 3-card redesign (#357)', () => {
+  it('renders the panel header naming the section', () => {
+    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
+    expect(screen.getByText(/awards race/i)).toBeInTheDocument()
+  })
+
+  it('renders three contender cards (Extension / 20-Plus / Retention)', () => {
+    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
     expect(
-      screen.getByRole('heading', { name: /Extension Award/i })
+      screen.getByRole('heading', { name: /president'?s extension award/i })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('heading', { name: /20-Plus Award/i })
+      screen.getByRole('heading', { name: /president'?s 20-plus award/i })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('heading', { name: /Retention Award/i })
+      screen.getByRole('heading', { name: /district club retention award/i })
     ).toBeInTheDocument()
   })
 
-  it('should highlight top 3 winners with medals', () => {
+  it('shows the leading district id + value on each card', () => {
     renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
 
-    // Each leaderboard shows winners. District 1, 2, 3 should be marked
-    // as winners in the Extension award
-    const winners = screen.getAllByLabelText(/winner/i)
-    expect(winners.length).toBeGreaterThan(0)
+    const ext = findCard(/extension/i)
+    expect(within(ext).getByText(/D17/)).toBeInTheDocument()
+    expect(within(ext).getByText(/14/)).toBeInTheDocument()
+
+    const twenty = findCard(/20-plus/i)
+    expect(within(twenty).getByText(/D60/)).toBeInTheDocument()
+    expect(within(twenty).getByText(/22/)).toBeInTheDocument()
+
+    const ret = findCard(/retention/i)
+    expect(within(ret).getByText(/D102/)).toBeInTheDocument()
+    // Allow the renderer to format 94.1% how it likes — check substring
+    expect(within(ret).getByText(/94/)).toBeInTheDocument()
   })
 
-  it('should not render when standings is null', () => {
+  it('signals "Achieved" on cards where the leader has won', () => {
+    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
+    // 20-Plus + Retention leaders are winners in the fixture
+    const twenty = findCard(/20-plus/i)
+    expect(within(twenty).getByText(/achieved/i)).toBeInTheDocument()
+
+    const ret = findCard(/retention/i)
+    expect(within(ret).getByText(/achieved/i)).toBeInTheDocument()
+  })
+
+  it('does NOT signal "Achieved" on cards where no winner exists yet', () => {
+    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
+    // Extension fixture has zero winners — should show in-progress copy
+    const ext = findCard(/extension/i)
+    expect(within(ext).queryByText(/achieved/i)).not.toBeInTheDocument()
+  })
+
+  it('links the leader to its district detail page', () => {
+    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
+    const ext = findCard(/extension/i)
+    const link = within(ext).getByRole('link', { name: /D17/ })
+    expect(link).toHaveAttribute('href', '/district/17')
+  })
+
+  it('does NOT render top-10 leaderboards (deferred to Awards page Epic #370)', () => {
+    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
+    // No <table> rendered — the deeper top-10 list lives on /awards (deferred)
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('does not render when standings is null', () => {
     const { container } = renderWithRouter(
       <AwardsRaceSection standings={null} />
     )
-    // The MemoryRouter wrapper renders an empty div, so check that
-    // AwardsRaceSection itself didn't render anything
-    expect(container.querySelector('details')).toBeNull()
+    expect(container.querySelector('.awards-race-card')).toBeNull()
+  })
+
+  it('does not render when all award arrays are empty', () => {
+    const empty: CompetitiveAwardStandings = {
+      ...mockStandings,
+      extensionAward: [],
+      twentyPlusAward: [],
+      retentionAward: [],
+    }
+    const { container } = renderWithRouter(
+      <AwardsRaceSection standings={empty} />
+    )
+    expect(container.querySelector('.awards-race-card')).toBeNull()
   })
 })

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -314,4 +314,141 @@
     color: var(--link);
     font-weight: 600;
   }
+
+  /* Awards Race 3-card contender summary (#357). Sits between the
+     Districts page KPI strip and the rankings table. The deeper
+     top-10 leaderboards live on the future Awards page (Epic #370). */
+  .awards-race {
+    margin-bottom: 20px;
+  }
+
+  .awards-race__header {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-bottom: 12px;
+  }
+
+  .awards-race__title {
+    margin: 0;
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: -0.005em;
+    color: var(--ink);
+  }
+
+  .awards-race__subtitle {
+    margin: 0;
+    font-family: var(--sans);
+    font-size: 12px;
+    color: var(--ink-3);
+  }
+
+  .awards-race__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  @media (min-width: 768px) {
+    .awards-race__grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .awards-race-card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px 18px;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-md);
+    box-shadow: var(--rds-shadow-sm);
+  }
+
+  .awards-race-card__header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .awards-race-card__title {
+    margin: 0;
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 14px;
+    color: var(--ink);
+  }
+
+  .awards-race-card__description {
+    margin: 0;
+    font-family: var(--sans);
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--ink-3);
+  }
+
+  .awards-race-card__leader {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .awards-race-card__leader-link {
+    font-family: var(--mono);
+    font-weight: 500;
+    font-size: 16px;
+    color: var(--link);
+    text-decoration: none;
+  }
+
+  .awards-race-card__leader-link:hover {
+    text-decoration: underline;
+  }
+
+  .awards-race-card__leader-value {
+    font-family: var(--serif);
+    font-weight: 800;
+    font-size: 24px;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    color: var(--ink);
+    tabular-nums: 1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .awards-race-card__footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    padding-top: 8px;
+    border-top: 1px solid var(--line-2);
+    font-family: var(--sans);
+    font-size: 12px;
+    color: var(--ink-3);
+  }
+
+  .awards-race-card__status {
+    font-weight: 500;
+  }
+
+  .awards-race-card__status--achieved {
+    color: var(--green-600);
+  }
+
+  .awards-race-card__hint {
+    color: var(--ink-3);
+  }
+
+  .awards-race-card__empty {
+    margin: 0;
+    font-family: var(--sans);
+    font-size: 12px;
+    color: var(--ink-3);
+    font-style: italic;
+  }
 }

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -416,7 +416,6 @@
     line-height: 1;
     letter-spacing: -0.02em;
     color: var(--ink);
-    tabular-nums: 1;
     font-variant-numeric: tabular-nums;
   }
 

--- a/frontend/src/styles/tokens/redesign.css
+++ b/frontend/src/styles/tokens/redesign.css
@@ -81,4 +81,12 @@
   --rds-shadow-lg: 0 1px 2px rgba(0, 0, 0, .3), 0 8px 24px rgba(0, 0, 0, .5);
 
   --rds-surface-rgb: 17, 25, 34;
+
+  /* Lift status colors so they read on the dark surface scale.
+     Light-mode --green-{500,600} are tuned for white backgrounds and
+     drop below 4.5:1 contrast on --surface in dark. */
+  --green-500: #4ade80;
+  --green-600: #22c55e;
+  --red-500: #f87171;
+  --red-600: #ef4444;
 }


### PR DESCRIPTION
## Summary

Sprint 2 / Issue #357 — replaces the prior expandable top-3 leaderboard tables with the handoff's 3-card contender summary. Same component name + props, so `LandingPage` doesn't change.

Each card:
- Title + criterion sub-line
- Leader district code (`D{id}`) as a `react-router` `<Link>` to `/district/:id`, in JetBrains Mono
- Leader value formatted per award (`+14`, `94.1%`, etc.)
- Footer: `✓ Achieved · N districts qualifying` when leader has won, else `Leader · next contender at {value}`

CSS lives in `app-shell.css` under `@layer brand` alongside the existing `.districts-*` redesign classes. Uses `--surface`, `--line`, `--rds-radius-md`, `--rds-shadow-sm`, `--green-600` tokens.

Status colors get **dark-mode overrides** in `redesign.css` — `--green-500/600` and `--red-500/600` were tuned for white backgrounds and dropped below 4.5:1 contrast on the dark `--surface` scale. Lifted to `#4ade80 / #22c55e` and `#f87171 / #ef4444` respectively.

## Out of scope (deferred)

- **Threshold-based progress bars** + "X to go · N within reach" copy — needs threshold data added to `analytics-core` or surfaced in `CompetitiveAwardStandings`. Captured the simpler "Leader · next at X" copy for v1.
- **Top-10 leaderboards per award** — Epic #370 (future Awards page).

## Test plan

- [x] `npx vitest --run src/components/__tests__/AwardsRaceSection.test.tsx` — 9/9 pass
- [x] Full frontend suite — 2079/2079 pass
- [x] `npx tsc --noEmit` — clean
- [ ] After CI deploys: confirm 3 contender cards render between the KPI strip and the rankings table on `/`, leader links don't full-page-reload, dark mode contrast is readable

## Reviewer findings (applied unless noted)

- **HIGH (fixed)**: leader link was a plain `<a href>`, would have triggered full page reload on click. Switched to `react-router-dom` `<Link to>`.
- **MEDIUM (fixed)**: status colors had no dark-mode overrides and lost contrast on dark surfaces. Added overrides in `tokens/redesign.css`.
- **LOW (fixed)**: dropped invalid `tabular-nums: 1;` declaration (the `font-variant-numeric: tabular-nums;` line below does the actual work).
- **MEDIUM (deferred)**: status color overrides (`--green-500/600`, `--red-500/600`) live in the unscoped `[data-theme='dark']` block, so any future component pulling these tokens silently gets the lifted shade. Acceptable today (only consumer is this PR), worth namespacing as `--status-green-*` if more consumers land. Tracking note for future tokens cleanup.
- **LOW (deferred)**: add `@remarks Sorted descending by value` to `CompetitiveAwardStandings.{extension,twentyPlus,retention}Award` so the next reader knows `entries[0]` is the leader by construction.

## Related

- Closes #357
- Part of Epic #352 / Sprint 2 (closes Sprint 2 — chrome + KPI strip + Awards Race summary)
- Followed by Sprint 3 — District detail page (#358 header, #359 tab bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
