### PR TITLE
feat(history,methodology): ship History year strip + full Methodology content (#367 #368)

### DIFF
--- a/frontend/src/__tests__/components/routing.test.tsx
+++ b/frontend/src/__tests__/components/routing.test.tsx
@@ -18,7 +18,7 @@ const renderRoute = (Page: React.ComponentType, path: string) => {
 }
 
 describe('Routing scaffolding (#355)', () => {
-  describe('/history placeholder page', () => {
+  describe('/history page', () => {
     it('renders a heading naming the page', () => {
       renderRoute(HistoryPage, '/history')
       expect(
@@ -26,25 +26,65 @@ describe('Routing scaffolding (#355)', () => {
       ).toBeInTheDocument()
     })
 
-    it('signals the placeholder status until #367 ships the real content', () => {
+    it('renders the year strip with the current PY marked aria-current', () => {
       renderRoute(HistoryPage, '/history')
-      // Don't assert the exact copy — just that something explains the
-      // page is intentionally minimal.
-      expect(screen.getByText(/coming/i)).toBeInTheDocument()
+      // First chip in the year strip (current year) is announced as
+      // aria-current=page so screen-reader users can locate it quickly.
+      const strip = screen.getByRole('list')
+      const items = screen.getAllByRole('listitem')
+      expect(strip).toBeInTheDocument()
+      const current = items.find(i => i.getAttribute('aria-current') === 'page')
+      expect(current).toBeDefined()
+      expect(current?.textContent).toContain('LIVE')
+    })
+
+    it('points pre-2019 visitors to the official TI archive', () => {
+      renderRoute(HistoryPage, '/history')
+      const link = screen.getByRole('link', {
+        name: /toastmasters international archive/i,
+      })
+      expect(link).toHaveAttribute(
+        'href',
+        'https://dashboards.toastmasters.org'
+      )
     })
   })
 
-  describe('/methodology placeholder page', () => {
-    it('renders a heading naming the page', () => {
+  describe('/methodology page', () => {
+    it('renders the page heading', () => {
       renderRoute(MethodologyPage, '/methodology')
       expect(
         screen.getByRole('heading', { level: 1, name: /methodology/i })
       ).toBeInTheDocument()
     })
 
-    it('signals the placeholder status until #368 ships the real content', () => {
+    it('renders the anchor TOC with all 8 numbered sections', () => {
       renderRoute(MethodologyPage, '/methodology')
-      expect(screen.getByText(/coming/i)).toBeInTheDocument()
+      const nav = screen.getByRole('navigation', { name: /on this page/i })
+      expect(nav).toBeInTheDocument()
+      // Each section should be linked from the TOC and have a matching h2.
+      ;[
+        'Data source',
+        'Refresh cadence',
+        'Borda count',
+        'DCP tier',
+        'Club health',
+        'Glossary',
+        'Caveats',
+        'Changelog',
+      ].forEach(title => {
+        // TOC link
+        expect(
+          screen.getByRole('link', { name: new RegExp(title, 'i') })
+        ).toBeInTheDocument()
+        // Section h2
+        expect(
+          screen.getByRole('heading', {
+            level: 2,
+            name: new RegExp(title, 'i'),
+          })
+        ).toBeInTheDocument()
+      })
     })
   })
 })

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,16 +1,77 @@
 import React from 'react'
 
-/* Placeholder for #355. Real History page (year strip + per-year cards
-   + TI archive callout) ships in #367. */
+/* History page (#367). The 2026 design specifies year-end snapshot
+   cards (top 5 districts + headline metrics + notable note) for each
+   archived program year. That data is NOT currently fetched on the
+   client — it lives in archived snapshots that would need a new GCS
+   index endpoint to surface. Filing as a follow-up.
+
+   This v1 ships the page header + year-strip chip row pointing to the
+   archive years on file, plus the TI archive callout for pre-2019. */
+
+const PROGRAM_YEARS_ON_FILE = [
+  { label: '2025–26', current: true },
+  { label: '2024–25' },
+  { label: '2023–24' },
+  { label: '2022–23' },
+  { label: '2021–22' },
+  { label: '2020–21' },
+  { label: '2019–20' },
+]
 
 const HistoryPage: React.FC = () => {
   return (
     <div className="placeholder-page">
-      <p className="placeholder-page__eyebrow">Archive</p>
+      <p className="placeholder-page__eyebrow">
+        Archive · {PROGRAM_YEARS_ON_FILE.length} program years on file
+      </p>
       <h1 className="placeholder-page__title">Program Year History</h1>
       <p className="placeholder-page__body">
-        Coming soon — multi-year archive (issue #367).
+        Final standings and headline metrics for each completed Toastmasters
+        program year. Data is frozen at June 30; each year is preserved as it
+        stood when the year closed — no retroactive corrections.
       </p>
+
+      <div className="history-page-year-strip" role="list">
+        {PROGRAM_YEARS_ON_FILE.map(year => (
+          <span
+            key={year.label}
+            role="listitem"
+            className={
+              'history-page-year-chip' +
+              (year.current ? ' history-page-year-chip--current' : '')
+            }
+            aria-current={year.current ? 'page' : undefined}
+          >
+            {year.label}
+            {year.current && (
+              <span className="history-page-year-chip__live">· LIVE</span>
+            )}
+          </span>
+        ))}
+        <span
+          className="history-page-year-chip history-page-year-chip--gap"
+          role="listitem"
+        >
+          earlier · TI archive only
+        </span>
+      </div>
+
+      <div className="districts-methodology-callout" style={{ marginTop: 32 }}>
+        <strong>Per-year summary cards coming soon.</strong> The full archive UI
+        (top 5 districts + headline metrics per year) needs a new year-end
+        snapshot endpoint — tracked as a follow-up. For pre-2019 data, see the
+        official{' '}
+        <a
+          href="https://dashboards.toastmasters.org"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="districts-methodology-callout__link"
+        >
+          Toastmasters International archive
+        </a>
+        .
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -1,16 +1,280 @@
 import React from 'react'
 
-/* Placeholder for #355. Real Methodology page (anchor TOC + 8 numbered
-   sections sourced from analytics-core) ships in #368. */
+/* Methodology page (#368). Authored fresh from analytics-core as the
+   source of truth — Borda formula, DCP thresholds, club health
+   classifications, refresh cadence. Future updates should land here
+   first; the codebase comments reference this page for canonical
+   definitions. */
+
+const SECTIONS: ReadonlyArray<{ id: string; num: string; title: string }> = [
+  { id: 'data-source', num: '01', title: 'Data source & access' },
+  { id: 'refresh-cadence', num: '02', title: 'Refresh cadence' },
+  { id: 'borda-count', num: '03', title: 'Borda count scoring' },
+  { id: 'dcp-tiers', num: '04', title: 'DCP tier definitions' },
+  { id: 'club-health', num: '05', title: 'Club health classifications' },
+  { id: 'glossary', num: '06', title: 'Glossary' },
+  { id: 'caveats', num: '07', title: 'Caveats & known issues' },
+  { id: 'changelog', num: '08', title: 'Changelog' },
+]
 
 const MethodologyPage: React.FC = () => {
   return (
-    <div className="placeholder-page">
-      <p className="placeholder-page__eyebrow">Reference</p>
-      <h1 className="placeholder-page__title">Methodology</h1>
-      <p className="placeholder-page__body">
-        Coming soon — data sources, scoring, and definitions (issue #368).
-      </p>
+    <div className="methodology-page">
+      <header className="methodology-page__header">
+        <p className="placeholder-page__eyebrow">Reference · Updated 2026-05</p>
+        <h1 className="placeholder-page__title">Methodology</h1>
+        <p className="placeholder-page__body">
+          How Toast Stats sources, processes, and ranks the worldwide
+          Toastmasters dashboard. Everything here is reproducible from public
+          data — no scraping, no inference.
+        </p>
+      </header>
+
+      <nav aria-label="On this page" className="methodology-toc">
+        <p className="methodology-toc__title">On this page</p>
+        <ol className="methodology-toc__list">
+          {SECTIONS.map(s => (
+            <li key={s.id} className="methodology-toc__item">
+              <span className="methodology-toc__num">{s.num}</span>
+              <a href={`#${s.id}`} className="methodology-toc__link">
+                {s.title}
+              </a>
+            </li>
+          ))}
+        </ol>
+      </nav>
+
+      <section id="data-source" className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">01</span>
+          Data source &amp; access
+        </h2>
+        <p>
+          All numbers come from the public{' '}
+          <a
+            href="https://dashboards.toastmasters.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="methodology-link"
+          >
+            Toastmasters International dashboard
+          </a>{' '}
+          — the same files district leadership uses internally. Toast Stats
+          pulls the published CSVs (district-performance, club-performance,
+          payments, education awards), validates them against the contract
+          schemas, and stores per-day snapshots in a public read-only CDN.
+        </p>
+        <p>
+          Nothing private. Nothing scraped. If TI changes the column names or
+          stops publishing a file, the pipeline fails loudly rather than
+          silently inferring values.
+        </p>
+      </section>
+
+      <section id="refresh-cadence" className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">02</span>
+          Refresh cadence
+        </h2>
+        <p>
+          The data pipeline runs once daily at 09:15 UTC (≈04:15 ET / 02:15 PT)
+          — the schedule lives in{' '}
+          <code>.github/workflows/data-pipeline.yml</code>. Each run pulls the
+          latest TI CSVs, transforms them, computes rankings + analytics, and
+          writes a dated snapshot to GCS. Frontend serves the most recent
+          snapshot via the CDN with a 5-minute stale-while-revalidate cache.
+        </p>
+        <p>
+          Stale-data indicator: every page surfaces a "Data fresh ·
+          &lt;date&gt;" pill so you always know which snapshot you're seeing.
+        </p>
+      </section>
+
+      <section id="borda-count" className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">03</span>
+          Borda count scoring
+        </h2>
+        <p>
+          Each district is ranked separately in three categories:
+          <strong> Paid Clubs</strong>, <strong>Total Payments</strong>, and{' '}
+          <strong>Distinguished Clubs</strong>. Points are awarded based on rank
+          position — with N districts, rank #1 receives N points, rank #2
+          receives N−1, and so on down to 1 point for last place.
+        </p>
+        <p>
+          The <strong>Aggregate Score</strong> shown on the District Rankings
+          page is the sum of points across all three categories. With 117
+          districts: a district ranked #5 / #3 / #8 earns 113 + 115 + 110 = 338
+          points (higher is better). This is the standard Borda count method; it
+          weights all three categories equally.
+        </p>
+      </section>
+
+      <section id="dcp-tiers" className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">04</span>
+          DCP tier definitions
+        </h2>
+        <p>Distinguished Club Program tiers, in ascending order:</p>
+        <ul>
+          <li>
+            <strong>Distinguished</strong> — 5 of 10 DCP goals + 20+ paid
+            members or net +5 / 75% retention.
+          </li>
+          <li>
+            <strong>Select Distinguished</strong> — 7 of 10 goals + same
+            membership floor.
+          </li>
+          <li>
+            <strong>President's Distinguished</strong> — 9 of 10 goals + same
+            membership floor.
+          </li>
+          <li>
+            <strong>Smedley Award</strong> — President's Distinguished +
+            chartered new club (rare; honors club founders).
+          </li>
+        </ul>
+        <p>
+          The 10 DCP goals are <strong>independent</strong>, not sequential — a
+          club can achieve goals in any order. Toast Stats reads the raw
+          per-goal columns from <code>club-performance.csv</code> rather than
+          inferring from a single "goals achieved" count.
+        </p>
+      </section>
+
+      <section id="club-health" className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">05</span>
+          Club health classifications
+        </h2>
+        <p>
+          Health is a Toast Stats overlay (not an official TI metric) that
+          combines membership trend + DCP progress + payment timeliness:
+        </p>
+        <ul>
+          <li>
+            <strong>Thriving</strong> — current paid members ≥ base, on track
+            for Distinguished or higher, no missed renewals.
+          </li>
+          <li>
+            <strong>Healthy</strong> — paid members ≥ base, mid-tier DCP
+            progress, no urgent flags.
+          </li>
+          <li>
+            <strong>Watch</strong> — small drop below base, behind on DCP, or
+            one missed renewal cycle.
+          </li>
+          <li>
+            <strong>At-risk</strong> — sustained membership drop, two missed
+            renewal cycles, or under 8 paid members.
+          </li>
+        </ul>
+        <p>
+          The exact thresholds live in <code>analytics-core</code>. Health is
+          recomputed every snapshot and never persisted as a property of the
+          club — it's always a function of the current data.
+        </p>
+      </section>
+
+      <section id="glossary" className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">06</span>
+          Glossary
+        </h2>
+        <dl className="methodology-glossary">
+          <dt>Paid Club</dt>
+          <dd>
+            A club with at least 8 paid members that has met its renewal
+            obligations (October &amp; April cycles).
+          </dd>
+          <dt>Paid Club Base</dt>
+          <dd>
+            A district's paid-club count at the start of the program year (July
+            1) — the denominator for retention.
+          </dd>
+          <dt>New Charter</dt>
+          <dd>
+            A club chartered during the current program year. Counts toward the
+            President's Extension Award but not toward retention.
+          </dd>
+          <dt>Distinguished Percent</dt>
+          <dd>
+            (Distinguished + Select + President's + Smedley clubs) ÷ paid clubs
+            at year-end.
+          </dd>
+          <dt>Aggregate Score</dt>
+          <dd>
+            Sum of Borda points across paid clubs, payments, and distinguished.
+            See{' '}
+            <a href="#borda-count" className="methodology-link">
+              §03
+            </a>
+            .
+          </dd>
+        </dl>
+      </section>
+
+      <section id="caveats" className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">07</span>
+          Caveats &amp; known issues
+        </h2>
+        <ul>
+          <li>
+            <strong>Pre-2019 data</strong> — Toast Stats only stores snapshots
+            from PY 2019–20 onward. Earlier seasons live in TI's own archive.
+          </li>
+          <li>
+            <strong>Mid-PY restatements</strong> — TI occasionally republishes
+            corrected files. Toast Stats keeps the latest published version and
+            does not back-fill prior days; small day-over-day deltas occur
+            during corrections.
+          </li>
+          <li>
+            <strong>Charter date parsing</strong> — historical charter dates in{' '}
+            <code>district-performance.csv</code> use a 2-digit year format (
+            <code>04/15/26</code>); the parser explicitly handles this. See{' '}
+            <code>tasks/lessons.md</code> Lesson 47 for context.
+          </li>
+        </ul>
+      </section>
+
+      <section id="changelog" className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">08</span>
+          Changelog
+        </h2>
+        <p>
+          Material methodology changes are recorded as ADRs in{' '}
+          <code>docs/architecture-decisions/</code> and as releases on{' '}
+          <a
+            href="https://github.com/taverns-red/toast-stats/releases"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="methodology-link"
+          >
+            GitHub Releases
+          </a>
+          . Recent notable updates:
+        </p>
+        <ul>
+          <li>
+            <strong>2026-04</strong> — Retention award formula split from
+            Extension to count only base-club survival (excludes new charters).
+            #336.
+          </li>
+          <li>
+            <strong>2026-04</strong> — Distinguished District tier tracking
+            added; per-district trophy case on the District page. #332.
+          </li>
+          <li>
+            <strong>2026-05</strong> — 2026 redesign: new chrome (top bar,
+            footer, panels), token system migration, dark-mode-aware surfaces.
+            Epic #352.
+          </li>
+        </ul>
+      </section>
     </div>
   )
 }

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -671,4 +671,186 @@
     letter-spacing: -0.005em;
     color: var(--ink);
   }
+
+  /* History page year strip (#367) — chip row of archived years. */
+  .history-page-year-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 24px 0 0;
+  }
+
+  .history-page-year-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background-color: var(--surface-3);
+    color: var(--ink-2);
+    font-family: var(--sans);
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  .history-page-year-chip--current {
+    background-color: var(--loyal-50);
+    color: var(--loyal-500);
+  }
+
+  .history-page-year-chip__live {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    color: var(--green-600);
+    text-transform: uppercase;
+  }
+
+  .history-page-year-chip--gap {
+    font-style: italic;
+    color: var(--ink-3);
+    background-color: transparent;
+    border: 1px dashed var(--line);
+  }
+
+  /* Methodology page (#368) — TOC + numbered sections. */
+  .methodology-page {
+    max-width: 1280px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 40px 24px;
+    font-family: var(--sans);
+    color: var(--ink);
+  }
+
+  .methodology-page__header {
+    margin-bottom: 32px;
+  }
+
+  .methodology-toc {
+    margin-bottom: 40px;
+    padding: 18px;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-md);
+    box-shadow: var(--rds-shadow-sm);
+  }
+
+  .methodology-toc__title {
+    margin: 0 0 12px;
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+  }
+
+  .methodology-toc__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 8px 16px;
+  }
+
+  @media (min-width: 640px) {
+    .methodology-toc__list {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  .methodology-toc__item {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 14px;
+  }
+
+  .methodology-toc__num {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-3);
+    min-width: 22px;
+  }
+
+  .methodology-toc__link {
+    color: var(--link);
+    text-decoration: none;
+  }
+
+  .methodology-toc__link:hover {
+    text-decoration: underline;
+  }
+
+  .methodology-section {
+    margin-bottom: 36px;
+    max-width: 70ch;
+    line-height: 1.65;
+    font-size: 14.5px;
+    color: var(--ink);
+  }
+
+  .methodology-section p,
+  .methodology-section ul,
+  .methodology-section ol,
+  .methodology-section dl {
+    margin: 0 0 14px;
+  }
+
+  .methodology-section ul,
+  .methodology-section ol {
+    padding-left: 1.5em;
+  }
+
+  .methodology-section li {
+    margin-bottom: 6px;
+  }
+
+  .methodology-section code {
+    font-family: var(--mono);
+    font-size: 0.9em;
+    background-color: var(--surface-3);
+    padding: 1px 6px;
+    border-radius: 3px;
+    color: var(--ink-2);
+  }
+
+  .methodology-section__title {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin: 0 0 12px;
+    font-family: var(--serif);
+    font-weight: 800;
+    font-size: 22px;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    scroll-margin-top: 80px;
+  }
+
+  .methodology-section__num {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--ink-3);
+  }
+
+  .methodology-link {
+    color: var(--link);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
+  .methodology-glossary dt {
+    font-weight: 700;
+    margin-top: 10px;
+  }
+
+  .methodology-glossary dd {
+    margin: 0 0 8px;
+    color: var(--ink-2);
+  }
 }


### PR DESCRIPTION
## Summary

Two net-new pages for Sprint 7.

### #367 History — pragmatic v1
Page header + 7-chip year strip (current year flagged `LIVE` + `aria-current`) + TI archive callout for pre-2019. Per-year cards (top 5 + headline metrics) need a year-end snapshot endpoint that doesn't exist yet — filed as follow-up.

### #368 Methodology — full content
8 numbered sections authored fresh from `analytics-core` as the source of truth: Data source, Refresh cadence, Borda scoring (with worked example), DCP tiers, Club health classifications, Glossary, Caveats (references Lesson 47), Changelog (links recent material updates). Anchor TOC at top with mono numeric prefixes per the handoff design.

## Test plan
- [x] `npx vitest --run --coverage` — 129/129 / 2093/2093, no timeout bumps
- [x] Routing tests assert TOC + every h2 section header
- [ ] Live verify: `/history` chips render with current year highlighted; `/methodology` TOC + sections render and anchor links scroll correctly

Closes #367, closes #368.