### PR TITLE
feat(awards): ship /awards page with top-10 leaderboards (#370 #371 #372 #373)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,9 @@ const HistoryPage = React.lazy(() => import('./pages/HistoryPage'))
 // Code-split: MethodologyPage placeholder (#355) — real content in #368
 const MethodologyPage = React.lazy(() => import('./pages/MethodologyPage'))
 
+// Code-split: AwardsPage — top-10 leaderboards per district award (#370-#373)
+const AwardsPage = React.lazy(() => import('./pages/AwardsPage'))
+
 /** Loading fallback for lazy-loaded pages */
 function PageLoadingFallback(): React.JSX.Element {
   // AppShell owns the <main id="main-content"> landmark; this fallback
@@ -86,6 +89,14 @@ const router = createBrowserRouter(
           element: (
             <Suspense fallback={<PageLoadingFallback />}>
               <MethodologyPage />
+            </Suspense>
+          ),
+        },
+        {
+          path: 'awards',
+          element: (
+            <Suspense fallback={<PageLoadingFallback />}>
+              <AwardsPage />
             </Suspense>
           ),
         },

--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -59,6 +59,10 @@ describe('AppShell (#354)', () => {
       expect(
         within(nav).getByRole('link', { name: 'Districts' })
       ).toHaveAttribute('href', '/')
+      expect(within(nav).getByRole('link', { name: 'Awards' })).toHaveAttribute(
+        'href',
+        '/awards'
+      )
       expect(
         within(nav).getByRole('link', { name: 'History' })
       ).toHaveAttribute('href', '/history')
@@ -67,11 +71,13 @@ describe('AppShell (#354)', () => {
       ).toHaveAttribute('href', '/methodology')
     })
 
-    it('does NOT render Regions or Awards "soon" stubs (omitted per Epic #352)', () => {
+    it('does NOT render Regions or any "soon" stubs (omitted per Epic #352)', () => {
+      // Awards was a "soon" stub at #354 launch; #371 enabled the real
+      // /awards page and re-included Awards in the primary nav. Regions
+      // remains omitted until that page exists.
       renderShell()
       const nav = screen.getByRole('navigation', { name: /primary/i })
       expect(within(nav).queryByText(/regions/i)).not.toBeInTheDocument()
-      expect(within(nav).queryByText(/awards/i)).not.toBeInTheDocument()
       expect(within(nav).queryByText(/soon/i)).not.toBeInTheDocument()
     })
 

--- a/frontend/src/components/AppShell/AppShellTopBar.tsx
+++ b/frontend/src/components/AppShell/AppShellTopBar.tsx
@@ -3,6 +3,7 @@ import { NavLink, Link } from 'react-router-dom'
 
 const NAV_ITEMS = [
   { to: '/', label: 'Districts', end: true },
+  { to: '/awards', label: 'Awards', end: false },
   { to: '/history', label: 'History', end: false },
   { to: '/methodology', label: 'Methodology', end: false },
 ] as const

--- a/frontend/src/pages/AwardsPage.tsx
+++ b/frontend/src/pages/AwardsPage.tsx
@@ -1,0 +1,161 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
+import type {
+  CompetitiveAwardRanking,
+  CompetitiveAwardStandings,
+} from '../services/cdn'
+
+/* /awards page (#371-#373). Full top-10 leaderboards per district award
+   — the deeper view that the Districts page's Awards Race summary
+   defers to. Uses the existing useCompetitiveAwards hook for data. */
+
+interface AwardSpec {
+  key: keyof Pick<
+    CompetitiveAwardStandings,
+    'extensionAward' | 'twentyPlusAward' | 'retentionAward'
+  >
+  title: string
+  description: string
+  formatValue: (v: number) => string
+  methodologyAnchor: string
+}
+
+const AWARDS: ReadonlyArray<AwardSpec> = [
+  {
+    key: 'extensionAward',
+    title: "President's Extension Award",
+    description:
+      'Largest net club growth — chartering and reviving clubs above the program-year baseline.',
+    formatValue: v => (v >= 0 ? `+${v}` : `${v}`),
+    methodologyAnchor: '#caveats',
+  },
+  {
+    key: 'twentyPlusAward',
+    title: "President's 20-Plus Award",
+    description:
+      'Highest percentage of clubs achieving 20+ paid members — depth, not just count.',
+    formatValue: v => `${v.toFixed(1)}%`,
+    methodologyAnchor: '#dcp-tiers',
+  },
+  {
+    key: 'retentionAward',
+    title: 'District Club Retention Award',
+    description:
+      'Top retention of base clubs (≥90% of last year’s paid clubs survived).',
+    formatValue: v => `${v.toFixed(1)}%`,
+    methodologyAnchor: '#caveats',
+  },
+]
+
+const AwardsPage: React.FC = () => {
+  // Latest snapshot — pass undefined and let the hook resolve.
+  const { data: standings, isLoading } = useCompetitiveAwards(undefined)
+
+  return (
+    <div className="awards-page">
+      <header className="awards-page__header">
+        <p className="placeholder-page__eyebrow">
+          Awards · {standings?.metadata?.totalDistricts ?? 117} districts
+        </p>
+        <h1 className="placeholder-page__title">District Awards</h1>
+        <p className="placeholder-page__body">
+          Competitive district-level awards from Toastmasters International.
+          Rankings are computed from the same public data as the District
+          leaderboard — see the{' '}
+          <Link
+            to="/methodology#borda-count"
+            className="districts-methodology-callout__link"
+          >
+            Methodology
+          </Link>{' '}
+          page for the full Borda definition and per-award threshold notes.
+        </p>
+      </header>
+
+      {isLoading && (
+        <p className="awards-page__empty">Loading award standings…</p>
+      )}
+
+      {!isLoading && !standings && (
+        <p className="awards-page__empty">
+          No award standings available for the current snapshot.
+        </p>
+      )}
+
+      {standings && (
+        <div className="awards-page__grid">
+          {AWARDS.map(spec => (
+            <AwardLeaderboard
+              key={spec.title}
+              spec={spec}
+              entries={(standings[spec.key] ?? []).slice(0, 10)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default AwardsPage
+
+interface AwardLeaderboardProps {
+  spec: AwardSpec
+  entries: CompetitiveAwardRanking[]
+}
+
+const AwardLeaderboard: React.FC<AwardLeaderboardProps> = ({
+  spec,
+  entries,
+}) => {
+  const winnerCount = entries.filter(e => e.isWinner).length
+
+  return (
+    <section
+      className="awards-page-card"
+      aria-labelledby={`award-${spec.key}-title`}
+    >
+      <header className="awards-page-card__header">
+        <h2 id={`award-${spec.key}-title`} className="awards-page-card__title">
+          {spec.title}
+        </h2>
+        <p className="awards-page-card__description">{spec.description}</p>
+        <div className="awards-page-card__meta">
+          {winnerCount > 0 && (
+            <span className="awards-page-card__achieved">
+              ✓ {winnerCount} achieved
+            </span>
+          )}
+          <Link
+            to={`/methodology${spec.methodologyAnchor}`}
+            className="awards-page-card__methodology-link"
+          >
+            Methodology
+          </Link>
+        </div>
+      </header>
+      {entries.length === 0 ? (
+        <p className="awards-page-card__empty">No standings yet.</p>
+      ) : (
+        <ol className="awards-page-card__list">
+          {entries.map(entry => (
+            <li key={entry.districtId} className="awards-page-card__row">
+              <span className="awards-page-card__rank">#{entry.rank}</span>
+              <Link
+                to={`/district/${entry.districtId}`}
+                className="awards-page-card__district"
+              >
+                {entry.districtName}
+              </Link>
+              <span className="awards-page-card__region">R{entry.region}</span>
+              <span className="awards-page-card__value">
+                {spec.formatValue(entry.value)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/pages/__tests__/AwardsPage.test.tsx
+++ b/frontend/src/pages/__tests__/AwardsPage.test.tsx
@@ -1,0 +1,144 @@
+/* /awards page (#370 / #371-#373).
+   Mounts AwardsPage with mocked useCompetitiveAwards data so the test
+   stays small (no full-app mount). */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { CompetitiveAwardStandings } from '../../services/cdn'
+
+const mockStandings: CompetitiveAwardStandings = {
+  metadata: {
+    snapshotId: '2026-04-15',
+    calculatedAt: '2026-04-15T00:00:00.000Z',
+    totalDistricts: 117,
+  },
+  extensionAward: [
+    {
+      districtId: '17',
+      districtName: 'District 17',
+      region: '5',
+      rank: 1,
+      value: 14,
+      isWinner: false,
+    },
+    {
+      districtId: '60',
+      districtName: 'District 60',
+      region: '8',
+      rank: 2,
+      value: 10,
+      isWinner: false,
+    },
+    {
+      districtId: '93',
+      districtName: 'District 93',
+      region: '11',
+      rank: 3,
+      value: 9,
+      isWinner: false,
+    },
+  ],
+  twentyPlusAward: [
+    {
+      districtId: '60',
+      districtName: 'District 60',
+      region: '8',
+      rank: 1,
+      value: 22,
+      isWinner: true,
+    },
+    {
+      districtId: '57',
+      districtName: 'District 57',
+      region: '1',
+      rank: 2,
+      value: 18,
+      isWinner: true,
+    },
+  ],
+  retentionAward: [
+    {
+      districtId: '102',
+      districtName: 'District 102',
+      region: '14',
+      rank: 1,
+      value: 94.1,
+      isWinner: true,
+    },
+  ],
+  byDistrict: {},
+}
+
+vi.mock('../../hooks/useCompetitiveAwards', () => ({
+  useCompetitiveAwards: () => ({
+    data: mockStandings,
+    isLoading: false,
+    isError: false,
+  }),
+}))
+
+import AwardsPage from '../AwardsPage'
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <AwardsPage />
+    </MemoryRouter>
+  )
+
+describe('AwardsPage (#371-#373)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  describe('page header', () => {
+    it('renders the eyebrow + h1 + lede', () => {
+      renderPage()
+      expect(screen.getByText(/awards · 117 districts/i)).toBeInTheDocument()
+      expect(
+        screen.getByRole('heading', { level: 1, name: /district awards/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(/competitive district-level awards/i)
+      ).toBeInTheDocument()
+    })
+
+    it('links to /methodology section for Borda details (#373)', () => {
+      renderPage()
+      const links = screen.getAllByRole('link', { name: /methodology/i })
+      const methodology = links.find(l =>
+        l.getAttribute('href')?.startsWith('/methodology')
+      )
+      expect(methodology).toBeDefined()
+    })
+  })
+
+  describe('award leaderboards', () => {
+    it("renders President's Extension Award with all 3 fixture rows", () => {
+      renderPage()
+      const heading = screen.getByRole('heading', {
+        name: /president'?s extension award/i,
+      })
+      const section = heading.closest('section')
+      expect(section).toBeTruthy()
+      expect(within(section!).getByText('District 17')).toBeInTheDocument()
+      expect(within(section!).getByText('District 60')).toBeInTheDocument()
+      expect(within(section!).getByText('District 93')).toBeInTheDocument()
+    })
+
+    it('marks Achieved status on awards with winners (#372)', () => {
+      renderPage()
+      const heading = screen.getByRole('heading', {
+        name: /20-plus award/i,
+      })
+      const section = heading.closest('section')
+      expect(within(section!).getByText(/achieved/i)).toBeInTheDocument()
+    })
+
+    it('links each district to its detail page', () => {
+      renderPage()
+      const link = screen.getByRole('link', { name: /district 17/i })
+      expect(link).toHaveAttribute('href', '/district/17')
+    })
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -853,4 +853,150 @@
     margin: 0 0 8px;
     color: var(--ink-2);
   }
+
+  /* Awards page (#371-#373). Top-10 leaderboards per district award. */
+  .awards-page {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 32px 24px 48px;
+  }
+
+  .awards-page__header {
+    margin-bottom: 24px;
+  }
+
+  .awards-page__grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: 1fr;
+  }
+
+  @media (min-width: 980px) {
+    .awards-page__grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .awards-page__empty {
+    margin: 24px 0;
+    color: var(--ink-3);
+    font-style: italic;
+  }
+
+  .awards-page-card {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-md);
+    box-shadow: var(--rds-shadow-sm);
+    overflow: hidden;
+  }
+
+  .awards-page-card__header {
+    padding: 16px 18px;
+    border-bottom: 1px solid var(--line-2);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .awards-page-card__title {
+    margin: 0;
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 14px;
+    color: var(--ink);
+  }
+
+  .awards-page-card__description {
+    margin: 0;
+    font-family: var(--sans);
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--ink-3);
+  }
+
+  .awards-page-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-top: 4px;
+    font-family: var(--sans);
+    font-size: 12px;
+  }
+
+  .awards-page-card__achieved {
+    color: var(--green-600);
+    font-weight: 600;
+  }
+
+  .awards-page-card__methodology-link {
+    color: var(--link);
+    text-decoration: none;
+  }
+
+  .awards-page-card__methodology-link:hover {
+    text-decoration: underline;
+  }
+
+  .awards-page-card__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .awards-page-card__row {
+    display: grid;
+    grid-template-columns: 36px 1fr auto auto;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 18px;
+    border-bottom: 1px solid var(--line-2);
+    font-family: var(--sans);
+    font-size: 13px;
+  }
+
+  .awards-page-card__row:last-child {
+    border-bottom: 0;
+  }
+
+  .awards-page-card__rank {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-3);
+  }
+
+  .awards-page-card__district {
+    color: var(--link);
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .awards-page-card__district:hover {
+    text-decoration: underline;
+  }
+
+  .awards-page-card__region {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-3);
+  }
+
+  .awards-page-card__value {
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 14px;
+    color: var(--ink);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .awards-page-card__empty {
+    margin: 0;
+    padding: 16px 18px;
+    font-size: 12px;
+    font-style: italic;
+    color: var(--ink-3);
+  }
 }

--- a/tasks/founder-log-2026-05-10.md
+++ b/tasks/founder-log-2026-05-10.md
@@ -89,3 +89,31 @@ Realistic scope check: doing each tab "1:1 match handoff" with chart visual rest
 This trades "1:1 handoff fidelity" for "architectural redesign complete" — each tab is dark-mode-aware, uses redesign tokens, matches the design's typography rhythm. Pixel polish is real work that deserves its own focused PR.
 
 **Tactic**: introduce a single `.redesign-panel` class in `app-shell.css` with the token-driven panel chrome. Apply it to existing components in a small touch (replace 3 hardcoded class strings per component). Heavy lift comes only when a section is genuinely new.
+
+### 14:50 UTC — #387 (#360 Overview chrome) merged
+
+`.redesign-panel` shared class shipped + applied to DistrictOverview, DistinguishedDistrictTrophyCase, PaymentCompositionCard. Static guard test ensures the rule stays token-driven (no hardcoded hex/rgba).
+
+### 15:05 UTC — #388 bulk chrome migration (#361-#365) merged
+
+26 components migrated from `bg-white rounded-lg shadow-md p-{4,6}` → `.redesign-panel`. Single PR closes Sprints 4 + 5 chrome work. Each tab's remaining content acceptance criteria (filter chips, criteria explainer, ranking-progression metric toggle) filed as deferred follow-ups.
+
+### 15:15 UTC — #389 (#366 Club detail chrome) merged
+
+3 panel swaps + 3 bg-gray-100 strips on ClubDetailPage. Loyal-blue hero retained.
+
+### 15:20 UTC — #390 (#367 History + #368 Methodology) merged
+
+History page = year-strip chip row + TI archive callout (per-year cards deferred — needs new year-end snapshot endpoint). Methodology = full 8-section content authored from analytics-core: Borda formula + DCP tiers + club health + glossary + caveats (incl. Lesson 47 reference) + changelog.
+
+### 15:30 UTC — #391 (#369 cleanup) merged. EPIC #352 COMPLETE.
+
+LandingPage.tsx → DistrictsPage.tsx (file rename via git mv; 5 test files too). Deleted dead components: Header/, Navigation/, DashboardLayout, NavigationHeaderIntegration test. All 17 child issues of Epic #352 shipped.
+
+### Status checkpoint
+
+**Epic #352 (2026 redesign) — COMPLETE.** 17/17 issues shipped through 11 PRs (#374 #378 #379 #380 #381 #382 #383 #385 #386 #387 #388 #389 #390 #391). Coverage suite green throughout. Filed deferred follow-ups: #384 (a11y tablist arrow-key nav), per-tab content polish on #361-#365.
+
+### 15:35 UTC — Awards epic #370 (stretch)
+
+Time remaining in 24h budget: substantial. Going for the Awards epic. Plan: revive the old top-10 leaderboard component pattern (deleted from AwardsRaceSection in #382) on a dedicated `/awards` page. Add Awards to the AppShell nav. Cross-link to /methodology Borda section.


### PR DESCRIPTION
## Summary

Closes Epic #370 (Awards page). Three child issues bundled — they're tightly coupled and ship cleaner together.

### #371 — /awards route + AppShell wiring
- New `AwardsPage.tsx` (lazy-loaded)
- New `/awards` route in App.tsx
- Awards added back to AppShell primary nav (was deferred at #354 launch as a "soon" stub; now real)

### #372 — Full top-10 leaderboards
- 3 award cards: President's Extension, President's 20-Plus, District Club Retention
- Each card: top 10 districts with rank + name (linked) + region + value formatted per award
- "Achieved" badge counts winners
- Reuses `useCompetitiveAwards` (same data source as the Districts page Awards Race summary)

### #373 — Per-award methodology cross-links
- Page lede has a Methodology link with #borda-count anchor
- Each card has its own Methodology link with relevant section anchor

Updated AppShell test that asserted Awards was OMITTED — now it asserts Awards IS present, and only Regions remains a placeholder.

## Test plan
- [x] `npx vitest --run --coverage` — 126/126 / 2076/2076, no timeout bumps
- [x] `npx tsc --noEmit` clean
- [ ] After deploy: navigate to /awards; verify the 3 cards render the 3 most recent leader districts; click a district and confirm it navigates to /district/:id

🤖 Generated with [Claude Code](https://claude.com/claude-code)