### PR TITLE
fix(breadcrumbs): drop redundant top-level crumb on district + club detail (#442)

### DIFF
--- a/frontend/src/components/DistrictDetailHeader.tsx
+++ b/frontend/src/components/DistrictDetailHeader.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback } from 'react'
-import { Link } from 'react-router-dom'
 import { ProgramYearSelector } from './ProgramYearSelector'
 import { DistrictExportButton } from './DistrictExportButton'
 import type { ProgramYear } from '../utils/programYear'
@@ -37,24 +36,11 @@ export const DistrictDetailHeader: React.FC<DistrictDetailHeaderProps> = ({
 }) => {
   return (
     <>
-      <nav aria-label="Breadcrumb" className="district-detail-breadcrumbs">
-        <Link to="/" className="district-detail-breadcrumbs__link">
-          Districts
-        </Link>
-        <span
-          aria-hidden="true"
-          className="district-detail-breadcrumbs__separator"
-        >
-          ›
-        </span>
-        <span
-          aria-current="page"
-          className="district-detail-breadcrumbs__current"
-        >
-          {districtName}
-        </span>
-      </nav>
-
+      {/* Breadcrumb removed per #442 — duplicated the AppShell's active
+          'Districts' nav tab and the H1 below. The active nav + H1 give
+          the user their location without redundant chrome. The
+          breadcrumb on Club Detail still provides 'back to district'
+          navigation since AppShell has no Club tab. */}
       <div className="district-detail-page-header">
         <div className="district-detail-page-header__intro">
           <p className="district-detail-page-header__eyebrow">

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -395,23 +395,25 @@ const ClubDetailPage: React.FC = () => {
     <ErrorBoundary>
       <div className="min-h-screen">
         <div className="container mx-auto px-4 py-4 sm:py-8">
-          {/* Breadcrumbs */}
+          {/* Breadcrumbs — leading 'Home' crumb removed per #442 (the
+              AppShell's 'Districts' active nav already serves as the
+              top-level location signal). Trail starts at the parent
+              district so 'back to district' navigation stays one click
+              away. */}
           <nav
             className="flex items-center gap-2 text-sm text-gray-500 mb-6 font-tm-body"
             aria-label="Breadcrumb"
           >
-            <Link to="/" className="hover:text-tm-loyal-blue transition-colors">
-              Home
-            </Link>
-            <span>›</span>
             <Link
               to={`/district/${districtId}`}
               className="hover:text-tm-loyal-blue transition-colors"
             >
               {districtName}
             </Link>
-            <span>›</span>
-            <span className="text-gray-900 font-medium">{club.clubName}</span>
+            <span aria-hidden="true">›</span>
+            <span className="text-gray-900 font-medium" aria-current="page">
+              {club.clubName}
+            </span>
           </nav>
 
           {/* Redesigned hero per handoff (#23 follow-up). Loyal-blue panel

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -130,9 +130,10 @@ describe('ClubDetailPage (#208)', () => {
       screen.getAllByText('St Lawrence Toastmasters').length
     ).toBeGreaterThanOrEqual(1)
 
-    // Breadcrumbs (the new hero also renders "District 61" in its
-    // sub-line — query for the breadcrumb anchor explicitly)
-    expect(screen.getByText('Home')).toBeInTheDocument()
+    // Breadcrumbs (#442) — leading 'Home' crumb removed; trail starts at
+    // the parent district. The new hero also renders "District 61" in
+    // its sub-line, so query the breadcrumb anchor explicitly.
+    expect(screen.queryByText('Home')).not.toBeInTheDocument()
     const breadcrumbLink = screen.getByRole('link', { name: 'District 61' })
     expect(breadcrumbLink).toHaveAttribute('href', '/district/61')
   })

--- a/frontend/src/pages/__tests__/DistrictDetailPage.redesign.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.redesign.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react'
 import { describe, it, expect } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import { MemoryRouter } from 'react-router-dom'
@@ -44,22 +44,12 @@ const renderHeader = (
 }
 
 describe('DistrictDetailHeader (#358)', () => {
-  describe('breadcrumbs', () => {
-    it('renders a Districts → District N breadcrumb trail', () => {
+  describe('breadcrumbs (#442 — removed)', () => {
+    it('does NOT render a breadcrumb (would duplicate AppShell nav + H1)', () => {
       renderHeader()
-      const nav = screen.getByRole('navigation', { name: /breadcrumb/i })
-      const districtsLink = within(nav).getByRole('link', {
-        name: /districts/i,
-      })
-      expect(districtsLink).toHaveAttribute('href', '/')
-      expect(within(nav).getByText(/district 57/i)).toBeInTheDocument()
-    })
-
-    it('marks the current crumb with aria-current="page"', () => {
-      renderHeader()
-      const nav = screen.getByRole('navigation', { name: /breadcrumb/i })
-      const current = within(nav).getByText(/district 57/i)
-      expect(current).toHaveAttribute('aria-current', 'page')
+      expect(
+        screen.queryByRole('navigation', { name: /breadcrumb/i })
+      ).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Summary
Per live user feedback ('this doesn't line up and look bad' on a screenshot showing 'Districts' above '› District 61' stacked, mismatched in size/position):

- **DistrictDetailHeader**: breadcrumb removed entirely. AppShell's 'Districts' active nav + the H1 'District N' below it already give the user their location.
- **ClubDetailPage**: leading 'Home' crumb dropped. Trail now starts at the parent district name (still a Link → /district/:id) so 'back to district' navigation stays one click away.

Closes #442.

## Test plan
- [x] District header asserts no breadcrumb nav
- [x] Club detail asserts no 'Home' text; District link still resolves to /district/61
- [x] Full frontend suite: 2108/2108
- [ ] Live verify on https://ts.taverns.red/district/61 + /district/61/club/<X> after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)