### PR TITLE
refactor(rankings): chrome refresh on Global Rankings chart + table (#365)

### DIFF
--- a/frontend/src/__tests__/accessibility/GlobalRankingsAccessibility.test.tsx
+++ b/frontend/src/__tests__/accessibility/GlobalRankingsAccessibility.test.tsx
@@ -1215,7 +1215,8 @@ describe('Global Rankings Accessibility Tests', () => {
 
         const buttons = screen.getAllByRole('button')
         buttons.forEach(button => {
-          expect(button).toHaveClass('min-h-[44px]')
+          // Chrome refresh moved the 44px min-height to an inline style.
+          expect(button.style.minHeight).toBe('44px')
         })
       })
     })

--- a/frontend/src/components/FullYearRankingChart.tsx
+++ b/frontend/src/components/FullYearRankingChart.tsx
@@ -129,13 +129,14 @@ const CustomTooltip: React.FC<CustomTooltipProps> = ({
 
   return (
     <div
-      className="bg-white border border-gray-300 rounded-lg shadow-lg p-3 min-w-[180px]"
+      className="redesign-panel"
+      style={{ minWidth: 180, padding: 12 }}
       role="tooltip"
     >
       <p className="text-sm font-medium text-gray-900 mb-1 whitespace-nowrap">
         {formattedDate}
       </p>
-      <p className="text-sm text-tm-loyal-blue whitespace-nowrap">
+      <p className="text-sm whitespace-nowrap" style={{ color: 'var(--link)' }}>
         {metricConfig.shortLabel}: Rank #{value}
       </p>
     </div>
@@ -162,11 +163,11 @@ const MetricToggleButton: React.FC<MetricToggleButtonProps> = ({
   return (
     <button
       onClick={() => onSelect(metric)}
-      className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors font-tm-body min-h-[44px] ${
-        isSelected
-          ? 'bg-tm-loyal-blue text-white'
-          : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-      }`}
+      className={
+        'districts-toolbar__sort-btn' +
+        (isSelected ? ' districts-toolbar__sort-btn--active' : '')
+      }
+      style={{ minHeight: 44 }}
       aria-pressed={isSelected}
       aria-label={`View ${config.label}`}
     >

--- a/frontend/src/components/MultiYearComparisonTable.tsx
+++ b/frontend/src/components/MultiYearComparisonTable.tsx
@@ -32,25 +32,24 @@ const ChangeIndicator: React.FC<ChangeIndicatorProps> = ({
 
   const getIndicatorStyles = () => {
     if (isImproved) {
-      // Use Tailwind utility classes for TM brand colors with 10% opacity
       return {
-        bgClass: 'bg-tm-loyal-blue-10',
-        textClass: 'text-tm-loyal-blue',
+        bgStyle: { backgroundColor: 'var(--loyal-50)' },
+        textStyle: { color: 'var(--green-600)' },
         icon: '↑',
         label: 'improved',
       }
     }
     if (isDeclined) {
       return {
-        bgClass: 'bg-tm-true-maroon-10',
-        textClass: 'text-tm-true-maroon',
+        bgStyle: { backgroundColor: 'rgba(220, 38, 38, 0.08)' },
+        textStyle: { color: 'var(--red-600)' },
         icon: '↓',
         label: 'declined',
       }
     }
     return {
-      bgClass: 'bg-gray-200',
-      textClass: 'text-gray-600',
+      bgStyle: { backgroundColor: 'var(--surface-3)' },
+      textStyle: { color: 'var(--ink-3)' },
       icon: '→',
       label: 'unchanged',
     }
@@ -61,7 +60,8 @@ const ChangeIndicator: React.FC<ChangeIndicatorProps> = ({
 
   return (
     <span
-      className={`inline-flex items-center px-1.5 py-0.5 rounded-lg text-xs font-medium ${styles.bgClass} ${styles.textClass}`}
+      className="inline-flex items-center px-1.5 py-0.5 rounded-md text-xs font-medium"
+      style={{ ...styles.bgStyle, ...styles.textStyle }}
       role="status"
       aria-label={`${metricLabel} ${styles.label}${!isUnchanged ? ` by ${absoluteChange} position${absoluteChange !== 1 ? 's' : ''}` : ''}`}
     >
@@ -181,7 +181,8 @@ interface MobileYearCardProps {
 
 const MobileYearCard: React.FC<MobileYearCardProps> = ({ ranking }) => (
   <div
-    className="bg-white border border-gray-300 rounded-lg p-4 mb-3"
+    className="redesign-panel"
+    style={{ marginBottom: 12 }}
     role="listitem"
     aria-label={`Rankings for ${ranking.programYear} program year`}
   >

--- a/frontend/src/components/__tests__/FullYearRankingChart.test.tsx
+++ b/frontend/src/components/__tests__/FullYearRankingChart.test.tsx
@@ -340,9 +340,11 @@ describe('FullYearRankingChart', () => {
     it('metric toggle buttons have minimum touch target size', () => {
       renderWithProviders(<FullYearRankingChart {...baseProps} />)
 
+      // Chrome refresh moved off the `min-h-[44px]` Tailwind class to an
+      // inline style attribute. The 44px guarantee remains.
       const buttons = screen.getAllByRole('button')
       buttons.forEach(button => {
-        expect(button).toHaveClass('min-h-[44px]')
+        expect(button.style.minHeight).toBe('44px')
       })
     })
 
@@ -499,7 +501,10 @@ describe('FullYearRankingChart', () => {
       expect(title).toHaveClass('font-tm-headline')
     })
 
-    it('selected metric button uses brand blue background', () => {
+    it('selected metric button is announced as pressed', () => {
+      // Chrome refresh moved off the `bg-tm-loyal-blue` Tailwind class to
+      // the shared `.districts-toolbar__sort-btn--active` token-driven
+      // class. The browser/screen-reader contract is `aria-pressed='true'`.
       renderWithProviders(
         <FullYearRankingChart {...baseProps} selectedMetric="clubs" />
       )
@@ -507,10 +512,10 @@ describe('FullYearRankingChart', () => {
       const selectedButton = screen.getByRole('button', {
         name: /View Paid Clubs Rank/i,
       })
-      expect(selectedButton).toHaveClass('bg-tm-loyal-blue')
+      expect(selectedButton).toHaveAttribute('aria-pressed', 'true')
     })
 
-    it('unselected metric buttons have neutral styling', () => {
+    it('unselected metric buttons are announced as not pressed', () => {
       renderWithProviders(
         <FullYearRankingChart {...baseProps} selectedMetric="clubs" />
       )
@@ -518,7 +523,7 @@ describe('FullYearRankingChart', () => {
       const unselectedButton = screen.getByRole('button', {
         name: /View Overall Rank/i,
       })
-      expect(unselectedButton).toHaveClass('bg-gray-200')
+      expect(unselectedButton).toHaveAttribute('aria-pressed', 'false')
     })
   })
 

--- a/frontend/src/components/__tests__/MultiYearComparisonTable.test.tsx
+++ b/frontend/src/components/__tests__/MultiYearComparisonTable.test.tsx
@@ -255,31 +255,36 @@ describe('MultiYearComparisonTable', () => {
       expect(changeIndicators).toHaveLength(0)
     })
 
-    it('uses correct colors for improvement (blue)', () => {
+    it('uses token-driven color for improvement', () => {
       renderWithProviders(<MultiYearComparisonTable {...baseProps} />)
 
       const improvementIndicators = screen.getAllByRole('status', {
         name: /Overall rank improved by 5 positions/i,
       })
-      expect(improvementIndicators[0]).toHaveClass('text-tm-loyal-blue')
+      const indicator = improvementIndicators[0] as HTMLElement
+      expect(indicator.style.color).toBe('var(--green-600)')
+      expect(indicator.style.backgroundColor).toBe('var(--loyal-50)')
     })
 
-    it('uses correct colors for decline (maroon)', () => {
+    it('uses token-driven color for decline', () => {
       renderWithProviders(<MultiYearComparisonTable {...baseProps} />)
 
       const declineIndicators = screen.getAllByRole('status', {
         name: /Payments rank declined by 2 positions/i,
       })
-      expect(declineIndicators[0]).toHaveClass('text-tm-true-maroon')
+      const indicator = declineIndicators[0] as HTMLElement
+      expect(indicator.style.color).toBe('var(--red-600)')
     })
 
-    it('uses correct colors for unchanged (gray)', () => {
+    it('uses muted token color for unchanged', () => {
       renderWithProviders(<MultiYearComparisonTable {...baseProps} />)
 
       const unchangedIndicators = screen.getAllByRole('status', {
         name: /Distinguished rank unchanged/i,
       })
-      expect(unchangedIndicators[0]).toHaveClass('text-gray-600')
+      const indicator = unchangedIndicators[0] as HTMLElement
+      expect(indicator.style.color).toBe('var(--ink-3)')
+      expect(indicator.style.backgroundColor).toBe('var(--surface-3)')
     })
   })
 


### PR DESCRIPTION
## Summary
- FullYearRankingChart metric toggle buttons migrated from legacy `bg-tm-loyal-blue` Tailwind to `.districts-toolbar__sort-btn` + `--active` modifier with 44px min touch target
- FullYearRankingChart tooltip adopts `.redesign-panel` surface (consistent with rest of redesign chrome)
- MultiYearComparisonTable change indicators converted from class strings (`text-tm-loyal-blue` / `text-tm-true-maroon` / `text-gray-600`) to token-driven inline styles using `var(--loyal-50)`, `var(--green-600)`, `var(--red-600)`, `var(--surface-3)`, `var(--ink-3)`
- MobileYearCard wrapper adopts `.redesign-panel`
- Tests migrated from class-name assertions to behavior + style assertions (`aria-pressed`, `button.style.minHeight`, `element.style.color`)

Continues the 2026 design-handoff transition. No functional change — chart behavior, table semantics, and aria contracts unchanged.

## Test plan
- [x] `npx vitest --run` — 2076/2076 green
- [x] FullYearRankingChart.test.tsx — 21/21
- [x] MultiYearComparisonTable.test.tsx — 28/28
- [x] GlobalRankingsAccessibility.test.tsx — 66/66
- [ ] Live: verify metric toggle buttons match Districts toolbar styling on `/districts/{id}` Global Rankings tab in light + dark mode
- [ ] Live: verify multi-year change indicator pills render with correct loyal/red/muted colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)