### PR TITLE
feat(tabs): bulk redesign panel chrome across all tab components (#361-#365)

### DIFF
--- a/frontend/src/components/AreaPerformanceChart.tsx
+++ b/frontend/src/components/AreaPerformanceChart.tsx
@@ -96,7 +96,7 @@ export const AreaPerformanceChart: React.FC<AreaPerformanceChartProps> = ({
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-md">
+    <div className="redesign-panel">
       {/* Header */}
       <div className="p-6 border-b border-gray-200">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/frontend/src/components/ChartLegend.tsx
+++ b/frontend/src/components/ChartLegend.tsx
@@ -211,7 +211,7 @@ export const ChartContainer: React.FC<ChartContainerProps> = ({
 
   if (isLoading) {
     return (
-      <div className={`bg-white rounded-lg shadow-md p-6 ${className}`}>
+      <div className={`redesign-panel ${className}`}>
         {title && <ChartTitle title={title} {...(subtitle && { subtitle })} />}
         <div className="flex items-center justify-center h-80">
           <div className="animate-pulse flex flex-col items-center">
@@ -225,10 +225,7 @@ export const ChartContainer: React.FC<ChartContainerProps> = ({
 
   if (error) {
     return (
-      <div
-        className={`bg-white rounded-lg shadow-md p-6 ${className}`}
-        role="alert"
-      >
+      <div className={`redesign-panel ${className}`} role="alert">
         {title && <ChartTitle title={title} {...(subtitle && { subtitle })} />}
         <div className="flex items-center justify-center h-80">
           <div className="text-center">
@@ -243,7 +240,7 @@ export const ChartContainer: React.FC<ChartContainerProps> = ({
   }
 
   return (
-    <div className={`bg-white rounded-lg shadow-md p-6 ${className}`}>
+    <div className={`redesign-panel ${className}`}>
       {title && <ChartTitle title={title} {...(subtitle && { subtitle })} />}
 
       {legend && legendPosition === 'top' && (

--- a/frontend/src/components/ClubDCPGoalsCard.tsx
+++ b/frontend/src/components/ClubDCPGoalsCard.tsx
@@ -51,7 +51,7 @@ export const ClubDCPGoalsCard: React.FC<ClubDCPGoalsCardProps> = ({
 }) => {
   if (isLoading) {
     return (
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="animate-pulse space-y-3">
           <div className="h-6 bg-gray-200 rounded-sm w-1/3"></div>
           <div className="h-4 bg-gray-200 rounded-sm w-full"></div>
@@ -80,7 +80,7 @@ export const ClubDCPGoalsCard: React.FC<ClubDCPGoalsCardProps> = ({
   ]
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-6">
+    <div className="redesign-panel">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-semibold text-gray-900 font-tm-headline flex items-center gap-2">
           <svg

--- a/frontend/src/components/ClubPerformanceTable.tsx
+++ b/frontend/src/components/ClubPerformanceTable.tsx
@@ -154,7 +154,7 @@ const ClubPerformanceTable: React.FC<ClubPerformanceTableProps> = ({
   if (isLoading) {
     return (
       <section
-        className="bg-white rounded-lg shadow-md p-6"
+        className="redesign-panel"
         aria-busy="true"
         aria-label="Loading club performance data"
       >
@@ -172,7 +172,7 @@ const ClubPerformanceTable: React.FC<ClubPerformanceTableProps> = ({
 
   return (
     <section
-      className="bg-white rounded-lg shadow-md p-4 sm:p-6"
+      className="redesign-panel sm:p-6"
       aria-label="Club performance table"
     >
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-4 gap-3 sm:gap-4">

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -330,7 +330,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-md">
+    <div className="redesign-panel">
       {/* Header with Export and Results Count */}
       <div className="p-6 border-b border-gray-200">
         <div className="flex items-center justify-between mb-4">

--- a/frontend/src/components/ComparisonPanel.tsx
+++ b/frontend/src/components/ComparisonPanel.tsx
@@ -158,7 +158,7 @@ const ComparisonPanel: React.FC<ComparisonPanelProps> = ({
   ]
 
   return (
-    <div className="bg-white rounded-lg shadow-md mb-4 p-4 border-l-4 border-tm-loyal-blue">
+    <div className="redesign-panel mb-4 p-4 border-l-4 border-tm-loyal-blue">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-bold text-gray-900 font-tm-headline">

--- a/frontend/src/components/DCPGoalAnalysis.tsx
+++ b/frontend/src/components/DCPGoalAnalysis.tsx
@@ -22,7 +22,7 @@ export const DCPGoalAnalysis: React.FC<DCPGoalAnalysisProps> = ({
 }) => {
   if (isLoading) {
     return (
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="animate-pulse space-y-4">
           <div className="h-6 bg-gray-200 rounded-sm w-1/3"></div>
           <div className="h-64 bg-gray-200 rounded-sm"></div>
@@ -33,7 +33,7 @@ export const DCPGoalAnalysis: React.FC<DCPGoalAnalysisProps> = ({
 
   if (!dcpGoalAnalysis) {
     return (
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <p className="text-gray-600">
           No DCP goal analysis available. Please use the Admin Panel to collect
           historical data.
@@ -110,7 +110,7 @@ export const DCPGoalAnalysis: React.FC<DCPGoalAnalysisProps> = ({
     <div className="space-y-6">
       {/* Overview Cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-white rounded-lg shadow-md p-4">
+        <div className="redesign-panel">
           <div className="flex items-center gap-2 mb-2">
             <svg
               className="w-5 h-5 text-tm-loyal-blue"
@@ -136,7 +136,7 @@ export const DCPGoalAnalysis: React.FC<DCPGoalAnalysisProps> = ({
           </p>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-4">
+        <div className="redesign-panel">
           <div className="flex items-center gap-2 mb-2">
             <svg
               className="w-5 h-5 text-tm-true-maroon"
@@ -162,7 +162,7 @@ export const DCPGoalAnalysis: React.FC<DCPGoalAnalysisProps> = ({
           </p>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-4">
+        <div className="redesign-panel">
           <div className="flex items-center gap-2 mb-2">
             <svg
               className="w-5 h-5 text-tm-loyal-blue"
@@ -187,7 +187,7 @@ export const DCPGoalAnalysis: React.FC<DCPGoalAnalysisProps> = ({
       </div>
 
       {/* Most Commonly Achieved Goals */}
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="flex items-center gap-2 mb-4">
           <svg
             className="w-6 h-6 text-green-600"
@@ -215,7 +215,7 @@ export const DCPGoalAnalysis: React.FC<DCPGoalAnalysisProps> = ({
       </div>
 
       {/* Least Commonly Achieved Goals */}
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="flex items-center gap-2 mb-4">
           <svg
             className="w-6 h-6 text-red-600"
@@ -244,7 +244,7 @@ export const DCPGoalAnalysis: React.FC<DCPGoalAnalysisProps> = ({
       </div>
 
       {/* Heatmap Visualization */}
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <h3 className="text-xl font-semibold text-gray-900 mb-4">
           DCP Goal Achievement Heatmap
         </h3>

--- a/frontend/src/components/DCPProjectionsTable.tsx
+++ b/frontend/src/components/DCPProjectionsTable.tsx
@@ -221,7 +221,7 @@ export const DCPProjectionsTable: React.FC<DCPProjectionsTableProps> = ({
 
   if (isLoading) {
     return (
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <h3 className="text-xl font-bold text-gray-900 font-tm-headline mb-4">
           DCP Projections
         </h3>
@@ -231,10 +231,7 @@ export const DCPProjectionsTable: React.FC<DCPProjectionsTableProps> = ({
   }
 
   return (
-    <div
-      className="bg-white rounded-lg shadow-md"
-      data-testid="dcp-projections-table"
-    >
+    <div className="redesign-panel" data-testid="dcp-projections-table">
       {/* Header */}
       <div className="p-6 border-b border-gray-200">
         <h3 className="text-xl font-bold text-gray-900 font-tm-headline mb-4">

--- a/frontend/src/components/DistinguishedProgressChart.tsx
+++ b/frontend/src/components/DistinguishedProgressChart.tsx
@@ -48,7 +48,7 @@ export const DistinguishedProgressChart: React.FC<
       : 0
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-6">
+    <div className="redesign-panel">
       <div className="flex items-center gap-2 mb-6">
         <h3 className="text-xl font-tm-headline font-bold text-tm-black">
           Distinguished Club Progress

--- a/frontend/src/components/DivisionAreaProgressSummary.tsx
+++ b/frontend/src/components/DivisionAreaProgressSummary.tsx
@@ -307,7 +307,7 @@ export const DivisionAreaProgressSummary: React.FC<
   if (isLoading) {
     return (
       <div
-        className="bg-white rounded-lg shadow-md"
+        className="redesign-panel"
         role="status"
         aria-label="Loading division and area progress summaries"
         aria-busy="true"
@@ -335,7 +335,7 @@ export const DivisionAreaProgressSummary: React.FC<
   // Empty state
   if (!divisions || divisions.length === 0) {
     return (
-      <div className="bg-white rounded-lg shadow-md">
+      <div className="redesign-panel">
         {/* Header */}
         <div className="p-6 border-b border-gray-200">
           <h3 className="text-xl font-bold text-gray-900 font-tm-headline">
@@ -360,7 +360,7 @@ export const DivisionAreaProgressSummary: React.FC<
   // Main render
   return (
     <section
-      className="bg-white rounded-lg shadow-md"
+      className="redesign-panel"
       aria-label="Division and Area Progress Summary"
       role="region"
     >

--- a/frontend/src/components/DivisionAreaRecognitionPanel.tsx
+++ b/frontend/src/components/DivisionAreaRecognitionPanel.tsx
@@ -110,7 +110,7 @@ export const DivisionAreaRecognitionPanel: React.FC<
         aria-busy="true"
       >
         {/* Section Header Skeleton */}
-        <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="redesign-panel">
           <div className="animate-pulse">
             <div className="h-7 bg-gray-200 rounded w-1/3 mb-2"></div>
             <div className="h-4 bg-gray-200 rounded w-2/3"></div>
@@ -131,7 +131,7 @@ export const DivisionAreaRecognitionPanel: React.FC<
     return (
       <section className="space-y-6" aria-label="Division and Area Recognition">
         {/* Section Header */}
-        <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="redesign-panel">
           <h2 className="text-2xl font-bold text-gray-900 font-tm-headline">
             Division and Area Recognition
           </h2>
@@ -145,7 +145,7 @@ export const DivisionAreaRecognitionPanel: React.FC<
         </div>
 
         {/* Empty State Message */}
-        <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="redesign-panel">
           <div className="text-center py-12">
             <svg
               className="mx-auto h-12 w-12 text-gray-400 mb-4"
@@ -188,7 +188,7 @@ export const DivisionAreaRecognitionPanel: React.FC<
       role="region"
     >
       {/* Section Header - Requirement 10.2, 10.7: Updated header */}
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="flex items-center gap-3 mb-2">
           <svg
             className="w-8 h-8 text-tm-loyal-blue flex-shrink-0"
@@ -221,7 +221,7 @@ export const DivisionAreaRecognitionPanel: React.FC<
       <DivisionAreaProgressSummary divisions={divisions} isLoading={false} />
 
       {/* Summary Footer - Requirement 1.3: Consistent styling */}
-      <div className="bg-white rounded-lg shadow-md p-4">
+      <div className="redesign-panel">
         <p
           className="font-tm-body text-gray-600 text-center"
           style={{ fontSize: '14px' }}

--- a/frontend/src/components/DivisionPerformanceCards.tsx
+++ b/frontend/src/components/DivisionPerformanceCards.tsx
@@ -77,7 +77,7 @@ export const DivisionPerformanceCards: React.FC<
   // Loading state
   if (isLoading) {
     return (
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="flex items-center justify-center py-12">
           <div className="text-center">
             <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-tm-loyal-blue mb-4"></div>
@@ -96,7 +96,7 @@ export const DivisionPerformanceCards: React.FC<
   // Error state - invalid or missing data
   if (!districtSnapshot) {
     return (
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="text-center py-12">
           <svg
             className="mx-auto h-12 w-12 text-gray-400 mb-4"
@@ -133,7 +133,7 @@ export const DivisionPerformanceCards: React.FC<
   // Empty state - no divisions found
   if (divisions.length === 0) {
     return (
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="text-center py-12">
           <svg
             className="mx-auto h-12 w-12 text-gray-400 mb-4"
@@ -171,7 +171,7 @@ export const DivisionPerformanceCards: React.FC<
     <div className="space-y-6">
       {/* Snapshot Timestamp Header */}
       {snapshotTimestamp && (
-        <div className="bg-white rounded-lg shadow-md p-4">
+        <div className="redesign-panel">
           <div className="flex items-center justify-between">
             <div>
               <h2
@@ -220,7 +220,7 @@ export const DivisionPerformanceCards: React.FC<
       </div>
 
       {/* Summary Footer */}
-      <div className="bg-white rounded-lg shadow-md p-4">
+      <div className="redesign-panel">
         <p
           className="font-tm-body text-gray-600 text-center"
           style={{ fontSize: '14px' }}

--- a/frontend/src/components/DivisionRankings.tsx
+++ b/frontend/src/components/DivisionRankings.tsx
@@ -277,7 +277,7 @@ export const DivisionRankings: React.FC<DivisionRankingsProps> = ({
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-md">
+    <div className="redesign-panel">
       {/* Header */}
       <div className="p-6 border-b border-gray-200">
         <div className="flex items-center justify-between">

--- a/frontend/src/components/EducationalAwardsChart.tsx
+++ b/frontend/src/components/EducationalAwardsChart.tsx
@@ -54,7 +54,7 @@ const EducationalAwardsChart: React.FC<EducationalAwardsChartProps> = ({
   if (isLoading) {
     return (
       <section
-        className="bg-white rounded-lg shadow-md p-6"
+        className="redesign-panel"
         aria-busy="true"
         aria-label="Loading educational awards"
       >
@@ -74,7 +74,7 @@ const EducationalAwardsChart: React.FC<EducationalAwardsChartProps> = ({
   if (isError) {
     return (
       <section
-        className="bg-white rounded-lg shadow-md p-6"
+        className="redesign-panel"
         role="alert"
         aria-label="Educational awards error"
       >
@@ -98,7 +98,7 @@ const EducationalAwardsChart: React.FC<EducationalAwardsChartProps> = ({
   if (!data) {
     return (
       <section
-        className="bg-white rounded-lg shadow-md p-6"
+        className="redesign-panel"
         role="status"
         aria-label="Educational awards"
       >

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -62,7 +62,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
       return (
         <div className="min-h-screen bg-gray-100 flex items-center justify-center px-4">
-          <div className="bg-white rounded-lg shadow-md p-8 max-w-md w-full">
+          <div className="redesign-panel p-8 max-w-md w-full">
             <div className="flex items-center justify-center w-12 h-12 mx-auto bg-red-100 rounded-full mb-4">
               <svg
                 className="w-6 h-6 text-red-600"

--- a/frontend/src/components/FullYearRankingChart.tsx
+++ b/frontend/src/components/FullYearRankingChart.tsx
@@ -180,7 +180,7 @@ const MetricToggleButton: React.FC<MetricToggleButtonProps> = ({
  */
 const ChartLoadingSkeleton: React.FC = () => (
   <section
-    className="bg-white rounded-lg shadow-md p-4 sm:p-6"
+    className="redesign-panel sm:p-6"
     aria-busy="true"
     aria-label="Loading ranking progression chart"
   >
@@ -214,7 +214,7 @@ interface EmptyStateProps {
 
 const EmptyState: React.FC<EmptyStateProps> = ({ programYear }) => (
   <section
-    className="bg-white rounded-lg shadow-md p-4 sm:p-6"
+    className="redesign-panel sm:p-6"
     role="status"
     aria-label="No ranking data available"
   >
@@ -292,7 +292,7 @@ const FullYearRankingChart: React.FC<FullYearRankingChartProps> = ({
 
   return (
     <section
-      className="bg-white rounded-lg shadow-md p-4 sm:p-6"
+      className="redesign-panel sm:p-6"
       aria-label="Full year ranking progression chart"
     >
       {/* Header */}

--- a/frontend/src/components/GlobalRankingsTab.tsx
+++ b/frontend/src/components/GlobalRankingsTab.tsx
@@ -56,11 +56,7 @@ interface ErrorStateProps {
 }
 
 const ErrorState: React.FC<ErrorStateProps> = ({ error, onRetry }) => (
-  <div
-    className="bg-white rounded-lg shadow-md p-6 sm:p-8"
-    role="alert"
-    aria-live="polite"
-  >
+  <div className="redesign-panel sm:p-8" role="alert" aria-live="polite">
     <div className="flex flex-col items-center text-center">
       {/* Error Icon */}
       <div className="w-16 h-16 rounded-full tm-bg-true-maroon-10 flex items-center justify-center mb-4">
@@ -124,7 +120,7 @@ interface EmptyStateProps {
 
 const EmptyState: React.FC<EmptyStateProps> = ({ districtName }) => (
   <div
-    className="bg-white rounded-lg shadow-md p-6 sm:p-8"
+    className="redesign-panel sm:p-8"
     role="status"
     aria-label="No ranking data available"
   >

--- a/frontend/src/components/HistoricalRankChart.tsx
+++ b/frontend/src/components/HistoricalRankChart.tsx
@@ -102,7 +102,7 @@ const HistoricalRankChart: React.FC<HistoricalRankChartProps> = ({
   if (isLoading) {
     return (
       <section
-        className="bg-white rounded-lg shadow-md p-6"
+        className="redesign-panel"
         aria-busy="true"
         aria-label="Loading historical rank data"
       >
@@ -122,7 +122,7 @@ const HistoricalRankChart: React.FC<HistoricalRankChartProps> = ({
   if (isError) {
     return (
       <section
-        className="bg-white rounded-lg shadow-md p-6"
+        className="redesign-panel"
         role="alert"
         aria-label="Historical rank data error"
       >
@@ -146,7 +146,7 @@ const HistoricalRankChart: React.FC<HistoricalRankChartProps> = ({
   if (!data || data.length === 0) {
     return (
       <section
-        className="bg-white rounded-lg shadow-md p-6"
+        className="redesign-panel"
         role="status"
         aria-label="Historical rank data"
       >
@@ -217,7 +217,7 @@ const HistoricalRankChart: React.FC<HistoricalRankChartProps> = ({
 
   return (
     <section
-      className="bg-white rounded-lg shadow-md p-4 sm:p-6"
+      className="redesign-panel sm:p-6"
       aria-label="Historical rank progression chart"
     >
       <div className="flex flex-col gap-4 mb-4">

--- a/frontend/src/components/LeadershipInsights.tsx
+++ b/frontend/src/components/LeadershipInsights.tsx
@@ -63,7 +63,7 @@ export const LeadershipInsights: React.FC<LeadershipInsightsProps> = ({
 }) => {
   if (isLoading) {
     return (
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="animate-pulse space-y-4">
           <div className="h-6 bg-gray-200 rounded-sm w-1/3"></div>
           <div className="h-32 bg-gray-200 rounded-sm"></div>
@@ -75,7 +75,7 @@ export const LeadershipInsights: React.FC<LeadershipInsightsProps> = ({
 
   if (!insights) {
     return (
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <p className="text-gray-600">
           No leadership insights available. Please use the Admin Panel to
           collect historical data.
@@ -160,7 +160,7 @@ export const LeadershipInsights: React.FC<LeadershipInsightsProps> = ({
     <div className="space-y-6">
       {/* Summary Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-white rounded-lg shadow-md p-4">
+        <div className="redesign-panel">
           <p className="text-sm text-gray-600 mb-1">Average Leadership Score</p>
           <p
             className={`text-3xl font-bold ${getScoreColor(insights.summary.averageLeadershipScore)}`}
@@ -168,13 +168,13 @@ export const LeadershipInsights: React.FC<LeadershipInsightsProps> = ({
             {insights.summary.averageLeadershipScore}
           </p>
         </div>
-        <div className="bg-white rounded-lg shadow-md p-4">
+        <div className="redesign-panel">
           <p className="text-sm text-gray-600 mb-1">Best Practice Divisions</p>
           <p className="text-3xl font-bold text-tm-loyal-blue">
             {insights.summary.totalBestPracticeDivisions}
           </p>
         </div>
-        <div className="bg-white rounded-lg shadow-md p-4">
+        <div className="redesign-panel">
           <p className="text-sm text-gray-600 mb-1">Top Division</p>
           <p className="text-lg font-semibold text-gray-900 truncate">
             {insights.summary.topPerformingDivisions[0]?.divisionName || 'N/A'}
@@ -183,7 +183,7 @@ export const LeadershipInsights: React.FC<LeadershipInsightsProps> = ({
             Score: {insights.summary.topPerformingDivisions[0]?.score || 0}
           </p>
         </div>
-        <div className="bg-white rounded-lg shadow-md p-4">
+        <div className="redesign-panel">
           <p className="text-sm text-gray-600 mb-1">Top Area</p>
           <p className="text-lg font-semibold text-gray-900 truncate">
             {insights.summary.topPerformingAreas[0]?.areaName || 'N/A'}
@@ -195,7 +195,7 @@ export const LeadershipInsights: React.FC<LeadershipInsightsProps> = ({
       </div>
 
       {/* Leadership Effectiveness Scores */}
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <h3 className="text-xl font-semibold text-gray-900 mb-4">
           Leadership Effectiveness Scores
         </h3>
@@ -282,7 +282,7 @@ export const LeadershipInsights: React.FC<LeadershipInsightsProps> = ({
 
       {/* Best Practice Divisions */}
       {insights.bestPracticeDivisions.length > 0 && (
-        <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="redesign-panel">
           <h3 className="text-xl font-semibold text-gray-900 mb-4">
             Best Practice Divisions
           </h3>
@@ -325,7 +325,7 @@ export const LeadershipInsights: React.FC<LeadershipInsightsProps> = ({
 
       {/* Leadership Changes */}
       {insights.leadershipChanges.length > 0 && (
-        <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="redesign-panel">
           <h3 className="text-xl font-semibold text-gray-900 mb-4">
             Performance Changes
           </h3>
@@ -377,7 +377,7 @@ export const LeadershipInsights: React.FC<LeadershipInsightsProps> = ({
       )}
 
       {/* Area Director Correlations */}
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <h3 className="text-xl font-semibold text-gray-900 mb-4">
           Area Performance Indicators
         </h3>

--- a/frontend/src/components/LoadingSkeleton.tsx
+++ b/frontend/src/components/LoadingSkeleton.tsx
@@ -23,7 +23,7 @@ export const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({
   if (variant === 'card') {
     return (
       <div
-        className={`bg-white rounded-lg shadow-md p-6 ${className}`}
+        className={`redesign-panel ${className}`}
         role="status"
         aria-label="Loading"
       >
@@ -39,7 +39,7 @@ export const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({
   if (variant === 'table') {
     return (
       <div
-        className={`bg-white rounded-lg shadow-md ${className}`}
+        className={`redesign-panel ${className}`}
         role="status"
         aria-label="Loading table"
       >
@@ -73,7 +73,7 @@ export const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({
   if (variant === 'stat') {
     return (
       <div
-        className={`bg-white rounded-lg shadow-md p-4 ${className}`}
+        className={`redesign-panel ${className}`}
         role="status"
         aria-label="Loading statistics"
       >

--- a/frontend/src/components/MembershipPaymentsChart.tsx
+++ b/frontend/src/components/MembershipPaymentsChart.tsx
@@ -325,7 +325,7 @@ export const MembershipPaymentsChart: React.FC<
 
   return (
     <div
-      className="bg-white rounded-lg shadow-md p-6"
+      className="redesign-panel"
       aria-label="Membership payments trend chart"
     >
       {/* Header */}

--- a/frontend/src/components/MembershipTrendChart.tsx
+++ b/frontend/src/components/MembershipTrendChart.tsx
@@ -266,7 +266,7 @@ export const MembershipTrendChart: React.FC<MembershipTrendChartProps> = ({
 
   return (
     <div
-      className="bg-white rounded-lg shadow-md p-6"
+      className="redesign-panel"
       aria-label="District membership trend chart"
     >
       <div className="mb-6">

--- a/frontend/src/components/MultiYearComparisonTable.tsx
+++ b/frontend/src/components/MultiYearComparisonTable.tsx
@@ -111,7 +111,7 @@ const PartialYearBadge: React.FC = () => (
  */
 const TableLoadingSkeleton: React.FC = () => (
   <section
-    className="bg-white rounded-lg shadow-md p-4 sm:p-6"
+    className="redesign-panel sm:p-6"
     aria-busy="true"
     aria-label="Loading multi-year comparison table"
   >
@@ -129,7 +129,7 @@ const TableLoadingSkeleton: React.FC = () => (
  */
 const EmptyState: React.FC = () => (
   <section
-    className="bg-white rounded-lg shadow-md p-4 sm:p-6"
+    className="redesign-panel sm:p-6"
     role="status"
     aria-label="No multi-year ranking data available"
   >
@@ -299,7 +299,7 @@ const MultiYearComparisonTable: React.FC<MultiYearComparisonTableProps> = ({
 
   return (
     <section
-      className="bg-white rounded-lg shadow-md p-4 sm:p-6"
+      className="redesign-panel sm:p-6"
       aria-labelledby="multi-year-comparison-heading"
     >
       {/* Header */}

--- a/frontend/src/components/TopGrowthClubs.tsx
+++ b/frontend/src/components/TopGrowthClubs.tsx
@@ -43,7 +43,7 @@ export const TopGrowthClubs: React.FC<TopGrowthClubsProps> = ({
 
   if (isLoading) {
     return (
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="animate-pulse space-y-4">
           <div className="h-6 bg-gray-200 rounded w-1/3"></div>
           <div className="h-32 bg-gray-200 rounded"></div>
@@ -127,7 +127,7 @@ export const TopGrowthClubs: React.FC<TopGrowthClubsProps> = ({
   return (
     <div className="space-y-6">
       {/* Top Growth Clubs */}
-      <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="redesign-panel">
         <div className="flex items-center gap-2 mb-4">
           <svg
             className="w-6 h-6 text-green-600"
@@ -209,7 +209,7 @@ export const TopGrowthClubs: React.FC<TopGrowthClubsProps> = ({
 
       {/* Top DCP Goal Achievement Clubs */}
       {topDCPClubs && topDCPClubs.length > 0 && (
-        <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="redesign-panel">
           <div className="flex items-center gap-2 mb-4">
             <svg
               className="w-6 h-6 text-tm-loyal-blue"

--- a/frontend/src/components/YearOverYearComparison.tsx
+++ b/frontend/src/components/YearOverYearComparison.tsx
@@ -202,10 +202,7 @@ export const YearOverYearComparison: React.FC<YearOverYearComparisonProps> = ({
   const chartDescription = `Bar chart comparing current year metrics to previous year. ${improvements} metric(s) improved, ${declines} metric(s) declined.`
 
   return (
-    <div
-      className="bg-white rounded-lg shadow-md p-6"
-      aria-label="Year-over-year comparison"
-    >
+    <div className="redesign-panel" aria-label="Year-over-year comparison">
       <div className="mb-6">
         <h2 className="text-xl font-semibold text-gray-900">
           Year-Over-Year Comparison

--- a/frontend/src/components/ui/Form/FormExample.tsx
+++ b/frontend/src/components/ui/Form/FormExample.tsx
@@ -71,7 +71,7 @@ export const FormExample: React.FC = () => {
   }
 
   return (
-    <div className="max-w-2xl mx-auto p-6 bg-white rounded-lg shadow-md">
+    <div className="max-w-2xl mx-auto p-6 redesign-panel">
       <h2 className="tm-h2 mb-6">Contact Form Example</h2>
       <p className="tm-body-medium text-gray-600 mb-8">
         This form demonstrates all brand-compliant form components with proper


### PR DESCRIPTION
## Summary

Bulk Sprint 4-5 chrome refresh: 26 components migrated from the legacy \`bg-white rounded-lg shadow-md p-{4,6}\` Tailwind triplet to the shared \`.redesign-panel\` class introduced in #360. Dark-mode-aware via redesign tokens.

This PR ships the **bulk visual chrome** for the District tabs (Clubs, Divisions & Areas, Trends, Analytics, Global Rankings) plus a few Club detail surfaces. Each issue's remaining content acceptance criteria (filter chips, explainers, metric toggles) gets a separate small follow-up PR.

## Files migrated by tab

- **#361 Clubs**: ClubsTable
- **#362 Divisions & Areas**: DivisionPerformanceCards, DivisionAreaRecognitionPanel, AreaPerformanceChart, AreaPerformanceTable, DivisionRankings, DivisionAreaProgressSummary
- **#363 Trends**: MembershipPaymentsChart, YearOverYearComparison, ChartLegend
- **#364 Analytics**: TopGrowthClubs, DCPGoalAnalysis, LeadershipInsights, ComparisonPanel
- **#365 Global Rankings + Club detail**: GlobalRankingsTab, FullYearRankingChart, MultiYearComparisonTable, EducationalAwardsChart, DistinguishedProgressChart, DCPProjectionsTable, ClubPerformanceTable, ClubDCPGoalsCard
- **Shared chrome**: LoadingSkeleton, FormExample

## Test plan

- [x] \`npx vitest --run --coverage\` — 129/129 files, 2092/2092 tests, zero timeout bumps
- [x] \`npx tsc --noEmit\` clean
- [ ] Live verify: every tab in dark mode shows token-driven panels (no white islands)

## Out of scope (per-issue follow-ups)

- #361: search input + status segmented filter + quick-filter chips
- #362: \"Distinguished Program criteria\" collapsible explainer
- #363: 3-year membership trend overlay treatment + cumulative payments
- #365: ranking-progression chart with metric toggle + multi-year comparison table
- Pixel-perfect chart line/dot/gridline polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)