### PR TITLE
fix(methodology): correct DCP tier definitions + club health classifications (#439, #440)

### DIFF
--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -124,20 +124,21 @@ const MethodologyPage: React.FC = () => {
         <p>Distinguished Club Program tiers, in ascending order:</p>
         <ul>
           <li>
-            <strong>Distinguished</strong> — 5 of 10 DCP goals + 20+ paid
-            members or net +5 / 75% retention.
+            <strong>Distinguished</strong> — 5 of 10 DCP goals AND (20+ paid
+            members OR net growth ≥ 3).
           </li>
           <li>
-            <strong>Select Distinguished</strong> — 7 of 10 goals + same
-            membership floor.
+            <strong>Select Distinguished</strong> — 7 of 10 goals AND (20+ paid
+            members OR net growth ≥ 5).
           </li>
           <li>
-            <strong>President's Distinguished</strong> — 9 of 10 goals + same
-            membership floor.
+            <strong>President's Distinguished</strong> — 9 of 10 goals AND 20+
+            paid members. <em>No growth alternative.</em>
           </li>
           <li>
-            <strong>Smedley Award</strong> — President's Distinguished +
-            chartered new club (rare; honors club founders).
+            <strong>Smedley Distinguished</strong> — 10 of 10 goals AND 25+ paid
+            members. <em>No growth alternative.</em> New for the 2025-2026
+            program year.
           </li>
         </ul>
         <p>
@@ -145,6 +146,13 @@ const MethodologyPage: React.FC = () => {
           club can achieve goals in any order. Toast Stats reads the raw
           per-goal columns from <code>club-performance.csv</code> rather than
           inferring from a single "goals achieved" count.
+        </p>
+        <p className="methodology-source">
+          Source: <code>docs/toastmasters-rules-reference.md</code> §3.2 /
+          Toastmasters Distinguished Club Program documentation. The
+          determination logic lives in{' '}
+          <code>frontend/src/utils/dcpProjections.ts</code> (
+          <code>determineLevel</code>).
         </p>
       </section>
 
@@ -154,31 +162,43 @@ const MethodologyPage: React.FC = () => {
           Club health classifications
         </h2>
         <p>
-          Health is a Toast Stats overlay (not an official TI metric) that
-          combines membership trend + DCP progress + payment timeliness:
+          Toast Stats classifies each club into one of three mutually exclusive
+          health statuses, recomputed every snapshot from the current data
+          (never persisted as a property of the club):
         </p>
         <ul>
           <li>
-            <strong>Thriving</strong> — current paid members ≥ base, on track
-            for Distinguished or higher, no missed renewals.
+            <strong>Thriving</strong> (<code>thriving</code>) — meets all three:
+            <ul>
+              <li>
+                20+ paid members OR net growth ≥ 3 since program-year base
+              </li>
+              <li>On track for the program-month DCP checkpoint</li>
+              <li>Club Success Plan (CSP) submitted (2025-26 onward)</li>
+            </ul>
           </li>
           <li>
-            <strong>Healthy</strong> — paid members ≥ base, mid-tier DCP
-            progress, no urgent flags.
+            <strong>Vulnerable</strong> (<code>vulnerable</code>) — at least one
+            of the three Thriving requirements is unmet, but the club has not
+            crossed the intervention threshold below.
           </li>
           <li>
-            <strong>Watch</strong> — small drop below base, behind on DCP, or
-            one missed renewal cycle.
-          </li>
-          <li>
-            <strong>At-risk</strong> — sustained membership drop, two missed
-            renewal cycles, or under 8 paid members.
+            <strong>Intervention Required</strong> (
+            <code>intervention-required</code>) — paid members &lt; 12 AND net
+            growth &lt; 3 since program-year base. This rule overrides all other
+            criteria.
           </li>
         </ul>
-        <p>
-          The exact thresholds live in <code>analytics-core</code>. Health is
-          recomputed every snapshot and never persisted as a property of the
-          club — it's always a function of the current data.
+        <p className="methodology-source">
+          Source:{' '}
+          <code>
+            packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
+          </code>{' '}
+          (lines 316–360); type definition in{' '}
+          <code>packages/shared-contracts/src/types/club-health-status.ts</code>
+          . The DCP checkpoint progression by program month lives in the same
+          analytics module. Toast Stats health is a project-specific overlay,
+          not an official Toastmasters International metric.
         </p>
       </section>
 

--- a/frontend/src/pages/__tests__/MethodologyPage.test.tsx
+++ b/frontend/src/pages/__tests__/MethodologyPage.test.tsx
@@ -1,0 +1,76 @@
+/* /methodology page — content correctness against authoritative sources
+   (#439 DCP tier definitions, #440 Club health classifications). */
+
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import MethodologyPage from '../MethodologyPage'
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <MethodologyPage />
+    </MemoryRouter>
+  )
+
+describe('MethodologyPage — DCP tier definitions (#439)', () => {
+  it('Distinguished tier alt is net growth ≥ 3 (NOT 75% retention)', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toMatch(/distinguished.*net growth ≥ 3/i)
+    // The fictional '75% retention' / 'net +5 / 75% retention' wording is gone
+    expect(txt).not.toMatch(/75% retention/i)
+  })
+
+  it("Select Distinguished alt is net growth ≥ 5 (NOT 'same membership floor')", () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toMatch(/select distinguished.*net growth ≥ 5/i)
+  })
+
+  it("President's Distinguished explicitly notes no growth alternative", () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toMatch(
+      /president's distinguished[\s\S]{0,80}no growth alternative/i
+    )
+  })
+
+  it('Smedley is named "Smedley Distinguished" with 10 goals + 25 members (not "Award" + chartered new club)', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toMatch(/smedley distinguished[\s\S]{0,80}10[\s\S]{0,40}25/i)
+    expect(txt).not.toMatch(/chartered new club/i)
+  })
+})
+
+describe('MethodologyPage — Club health classifications (#440)', () => {
+  it('lists exactly three statuses (no invented "Healthy" or "Watch" or "At-risk")', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toMatch(/thriving/i)
+    expect(txt).toMatch(/vulnerable/i)
+    expect(txt).toMatch(/intervention required/i)
+    // Invented tiers must not appear in the section copy
+    expect(txt).not.toMatch(/\bhealthy\b/i)
+    expect(txt).not.toMatch(/\bwatch\b.*missed renewal/i)
+    expect(txt).not.toMatch(/under 8 paid members/i)
+  })
+
+  it('Thriving criteria mention all three actual gates: membership, DCP checkpoint, CSP', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    // Thriving text mentions all 3 requirements
+    expect(txt).toMatch(/CSP|Club Success Plan/i)
+    expect(txt).toMatch(/DCP checkpoint/i)
+    expect(txt).toMatch(/20\+ paid members.*net growth ≥ 3/i)
+  })
+
+  it('Intervention Required uses < 12 (not under 8) AND net growth < 3', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toMatch(/paid members\s*&?lt;?\s*12|paid members\s*<\s*12/i)
+    expect(txt).toMatch(/net growth\s*&?lt;?\s*3|net growth\s*<\s*3/i)
+  })
+})


