### PR TITLE
feat(districts): region filter — solo-select + state badge (#434)

### DIFF
--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -677,49 +677,74 @@ const DistrictsPage: React.FC = () => {
             </button>
           </div>
 
-          {/* Region Filter — pill toggle bar (#326) */}
-          <div className="districts-toolbar__row">
-            <span className="districts-toolbar__label">Regions:</span>
-            <button
-              onClick={() => setSelectedRegions([])}
-              className={`districts-toolbar__region-chip${selectedRegions.length === 0 ? ' districts-toolbar__region-chip--active' : ''}`}
-            >
-              All
-            </button>
-            {regions.map(region => {
-              const isActive = selectedRegions.includes(region)
-              return (
+          {/* Region Filter — solo-select pill bar (#434).
+              Plain click = solo that region; click again = back to all.
+              Shift-click = additive toggle. The "All" pill explicitly
+              selects every region and is the active state when no
+              filtering is happening. */}
+          {(() => {
+            const isAllActive =
+              regions.length > 0 &&
+              (selectedRegions.length === 0 ||
+                selectedRegions.length === regions.length)
+            const handleRegionClick = (region: string, shiftKey: boolean) => {
+              if (shiftKey) {
+                setSelectedRegions(
+                  selectedRegions.includes(region)
+                    ? selectedRegions.filter(r => r !== region)
+                    : [...selectedRegions, region]
+                )
+                return
+              }
+              const isSoloActive =
+                selectedRegions.length === 1 && selectedRegions[0] === region
+              setSelectedRegions(isSoloActive ? regions : [region])
+            }
+            const stateLabel = isAllActive
+              ? 'Showing all regions'
+              : selectedRegions.length === 1
+                ? `Showing region ${selectedRegions[0]} only`
+                : `Showing ${selectedRegions.length} of ${regions.length} regions`
+            return (
+              <div className="districts-toolbar__row">
+                <span className="districts-toolbar__label">Regions:</span>
                 <button
-                  key={region}
-                  onClick={() => {
-                    if (isActive) {
-                      const next = selectedRegions.filter(r => r !== region)
-                      setSelectedRegions(next)
-                    } else {
-                      setSelectedRegions([...selectedRegions, region])
-                    }
-                  }}
-                  className={`districts-toolbar__region-chip${isActive ? ' districts-toolbar__region-chip--active' : ''}`}
-                  aria-pressed={isActive}
-                  aria-label={`Region ${region}`}
+                  type="button"
+                  onClick={() => setSelectedRegions(regions)}
+                  className={`districts-toolbar__region-chip${isAllActive ? ' districts-toolbar__region-chip--active' : ''}`}
+                  aria-pressed={isAllActive}
                 >
-                  {region}
+                  All
                 </button>
-              )
-            })}
-            {selectedRegions.length > 0 &&
-              selectedRegions.length < regions.length && (
+                {regions.map(region => {
+                  const isActive = selectedRegions.includes(region)
+                  return (
+                    <button
+                      key={region}
+                      type="button"
+                      onClick={e => handleRegionClick(region, e.shiftKey)}
+                      className={`districts-toolbar__region-chip${isActive && !isAllActive ? ' districts-toolbar__region-chip--active' : ''}`}
+                      aria-pressed={isActive && !isAllActive}
+                      aria-label={`Region ${region}`}
+                      title="Click to isolate · shift-click to add"
+                    >
+                      {region}
+                    </button>
+                  )
+                })}
                 <span
+                  className="districts-toolbar__region-state"
                   style={{
                     fontSize: 12,
                     color: 'var(--ink-3)',
                     marginLeft: 4,
                   }}
                 >
-                  {filteredRankings.length} districts
+                  {stateLabel}
                 </span>
-              )}
-          </div>
+              </div>
+            )
+          })()}
         </div>
 
         {/* Search Bar */}

--- a/frontend/src/pages/__tests__/DistrictsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.test.tsx
@@ -543,3 +543,124 @@ describe('DistrictsPage - Layout Order (#83)', () => {
     expect(regionPills.length).toBeGreaterThan(0)
   })
 })
