### PR TITLE
fix(district): rename heading to 'Distinguished District Status' per design

### DIFF
--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -112,7 +112,7 @@ export const DistinguishedDistrictTrophyCase: React.FC<
       <div className="flex items-start justify-between gap-4 mb-4">
         <div>
           <h2 className="text-lg font-bold text-gray-900 font-tm-headline mb-1">
-            District Recognition
+            Distinguished District Status
           </h2>
           <p className="text-sm text-gray-500 font-tm-body">
             Distinguished District Program (Item 1490)


### PR DESCRIPTION
Single-line copy change to match design 02-district-detail.png. Tests: 2084/2084 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)