### PR TITLE
fix(css): tailwind preflight broke every brand class — split layers + redesign top bar

### DIFF
--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -71,29 +71,28 @@ describe('AppShell (#354)', () => {
       ).toHaveAttribute('href', '/methodology')
     })
 
-    it('does NOT render Regions or any "soon" stubs (omitted per Epic #352)', () => {
-      // Awards was a "soon" stub at #354 launch; #371 enabled the real
-      // /awards page and re-included Awards in the primary nav. Regions
-      // remains omitted until that page exists.
+    it('renders Regions as a disabled "soon" stub per design parity', () => {
+      // Design (screenshots/01-districts.png) shows Regions in the primary
+      // nav with a soon badge. Awards shipped (#371) so it is a real link.
       renderShell()
       const nav = screen.getByRole('navigation', { name: /primary/i })
-      expect(within(nav).queryByText(/regions/i)).not.toBeInTheDocument()
-      expect(within(nav).queryByText(/soon/i)).not.toBeInTheDocument()
+      const regionsLink = within(nav).getByRole('link', { name: /regions/i })
+      expect(regionsLink).toHaveClass('app-shell-nav__link--soon')
+      expect(regionsLink).toHaveAttribute('aria-disabled', 'true')
     })
 
-    it('does NOT render notifications, help, or avatar elements (no auth today)', () => {
+    it('renders the top-bar tools cluster (notifications, help, avatar)', () => {
+      // Design shows a bell + ? + JS avatar on the right side of the
+      // top bar. They are visual stubs until auth lands.
       renderShell()
-      // Scope to the top bar so a future footer button doesn't trip this.
       const header = screen.getByRole('banner')
       expect(
-        within(header).queryByRole('button', { name: /notifications/i })
-      ).not.toBeInTheDocument()
+        within(header).getByRole('button', { name: /notifications/i })
+      ).toBeInTheDocument()
       expect(
-        within(header).queryByRole('button', { name: /help/i })
-      ).not.toBeInTheDocument()
-      expect(
-        within(header).queryByRole('img', { name: /avatar|profile/i })
-      ).not.toBeInTheDocument()
+        within(header).getByRole('button', { name: /help/i })
+      ).toBeInTheDocument()
+      expect(within(header).getByLabelText(/account/i)).toBeInTheDocument()
     })
 
     it('marks the active nav link with aria-current="page"', () => {

--- a/frontend/src/__tests__/css-migration/structure.test.ts
+++ b/frontend/src/__tests__/css-migration/structure.test.ts
@@ -36,11 +36,20 @@ describe('CSS Layer Architecture Structure', () => {
       expect(layerMatch?.[1]).toBe('base, brand, utilities')
     })
 
-    it('Tailwind is imported into utilities layer', () => {
+    it('Tailwind preflight goes to base layer; utilities go to utilities layer', () => {
+      // Tailwind v4's `@import "tailwindcss"` bundles preflight + theme +
+      // utilities. If imported as `layer(utilities)`, the preflight reset
+      // (`* { padding: 0 }`) ends up in utilities and silently overrides
+      // every brand component class. Splitting the import keeps preflight
+      // in `base` (lowest precedence) and utilities in `utilities` (highest).
       const css = readCssFile('index.css')
-
-      // Verify Tailwind is imported with layer(utilities)
-      expect(css).toMatch(/@import\s+["']tailwindcss["']\s+layer\(utilities\)/)
+      expect(css).toMatch(
+        /@import\s+["']tailwindcss\/preflight["']\s+layer\(base\)[\s\S]*@import\s+["']tailwindcss\/utilities["']\s+layer\(utilities\)/
+      )
+      // Guard against regressing to the bundled import.
+      expect(css).not.toMatch(
+        /@import\s+["']tailwindcss["']\s+layer\(utilities\)/
+      )
     })
 
     it('layer declaration appears before any style imports', () => {
@@ -166,7 +175,7 @@ describe('CSS Layer Architecture Structure', () => {
 
       // Verification 2: Tailwind is in utilities layer
       expect(indexCss).toMatch(
-        /@import\s+["']tailwindcss["']\s+layer\(utilities\)/
+        /@import\s+["']tailwindcss\/preflight["']\s+layer\(base\)[\s\S]*@import\s+["']tailwindcss\/utilities["']\s+layer\(utilities\)/
       )
 
       // Verification 3: .tm-btn-primary is in brand layer
@@ -274,7 +283,7 @@ describe('CSS Layer Architecture Structure', () => {
 
       // Verification 2: Tailwind is in utilities layer
       expect(indexCss).toMatch(
-        /@import\s+["']tailwindcss["']\s+layer\(utilities\)/
+        /@import\s+["']tailwindcss\/preflight["']\s+layer\(base\)[\s\S]*@import\s+["']tailwindcss\/utilities["']\s+layer\(utilities\)/
       )
 
       // Verification 3: min-height is in base layer
@@ -358,7 +367,7 @@ describe('CSS Layer Architecture Structure', () => {
 
       // Verification 2: Tailwind is in utilities layer
       expect(indexCss).toMatch(
-        /@import\s+["']tailwindcss["']\s+layer\(utilities\)/
+        /@import\s+["']tailwindcss\/preflight["']\s+layer\(base\)[\s\S]*@import\s+["']tailwindcss\/utilities["']\s+layer\(utilities\)/
       )
 
       // Verification 3: Typography classes are in brand layer
@@ -452,7 +461,7 @@ describe('CSS Layer Architecture Structure', () => {
 
       // Verification 2: Tailwind is in utilities layer
       expect(indexCss).toMatch(
-        /@import\s+["']tailwindcss["']\s+layer\(utilities\)/
+        /@import\s+["']tailwindcss\/preflight["']\s+layer\(base\)[\s\S]*@import\s+["']tailwindcss\/utilities["']\s+layer\(utilities\)/
       )
 
       // Verification 3: .tm-card is in brand layer

--- a/frontend/src/components/AppShell/AppShellTopBar.tsx
+++ b/frontend/src/components/AppShell/AppShellTopBar.tsx
@@ -11,26 +11,85 @@ const NAV_ITEMS = [
 const AppShellTopBar: React.FC = () => {
   return (
     <header className="app-shell-top-bar">
-      <div className="app-shell-top-bar__inner">
-        <Link to="/" aria-label="Toast Stats home" className="app-shell-brand">
-          <span aria-hidden="true" className="app-shell-brand__mark">
-            TS
-          </span>
-          <span className="app-shell-brand__name">Toast Stats</span>
-        </Link>
+      <Link to="/" aria-label="Toast Stats home" className="app-shell-brand">
+        <span aria-hidden="true" className="app-shell-brand__mark">
+          TS
+        </span>
+        <span className="app-shell-brand__name">Toast Stats</span>
+      </Link>
 
-        <nav aria-label="Primary" className="app-shell-nav">
-          {NAV_ITEMS.map(item => (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              end={item.end}
-              className="app-shell-nav__link"
-            >
-              {item.label}
-            </NavLink>
-          ))}
-        </nav>
+      <nav aria-label="Primary" className="app-shell-nav">
+        <NavLink to="/" end className="app-shell-nav__link">
+          Districts
+        </NavLink>
+        <a
+          href="#regions"
+          aria-disabled="true"
+          tabIndex={-1}
+          onClick={e => e.preventDefault()}
+          className="app-shell-nav__link app-shell-nav__link--soon"
+        >
+          Regions
+        </a>
+        {NAV_ITEMS.filter(i => i.to !== '/').map(item => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            end={item.end}
+            className="app-shell-nav__link"
+          >
+            {item.label}
+          </NavLink>
+        ))}
+      </nav>
+
+      <div className="app-shell-tools">
+        <button
+          type="button"
+          className="app-shell-icon-btn"
+          aria-label="Notifications"
+          title="Notifications"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            aria-hidden="true"
+          >
+            <path d="M3 13h10l-1.5-2v-3.5a3.5 3.5 0 0 0-7 0V11L3 13Z" />
+            <path d="M6.5 13.5a1.5 1.5 0 0 0 3 0" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          className="app-shell-icon-btn"
+          aria-label="Help"
+          title="Help"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            aria-hidden="true"
+          >
+            <circle cx="8" cy="8" r="6.5" />
+            <path d="M6.2 6.2a1.8 1.8 0 1 1 2.4 1.7c-.5.2-.6.5-.6.9V10" />
+            <circle cx="8" cy="12" r=".4" fill="currentColor" />
+          </svg>
+        </button>
+        <span
+          className="app-shell-avatar"
+          aria-label="Account (placeholder)"
+          role="img"
+        >
+          TS
+        </span>
       </div>
     </header>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,13 +2,22 @@
 
 /* CSS Cascade Layer Declaration - MUST come before any imports
  * Layer order establishes cascade priority (lowest to highest):
- * - base: Element-level defaults (easily overridable)
+ * - base: Element-level defaults (Tailwind preflight + project resets)
  * - brand: Toastmasters brand component classes
  * - utilities: Tailwind utilities (highest priority, always wins when applied)
+ *
+ * NOTE: Tailwind v4's `@import "tailwindcss"` bundles preflight, theme,
+ * and utilities together. If imported as `layer(utilities)`, the
+ * preflight reset (`* { padding: 0; margin: 0 }`) ends up in the
+ * utilities layer and silently overrides every brand component class.
+ * That broke the entire redesign chrome on prod. Fix: import preflight
+ * to base, theme to its own layer, and utilities to utilities.
  */
 @layer base, brand, utilities;
 
-@import "tailwindcss" layer(utilities);
+@import "tailwindcss/theme" layer(theme);
+@import "tailwindcss/preflight" layer(base);
+@import "tailwindcss/utilities" layer(utilities);
 @import './styles/tokens/colors.css';
 @import './styles/tokens/typography.css';
 @import './styles/tokens/spacing.css';

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -15,16 +15,19 @@
     flex: 1;
   }
 
+  /* Top bar: 3-column flex (brand | nav with flex:1 | tools) per design.
+     The bar spans the viewport edge-to-edge with 24px gutter padding;
+     the .app-shell__page wrapper handles content max-width below. */
   .app-shell-top-bar {
     position: sticky;
     top: 0;
     z-index: 40;
     height: 56px;
     border-bottom: 1px solid var(--line);
-    /* Use a fully opaque surface as the fallback so the bar is visible
-       even when backdrop-filter is unsupported (still some Firefox).
-       Browsers that support backdrop-filter overlay the alpha-tinted
-       background on top so the blurred translucency works there. */
+    padding: 0 24px;
+    display: flex;
+    align-items: center;
+    gap: 24px;
     background-color: var(--surface);
     -webkit-backdrop-filter: saturate(140%) blur(8px);
     backdrop-filter: saturate(140%) blur(8px);
@@ -37,24 +40,21 @@
     }
   }
 
-  .app-shell-top-bar__inner {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: 100%;
-    padding-left: 24px;
-    padding-right: 24px;
-    max-width: 1280px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
   .app-shell-brand {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
     text-decoration: none;
     color: var(--ink);
+    font-family: var(--serif);
+    font-weight: 800;
+    font-size: 16px;
+    letter-spacing: -0.005em;
+    flex-shrink: 0;
+  }
+
+  .app-shell-brand:hover {
+    text-decoration: none;
   }
 
   .app-shell-brand__mark {
@@ -63,30 +63,30 @@
     justify-content: center;
     width: 24px;
     height: 24px;
-    border-radius: var(--rds-radius-sm);
+    border-radius: 5px;
     background-color: var(--loyal-500);
     color: #ffffff;
     font-family: var(--serif);
     font-weight: 800;
-    font-size: 11px;
-    letter-spacing: -0.02em;
+    font-size: 12px;
   }
 
   .app-shell-brand__name {
     font-family: var(--serif);
-    font-weight: 700;
-    font-size: 15px;
-    letter-spacing: -0.01em;
+    font-weight: 800;
+    font-size: 16px;
+    letter-spacing: -0.005em;
   }
 
   .app-shell-nav {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     gap: 4px;
+    flex: 1;
   }
 
   .app-shell-nav__link {
-    padding: 6px 12px;
+    padding: 8px 12px;
     border-radius: var(--rds-radius-sm);
     text-decoration: none;
     color: var(--ink-2);
@@ -99,11 +99,82 @@
 
   .app-shell-nav__link:hover {
     background-color: var(--surface-3);
+    text-decoration: none;
   }
 
   .app-shell-nav__link[aria-current='page'] {
     color: var(--loyal-500);
     background-color: var(--loyal-50);
+  }
+
+  .app-shell-nav__link--soon {
+    color: var(--ink-4);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .app-shell-nav__link--soon::after {
+    content: 'soon';
+    font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+    font-size: 9px;
+    font-weight: 500;
+    background-color: var(--surface-3);
+    color: var(--ink-4);
+    padding: 1px 4px;
+    border-radius: 3px;
+    margin-left: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    vertical-align: 1px;
+  }
+
+  .app-shell-tools {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+  }
+
+  .app-shell-icon-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: var(--rds-radius-sm);
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--ink-3);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .app-shell-icon-btn:hover {
+    background-color: var(--surface-3);
+    color: var(--ink);
+  }
+
+  .app-shell-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background-color: var(--maroon-500);
+    color: #ffffff;
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Universal page-content wrapper. Use on any route that needs the
+     1280px-centered 24px-padded chrome. Districts/DistrictDetail have
+     their own scoped wrappers and don't need this. */
+  .app-shell__page {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 24px;
   }
 
   .app-shell-footer {

--- a/tasks/visual-audit-2026-05-10.md
+++ b/tasks/visual-audit-2026-05-10.md
@@ -1,0 +1,84 @@
+# Visual Audit — 2026-05-10 14:35
+
+User feedback: **"the site is materially worse than we started"**.
+
+I previously declared the redesign "complete" based on CSS class presence in the prod bundle. That was wrong — class presence ≠ visual fidelity. This document captures the real gap between the live deploy and the design handoff at `/Users/rservant/Downloads/design_handoff_toast_stats/`.
+
+## Method
+
+- Captured 1280×720 screenshots of all 5 routes from `https://ts.taverns.red/` via Playwright (`/tmp/live-audit/`).
+- Compared side-by-side to designer screenshots (`screenshots/01..05.png`) and reference HTML (`designs/Toast Stats - *.html`).
+
+## Universal defects (every page)
+
+1. **Top bar nav layout is wrong.** Design centers the nav between the brand (left) and the icon-tools cluster (right). Live has brand-left + nav-right with no center column and no tools cluster.
+2. **Missing top-bar action tools.** Design has bell icon, ? help icon, JS avatar pill on the right of the bar. Live has none of these.
+3. **Nav items are wrong.** Design has 5 items: `Districts | Regions [SOON] | Awards [SOON] | History | Methodology`. Live has 4: `Districts Awards History Methodology` (no Regions; Awards is live, not "SOON"). The "SOON" disabled-with-badge styling is missing entirely.
+4. **No "Toast Stats" wordmark consistency.** Design always shows the `TS` mark + the `Toast Stats` wordmark. Live ranges from showing it (History) to not showing it cleanly (Districts).
+5. **Active-page indication.** Design active item uses a filled rounded-pill `--loyal-50` background. Live works on History but on Districts the active state appears unstyled (looks like all items are equal).
+
+## Per-page defects
+
+### `/` Districts (live screenshot vs design 01-districts.png)
+
+1. **Action cluster missing.** Design has `Data fresh · Apr 26, 2026` pill + `↓ Export CSV` outline button + `↑ Share` filled-loyal button on the right of the page header. Live has just `Data as of May 9 · 9h ago` text — no buttons, no pill chrome.
+2. **KPI numbers are too small.** Design `kpi-value` is 30px serif 800. Live is ~24px and feels lighter.
+3. **Program-Year + Date selector + progress meter** are jammed into a single horizontal row with weird widths. Designer never showed these — they replace what should be the Awards Race + table chrome. The progress meter (`Program Year Progress 86% Jul 1, 2025 – Jun 30, 2026`) is not in the design at all and should be removed or relocated.
+4. **Awards Race contender cards** are missing the progress-bar meter (a colored gradient line). Live has just text.
+5. **Awards Race column subtitles** wrong wording. Design: `15 new charter strength clubs` / `+20 paid clubs vs prior year` / `90% retention of last yr clubs`. Live: `Largest net club growth` / `Highest % clubs with 20+ paid members` / `Top retention (≥90% paid clubs)`.
+6. **`SORT BY:` and `REGIONS:` rows are unstyled raw text.** Design replaces these with a proper toolbar: a search input on the left, a segmented sort control in the middle, and region chips on a separate row below.
+7. **Rankings table chrome.** Design shows a clean borderless table with mono numerics and a thin row separator. Live appears to have inherited the legacy table chrome (still cut off in the screenshot).
+
+### `/district/61` District Detail (live vs 02-district-detail.png)
+
+1. **Tab bar primitive is broken.** Design shows a horizontal tab strip with active-underline + count badges (`Overview | Clubs 305 | Divisions & Areas 7 | Trends | Analytics | Global Rankings`). Live renders the labels run-together as plain text: `OverviewClubs Divisions & AreasTrendsAnalyticsGlobal Rankings`. **Issue #359 was supposed to ship this — it did not.**
+2. **Page header is cramped.** Design has Districts > District 57 breadcrumb on top, then the eyebrow `REGION 1 · PROGRAM YEAR 2025–2026`, then a large `District 57` heading, then the lede `Northern California — 305 active clubs across 7 divisions...`. Live mashes the breadcrumb + eyebrow + heading into a small column on the left.
+3. **Action cluster** (Data fresh pill + PY select + date select + Export + Share) is partially present but visually disconnected — no group framing.
+4. **Distinguished District Status panel** missing entirely from live. Design shows a panel with `Distinguished District Status` header + `On track — President's Distinguished` yellow pill + 4 award chips (Club Strength, Leadership, Education, Club Growth Officer).
+5. **KPI numbers** truncated: live shows `MEMBER PAYM…#3 of` and `DISTINGUISHED (#2 of` — the rank-position chip is wrapping into the label and breaking the layout.
+
+### `/district/61/club/00045123` Club Detail (live vs 03-club-detail.png)
+
+1. **Live returns "Club Not Found"** because club 00045123 doesn't exist in district 61. The design uses `Walnut Creek Speakers` in D57. Need a valid club ID for visual comparison — but my code shouldn't have shipped this URL pattern in any docs.
+2. **(Once a valid club is loaded)** the design shows: loyal-blue hero with `CLUB #00045123 · CHARTERED MAY 1982` eyebrow + huge `Walnut Creek Speakers` heading + `Area 04 · Division A · District 57` sub-line + right-side `· Thriving` pill + `Distinguished` outlined pill. Need to verify that against a real club.
+3. **`CHARTERED MAY 1982`** part of the eyebrow is missing in our live hero — we have only `Club #<id>`. We need the charter date.
+
+### `/history` History (live vs 04-history.png)
+
+1. **Year strip chips look right** (active 2025-26 + LIVE green badge). This is one of the few near-correct surfaces.
+2. **Per-year cards are missing** entirely (live admits this with `Per-year summary cards coming soon` paragraph). Design shows full per-year card with TOP 5 DISTRICTS list + HEADLINE METRICS column.
+3. **Layout** is edge-to-edge — same centering bug as everywhere.
+
+### `/methodology` Methodology (live vs 05-methodology.png)
+
+1. **TOC card** is rendered but visually broken — no border / shadow framing on live, items are crammed close. Design has it inside a clean white card with proper spacing and the `01..08` numbering aligned to the right.
+2. **Section headings** in the body are too tight against the body copy — design uses `01 Data source & access` with the number as a serif eyebrow before the heading.
+3. **Layout** is edge-to-edge — same bug.
+
+## Root-cause hypothesis
+
+Most of the visual gap traces to two issues:
+
+1. **The page-content max-width / padding wrapper is not consistently applied.** Districts has `.districts-page { max-width: 1280px; padding: 32px 24px; margin: 0 auto }` but other pages don't have an equivalent. The AppShell's `.app-shell__main { flex: 1 }` doesn't constrain width. So pages without their own constraint extend edge-to-edge.
+2. **The `.app-shell-top-bar__inner` uses `justify-content: space-between` and just two children (brand, nav)** — there's no third "tools" cluster, so flex distributes brand-left + nav-right with no center weighting. Design uses three children (brand, centered nav with `flex: 1`, tools cluster) which produces the correct visual.
+
+## Plan
+
+I will not declare this complete again. The plan, in priority order:
+
+1. **Fix the top bar nav** — three-column layout (brand | centered nav | tools cluster), add Regions [SOON] + Awards [SOON] disabled items, add bell + help + avatar tools.
+2. **Add a universal page wrapper** — `.app-shell__page { max-width: 1280px; margin: 0 auto; padding: 24px }` applied to every route.
+3. **Fix the District Detail tab bar** — actually render `#359` per the design.
+4. **Districts page action cluster** — add Data fresh pill + Export CSV + Share buttons; remove the program-year-progress meter that isn't in the design.
+5. **Awards Race progress bars** — add the progress-track + progress-fill meter line.
+6. **Awards Race subtitles** — match design wording.
+7. **Districts toolbar rebuild** — search input + segmented sort control + region chip row.
+8. **District Detail "Distinguished District Status" panel** — new section with the on-track pill + award chips.
+9. **History per-year cards** — needs new endpoint, deferred to its own issue.
+10. **Methodology TOC card framing** — visual polish.
+
+Each item gets its own focused PR with TDD discipline. No more bulk "I shipped 5 things" PRs without visual verification.
+
+## What I will not do
+
+- Declare anything "complete" until a Playwright screenshot of the live deploy has been compared, by me, to the designer's screenshot at the same viewport.


### PR DESCRIPTION
## The bug

`@import \"tailwindcss\" layer(utilities)` bundles preflight (`* { padding: 0; margin: 0 }`), theme, and utilities **all into the utilities layer**. Per CSS cascade-layer rules, that meant the universal-selector reset overrode every brand component class with `padding` or `margin` — `.app-shell-top-bar`, `.placeholder-page`, `.club-hero`, every `.districts-*`/`.district-detail-*` class, etc.

This is why the live site has looked nothing like the design handoff for the entire redesign: chrome padding/margin has been silently zeroed out.

Verified locally with Playwright + DevTools CSS API: `.app-shell-top-bar` was matching its `padding: 0 24px` rule but losing the cascade to `*, ::after, ::before, ::backdrop { padding: 0 }` from preflight.

## The fix

Split the Tailwind import per Tailwind v4's recommended pattern:

```css
@import \"tailwindcss/theme\"     layer(theme);
@import \"tailwindcss/preflight\" layer(base);
@import \"tailwindcss/utilities\" layer(utilities);
```

Now preflight lives in `base` (lowest precedence), brand classes establish their own padding/margin, Tailwind utilities still win when applied.

## Top bar redesign (necessary because the preflight bug had masked the layout for the entire epic)

- Three-column flex (brand | nav with `flex: 1` | tools cluster) per design HTML
- Adds Regions [SOON] disabled link with the soon pseudo-element badge
- Adds bell + help icon-buttons + JS avatar on the right
- Drops the obsolete `.app-shell-top-bar__inner` wrapper

## Test changes

- Flipped two AppShell.test.tsx assertions that previously enforced \"no Regions, no tools\" — those were tracking a since-revised scope decision
- Updated CSS layer structure tests to match the new split import
- Added a regression guard against the bundled `@import \"tailwindcss\"` form

## Visual verification

Local `vite preview` + Playwright at 1280×720:
- History page: matches `screenshots/04-history.png` for top bar + content centering + year strip + lede
- Methodology: matches `screenshots/05-methodology.png` for TOC card framing + numbered eyebrows

Districts page in preview shows the empty-data error state (no API in static preview), but the chrome is correct.

## What's still open after this lands

Filed at `tasks/visual-audit-2026-05-10.md`. Highlights: DistrictDetail tab bar (#359 actually broken on live), Districts action cluster (Data fresh / Export CSV / Share), Awards Race progress bars, Distinguished District Status panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)