### PR TITLE
feat(district-tabs): discoverability — bigger, bolder, hover preview (#437)

### DIFF
--- a/frontend/src/components/__tests__/DistrictDetailTabs.test.tsx
+++ b/frontend/src/components/__tests__/DistrictDetailTabs.test.tsx
@@ -124,4 +124,39 @@ describe('DistrictDetailTabs (#359)', () => {
       expect(stripped).toMatch(/min-height\s*:\s*44px\s*;/)
     })
   })
+
+  describe('discoverability (#437)', () => {
+    const css = readFileSync(
+      resolve(__dirname, '../../styles/components/app-shell.css'),
+      'utf-8'
+    )
+
+    it('uses font-size 14px (up from 13px) for legibility', () => {
+      const rule = css.match(
+        /\.district-detail-tabs__tab\s*\{([\s\S]*?)\n\s*\}/
+      )
+      const stripped = (rule?.[1] ?? '').replace(/\/\*[\s\S]*?\*\//g, '')
+      expect(stripped).toMatch(/font-size\s*:\s*14px\s*;/)
+    })
+
+    it('uses border-bottom-width 3px on the active tab (up from 2px)', () => {
+      const activeRule = css.match(
+        /\.district-detail-tabs__tab\[aria-selected='true'\]\s*\{([\s\S]*?)\n\s*\}/
+      )
+      const stripped = (activeRule?.[1] ?? '').replace(/\/\*[\s\S]*?\*\//g, '')
+      expect(stripped).toMatch(/border-bottom-width\s*:\s*3px\s*;/)
+    })
+
+    it('hover state preserves underline preview to advertise interactivity', () => {
+      const hoverRule = css.match(
+        /\.district-detail-tabs__tab:hover\s*\{([\s\S]*?)\n\s*\}/
+      )
+      const stripped = (hoverRule?.[1] ?? '').replace(/\/\*[\s\S]*?\*\//g, '')
+      // Hover should have a background-color OR a border-bottom hint to
+      // advertise interactivity beyond a color shift.
+      expect(
+        /background-color\s*:|border-bottom-color\s*:/.test(stripped)
+      ).toBe(true)
+    })
+  })
 })

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -1301,27 +1301,34 @@
        the explicit class assertion that was removed during the test
        migration). */
     min-height: 44px;
-    padding: 14px 16px;
+    padding: 14px 18px;
     margin-bottom: -1px;
     border: 0;
     background: transparent;
     color: var(--ink-2);
     font-family: var(--serif);
-    font-weight: 600;
-    font-size: 13px;
+    font-weight: 700;
+    font-size: 14px;
     white-space: nowrap;
     cursor: pointer;
-    border-bottom: 2px solid transparent;
-    transition: color 150ms ease, border-color 150ms ease;
+    border-bottom: 3px solid transparent;
+    transition: color 150ms ease, background-color 150ms ease,
+      border-color 150ms ease;
   }
 
+  /* Discoverability bumps (#437): hover gets a subtle bg-tint + a 50%
+     underline preview so users can see the tab is interactive before
+     they click. */
   .district-detail-tabs__tab:hover {
     color: var(--ink);
+    background-color: var(--surface-2);
+    border-bottom-color: var(--loyal-200);
   }
 
   .district-detail-tabs__tab[aria-selected='true'] {
     color: var(--loyal-500);
     border-bottom-color: var(--loyal-500);
+    border-bottom-width: 3px;
   }
 
   .district-detail-tabs__count {


### PR DESCRIPTION
## Summary
Per live user feedback ('I personally don't notice the club, Area and Division, Trends Analytics as options'):

CSS-only bumps to the District Detail tab bar — component API unchanged.

- font-size 13px → 14px
- font-weight 600 → 700
- padding 14px 16px → 14px 18px
- active underline 2px → 3px
- new hover state: subtle bg-tint + 50%-opacity underline preview so interactivity is visible *before* the click

Closes #437.

## Test plan
- [x] CSS guard tests for font-size 14px, active border 3px, hover state bg/border
- [x] All existing tab tests still pass: 12/12
- [x] Full frontend suite: 2107/2107
- [ ] Live verify on https://ts.taverns.red after deploy at 375px / 768px / 1280px / dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)