### PR TITLE
feat(overview): apply redesign panel chrome to Overview tab (#360)

### DIFF
--- a/frontend/src/__tests__/css-migration/redesign-panel.test.ts
+++ b/frontend/src/__tests__/css-migration/redesign-panel.test.ts
@@ -1,0 +1,41 @@
+/* Shared .redesign-panel class (#360). Used as the token-driven
+   replacement for the legacy `bg-white rounded-lg shadow-md p-6`
+   Tailwind triplet on Overview tab components. Static guard so future
+   edits don't accidentally drop the class or break dark mode. */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const css = readFileSync(
+  resolve(__dirname, '../../styles/components/app-shell.css'),
+  'utf-8'
+)
+
+describe('Shared redesign-panel chrome (#360)', () => {
+  it('declares .redesign-panel inside @layer brand with token-driven background + border + shadow', () => {
+    const rule = css.match(/\.redesign-panel\s*\{([\s\S]*?)\n\s*\}/)
+    expect(rule).toBeTruthy()
+    const block = rule?.[1] ?? ''
+    expect(block).toMatch(/background-color\s*:\s*var\(--surface\)/)
+    expect(block).toMatch(/border\s*:[^;]*var\(--line\)/)
+    expect(block).toMatch(/border-radius\s*:\s*var\(--rds-radius-md\)/)
+    expect(block).toMatch(/box-shadow\s*:\s*var\(--rds-shadow-sm\)/)
+  })
+
+  it('does NOT use hardcoded colors that would break dark mode', () => {
+    const rule = css.match(/\.redesign-panel\s*\{([\s\S]*?)\n\s*\}/)
+    const block = rule?.[1] ?? ''
+    // No bare hex / rgb() in the rule body.
+    expect(block).not.toMatch(/#[0-9a-f]{3,6}/i)
+    expect(block).not.toMatch(/rgba?\(/)
+  })
+
+  it('has a paired .redesign-panel__header rule with serif typography', () => {
+    const rule = css.match(/\.redesign-panel__header\s*\{([\s\S]*?)\n\s*\}/)
+    expect(rule).toBeTruthy()
+    const block = rule?.[1] ?? ''
+    expect(block).toMatch(/font-family\s*:\s*var\(--serif\)/)
+    expect(block).toMatch(/font-weight\s*:\s*700/)
+  })
+})

--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -108,7 +108,7 @@ export const DistinguishedDistrictTrophyCase: React.FC<
     status
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-6">
+    <div className="redesign-panel">
       <div className="flex items-start justify-between gap-4 mb-4">
         <div>
           <h2 className="text-lg font-bold text-gray-900 font-tm-headline mb-1">

--- a/frontend/src/components/DistrictOverview.tsx
+++ b/frontend/src/components/DistrictOverview.tsx
@@ -80,7 +80,7 @@ export const DistrictOverview: React.FC<DistrictOverviewProps> = ({
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-6">
+    <div className="redesign-panel">
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
         <div>
           <h2 className="text-2xl font-bold text-gray-900">Overview</h2>

--- a/frontend/src/components/PaymentCompositionCard.tsx
+++ b/frontend/src/components/PaymentCompositionCard.tsx
@@ -72,7 +72,7 @@ export const PaymentCompositionCard: React.FC<PaymentCompositionCardProps> = ({
   ]
 
   return (
-    <div className="payment-composition bg-white rounded-lg shadow-md p-6">
+    <div className="payment-composition redesign-panel">
       <h2 className="text-lg font-bold text-gray-900 font-tm-headline mb-3">
         Payment Composition
       </h2>

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -649,4 +649,26 @@
     background-color: var(--loyal-50);
     color: var(--loyal-500);
   }
+
+  /* Shared redesign panel chrome (#360+). Replaces the legacy
+     `bg-white rounded-lg shadow-md p-6` Tailwind triplet on existing
+     components — token-driven so dark mode just works. Each tab's
+     content rebuild applies this class to their card containers. */
+  .redesign-panel {
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-md);
+    box-shadow: var(--rds-shadow-sm);
+    padding: 18px;
+    color: var(--ink);
+  }
+
+  .redesign-panel__header {
+    margin: 0 0 12px;
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: -0.005em;
+    color: var(--ink);
+  }
 }

--- a/tasks/founder-log-2026-05-10.md
+++ b/tasks/founder-log-2026-05-10.md
@@ -71,3 +71,21 @@ Squash to `9c5df236`. Coverage suite green. Sprint 3 first half done.
 ### 14:15 UTC — Strategy decision: bundle #359 with AnalyticsTab tech debt
 
 #359 ships the tab bar primitive. The over-broad `AnalyticsTab.test.tsx` mounts the entire `DistrictDetailPage` to assert `<button>Analytics</button>` exists in the nav — exactly the pattern that bit #358. Extracting `DistrictDetailTabs.tsx` for #359 lets that test mount the small component instead. One PR, two wins.
+
+### 14:36 UTC — #385 (#359) merged. Sprint 3 complete.
+
+Tab bar primitive shipped + 6 brittle test files migrated from `.toHaveClass('text-tm-loyal-blue')` style assertions to `aria-selected`. Filed #384 as a deferred a11y follow-up (arrow-key nav + tabpanel linkage on the new tablist).
+
+### 14:43 UTC — #386 brittle-assertion cleanup merged
+
+12 `getAllByText('Test District 1')[0]` calls in `date-consistency.integration.test.tsx` migrated to `getByRole('heading', { level: 1, name: /test district 1/i })`. Lightweight DoD — single test file, no logic change.
+
+### 14:50 UTC — Sprint 4 strategy: pragmatic token chrome refresh
+
+Realistic scope check: doing each tab "1:1 match handoff" with chart visual restyling (thin strokes, dots, gridline polish, axis inversion etc.) is multi-day work. The 24h budget is finite. Pragmatic founder call:
+
+**For #360-#365**: apply the redesign tokens + dark-mode-aware panels to the existing tab content. Each section gets `var(--surface)` + `var(--rds-radius-md)` + `var(--rds-shadow-sm)` instead of hardcoded `bg-white rounded-lg shadow-md`. Panel headers shift to Montserrat 14/700. Functional content unchanged. Pixel-perfect chart restyling and the genuinely-new Global Rankings sections (ranking progression with metric toggle, multi-year comparison table) get filed as follow-up sub-issues.
+
+This trades "1:1 handoff fidelity" for "architectural redesign complete" — each tab is dark-mode-aware, uses redesign tokens, matches the design's typography rhythm. Pixel polish is real work that deserves its own focused PR.
+
+**Tactic**: introduce a single `.redesign-panel` class in `app-shell.css` with the token-driven panel chrome. Apply it to existing components in a small touch (replace 3 hardcoded class strings per component). Heavy lift comes only when a section is genuinely new.


### PR DESCRIPTION
## Summary

Sprint 4 / Issue #360. Pragmatic scope per founder log decision: token chrome refresh on the existing Overview tab content — dark-mode-aware, redesign-token-driven panels — rather than a multi-day pixel-perfect rebuild.

### What changed
- New shared \`.redesign-panel\` + \`.redesign-panel__header\` classes in \`app-shell.css\` under \`@layer brand\`. Token-driven: \`var(--surface)\` / \`var(--line)\` / \`var(--rds-radius-md)\` / \`var(--rds-shadow-sm)\`.
- Applied to \`DistrictOverview\`, \`DistinguishedDistrictTrophyCase\`, \`PaymentCompositionCard\` (3 single-line className swaps).
- Static guard test asserting the rule uses only token references — no hardcoded hex/rgba — so future edits can't accidentally re-introduce the dark-mode regression.

Tabs #361-#365 will reuse this shared class — keeps each subsequent Sprint-5 PR small.

## Out of scope (filed as follow-ups)

- Pixel-perfect chart restyling for MembershipTrend/Payments/YoY → #363
- "Vs all 117 districts" sparkline panel + ranking-progression chart with metric toggle + multi-year comparison table → #365
- KPI strip rank badges polish → if needed, separate sub-issue

## Test plan

- [x] \`npx vitest --run --coverage\` — 129/129 files, 2092/2092 tests
- [x] \`npx tsc --noEmit\` clean
- [ ] After deploy: Overview tab shows dark-mode-aware panels (no white islands on dark background)

🤖 Generated with [Claude Code](https://claude.com/claude-code)