### PR TITLE
feat(districts): rankings table — District first + standalone number chip (#436)

### DIFF
--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -891,11 +891,13 @@ const DistrictsPage: React.FC = () => {
             <table className="districts-rankings-table">
               <thead>
                 <tr>
+                  {/* District first (#436) — primary entity reads left-to-right.
+                      Rank moves to second column. */}
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-0 z-10">
-                    Rank
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-[72px] z-10 sticky-column-shadow">
                     District
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-[200px] z-10 sticky-column-shadow">
+                    Rank
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Region
@@ -932,50 +934,18 @@ const DistrictsPage: React.FC = () => {
                         isPinned ? 'bg-blue-50' : ''
                       }`}
                     >
+                      {/* District cell first (#436) — primary entity. The
+                          number is rendered as a standalone chip so the
+                          click affordance reads as obviously interactive. */}
                       <td className="px-6 py-4 whitespace-nowrap sticky left-0 z-10 bg-white">
-                        <div className="flex items-center gap-2">
-                          <button
-                            onClick={e => {
-                              e.stopPropagation()
-                              togglePin(district.districtId)
-                            }}
-                            disabled={pinDisabled}
-                            aria-label={
-                              isPinned
-                                ? `Unpin District ${district.districtId}`
-                                : `Pin District ${district.districtId}`
-                            }
-                            className={`flex-shrink-0 w-6 h-6 flex items-center justify-center rounded transition-colors ${
-                              isPinned
-                                ? 'text-tm-loyal-blue hover:text-red-500'
-                                : pinDisabled
-                                  ? 'text-gray-300 cursor-not-allowed'
-                                  : 'text-gray-400 hover:text-tm-loyal-blue'
-                            }`}
-                          >
-                            <svg
-                              className="w-4 h-4"
-                              fill={isPinned ? 'currentColor' : 'none'}
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
-                              />
-                            </svg>
-                          </button>
+                        <div className="flex items-center gap-3 flex-wrap">
                           <span
-                            className={`inline-flex items-center justify-center w-10 h-10 rounded-full font-bold ${getRankBadgeColor(rank)}`}
+                            data-testid={`district-number-chip-D${district.districtId}`}
+                            className="districts-rankings-table__district-chip"
+                            aria-hidden="true"
                           >
-                            {rank}
+                            D{district.districtId}
                           </span>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap sticky left-[72px] z-10 bg-white sticky-column-shadow">
-                        <div className="flex items-center gap-2 flex-wrap">
                           <span className="text-sm font-medium text-gray-900">
                             {district.districtName}
                           </span>
@@ -1034,6 +1004,51 @@ const DistrictsPage: React.FC = () => {
                         </div>
                         <div className="text-sm text-gray-500">
                           {district.activeClubs} active clubs
+                        </div>
+                      </td>
+                      {/* Rank cell — now second column (#436). Pin button
+                          stays adjacent to rank badge for symmetry with
+                          the existing comparison-pin UX. */}
+                      <td className="px-6 py-4 whitespace-nowrap sticky left-[200px] z-10 bg-white sticky-column-shadow">
+                        <div className="flex items-center gap-2">
+                          <button
+                            onClick={e => {
+                              e.stopPropagation()
+                              togglePin(district.districtId)
+                            }}
+                            disabled={pinDisabled}
+                            aria-label={
+                              isPinned
+                                ? `Unpin District ${district.districtId}`
+                                : `Pin District ${district.districtId}`
+                            }
+                            className={`flex-shrink-0 w-6 h-6 flex items-center justify-center rounded transition-colors ${
+                              isPinned
+                                ? 'text-tm-loyal-blue hover:text-red-500'
+                                : pinDisabled
+                                  ? 'text-gray-300 cursor-not-allowed'
+                                  : 'text-gray-400 hover:text-tm-loyal-blue'
+                            }`}
+                          >
+                            <svg
+                              className="w-4 h-4"
+                              fill={isPinned ? 'currentColor' : 'none'}
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+                              />
+                            </svg>
+                          </button>
+                          <span
+                            className={`inline-flex items-center justify-center w-10 h-10 rounded-full font-bold ${getRankBadgeColor(rank)}`}
+                          >
+                            {rank}
+                          </span>
                         </div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">

--- a/frontend/src/pages/__tests__/DistrictsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.test.tsx
@@ -556,7 +556,7 @@ describe('DistrictsPage - Rankings column order (#436)', () => {
     mockedFetchCdnRankings.mockResolvedValueOnce({
       rankings: [
         {
-          districtId: 'D61',
+          districtId: '61',
           districtName: 'District 61',
           region: '7',
           paidClubs: 100,

--- a/frontend/src/pages/__tests__/DistrictsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.test.tsx
@@ -545,6 +545,70 @@ describe('DistrictsPage - Layout Order (#83)', () => {
 })
 
 // ============================================================
+// Rankings table — column order + click affordance (#436)
+// ============================================================
+describe('DistrictsPage - Rankings column order (#436)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const setupSingleRow = () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        {
+          districtId: 'D61',
+          districtName: 'District 61',
+          region: '7',
+          paidClubs: 100,
+          paidClubBase: 90,
+          clubGrowthPercent: 11.1,
+          totalPayments: 5000,
+          paymentBase: 4500,
+          paymentGrowthPercent: 11.1,
+          activeClubs: 100,
+          distinguishedClubs: 50,
+          selectDistinguished: 20,
+          presidentsDistinguished: 10,
+          distinguishedPercent: 50,
+          clubsRank: 1,
+          paymentsRank: 1,
+          distinguishedRank: 1,
+          aggregateScore: 300,
+        },
+      ],
+      date: '2025-11-22',
+    })
+  }
+
+  it('renders District as the leftmost column header (before Rank)', async () => {
+    setupSingleRow()
+    renderWithProviders(<DistrictsPage />)
+
+    await screen.findByText('District 61')
+
+    const headers = screen.getAllByRole('columnheader')
+    const headerTexts = headers.map(h => h.textContent?.trim() ?? '')
+    const districtIdx = headerTexts.findIndex(t => /^district$/i.test(t))
+    const rankIdx = headerTexts.findIndex(t => /^rank$/i.test(t))
+    expect(districtIdx).toBeGreaterThanOrEqual(0)
+    expect(rankIdx).toBeGreaterThan(districtIdx)
+  })
+
+  it('renders the district number as a standalone visual chip (#436)', async () => {
+    setupSingleRow()
+    renderWithProviders(<DistrictsPage />)
+
+    await screen.findByText('District 61')
+
+    // The number "61" should appear as its own element (chip) — not just
+    // inline within "District 61"
+    const chip = screen.getByTestId('district-number-chip-D61')
+    expect(chip).toBeInTheDocument()
+    expect(chip.textContent).toMatch(/61/)
+  })
+})
+
+// ============================================================
 // Region filter — solo-select pattern (#434)
 // ============================================================
 describe('DistrictsPage - Region filter solo-select (#434)', () => {

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -643,6 +643,25 @@
     overflow: hidden;
   }
 
+  /* District-number chip on each ranking row (#436). Standalone visual
+     element so the click affordance reads as obviously interactive. */
+  .districts-rankings-table__district-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 48px;
+    padding: 4px 10px;
+    background-color: var(--loyal-50);
+    color: var(--loyal-600);
+    border: 1px solid var(--loyal-200);
+    border-radius: var(--rds-radius-sm);
+    font-family: var(--sans);
+    font-size: 13px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.02em;
+  }
+
   .districts-rankings-table {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
## Summary
Per live user feedback ('Still not obvious to click on a district once you have searched it. Can the rank and District columns be switched, and the District number be stand alone?'):

- District is now the leftmost column. Rank moves to second position. Same ordering in head + body.
- District number renders as a styled chip (\`D61\` pill) at the start of the District cell, visually separated from the district name. Reads as obviously interactive.
- Sticky offsets: District cell at left-0 (200px wide), Rank cell at left-200px.
- Pin button stays adjacent to rank badge (no comparison-pin UX disruption).
- \`data-testid='district-number-chip-D<id>'\` for stable test targeting.

Closes #436.

## Test plan
- [x] Headers in DOM order: District before Rank
- [x] District number chip renders with stable test-id
- [x] Existing tests still pass: 2106/2106
- [x] Pin button click stops propagation (no row navigation)
- [ ] Live verify on https://ts.taverns.red after deploy — visual check at 375px / 768px / 1280px

🤖 Generated with [Claude Code](https://claude.com/claude-code)