### PR TITLE
feat(club): redesign Close-to-Distinguished call-out + move under hero (#366)

### DIFF
--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -487,6 +487,42 @@ const ClubDetailPage: React.FC = () => {
             </div>
           </header>
 
+          {/* Close-to-Distinguished call-out (#366). Renders above the stats
+              grid when the club has met the goals threshold but is short on
+              members for Distinguished. */}
+          {projection &&
+            projection.gapToDistinguished.goals === 0 &&
+            projection.gapToDistinguished.members > 0 && (
+              <section
+                role="region"
+                aria-labelledby="close-to-distinguished-heading"
+                className="club-close-to-distinguished"
+              >
+                <span
+                  aria-hidden="true"
+                  className="club-close-to-distinguished__icon"
+                >
+                  ★
+                </span>
+                <div className="club-close-to-distinguished__body">
+                  <h2
+                    id="close-to-distinguished-heading"
+                    className="club-close-to-distinguished__title"
+                  >
+                    Close to Distinguished
+                  </h2>
+                  <p className="club-close-to-distinguished__copy">
+                    This club has met the {latestDcpGoals} DCP goal threshold.{' '}
+                    <strong>
+                      {projection.gapToDistinguished.members} more member
+                      {projection.gapToDistinguished.members > 1 ? 's' : ''}
+                    </strong>{' '}
+                    will lock in Distinguished status.
+                  </p>
+                </div>
+              </section>
+            )}
+
           {/* Stats Grid */}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
             {[
@@ -740,33 +776,6 @@ const ClubDetailPage: React.FC = () => {
               </div>
             </div>
           )}
-
-          {/* Close to Distinguished (Members Only) */}
-          {projection &&
-            projection.gapToDistinguished.goals === 0 &&
-            projection.gapToDistinguished.members > 0 && (
-              <div className="mb-6 bg-yellow-50 border border-yellow-200 rounded-lg shadow-sm p-6">
-                <h2 className="font-semibold text-yellow-900 mb-3 flex items-center gap-2 font-tm-headline">
-                  <svg
-                    className="w-5 h-5 text-yellow-600"
-                    fill="currentColor"
-                    viewBox="0 0 20 20"
-                  >
-                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                  </svg>
-                  Close to Distinguished
-                </h2>
-                <p className="text-yellow-800 font-tm-body">
-                  This club has already met the required {latestDcpGoals} DCP
-                  goals. They only need{' '}
-                  <strong>
-                    {projection.gapToDistinguished.members} more member
-                    {projection.gapToDistinguished.members > 1 ? 's' : ''}
-                  </strong>{' '}
-                  to achieve Distinguished status!
-                </p>
-              </div>
-            )}
 
           {/* DCP Goals Timeline */}
           {filteredDcpGoalsTrend.length > 0 && (

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -261,3 +261,76 @@ describe('Provisional Distinguished Badge — ClubDetailPage', () => {
     ).toBeGreaterThanOrEqual(1)
   })
 })
+
+// ============================================================
+// Close-to-Distinguished call-out banner — chrome refresh (#366)
+// ============================================================
+
+describe('Close-to-Distinguished call-out — ClubDetailPage', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  function setClubOverrides(overrides: Record<string, unknown>) {
+    vi.mocked(useDistrictAnalytics).mockReturnValue({
+      data: {
+        districtId: '61',
+        allClubs: [{ ...baseMockClub, ...overrides }],
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useDistrictAnalytics>)
+  }
+
+  it('renders the call-out with redesign chrome class when goals met but members short', () => {
+    // 5 goals (gap=0) + 17 members + base 17 (no growth) → memberGap=3
+    setClubOverrides({
+      membershipBase: 17,
+      membershipTrend: [{ date: '2026-03-15', count: 17 }],
+      dcpGoalsTrend: [{ date: '2026-03-15', goalsAchieved: 5 }],
+      distinguishedLevel: 'NotDistinguished',
+      aprilRenewals: 0,
+    })
+    renderWithRoute()
+
+    const callout = screen.getByRole('region', {
+      name: /close to distinguished/i,
+    })
+    expect(callout).toHaveClass('club-close-to-distinguished')
+  })
+
+  it('positions the call-out before the stats grid', () => {
+    setClubOverrides({
+      membershipBase: 17,
+      membershipTrend: [{ date: '2026-03-15', count: 17 }],
+      dcpGoalsTrend: [{ date: '2026-03-15', goalsAchieved: 5 }],
+      distinguishedLevel: 'NotDistinguished',
+      aprilRenewals: 0,
+    })
+    renderWithRoute()
+
+    const callout = screen.getByRole('region', {
+      name: /close to distinguished/i,
+    })
+    const baseLabel = screen.getByText('Base')
+    // DOCUMENT_POSITION_FOLLOWING (4) means callout precedes baseLabel
+    expect(callout.compareDocumentPosition(baseLabel)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+  })
+
+  it('does not render the call-out when neither goals nor members close', () => {
+    setClubOverrides({
+      membershipBase: 8,
+      membershipTrend: [{ date: '2026-03-15', count: 10 }],
+      dcpGoalsTrend: [{ date: '2026-03-15', goalsAchieved: 1 }],
+      distinguishedLevel: 'NotDistinguished',
+      aprilRenewals: 0,
+    })
+    renderWithRoute()
+
+    expect(
+      screen.queryByRole('region', { name: /close to distinguished/i })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -661,6 +661,57 @@
     border-color: rgba(123, 24, 40, 0.3);
   }
 
+  /* Close-to-Distinguished call-out (#366). Yellow accent banner that
+     surfaces directly under the hero when the club has met the goals
+     threshold but is members-short for Distinguished status. */
+  .club-close-to-distinguished {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    padding: 16px 20px;
+    margin-bottom: 24px;
+    border-radius: var(--rds-radius-md);
+    background: rgba(201, 183, 72, 0.12);
+    border: 1px solid rgba(201, 183, 72, 0.45);
+    border-left: 4px solid var(--yellow-600);
+    box-shadow: var(--rds-shadow-sm);
+  }
+
+  .club-close-to-distinguished__icon {
+    flex-shrink: 0;
+    font-size: 22px;
+    line-height: 1;
+    color: var(--yellow-600);
+    margin-top: 2px;
+  }
+
+  .club-close-to-distinguished__body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .club-close-to-distinguished__title {
+    margin: 0;
+    font-family: var(--display);
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--ink);
+  }
+
+  .club-close-to-distinguished__copy {
+    margin: 0;
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--ink-2);
+  }
+
+  .club-close-to-distinguished__copy strong {
+    color: var(--ink);
+    font-weight: 600;
+  }
+
   /* Clubs tab quick-filter chip strip (#24 follow-up). Sits above the
      ClubsTable toolbar on the District detail Clubs tab. */
   .clubs-quick-filters {


### PR DESCRIPTION
## Summary
- The yellow Close-to-Distinguished call-out was buried below the stats grid + DCP card. Per the 2026 handoff, this is a high-signal moment that should appear immediately under the hero.
- New \`.club-close-to-distinguished\` token-driven class: yellow accent (4px left border, tinted background, var(--rds-radius-md), shadow-sm), star eyebrow icon, var(--display) heading, var(--ink-2) copy.
- Section now wraps in \`<section role=\"region\" aria-labelledby=\"...\">\` for screen-reader landmarks.
- Trigger condition unchanged (gap to Distinguished: 0 goals + members > 0). No business-logic change.

## Test plan
- [x] 3 new tests in ClubDetailPage.test.tsx — chrome class, DOM position before stats grid, negative case
- [x] \`npx vitest --run\` — 2079/2079 green (3 net new)
- [ ] Live: visit a club where goals are met but members short, verify yellow banner appears directly under hero in light + dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)