### PR TITLE
feat(club): redesign Club detail hero header per handoff (#23)

### DIFF
--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -11,7 +11,6 @@ import {
   type ProgramYear,
 } from '../utils/programYear'
 import { formatDisplayDate } from '../utils/dateFormatting'
-import { getClubStatusBadge } from '../utils/clubStatusBadge'
 import {
   isProvisionallyDistinguished,
   getConfirmedLevel,
@@ -414,74 +413,79 @@ const ClubDetailPage: React.FC = () => {
             <span className="text-gray-900 font-medium">{club.clubName}</span>
           </nav>
 
-          {/* Header */}
-          <div className="bg-tm-loyal-blue rounded-lg shadow-md p-6 mb-6">
-            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
-              <div>
-                <h1 className="text-2xl sm:text-3xl font-tm-headline font-bold text-white">
-                  {club.clubName}
-                </h1>
-                <p className="text-tm-loyal-blue-20 mt-1 font-tm-body">
-                  {club.areaName} • {club.divisionName}
-                </p>
-              </div>
-
-              <div className="flex items-center gap-3 flex-wrap">
-                {/* Health status badge */}
-                <span
-                  className={`px-4 py-2 text-sm font-medium rounded-full border ${
-                    club.currentStatus === 'intervention-required'
-                      ? 'bg-red-100 text-red-800 border-red-300'
-                      : club.currentStatus === 'vulnerable'
-                        ? 'bg-yellow-100 text-yellow-800 border-yellow-300'
-                        : 'bg-green-100 text-green-800 border-green-300'
-                  }`}
-                >
-                  {club.currentStatus.toUpperCase()}
+          {/* Redesigned hero per handoff (#23 follow-up). Loyal-blue panel
+              with charter-style eyebrow + h1 + sub-line + right-side
+              health & DCP tier pills. */}
+          <header className="club-hero">
+            <div className="club-hero__intro">
+              <p className="club-hero__eyebrow">Club #{clubId}</p>
+              <h1 className="club-hero__title">{club.clubName}</h1>
+              <p className="club-hero__sub">
+                <span>{club.areaName}</span>
+                <span aria-hidden="true" className="club-hero__sub-divider">
+                  ·
                 </span>
-                {/* Club status badge */}
-                {club.clubStatus && (
+                <span>{club.divisionName}</span>
+                {districtId && (
+                  <>
+                    <span aria-hidden="true" className="club-hero__sub-divider">
+                      ·
+                    </span>
+                    <span>District {districtId}</span>
+                  </>
+                )}
+              </p>
+            </div>
+
+            <div className="club-hero__pills">
+              <span
+                className={
+                  'club-hero__pill ' +
+                  (club.currentStatus === 'intervention-required'
+                    ? 'club-hero__pill--at-risk'
+                    : club.currentStatus === 'vulnerable'
+                      ? 'club-hero__pill--watch'
+                      : 'club-hero__pill--thriving')
+                }
+              >
+                <span aria-hidden="true" className="club-hero__pill-dot" />
+                {club.currentStatus === 'intervention-required'
+                  ? 'Intervention required'
+                  : club.currentStatus === 'vulnerable'
+                    ? 'Vulnerable'
+                    : 'Thriving'}
+              </span>
+              {club.distinguishedLevel &&
+                club.distinguishedLevel !== 'NotDistinguished' && (
                   <span
-                    className={`px-4 py-2 text-sm font-medium rounded-full border ${getClubStatusBadge(club.clubStatus)}`}
+                    className={
+                      'club-hero__pill club-hero__pill--tier ' +
+                      (club.distinguishedLevel === 'President'
+                        ? 'club-hero__pill--tier-presidents'
+                        : club.distinguishedLevel === 'Select'
+                          ? 'club-hero__pill--tier-select'
+                          : 'club-hero__pill--tier-distinguished')
+                    }
+                    title={
+                      isProvisionallyDistinguished(club)
+                        ? getProvisionalTooltip(club)
+                        : undefined
+                    }
                   >
-                    {club.clubStatus}
+                    {club.distinguishedLevel === 'President'
+                      ? "President's"
+                      : club.distinguishedLevel}
+                    {isProvisionallyDistinguished(club) &&
+                      (() => {
+                        const confirmed = getConfirmedLevel(club)
+                        return confirmed === 'NotDistinguished'
+                          ? ' (provisional)'
+                          : ' (provisional)'
+                      })()}
                   </span>
                 )}
-                {/* Distinguished level */}
-                {club.distinguishedLevel &&
-                  club.distinguishedLevel !== 'NotDistinguished' && (
-                    <div className="flex flex-col items-center gap-1">
-                      <span className="px-4 py-2 bg-tm-happy-yellow-30 text-tm-true-maroon text-sm font-medium rounded-full">
-                        {club.distinguishedLevel === 'President'
-                          ? "President's"
-                          : club.distinguishedLevel}
-                      </span>
-                      {isProvisionallyDistinguished(club) &&
-                        (() => {
-                          const confirmed = getConfirmedLevel(club)
-                          const confirmedLabel =
-                            confirmed === 'NotDistinguished'
-                              ? 'at risk'
-                              : confirmed === 'President'
-                                ? "President's"
-                                : confirmed
-                          return (
-                            <span
-                              className="text-xs text-amber-600 font-medium"
-                              title={getProvisionalTooltip(club)}
-                            >
-                              Provisional
-                              {confirmed !== 'NotDistinguished'
-                                ? ` — Confirmed: ${confirmedLabel}`
-                                : ' — at risk of losing status'}
-                            </span>
-                          )
-                        })()}
-                    </div>
-                  )}
-              </div>
             </div>
-          </div>
+          </header>
 
           {/* Stats Grid */}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -130,9 +130,11 @@ describe('ClubDetailPage (#208)', () => {
       screen.getAllByText('St Lawrence Toastmasters').length
     ).toBeGreaterThanOrEqual(1)
 
-    // Breadcrumbs
+    // Breadcrumbs (the new hero also renders "District 61" in its
+    // sub-line — query for the breadcrumb anchor explicitly)
     expect(screen.getByText('Home')).toBeInTheDocument()
-    expect(screen.getByText('District 61')).toBeInTheDocument()
+    const breadcrumbLink = screen.getByRole('link', { name: 'District 61' })
+    expect(breadcrumbLink).toHaveAttribute('href', '/district/61')
   })
 
   it('renders membership stats grid with correct net change', () => {

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -529,6 +529,138 @@
     color: var(--ink-3);
   }
 
+  /* Club detail hero — loyal panel with charter eyebrow + h1 + sub-line +
+     health/DCP pills (#366 redesign hero per handoff 03-club-detail.png). */
+  .club-hero {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px 28px;
+    margin-bottom: 20px;
+    background-color: var(--loyal-500);
+    color: #ffffff;
+    border-radius: var(--rds-radius-lg);
+    box-shadow: var(--rds-shadow);
+  }
+
+  @media (min-width: 768px) {
+    .club-hero {
+      flex-direction: row;
+      align-items: flex-start;
+      justify-content: space-between;
+    }
+  }
+
+  .club-hero__intro {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .club-hero__eyebrow {
+    margin: 0;
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.78);
+  }
+
+  .club-hero__title {
+    margin: 8px 0 6px;
+    font-family: var(--serif);
+    font-weight: 800;
+    font-size: 30px;
+    line-height: 1.1;
+    letter-spacing: -0.015em;
+    color: #ffffff;
+  }
+
+  .club-hero__sub {
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    font-family: var(--sans);
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .club-hero__sub-divider {
+    color: rgba(255, 255, 255, 0.4);
+  }
+
+  .club-hero__pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .club-hero__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background-color: #ffffff;
+    color: var(--ink);
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: 13px;
+  }
+
+  /* Health pill variants — colored dot + neutral text on white pill */
+  .club-hero__pill-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .club-hero__pill--thriving .club-hero__pill-dot {
+    background-color: var(--green-500);
+  }
+
+  .club-hero__pill--healthy .club-hero__pill-dot {
+    background-color: var(--green-500);
+  }
+
+  .club-hero__pill--watch .club-hero__pill-dot {
+    background-color: var(--yellow-500);
+  }
+
+  .club-hero__pill--at-risk .club-hero__pill-dot {
+    background-color: var(--red-500);
+  }
+
+  /* DCP tier pill — outlined on white background by default */
+  .club-hero__pill--tier {
+    background-color: #ffffff;
+    color: var(--maroon-500);
+    border: 1px solid rgba(123, 24, 40, 0.2);
+  }
+
+  .club-hero__pill--tier-distinguished {
+    color: var(--green-600);
+    border-color: rgba(21, 128, 61, 0.25);
+  }
+
+  .club-hero__pill--tier-select {
+    color: var(--loyal-500);
+    border-color: rgba(0, 65, 101, 0.25);
+  }
+
+  .club-hero__pill--tier-presidents {
+    color: var(--yellow-600);
+    border-color: rgba(201, 183, 72, 0.4);
+  }
+
+  .club-hero__pill--tier-smedley {
+    color: var(--maroon-500);
+    border-color: rgba(123, 24, 40, 0.3);
+  }
+
   /* Awards Race 3-card contender summary (#357). Sits between the
      Districts page KPI strip and the rankings table. The deeper
      top-10 leaderboards live on the future Awards page (Epic #370). */


### PR DESCRIPTION
Replaces the legacy Club hero with the redesign per handoff 03-club-detail.png — loyal-500 panel, 'Club #N' eyebrow, h1 in Montserrat 800/30px, sub-line with Area/Division/District separators, right-side health pill (white bg with colored dot) + DCP tier pill (white bg with tier-colored text).\n\nTest plan: 126/126 / 2076/2076 green; tsc clean. After deploy verify the Club page hero renders with the new chrome.