### PR TITLE
feat(awards-race): wrap in single bordered panel + timestamp meta (#357)

### DIFF
--- a/frontend/src/components/AwardsRaceSection.tsx
+++ b/frontend/src/components/AwardsRaceSection.tsx
@@ -76,13 +76,27 @@ export const AwardsRaceSection: React.FC<AwardsRaceSectionProps> = ({
   const allEmpty = cardData.every(({ entries }) => entries.length === 0)
   if (allEmpty) return null
 
+  const updatedAt = (() => {
+    const raw = standings.metadata?.calculatedAt
+    if (!raw) return null
+    const d = new Date(raw)
+    if (Number.isNaN(d.getTime())) return null
+    return d.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  })()
+
   return (
     <section className="awards-race" aria-labelledby="awards-race-heading">
       <header className="awards-race__header">
         <h2 id="awards-race-heading" className="awards-race__title">
-          Awards Race
+          Awards Race · Top contenders
         </h2>
-        <p className="awards-race__subtitle">Top contender per award</p>
+        {updatedAt && (
+          <span className="awards-race__meta">Updated {updatedAt}</span>
+        )}
       </header>
       <div className="awards-race__grid">
         {cardData.map(({ spec, entries }) => (

--- a/frontend/src/components/__tests__/AwardsRaceSection.test.tsx
+++ b/frontend/src/components/__tests__/AwardsRaceSection.test.tsx
@@ -204,4 +204,16 @@ describe('AwardsRaceSection — 3-card redesign (#357)', () => {
     ).toBeInTheDocument()
     expect(screen.getByText(/90% retention of last year/i)).toBeInTheDocument()
   })
+
+  it('renders the section header on a single line with a timestamp meta', () => {
+    renderWithRouter(<AwardsRaceSection standings={mockStandings} />)
+    // Design 01-districts.png shows "Awards Race · Top contenders" on
+    // one line plus a right-aligned "Updated <date>" meta. Live used
+    // to render the title + subtitle on two stacked lines without a
+    // timestamp.
+    expect(
+      screen.getByText(/awards race · top contenders/i)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/updated /i)).toBeInTheDocument()
+  })
 })

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -893,15 +893,26 @@
   /* Awards Race 3-card contender summary (#357). Sits between the
      Districts page KPI strip and the rankings table. The deeper
      top-10 leaderboards live on the future Awards page (Epic #370). */
+  /* Awards Race renders as a single bordered .panel per design — header
+     row with title + right-aligned timestamp, then the 3 contender
+     columns separated by vertical dividers (no per-card border, no
+     per-card radius). */
   .awards-race {
     margin-bottom: 20px;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-md);
+    overflow: hidden;
   }
 
   .awards-race__header {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
-    margin-bottom: 12px;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--line);
   }
 
   .awards-race__title {
@@ -913,8 +924,7 @@
     color: var(--ink);
   }
 
-  .awards-race__subtitle {
-    margin: 0;
+  .awards-race__meta {
     font-family: var(--sans);
     font-size: 12px;
     color: var(--ink-3);
@@ -923,7 +933,6 @@
   .awards-race__grid {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 12px;
   }
 
   @media (min-width: 768px) {
@@ -936,11 +945,30 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
-    padding: 16px 18px;
-    background-color: var(--surface);
-    border: 1px solid var(--line);
-    border-radius: var(--rds-radius-md);
-    box-shadow: var(--rds-shadow-sm);
+    padding: 16px;
+    background-color: transparent;
+    border-right: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  @media (min-width: 768px) {
+    .awards-race-card {
+      border-bottom: none;
+    }
+    .awards-race-card:last-child {
+      border-right: none;
+    }
+  }
+
+  @media (max-width: 767px) {
+    .awards-race-card:last-child {
+      border-bottom: none;
+    }
+    .awards-race-card {
+      border-right: none;
+    }
   }
 
   .awards-race-card__header {


### PR DESCRIPTION
Renders the Awards Race as one bordered panel with title + right-aligned 'Updated <date>' timestamp, three columns separated by dividers — matching design 01-districts.png. Replaces the previous 3-standalone-cards layout.

Tests: 13/13 AwardsRaceSection green; 2085/2085 full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)