### PR TITLE
feat(clubs): redesign quick-filter chips on Clubs tab (#24)

### DIFF
--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -374,42 +374,191 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
             )}
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="clubs-quick-filters">
+            <span className="clubs-quick-filters__label">Quick filters:</span>
+
+            {/* ⭐ Close to Distinguished — clubs needing exactly 1 more member */}
             <button
+              type="button"
               onClick={() => {
                 const current = getFilter('membersNeeded')
                 if (
                   current &&
                   Array.isArray(current.value) &&
-                  current.value[0] === 1
+                  current.value[0] === 1 &&
+                  current.value[1] === 1
                 ) {
                   setFilter('membersNeeded', null)
                 } else {
                   setFilter('membersNeeded', {
                     field: 'membersNeeded',
                     type: 'numeric',
-                    value: [1, null],
+                    value: [1, 1],
                   })
                   setSortField('membersNeeded')
                   setSortDirection('asc')
                   onSortChange?.('membersNeeded', 'asc')
                 }
               }}
-              className={`px-3 py-1 text-xs font-medium border rounded-sm transition-colors font-tm-body ${
-                getFilter('membersNeeded')?.value?.[0] === 1
-                  ? 'bg-tm-loyal-blue text-white border-tm-loyal-blue'
-                  : 'text-tm-loyal-blue hover:text-tm-loyal-blue-80 border-tm-loyal-blue-30 hover:bg-tm-loyal-blue-10'
-              }`}
+              className={
+                'clubs-quick-filter-chip' +
+                (() => {
+                  const f = getFilter('membersNeeded')
+                  return Array.isArray(f?.value) &&
+                    f.value[0] === 1 &&
+                    f.value[1] === 1
+                    ? ' clubs-quick-filter-chip--active'
+                    : ''
+                })()
+              }
+              aria-pressed={(() => {
+                const f = getFilter('membersNeeded')
+                return (
+                  Array.isArray(f?.value) &&
+                  f.value[0] === 1 &&
+                  f.value[1] === 1
+                )
+              })()}
             >
+              <span
+                aria-hidden="true"
+                className="clubs-quick-filter-chip__star"
+              >
+                ★
+              </span>
               Close to Distinguished
