### PR TITLE
feat(districts): action cluster — Export CSV + Share buttons (#357)

### DIFF
--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -23,6 +23,7 @@ import {
 } from '../utils/programYear'
 import { formatDisplayDate } from '../utils/dateFormatting'
 import { DistrictRanking } from '../types/districts'
+import { arrayToCSV, downloadCSV } from '../utils/csvExport'
 
 const DistrictsPage: React.FC = () => {
   const navigate = useNavigate()
@@ -478,6 +479,73 @@ const DistrictsPage: React.FC = () => {
           </div>
           <div className="districts-page-header__actions">
             <DataFreshnessBadge />
+            <button
+              type="button"
+              className="districts-action-btn"
+              onClick={() => {
+                const header = [
+                  'Rank',
+                  'District',
+                  'Region',
+                  'Paid Clubs',
+                  'Total Payments',
+                  'Distinguished Clubs',
+                  'Aggregate Score',
+                ]
+                const rows: (string | number)[][] = sortedRankings.map(
+                  (r, i) => [
+                    i + 1,
+                    `D${r.districtId}`,
+                    r.region,
+                    r.paidClubs,
+                    r.totalPayments,
+                    r.distinguishedClubs,
+                    r.aggregateScore,
+                  ]
+                )
+                const csv = arrayToCSV([header, ...rows])
+                const dateLabel = (effectiveRankingsDate ?? 'latest').replace(
+                  /[^0-9a-z-]/gi,
+                  ''
+                )
+                downloadCSV(csv, `district-rankings-${dateLabel}.csv`)
+              }}
+            >
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                aria-hidden="true"
+              >
+                <path d="M3 10v3h10v-3M8 2v9M5 8l3 3 3-3" />
+              </svg>
+              Export CSV
+            </button>
+            <button
+              type="button"
+              className="districts-action-btn districts-action-btn--primary"
+              onClick={() => {
+                if (typeof navigator !== 'undefined' && navigator.clipboard) {
+                  void navigator.clipboard.writeText(window.location.href)
+                }
+              }}
+            >
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                aria-hidden="true"
+              >
+                <path d="M8 11.5V3.5M5 6l3-3 3 3M3 13h10" />
+              </svg>
+              Share
+            </button>
           </div>
         </div>
 
@@ -532,7 +600,7 @@ const DistrictsPage: React.FC = () => {
                   availableProgramYears={availableProgramYears}
                   selectedProgramYear={selectedProgramYear}
                   onProgramYearChange={setSelectedProgramYear}
-                  showProgress={true}
+                  showProgress={false}
                 />
               </div>
             )}

--- a/frontend/src/pages/__tests__/DistrictsPage.redesign.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.redesign.test.tsx
@@ -196,6 +196,35 @@ describe('Districts page redesign chrome (#356)', () => {
     })
   })
 
+  describe('action cluster (#357 follow-up)', () => {
+    it('renders Export CSV + Share buttons on the page header', async () => {
+      setupWithData()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByText('District 1')
+
+      expect(
+        screen.getByRole('button', { name: /export csv/i })
+      ).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /share/i })).toBeInTheDocument()
+    })
+
+    it('Share button copies the current URL to the clipboard', async () => {
+      setupWithData()
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        writable: true,
+        configurable: true,
+      })
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByText('District 1')
+
+      const shareBtn = screen.getByRole('button', { name: /share/i })
+      shareBtn.click()
+      expect(writeText).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('AppShell integration (Lesson 49 — prior PR shipped a regression that only manifests when nested under the real shell)', () => {
     it('does not declare its own min-height: 100vh — that belongs to AppShell', () => {
       // Static check: the .districts-page-root rule must NOT set min-height

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -332,6 +332,42 @@
     flex-wrap: wrap;
   }
 
+  /* Action cluster buttons (#357 follow-up). Mirrors the design's .btn /
+     .btn-primary chrome; namespaced .districts-* so they don't collide
+     with the legacy .tm-btn-* classes. */
+  .districts-action-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background-color: var(--surface);
+    color: var(--ink-2);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-sm);
+    padding: 7px 12px;
+    font-family: var(--sans);
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .districts-action-btn:hover {
+    background-color: var(--surface-3);
+    color: var(--ink);
+  }
+
+  .districts-action-btn--primary {
+    background-color: var(--loyal-500);
+    color: #ffffff;
+    border-color: var(--loyal-500);
+  }
+
+  .districts-action-btn--primary:hover {
+    background-color: var(--loyal-600);
+    border-color: var(--loyal-600);
+    color: #ffffff;
+  }
+
   /* 4-card KPI strip */
   .districts-kpi-strip {
     display: grid;


### PR DESCRIPTION
## Summary

Per the design handoff (designs/Toast Stats - Districts.html), the Districts page header should have **Data fresh pill** + **Export CSV** outline button + **Share** filled-loyal button on the right side. We had only the freshness pill before — buttons were missing.

- **Export CSV**: builds a CSV from the current sortedRankings (Rank, District, Region, Paid Clubs, Total Payments, Distinguished Clubs, Aggregate Score) and downloads it with a date-stamped filename
- **Share**: copies the current URL to the clipboard
- Removed the **Program Year Progress** meter — not in the design and was crowding the filters card
- New `.districts-action-btn` / `.districts-action-btn--primary` CSS classes mirror the design's `.btn` / `.btn-primary` chrome

## Test plan
- [x] 12/12 DistrictsPage redesign tests green (2 net new: button rendering + Share clipboard write)
- [x] Full suite 2081/2081
- [ ] Live: visit ts.taverns.red — confirm Export CSV button + Share filled-loyal button appear on right side of page header alongside Data fresh pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)