### PR TITLE
feat(membership-trend): methodology surfacing on chart + /methodology section (#438)

### DIFF
--- a/frontend/src/components/MembershipTrendChart.tsx
+++ b/frontend/src/components/MembershipTrendChart.tsx
@@ -270,11 +270,31 @@ export const MembershipTrendChart: React.FC<MembershipTrendChartProps> = ({
       aria-label="District membership trend chart"
     >
       <div className="mb-6">
-        <h2 className="text-xl font-semibold text-gray-900 font-tm-headline">
+        <h2 className="text-xl font-semibold text-gray-900 font-tm-headline flex items-center">
           District Membership Trend
+          <a
+            href="/methodology#district-membership-trend"
+            aria-label="info"
+            title="How is this calculated?"
+            className="ml-2 inline-flex items-center justify-center w-5 h-5 rounded-full text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <svg
+              className="w-3.5 h-3.5"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </a>
         </h2>
         <p className="text-sm text-gray-600 mt-1 font-tm-body">
-          Total membership over time with program year milestones
+          Paid members per snapshot · Source: Toastmasters District Performance
+          · Program-year milestones overlaid
         </p>
       </div>
 

--- a/frontend/src/components/__tests__/MembershipTrendChart.methodology.test.tsx
+++ b/frontend/src/components/__tests__/MembershipTrendChart.methodology.test.tsx
@@ -1,0 +1,43 @@
+/* District Membership Trend — methodology surfacing (#438).
+   Mounts the small chart component directly with a minimal trend
+   fixture (Lesson 51 — keep render scope tight). */
+
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { MembershipTrendChart } from '../MembershipTrendChart'
+
+const TREND = [
+  { date: '2025-07-01', count: 100 },
+  { date: '2025-08-01', count: 105 },
+  { date: '2025-09-01', count: 110 },
+]
+
+describe('MembershipTrendChart — methodology surfacing (#438)', () => {
+  it('renders a subtitle that names the metric explicitly (paid members)', () => {
+    render(<MembershipTrendChart membershipTrend={TREND} />)
+    const heading = screen.getByRole('heading', {
+      name: /district membership trend/i,
+    })
+    const panel = heading.closest('div[aria-label]') as HTMLElement
+    expect(panel).toBeTruthy()
+    // Subtitle should mention "paid members" — the actual metric being plotted
+    expect(within(panel).getByText(/paid members/i)).toBeInTheDocument()
+  })
+
+  it('subtitle cites Toastmasters District Performance as the source', () => {
+    render(<MembershipTrendChart membershipTrend={TREND} />)
+    expect(
+      screen.getByText(/Toastmasters District Performance/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders an info link to /methodology#district-membership-trend', () => {
+    render(<MembershipTrendChart membershipTrend={TREND} />)
+    const infoLink = screen.getByRole('link', { name: /^info$/i })
+    expect(infoLink).toBeInTheDocument()
+    expect(infoLink.getAttribute('href')).toBe(
+      '/methodology#district-membership-trend'
+    )
+  })
+})

--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -12,9 +12,14 @@ const SECTIONS: ReadonlyArray<{ id: string; num: string; title: string }> = [
   { id: 'borda-count', num: '03', title: 'Borda count scoring' },
   { id: 'dcp-tiers', num: '04', title: 'DCP tier definitions' },
   { id: 'club-health', num: '05', title: 'Club health classifications' },
-  { id: 'glossary', num: '06', title: 'Glossary' },
-  { id: 'caveats', num: '07', title: 'Caveats & known issues' },
-  { id: 'changelog', num: '08', title: 'Changelog' },
+  {
+    id: 'district-membership-trend',
+    num: '06',
+    title: 'District Membership Trend',
+  },
+  { id: 'glossary', num: '07', title: 'Glossary' },
+  { id: 'caveats', num: '08', title: 'Caveats & known issues' },
+  { id: 'changelog', num: '09', title: 'Changelog' },
 ]
 
 const MethodologyPage: React.FC = () => {
@@ -177,9 +182,54 @@ const MethodologyPage: React.FC = () => {
         </p>
       </section>
 
-      <section id="glossary" className="methodology-section">
+      <section id="district-membership-trend" className="methodology-section">
         <h2 className="methodology-section__title">
           <span className="methodology-section__num">06</span>
+          District Membership Trend
+        </h2>
+        <p>
+          The chart on the District Detail · Trends tab plots a single metric:
+          the district&apos;s <strong>total paid members</strong> at each
+          snapshot date during the selected program year (Jul 1 – Jun 30).
+        </p>
+        <ul>
+          <li>
+            <strong>Source.</strong> The raw value comes from the Toastmasters
+            District Performance dashboard — the same source the Toastmasters
+            International office uses for monthly published rankings.
+          </li>
+          <li>
+            <strong>Snapshot frequency.</strong> Toast Stats prunes to one
+            snapshot per month (typically the last business day&apos;s data).
+            Daily snapshots before pruning are not retained.
+          </li>
+          <li>
+            <strong>Program-year scope.</strong> The default chart shows the
+            currently selected program year. Use the program-year selector to
+            inspect prior years.
+          </li>
+          <li>
+            <strong>Comparison series.</strong> Prior-year data is overlaid as a
+            faint reference line so you can visually compare YoY growth at the
+            same calendar week.
+          </li>
+          <li>
+            <strong>Y-axis.</strong> &quot;Paid Members&quot; — count of members
+            with current paid memberships, NOT a payment count (members
+            typically pay twice per year, so payment count ≈ 2× member count
+            over a full year).
+          </li>
+        </ul>
+        <p>
+          Growth and decline period overlays in the chart are computed from
+          consecutive month-over-month deltas; the threshold and detection logic
+          live in <code>frontend/src/components/MembershipTrendChart.tsx</code>.
+        </p>
+      </section>
+
+      <section id="glossary" className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">07</span>
           Glossary
         </h2>
         <dl className="methodology-glossary">
@@ -217,7 +267,7 @@ const MethodologyPage: React.FC = () => {
 
       <section id="caveats" className="methodology-section">
         <h2 className="methodology-section__title">
-          <span className="methodology-section__num">07</span>
+          <span className="methodology-section__num">08</span>
           Caveats &amp; known issues
         </h2>
         <ul>
@@ -242,7 +292,7 @@ const MethodologyPage: React.FC = () => {
 
       <section id="changelog" className="methodology-section">
         <h2 className="methodology-section__title">
-          <span className="methodology-section__num">08</span>
+          <span className="methodology-section__num">09</span>
           Changelog
         </h2>
         <p>


### PR DESCRIPTION
## Summary
Per live user feedback ('In the trends, what is the District Membership Trend? It seems there is no real method to measuring this?'):

- Chart subtitle now names the metric explicitly: 'Paid members per snapshot · Source: Toastmasters District Performance · Program-year milestones overlaid'.
- New (i) info icon next to the chart title links to /methodology#district-membership-trend.
- New /methodology section 06 'District Membership Trend' explains source, snapshot frequency, program-year scope, comparison series, y-axis units.
- Glossary / Caveats / Changelog renumbered (07/08/09 from 06/07/08).

Closes #438.

## Test plan
- [x] Subtitle mentions 'paid members'
- [x] Subtitle cites 'Toastmasters District Performance'
- [x] Info link points to /methodology#district-membership-trend
- [x] Full frontend suite: 2112/2112
- [ ] Live verify on https://ts.taverns.red/district/61?tab=trends + /methodology#district-membership-trend after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)