+
+// ============================================================
+// Region filter — solo-select pattern (#434)
+// ============================================================
+describe('DistrictsPage - Region filter solo-select (#434)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Multi-region fixture — three districts in three different regions so we
+  // can verify solo-isolation actually filters the table.
+  const setupThreeRegions = () => {
+    const baseRow = (
+      i: number,
+      region: string
+    ): import('../../services/cdn').AllDistrictsRanking => ({
+      districtId: `D${i}`,
+      districtName: `District ${i}`,
+      region,
+      paidClubs: 100,
+      paidClubBase: 90,
+      clubGrowthPercent: 0,
+      totalPayments: 5000,
+      paymentBase: 4500,
+      paymentGrowthPercent: 0,
+      activeClubs: 100,
+      distinguishedClubs: 50,
+      selectDistinguished: 20,
+      presidentsDistinguished: 10,
+      distinguishedPercent: 50,
+      clubsRank: i,
+      paymentsRank: i,
+      distinguishedRank: i,
+      aggregateScore: 300 - i,
+    })
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [baseRow(1, '1'), baseRow(2, '2'), baseRow(3, '3')],
+      date: '2025-11-22',
+    })
+  }
+
+  it('clicking a region pill enters solo mode — only that region remains', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    setupThreeRegions()
+    renderWithProviders(<DistrictsPage />)
+
+    await screen.findByText('District 1')
+    expect(screen.getByText('District 2')).toBeInTheDocument()
+    expect(screen.getByText('District 3')).toBeInTheDocument()
+
+    const region2Pill = screen.getByRole('button', { name: 'Region 2' })
+    fireEvent.click(region2Pill)
+
+    // Only District 2 (region 2) should remain in the table
+    expect(screen.queryByText('District 1')).not.toBeInTheDocument()
+    expect(screen.getByText('District 2')).toBeInTheDocument()
+    expect(screen.queryByText('District 3')).not.toBeInTheDocument()
+
+    // Pill is marked active
+    expect(region2Pill).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('clicking the active solo pill returns to all regions', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    setupThreeRegions()
+    renderWithProviders(<DistrictsPage />)
+
+    await screen.findByText('District 1')
+    const region2Pill = screen.getByRole('button', { name: 'Region 2' })
+
+    // Solo Region 2
+    fireEvent.click(region2Pill)
+    expect(screen.queryByText('District 1')).not.toBeInTheDocument()
+
+    // Click again — back to all
+    fireEvent.click(region2Pill)
+    expect(screen.getByText('District 1')).toBeInTheDocument()
+    expect(screen.getByText('District 2')).toBeInTheDocument()
+    expect(screen.getByText('District 3')).toBeInTheDocument()
+  })
+
+  it('shift-click adds a region to the current solo selection (additive)', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    setupThreeRegions()
+    renderWithProviders(<DistrictsPage />)
+
+    await screen.findByText('District 1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Region 2' }))
+    expect(screen.queryByText('District 3')).not.toBeInTheDocument()
+
+    // Shift-click Region 3 — add without removing Region 2
+    fireEvent.click(screen.getByRole('button', { name: 'Region 3' }), {
+      shiftKey: true,
+    })
+    expect(screen.getByText('District 2')).toBeInTheDocument()
+    expect(screen.getByText('District 3')).toBeInTheDocument()
+    expect(screen.queryByText('District 1')).not.toBeInTheDocument()
+  })
+
+  it('renders a state badge that reflects the current selection', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    setupThreeRegions()
+    renderWithProviders(<DistrictsPage />)
+
+    await screen.findByText('District 1')
+
+    // Default: showing all regions
+    expect(screen.getByText(/showing all regions/i)).toBeInTheDocument()
+
+    // Solo Region 2
+    fireEvent.click(screen.getByRole('button', { name: 'Region 2' }))
+    expect(screen.getByText(/showing region 2 only/i)).toBeInTheDocument()
+
+    // Shift-click Region 3 → 2 of 3 selected
+    fireEvent.click(screen.getByRole('button', { name: 'Region 3' }), {
+      shiftKey: true,
+    })
+    expect(screen.getByText(/showing 2 of 3 regions/i)).toBeInTheDocument()
+  })
+})

--- a/tasks/founder-20-sprint-plan-2026-05-10.md
+++ b/tasks/founder-20-sprint-plan-2026-05-10.md
@@ -32,6 +32,7 @@ After the surface is clean and the redesign is finished, Sprints 14–17 add the
 | 4   | #436  | Swap Rank/District columns + standalone district click target | Click affordance broken on the rankings table            |
 | 5   | #437  | Tab discoverability (Clubs / Divisions / Trends / Analytics)  | Most of District value hidden behind under-weighted tabs |
 | 6   | #438  | District Membership Trend methodology + tooltips              | Trust gap on the central trends chart                    |
+| 6.5 | #442  | Drop redundant 'Districts' breadcrumb crumb (duplicates nav)  | Flagship-page chrome bug; small fix, big visual win      |
 
 ### Tier A2 — Methodology corrections (Sprint 7)
 
@@ -82,6 +83,7 @@ These are valid but lower priority than the 20 sprints above. Re-evaluate after 
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | #371, #372, #373                       | Awards page suite — net-new IA, less urgent than fixing the surfaces leaders already use                                             |
 | #429 (#430 + #431 + #432, closes #407) | Find-A-Club enrichment — bumped from Sprint 20 by methodology corrections; net-new data, lower urgency than fixing existing surfaces |
+| #443 epic (#444–#449)                  | Club anniversaries — depends on #429 charter date; ship as a follow-on sprint cluster once Find-A-Club data lands                    |
 | #427                                   | Print stylesheet — niche workflow                                                                                                    |
 | #384                                   | Tablist arrow-key a11y — adjacent to #437 (Sprint 5); revisit if not naturally absorbed                                              |
 | #340, #375                             | setState-in-effect fixes + dependabot bumps — unblock dev-deps after feature work stabilises                                         |


### PR DESCRIPTION
## Summary
- Plain click on a region pill now isolates that region (solo). Click the active solo pill to return to all. Shift-click stays additive.
- 'All' pill explicitly selects every region and is the active state when no filtering is happening.
- Visible state badge: 'Showing all regions' / 'Showing region N only' / 'Showing N of M regions'.

Closes #434.

## Why

User reported: "Region buttons are still 'click 13 buttons off, so that you can see the one region you want'." The old toggle behavior required N-1 clicks to isolate one region. Solo-select drops it to 1 click; shift-click preserves the multi-select for power users.

## Test plan
- [x] Unit tests: solo-select, click-again-restores, shift-click-additive, state badge copy
- [x] Full frontend suite: 2100/2100 (4 new)
- [x] Existing region pill bar test (#326) still passes
- [ ] Live verify on https://ts.taverns.red after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)