### PR TITLE
fix(deploy): footer version was rendering as bare "v" — fix yaml/shell quoting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,15 @@ jobs:
 
       - name: Read version from package.json
         id: pkg
-        run: echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+        # Use jq instead of node -p to avoid YAML/shell quote-escaping
+        # gymnastics that previously made the substitution silently fail
+        # (`require(\"./package.json\")` was parsed as invalid JS, $()
+        # returned empty, VITE_APP_VERSION became literal "v"). jq is
+        # already on the runner, no escaping needed.
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved package version: ${VERSION}"
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v3

--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -132,14 +132,23 @@ describe('AppShell (#354)', () => {
       expect(footer).toHaveTextContent(/mit license/i)
     })
 
-    it('does not double-prefix the version (deploy.yml already passes v<semver>)', () => {
-      // Regression guard: VITE_APP_VERSION ships as e.g. 'v2.10.0', so the
-      // footer must NOT add another 'v'. The fallback in tests is 'dev', so
-      // we assert no 'vdev'/'vv' substring.
+    it('renders a non-empty version (no double-v, no bare-v)', () => {
+      // Three regression guards:
+      //   1. No 'vv' — VITE_APP_VERSION ships pre-prefixed with 'v', so
+      //      the JSX must not add another 'v'.
+      //   2. No 'vdev' — same shape mistake when the env var is missing.
+      //   3. No bare 'v' followed by no number — happened on prod when
+      //      deploy.yml's `node -p 'require(\"./package.json\")...'` quoting
+      //      silently failed and $() resolved to empty, leaving
+      //      VITE_APP_VERSION="v". Fix: deploy.yml now uses jq.
       renderShell()
       const footer = screen.getByRole('contentinfo')
-      expect(footer.textContent).not.toMatch(/v\s*v/i)
-      expect(footer.textContent).not.toMatch(/vdev/i)
+      const text = footer.textContent ?? ''
+      expect(text).not.toMatch(/v\s*v/i)
+      expect(text).not.toMatch(/vdev/i)
+      // The version slot must end with either a digit-bearing version
+      // (matched after MIT License) OR the literal 'dev' fallback.
+      expect(text).toMatch(/MIT License\s*·\s*(?:v\d|dev)/i)
     })
 
     it('preserves the theme toggle for manual dark-mode access', () => {


### PR DESCRIPTION
## Summary

Live screenshot showed the footer reading **\`MIT License · v\`** with no version number.

Root cause: the deploy step's quote escaping was broken.

\`\`\`yaml
run: echo \"version=\$(node -p 'require(\\\"./package.json\\\").version')\" >> \"\$GITHUB_OUTPUT\"
\`\`\`

In bash, single quotes preserve backslashes, so node received literal \`require(\\\"./package.json\\\").version\` and threw \`SyntaxError\`. Because \`\$()\` captures only stdout, the error went to stderr and \`\$()\` returned empty. \`echo \"version=\"\` succeeded, so the step recorded success and \`pkg.outputs.version\` was empty. \`VITE_APP_VERSION: v\${{ steps.pkg.outputs.version }}\` evaluated to literal \`v\`.

## Fix

Switched to \`jq -r '.version' package.json\`. jq is already on the runner, no quoting gymnastics, fails loudly if the file is missing or malformed. Also echoes the resolved value to the log.

Tightened the AppShell footer regression test to also assert the version slot matches \`(?:v\\d|dev)\` so a future bare-\"v\" ship will fail tests.

## Test plan

- [x] \`jq -r '.version' package.json\` → 2.11.0 locally
- [x] AppShell footer test — 14/14 pass
- [ ] After deploy: footer reads \`MIT License · v2.11.0\` (or current pkg version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)