### PR DESCRIPTION
## Summary
User reported sections 04 + 05 of /methodology were 'almost completely wrong' against the code/business rules.

### Section 04 — DCP tier definitions (#439)
- **Distinguished**: 5 goals + (20 members OR net growth ≥ 3) — was 'net +5 / 75% retention' (figure does not exist in the rules).
- **Select Distinguished**: 7 goals + (20 members OR net growth ≥ 5) — was 'same membership floor' (alt jumps from +3 to +5).
- **President's Distinguished**: 9 goals + 20 members. *No growth alternative.*
- **Smedley Distinguished** (the official name; was 'Smedley Award'): 10 goals + 25 members. *No growth alternative.* The 'chartered new club' attribution was wrong — that's the President's Extension Award at the district level.

### Section 05 — Club health classifications (#440)
- **Three statuses, not four**. Previous 'Healthy' / 'Watch' / 'At-risk' invented tiers that don't exist in the code.
- Actual statuses: \`thriving\` / \`vulnerable\` / \`intervention-required\`.
- Thriving requires **three** gates (membership, DCP checkpoint, CSP) — previously listed only one.
- Intervention threshold is < 12 paid members AND net growth < 3 (was 'under 8' which was simply wrong).
- Renewal cycles play no part in classification — removed.

Both sections cite their authoritative sources in the code/spec.

Closes #439, #440.

## Test plan
- [x] 7 new content-correctness assertions in MethodologyPage.test.tsx
- [x] Full frontend suite: 2119/2119
- [ ] Live verify on https://ts.taverns.red/methodology after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)