### PR TITLE
feat(awards-race): add progress bars + threshold sub-line per design (#357)

### DIFF
--- a/frontend/src/components/AwardsRaceSection.tsx
+++ b/frontend/src/components/AwardsRaceSection.tsx
@@ -17,9 +17,12 @@ interface AwardsRaceSectionProps {
 
 interface AwardCardSpec {
   title: string
-  description: string
+  /** Threshold sub-line per design (e.g. "15 new charter strength clubs"). */
+  threshold: string
   /** Format the leader's value for display (e.g. "+14", "94.1%"). */
   formatValue: (value: number) => string
+  /** Compute progress percentage 0-100 from the leader's value. */
+  computeProgress: (value: number) => number
 }
 
 const AWARD_CARDS: ReadonlyArray<{
@@ -33,24 +36,29 @@ const AWARD_CARDS: ReadonlyArray<{
     key: 'extensionAward',
     spec: {
       title: "President's Extension Award",
-      description: 'Largest net club growth',
+      threshold: 'Most new paid clubs vs prior year',
       formatValue: v => (v >= 0 ? `+${v}` : `${v}`),
+      // Winners are flagged separately; non-winners progress against a
+      // soft target of 15 (matches the design's reference threshold).
+      computeProgress: v => Math.min(100, Math.max(0, (v / 15) * 100)),
     },
   },
   {
     key: 'twentyPlusAward',
     spec: {
       title: "President's 20-Plus Award",
-      description: 'Highest % clubs with 20+ paid members',
+      threshold: '% of paid clubs with 20+ members',
       formatValue: v => `${v.toFixed(1)}%`,
+      computeProgress: v => Math.min(100, Math.max(0, v)),
     },
   },
   {
     key: 'retentionAward',
     spec: {
       title: 'District Club Retention Award',
-      description: 'Top retention (≥90% paid clubs)',
+      threshold: '90% retention of last year’s clubs',
       formatValue: v => `${v.toFixed(1)}%`,
+      computeProgress: v => Math.min(100, Math.max(0, v)),
     },
   },
 ]
@@ -100,20 +108,22 @@ const AwardCard: React.FC<AwardCardProps> = ({ spec, entries }) => {
       <article className="awards-race-card">
         <header className="awards-race-card__header">
           <h3 className="awards-race-card__title">{spec.title}</h3>
-          <p className="awards-race-card__description">{spec.description}</p>
+          <p className="awards-race-card__threshold">{spec.threshold}</p>
         </header>
         <p className="awards-race-card__empty">No standings yet.</p>
       </article>
     )
   }
 
+  const progress = isAchieved ? 100 : spec.computeProgress(leader.value)
+
   return (
     <article className="awards-race-card">
       <header className="awards-race-card__header">
         <h3 className="awards-race-card__title">{spec.title}</h3>
-        <p className="awards-race-card__description">{spec.description}</p>
+        <p className="awards-race-card__threshold">{spec.threshold}</p>
       </header>
-      <div className="awards-race-card__leader">
+      <div className="awards-race-card__row">
         <Link
           to={`/district/${leader.districtId}`}
           className="awards-race-card__leader-link"
@@ -124,20 +134,36 @@ const AwardCard: React.FC<AwardCardProps> = ({ spec, entries }) => {
           {spec.formatValue(leader.value)}
         </span>
       </div>
-      <footer className="awards-race-card__footer">
+      <div
+        className="awards-race-card__progress-track"
+        role="progressbar"
+        aria-valuenow={Math.round(progress)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${spec.title} progress`}
+      >
+        <div
+          className={
+            'awards-race-card__progress-fill' +
+            (isAchieved ? ' awards-race-card__progress-fill--won' : '')
+          }
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <footer
+        className={
+          'awards-race-card__status' +
+          (isAchieved ? ' awards-race-card__status--won' : '')
+        }
+      >
+        <span aria-hidden="true" className="awards-race-card__status-dot" />
         {isAchieved ? (
-          <>
-            <span className="awards-race-card__status awards-race-card__status--achieved">
-              ✓ Achieved
-            </span>
-            {winners.length > 1 && (
-              <span className="awards-race-card__hint">
-                · {winners.length} districts qualifying
-              </span>
-            )}
-          </>
+          <span>
+            ✓ Achieved
+            {winners.length > 1 && ` · ${winners.length} districts qualifying`}
+          </span>
         ) : (
-          <span className="awards-race-card__status">
+          <span>
             Leader · next contender at{' '}
             {entries[1] ? spec.formatValue(entries[1].value) : '—'}
           </span>

--- a/frontend/src/components/__tests__/AwardsRaceSection.test.tsx
+++ b/frontend/src/components/__tests__/AwardsRaceSection.test.tsx
@@ -166,4 +166,42 @@ describe('AwardsRaceSection — 3-card redesign (#357)', () => {
     )
     expect(container.querySelector('.awards-race-card')).toBeNull()
   })
+
+  it('renders a progress bar on each card with a sensible width %', () => {
+    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
+
+    // Extension leader value=14, no winner — progress = min(100, 14/15*100) ≈ 93%
+    const ext = findCard(/extension/i)
+    const extBar = within(ext).getByRole('progressbar') as HTMLElement
+    const extFill = extBar.firstElementChild as HTMLElement
+    expect(parseFloat(extFill.style.width)).toBeGreaterThan(80)
+    expect(parseFloat(extFill.style.width)).toBeLessThanOrEqual(100)
+    expect(extFill).not.toHaveClass('awards-race-card__progress-fill--won')
+
+    // 20-Plus leader is a winner → progress = 100% with --won modifier
+    const twenty = findCard(/20-plus/i)
+    const twentyBar = within(twenty).getByRole('progressbar') as HTMLElement
+    const twentyFill = twentyBar.firstElementChild as HTMLElement
+    expect(twentyFill.style.width).toBe('100%')
+    expect(twentyFill).toHaveClass('awards-race-card__progress-fill--won')
+  })
+
+  it('shows a status dot in each card footer', () => {
+    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
+    // Each card's footer has a leading dot indicator
+    const dots = document.querySelectorAll('.awards-race-card__status-dot')
+    expect(dots.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('renders the threshold sub-line per card per design wording', () => {
+    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
+    // Design subtitles describe the award threshold below the title
+    expect(
+      screen.getByText(/most new paid clubs vs prior year/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/% of paid clubs with 20\+ members/i)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/90% retention of last year/i)).toBeInTheDocument()
+  })
 })

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -921,7 +921,8 @@
     color: var(--ink);
   }
 
-  .awards-race-card__description {
+  .awards-race-card__description,
+  .awards-race-card__threshold {
     margin: 0;
     font-family: var(--sans);
     font-size: 12px;
@@ -929,7 +930,7 @@
     color: var(--ink-3);
   }
 
-  .awards-race-card__leader {
+  .awards-race-card__row {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
@@ -937,10 +938,10 @@
   }
 
   .awards-race-card__leader-link {
-    font-family: var(--mono);
-    font-weight: 500;
-    font-size: 16px;
-    color: var(--link);
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 14px;
+    color: var(--loyal-500);
     text-decoration: none;
   }
 
@@ -951,35 +952,56 @@
   .awards-race-card__leader-value {
     font-family: var(--serif);
     font-weight: 800;
-    font-size: 24px;
+    font-size: 22px;
     line-height: 1;
     letter-spacing: -0.02em;
     color: var(--ink);
     font-variant-numeric: tabular-nums;
   }
 
-  .awards-race-card__footer {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 4px;
-    padding-top: 8px;
-    border-top: 1px solid var(--line-2);
-    font-family: var(--sans);
-    font-size: 12px;
-    color: var(--ink-3);
+  .awards-race-card__progress-track {
+    height: 4px;
+    background-color: var(--surface-3);
+    border: 1px solid var(--line-2);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .awards-race-card__progress-fill {
+    height: 100%;
+    background-color: var(--loyal-500);
+    border-radius: 2px;
+    transition: width 400ms ease;
+  }
+
+  .awards-race-card__progress-fill--won {
+    background-color: var(--yellow-500);
   }
 
   .awards-race-card__status {
-    font-weight: 500;
-  }
-
-  .awards-race-card__status--achieved {
-    color: var(--green-600);
-  }
-
-  .awards-race-card__hint {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 4px;
+    font-family: var(--sans);
+    font-size: 11px;
     color: var(--ink-3);
+  }
+
+  .awards-race-card__status--won {
+    color: var(--yellow-600);
+  }
+
+  .awards-race-card__status-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--ink-3);
+    flex-shrink: 0;
+  }
+
+  .awards-race-card__status--won .awards-race-card__status-dot {
+    background-color: var(--yellow-500);
   }
 
   .awards-race-card__empty {


### PR DESCRIPTION
## Summary
The Awards Race contender cards on the Districts page were missing two chrome elements vs the design handoff:

1. **Progress meter** (track + fill) under the leader row, with a yellow `--won` modifier for achieved awards
2. **Status dot** in the footer (gray for in-progress, yellow for achieved)

Also replaced the generic description sub-line with a threshold sub-line that names the award criterion.

The threshold copy reflects our actual data semantics rather than the design's example wording (the design assumed +20 paid-clubs delta for the 20-Plus award, but our pipeline computes "% of paid clubs with 20+ members" instead).

## Test plan
- [x] 12/12 AwardsRaceSection tests green (3 net new: progress width + --won, status dot count, threshold wording)
- [x] Full test suite green
- [ ] Live: visit ts.taverns.red — confirm each contender card has a progress meter under the leader row, dot before the status text, and yellow color on achieved awards (20-Plus, Retention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)