### PR TITLE
feat(comprehension): How it works rename + wire help icon + KPI/Awards-Race tooltips (#412 #410 #413)

### DIFF
--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -53,7 +53,7 @@ describe('AppShell (#354)', () => {
       expect(brand).toHaveAttribute('href', '/')
     })
 
-    it('renders nav links: Districts, History, Methodology', () => {
+    it('renders nav links: Districts, History, How it works (#412)', () => {
       renderShell()
       const nav = screen.getByRole('navigation', { name: /primary/i })
       expect(
@@ -67,7 +67,7 @@ describe('AppShell (#354)', () => {
         within(nav).getByRole('link', { name: 'History' })
       ).toHaveAttribute('href', '/history')
       expect(
-        within(nav).getByRole('link', { name: 'Methodology' })
+        within(nav).getByRole('link', { name: 'How it works' })
       ).toHaveAttribute('href', '/methodology')
     })
 
@@ -81,17 +81,27 @@ describe('AppShell (#354)', () => {
       expect(regionsLink).toHaveAttribute('aria-disabled', 'true')
     })
 
-    it('renders the top-bar tools cluster (notifications, help, avatar)', () => {
+    it('renders the top-bar tools cluster (notifications stub, help link, avatar)', () => {
       // Design shows a bell + ? + JS avatar on the right side of the
-      // top bar. They are visual stubs until auth lands.
+      // top bar. The notifications bell + avatar remain visual stubs
+      // until auth lands; the help icon is now a Link to /methodology
+      // (#410) so users have one-click access to the canonical
+      // definitions.
       renderShell()
       const header = screen.getByRole('banner')
       expect(
         within(header).getByRole('button', { name: /notifications/i })
       ).toBeInTheDocument()
-      expect(
-        within(header).getByRole('button', { name: /help/i })
-      ).toBeInTheDocument()
+      // The text 'How it works' appears twice in the header — as the
+      // primary nav link AND as the help icon's aria-label. Scope the
+      // help icon assertion to the tools cluster (everything outside the
+      // primary nav).
+      const tools = header.querySelector('.app-shell-tools') as HTMLElement
+      expect(tools).toBeInTheDocument()
+      const helpLink = within(tools).getByRole('link', {
+        name: /how it works/i,
+      })
+      expect(helpLink).toHaveAttribute('href', '/methodology')
       expect(within(header).getByLabelText(/account/i)).toBeInTheDocument()
     })
 

--- a/frontend/src/components/AppShell/AppShellTopBar.tsx
+++ b/frontend/src/components/AppShell/AppShellTopBar.tsx
@@ -5,7 +5,7 @@ const NAV_ITEMS = [
   { to: '/', label: 'Districts', end: true },
   { to: '/awards', label: 'Awards', end: false },
   { to: '/history', label: 'History', end: false },
-  { to: '/methodology', label: 'Methodology', end: false },
+  { to: '/methodology', label: 'How it works', end: false },
 ] as const
 
 const AppShellTopBar: React.FC = () => {
@@ -63,11 +63,11 @@ const AppShellTopBar: React.FC = () => {
             <path d="M6.5 13.5a1.5 1.5 0 0 0 3 0" />
           </svg>
         </button>
-        <button
-          type="button"
+        <Link
+          to="/methodology"
           className="app-shell-icon-btn"
-          aria-label="Help"
-          title="Help"
+          aria-label="How it works"
+          title="How it works"
         >
           <svg
             width="16"
@@ -82,7 +82,7 @@ const AppShellTopBar: React.FC = () => {
             <path d="M6.2 6.2a1.8 1.8 0 1 1 2.4 1.7c-.5.2-.6.5-.6.9V10" />
             <circle cx="8" cy="12" r=".4" fill="currentColor" />
           </svg>
-        </button>
+        </Link>
         <span
           className="app-shell-avatar"
           aria-label="Account (placeholder)"

--- a/frontend/src/components/AwardsRaceSection.tsx
+++ b/frontend/src/components/AwardsRaceSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import InfoTooltip from './InfoTooltip'
 import type {
   CompetitiveAwardRanking,
   CompetitiveAwardStandings,
@@ -93,6 +94,7 @@ export const AwardsRaceSection: React.FC<AwardsRaceSectionProps> = ({
       <header className="awards-race__header">
         <h2 id="awards-race-heading" className="awards-race__title">
           Awards Race · Top contenders
+          <InfoTooltip text="Top-3 districts contending for each Toastmasters competitive award this program year. Source: All-Districts CSV. See How it works for definitions." />
         </h2>
         {updatedAt && (
           <span className="awards-race__meta">Updated {updatedAt}</span>

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -577,10 +577,13 @@ const DistrictsPage: React.FC = () => {
           </div>
         </div>
 
-        {/* Global KPI strip (#356) */}
+        {/* Global KPI strip (#356, tooltips per #413) */}
         <div className="districts-kpi-strip">
           <div className="districts-kpi-card">
-            <p className="districts-kpi-card__label">Paid Clubs · Global</p>
+            <p className="districts-kpi-card__label">
+              Paid Clubs · Global
+              <InfoTooltip text="Sum of paid clubs across every tracked district worldwide. A 'paid club' has met its renewal obligations for the program year." />
+            </p>
             <div
               className="districts-kpi-card__value"
               data-testid="kpi-paid-clubs"
@@ -589,7 +592,10 @@ const DistrictsPage: React.FC = () => {
             </div>
           </div>
           <div className="districts-kpi-card">
-            <p className="districts-kpi-card__label">Total Payments</p>
+            <p className="districts-kpi-card__label">
+              Total Payments
+              <InfoTooltip text="Year-to-date membership payment count summed across every tracked district. Members typically pay twice/year so this approximately doubles total membership over a full program year." />
+            </p>
             <div
               className="districts-kpi-card__value"
               data-testid="kpi-total-payments"
@@ -598,7 +604,10 @@ const DistrictsPage: React.FC = () => {
             </div>
           </div>
           <div className="districts-kpi-card">
-            <p className="districts-kpi-card__label">Distinguished Clubs</p>
+            <p className="districts-kpi-card__label">
+              Distinguished Clubs
+              <InfoTooltip text="Clubs at Distinguished tier or higher (Distinguished / Select / President's / Smedley). See How it works for tier definitions." />
+            </p>
             <div
               className="districts-kpi-card__value"
               data-testid="kpi-distinguished-clubs"
@@ -607,7 +616,10 @@ const DistrictsPage: React.FC = () => {
             </div>
           </div>
           <div className="districts-kpi-card">
-            <p className="districts-kpi-card__label">Districts Tracked</p>
+            <p className="districts-kpi-card__label">
+              Districts Tracked
+              <InfoTooltip text="Number of districts in the current snapshot. Toastmasters has 117 districts worldwide; this counts those with usable data in the most recent rankings file." />
+            </p>
             <div
               className="districts-kpi-card__value"
               data-testid="kpi-districts-tracked"


### PR DESCRIPTION
## Summary
Sprint 15 — first slice of the comprehension polish bundle.

### #412 Rename 'Methodology' → 'How it works'
Top-bar nav label flips. Route stays \`/methodology\` (no breaking changes for existing links / bookmarks).

### #410 Wire the help icon
Top-bar help (?) icon was an inert \`<button>\`. Now a \`<Link to="/methodology">\` with matching \`aria-label="How it works"\` and \`title\`. One-click access to canonical definitions from anywhere.

### #413 KPI + Awards Race tooltips
Added (i) tooltips to:
- Paid Clubs · Global
- Total Payments
- Distinguished Clubs
- Districts Tracked
- Awards Race section header

Each tooltip cites the data source / definition; complex ones link to How it works.

### #414 Status
Already shipped — the rankings table columns (Paid Clubs / Total Payments / Distinguished / Score) carry InfoTooltips today. Issue can be closed alongside this PR.

## Test plan
- [x] AppShell test renames assertion to 'How it works'; help-icon assertion scoped to tools cluster
- [x] Full frontend suite: 2118/2118
- [ ] Live verify on https://ts.taverns.red after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)