+            </button>
+
+            {/* Needs members — clubs short by 2+ to reach next tier */}
+            <button
+              type="button"
+              onClick={() => {
+                const current = getFilter('membersNeeded')
+                const isActive =
+                  Array.isArray(current?.value) &&
+                  current.value[0] === 2 &&
+                  current.value[1] === null
+                if (isActive) {
+                  setFilter('membersNeeded', null)
+                } else {
+                  setFilter('membersNeeded', {
+                    field: 'membersNeeded',
+                    type: 'numeric',
+                    value: [2, null],
+                  })
+                }
+              }}
+              className={
+                'clubs-quick-filter-chip' +
+                (() => {
+                  const f = getFilter('membersNeeded')
+                  return Array.isArray(f?.value) &&
+                    f.value[0] === 2 &&
+                    f.value[1] === null
+                    ? ' clubs-quick-filter-chip--active'
+                    : ''
+                })()
+              }
+              aria-pressed={(() => {
+                const f = getFilter('membersNeeded')
+                return (
+                  Array.isArray(f?.value) &&
+                  f.value[0] === 2 &&
+                  f.value[1] === null
+                )
+              })()}
+            >
+              Needs members
+            </button>
+
+            {/* Missing renewals — clubs with 0 October renewals */}
+            <button
+              type="button"
+              onClick={() => {
+                const current = getFilter('octoberRenewals')
+                const isActive =
+                  Array.isArray(current?.value) &&
+                  current.value[0] === 0 &&
+                  current.value[1] === 0
+                if (isActive) {
+                  setFilter('octoberRenewals', null)
+                } else {
+                  setFilter('octoberRenewals', {
+                    field: 'octoberRenewals',
+                    type: 'numeric',
+                    value: [0, 0],
+                  })
+                }
+              }}
+              className={
+                'clubs-quick-filter-chip' +
+                (() => {
+                  const f = getFilter('octoberRenewals')
+                  return Array.isArray(f?.value) &&
+                    f.value[0] === 0 &&
+                    f.value[1] === 0
+                    ? ' clubs-quick-filter-chip--active'
+                    : ''
+                })()
+              }
+              aria-pressed={(() => {
+                const f = getFilter('octoberRenewals')
+                return (
+                  Array.isArray(f?.value) &&
+                  f.value[0] === 0 &&
+                  f.value[1] === 0
+                )
+              })()}
+            >
+              Missing renewals
+            </button>
+
+            {/* President's tier only */}
+            <button
+              type="button"
+              onClick={() => {
+                const current = getFilter('distinguished')
+                const isActive =
+                  Array.isArray(current?.value) &&
+                  (current.value as string[]).includes('President')
+                if (isActive) {
+                  setFilter('distinguished', null)
+                } else {
+                  setFilter('distinguished', {
+                    field: 'distinguished',
+                    type: 'categorical',
+                    value: ['President'],
+                  })
+                }
+              }}
+              className={
+                'clubs-quick-filter-chip' +
+                (() => {
+                  const f = getFilter('distinguished')
+                  return Array.isArray(f?.value) &&
+                    (f.value as string[]).includes('President')
+                    ? ' clubs-quick-filter-chip--active'
+                    : ''
+                })()
+              }
+              aria-pressed={(() => {
+                const f = getFilter('distinguished')
+                return (
+                  Array.isArray(f?.value) &&
+                  (f.value as string[]).includes('President')
+                )
+              })()}
+            >
+              President's tier only
             </button>
 
             {hasActiveFilters && (
               <button
+                type="button"
                 onClick={clearAllFilters}
-                className="px-3 py-1 text-xs text-tm-true-maroon hover:text-tm-true-maroon-80 font-medium border border-tm-true-maroon-30 rounded-sm hover:bg-tm-true-maroon-10 font-tm-body"
+                className="clubs-quick-filter-chip clubs-quick-filter-chip__clear"
               >
-                Clear All Filters ({activeFilterCount})
+                Clear all ({activeFilterCount})
               </button>
             )}
           </div>

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -661,6 +661,77 @@
     border-color: rgba(123, 24, 40, 0.3);
   }
 
+  /* Clubs tab quick-filter chip strip (#24 follow-up). Sits above the
+     ClubsTable toolbar on the District detail Clubs tab. */
+  .clubs-quick-filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .clubs-quick-filters__label {
+    font-family: var(--sans);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    margin-right: 4px;
+  }
+
+  .clubs-quick-filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background-color: var(--surface);
+    color: var(--ink-2);
+    font-family: var(--sans);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 150ms, border-color 150ms, color 150ms;
+  }
+
+  .clubs-quick-filter-chip:hover {
+    border-color: var(--loyal-200);
+    color: var(--loyal-500);
+  }
+
+  .clubs-quick-filter-chip--active {
+    background-color: var(--loyal-500);
+    border-color: var(--loyal-500);
+    color: #ffffff;
+  }
+
+  .clubs-quick-filter-chip--active:hover {
+    background-color: var(--loyal-600);
+    border-color: var(--loyal-600);
+    color: #ffffff;
+  }
+
+  .clubs-quick-filter-chip__star {
+    color: var(--yellow-600);
+  }
+
+  .clubs-quick-filter-chip--active .clubs-quick-filter-chip__star {
+    color: #ffffff;
+  }
+
+  .clubs-quick-filter-chip__clear {
+    color: var(--maroon-500);
+    border-color: rgba(123, 24, 40, 0.25);
+  }
+
+  .clubs-quick-filter-chip__clear:hover {
+    background-color: rgba(123, 24, 40, 0.06);
+    border-color: var(--maroon-500);
+    color: var(--maroon-500);
+  }
+
   /* Awards Race 3-card contender summary (#357). Sits between the
      Districts page KPI strip and the rankings table. The deeper
      top-10 leaderboards live on the future Awards page (Epic #370). */


### PR DESCRIPTION
Replaces the lone "Close to Distinguished" button with the full quick-filter chip strip per handoff. Four chips (⭐ Close to Distinguished / Needs members / Missing renewals / President's tier only) plus a maroon "Clear all (N)" chip when active. aria-pressed wired for a11y. Coverage 126/126 / 2076/2076.