### PR TITLE
feat(districts): localStorage primitive + my-district sticky pin (#420 #417)

### DIFF
--- a/frontend/src/hooks/useMyDistrict.ts
+++ b/frontend/src/hooks/useMyDistrict.ts
@@ -1,0 +1,38 @@
+/* My District (#417) — single district the viewer has pinned as 'theirs'.
+   Sticky-pin to the top of the rankings table on the Districts page;
+   foundation for future 'my dashboard' style features. */
+
+import { useCallback, useEffect, useState } from 'react'
+import { readJson, writeJson, removeKey } from '../utils/localStorageStore'
+
+const STORAGE_NAME = 'my-district-id'
+
+export function useMyDistrict(): {
+  myDistrictId: string | null
+  setMyDistrict: (id: string | null) => void
+  isMyDistrict: (id: string) => boolean
+} {
+  const [myDistrictId, setMyDistrictIdState] = useState<string | null>(() =>
+    readJson<string | null>(STORAGE_NAME, null)
+  )
+
+  // Sync to localStorage whenever the value changes (after first render).
+  useEffect(() => {
+    if (myDistrictId === null) {
+      removeKey(STORAGE_NAME)
+    } else {
+      writeJson(STORAGE_NAME, myDistrictId)
+    }
+  }, [myDistrictId])
+
+  const setMyDistrict = useCallback((id: string | null) => {
+    setMyDistrictIdState(id)
+  }, [])
+
+  const isMyDistrict = useCallback(
+    (id: string) => myDistrictId === id,
+    [myDistrictId]
+  )
+
+  return { myDistrictId, setMyDistrict, isMyDistrict }
+}

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -14,6 +14,7 @@ import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
 import { ProgramYearSelector } from '../components/ProgramYearSelector'
 import { useRankHistory } from '../hooks/useRankHistory'
 import InfoTooltip from '../components/InfoTooltip'
+import { useMyDistrict } from '../hooks/useMyDistrict'
 import DataFreshnessBadge from '../components/DataFreshnessBadge'
 import { LazyComparisonPanel as ComparisonPanel } from '../components/LazyCharts'
 import {
@@ -36,6 +37,7 @@ const DistrictsPage: React.FC = () => {
   )
   const searchInputRef = useRef<HTMLInputElement>(null)
   const [searchFocused, setSearchFocused] = useState<boolean>(false)
+  const { myDistrictId, setMyDistrict, isMyDistrict } = useMyDistrict()
 
   // '/' keyboard shortcut focuses the search input — but only when no
   // other input is currently focused (don't steal focus while typing).
@@ -273,7 +275,7 @@ const DistrictsPage: React.FC = () => {
   )
 
   // Filter by search query (district number or name) — rank is preserved
-  const displayRankings = React.useMemo(() => {
+  const filteredRankingsBySearch = React.useMemo(() => {
     if (!searchQuery.trim()) return rankedRankings
     const query = searchQuery.trim().toLowerCase()
     return rankedRankings.filter(
@@ -282,6 +284,20 @@ const DistrictsPage: React.FC = () => {
         r.districtName.toLowerCase().includes(query)
     )
   }, [rankedRankings, searchQuery])
+
+  // Sticky-pin 'my district' to the top of the rankings table (#417).
+  // Reorder ONLY for visual placement; ranks stay correct.
+  const displayRankings = React.useMemo(() => {
+    if (!myDistrictId) return filteredRankingsBySearch
+    const myRow = filteredRankingsBySearch.find(
+      r => r.districtId === myDistrictId
+    )
+    if (!myRow) return filteredRankingsBySearch
+    const rest = filteredRankingsBySearch.filter(
+      r => r.districtId !== myDistrictId
+    )
+    return [myRow, ...rest]
+  }, [filteredRankingsBySearch, myDistrictId])
 
   // Type-ahead suggestions for the search bar (#435). Top 5 matches.
   const searchSuggestions = React.useMemo(() => {
@@ -938,19 +954,63 @@ const DistrictsPage: React.FC = () => {
                   const isPinned = pinnedDistrictIds.has(district.districtId)
                   const pinDisabled =
                     !isPinned && pinnedDistrictIds.size >= MAX_PINNED
+                  const isMine = isMyDistrict(district.districtId)
                   return (
                     <tr
                       key={district.districtId}
                       onClick={() => handleDistrictClick(district.districtId)}
                       className={`cursor-pointer ${
-                        isPinned ? 'bg-blue-50' : ''
+                        isMine
+                          ? 'bg-yellow-50 border-l-4 border-l-tm-loyal-blue'
+                          : isPinned
+                            ? 'bg-blue-50'
+                            : ''
                       }`}
                     >
                       {/* District cell first (#436) — primary entity. The
                           number is rendered as a standalone chip so the
-                          click affordance reads as obviously interactive. */}
+                          click affordance reads as obviously interactive.
+                          (#417) Star button toggles 'my district'. */}
                       <td className="px-6 py-4 whitespace-nowrap sticky left-0 z-10 bg-white">
                         <div className="flex items-center gap-3 flex-wrap">
+                          <button
+                            type="button"
+                            onClick={e => {
+                              e.stopPropagation()
+                              setMyDistrict(isMine ? null : district.districtId)
+                            }}
+                            aria-label={
+                              isMine
+                                ? `Unset District ${district.districtId} as my district`
+                                : `Set District ${district.districtId} as my district`
+                            }
+                            aria-pressed={isMine}
+                            title={
+                              isMine
+                                ? 'Click to clear · this district pins to top across visits'
+                                : 'Click to mark as my district · pins to top across visits'
+                            }
+                            className={`flex-shrink-0 w-6 h-6 inline-flex items-center justify-center rounded transition-colors ${
+                              isMine
+                                ? 'text-yellow-500 hover:text-gray-400'
+                                : 'text-gray-300 hover:text-yellow-500'
+                            }`}
+                          >
+                            <svg
+                              className="w-4 h-4"
+                              fill={isMine ? 'currentColor' : 'none'}
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                              aria-hidden="true"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
+                              />
+                            </svg>
+                          </button>
                           <span
                             data-testid={`district-number-chip-D${district.districtId}`}
                             className="districts-rankings-table__district-chip"

--- a/frontend/src/pages/__tests__/DistrictsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.test.tsx
@@ -545,6 +545,93 @@ describe('DistrictsPage - Layout Order (#83)', () => {
 })
 
 // ============================================================
+// My District — sticky-pin to top of rankings (#417)
+// ============================================================
+describe('DistrictsPage - My District sticky pin (#417)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  const setupTwoRows = () => {
+    const baseRow = (
+      i: number
+    ): import('../../services/cdn').AllDistrictsRanking => ({
+      districtId: `${i}`,
+      districtName: `District ${i}`,
+      region: '1',
+      paidClubs: 100,
+      paidClubBase: 90,
+      clubGrowthPercent: 0,
+      totalPayments: 5000,
+      paymentBase: 4500,
+      paymentGrowthPercent: 0,
+      activeClubs: 100,
+      distinguishedClubs: 50,
+      selectDistinguished: 20,
+      presidentsDistinguished: 10,
+      distinguishedPercent: 50,
+      clubsRank: i,
+      paymentsRank: i,
+      distinguishedRank: i,
+      aggregateScore: 300 - i,
+    })
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [baseRow(1), baseRow(2)],
+      date: '2025-11-22',
+    })
+  }
+
+  it('renders a my-district star button per row, defaulting to off', async () => {
+    setupTwoRows()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 1')
+    const stars = screen.getAllByRole('button', {
+      name: /set district \d+ as my district/i,
+    })
+    expect(stars.length).toBe(2)
+  })
+
+  it('clicking the star sets the district as mine and pins it to the top', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    setupTwoRows()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 1')
+
+    // District 2 starts below District 1 in rankings (rank 2 vs 1)
+    const star2 = screen.getByRole('button', {
+      name: /set district 2 as my district/i,
+    })
+    fireEvent.click(star2)
+
+    // After click, District 2 should appear before District 1 in DOM order
+    const rows = screen.getAllByRole('row')
+    const dataRows = rows.slice(1) // skip header
+    const firstDistrictText =
+      dataRows[0]?.querySelector('td:first-child')?.textContent || ''
+    expect(firstDistrictText).toMatch(/D2/)
+  })
+
+  it('persists the my-district choice to localStorage', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    setupTwoRows()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 1')
+
+    const star1 = screen.getByRole('button', {
+      name: /set district 1 as my district/i,
+    })
+    fireEvent.click(star1)
+
+    // Wait a tick for the useEffect that writes to localStorage
+    await new Promise(r => setTimeout(r, 0))
+    expect(localStorage.getItem('toast-stats:v1:my-district-id')).toBe(
+      JSON.stringify('1')
+    )
+  })
+})
+
+// ============================================================
 // Rankings table — column order + click affordance (#436)
 // ============================================================
 describe('DistrictsPage - Rankings column order (#436)', () => {

--- a/frontend/src/utils/__tests__/localStorageStore.test.ts
+++ b/frontend/src/utils/__tests__/localStorageStore.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import {
+  STORAGE_VERSION,
+  storageKey,
+  readJson,
+  writeJson,
+  removeKey,
+} from '../localStorageStore'
+
+describe('localStorageStore — versioned localStorage primitive (#420)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('storageKey', () => {
+    it('namespaces keys with toast-stats prefix and a version', () => {
+      expect(storageKey('foo')).toBe(`toast-stats:v${STORAGE_VERSION}:foo`)
+    })
+  })
+
+  describe('readJson', () => {
+    it('returns the fallback when no value is stored', () => {
+      expect(readJson('missing', { x: 1 })).toEqual({ x: 1 })
+    })
+
+    it('returns the parsed value when present', () => {
+      writeJson('greeting', { hello: 'world' })
+      expect(readJson('greeting', null)).toEqual({ hello: 'world' })
+    })
+
+    it('returns the fallback when the stored value is not valid JSON', () => {
+      localStorage.setItem(storageKey('broken'), '{not json')
+      expect(readJson('broken', 'fallback')).toBe('fallback')
+    })
+
+    it('returns the fallback if localStorage throws (e.g. private mode)', () => {
+      const spy = vi
+        .spyOn(window.localStorage, 'getItem')
+        .mockImplementation(() => {
+          throw new Error('quota exceeded')
+        })
+      try {
+        expect(readJson('foo', 'safe')).toBe('safe')
+      } finally {
+        spy.mockRestore()
+      }
+    })
+  })
+
+  describe('writeJson', () => {
+    it('writes a JSON-serialised value', () => {
+      writeJson('coords', { lat: 1, lng: 2 })
+      const raw = localStorage.getItem(storageKey('coords'))
+      expect(raw).toBe(JSON.stringify({ lat: 1, lng: 2 }))
+    })
+
+    it('swallows storage errors and returns false', () => {
+      const spy = vi
+        .spyOn(window.localStorage, 'setItem')
+        .mockImplementation(() => {
+          throw new Error('quota')
+        })
+      try {
+        expect(writeJson('foo', 1)).toBe(false)
+      } finally {
+        spy.mockRestore()
+      }
+    })
+  })
+
+  describe('removeKey', () => {
+    it('removes a stored value', () => {
+      writeJson('temp', 1)
+      removeKey('temp')
+      expect(readJson('temp', null)).toBe(null)
+    })
+  })
+})

--- a/frontend/src/utils/localStorageStore.ts
+++ b/frontend/src/utils/localStorageStore.ts
@@ -1,0 +1,38 @@
+/* Versioned localStorage primitive (#420). All persistence — favorites,
+   filters, last-visited, my-district pin — goes through this module so
+   schema migrations stay tractable. Bump STORAGE_VERSION whenever the
+   shape of any stored value changes incompatibly. */
+
+export const STORAGE_VERSION = 1
+const PREFIX = 'toast-stats'
+
+export function storageKey(name: string): string {
+  return `${PREFIX}:v${STORAGE_VERSION}:${name}`
+}
+
+export function readJson<T>(name: string, fallback: T): T {
+  try {
+    const raw = window.localStorage.getItem(storageKey(name))
+    if (raw === null) return fallback
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
+}
+
+export function writeJson(name: string, value: unknown): boolean {
+  try {
+    window.localStorage.setItem(storageKey(name), JSON.stringify(value))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function removeKey(name: string): void {
+  try {
+    window.localStorage.removeItem(storageKey(name))
+  } catch {
+    // ignore — localStorage may be disabled
+  }
+}


### PR DESCRIPTION
## Summary

### #420 Versioned localStorage primitive
New \`frontend/src/utils/localStorageStore.ts\`:
- \`storageKey('foo')\` → \`'toast-stats:v1:foo'\` (versioned namespace)
- \`readJson\` / \`writeJson\` / \`removeKey\` with try/catch around quota / private mode / malformed JSON
- 8 unit tests covering all branches
- Foundation for #417 (my district), #416 (remember filters), #418 (diff strip)

### #417 My-district sticky pin
New \`useMyDistrict\` hook:
- Star button in each rankings-table row toggles 'this is my district'
- Once pinned, the row floats to the top of the rankings on every visit (display-only sort, ranks unchanged)
- Yellow background + loyal-blue left border highlights the my-district row
- Persists across visits via the localStorage primitive

### #416 Remember last filter/sort
Partially addressed — the primitive is now in place. Persisting sortBy / searchQuery / selectedRegions is a small follow-up so this PR stays focused.

Closes #420, #417. Partially addresses #416.

## Test plan
- [x] localStorage primitive: 8 unit tests (versioned key, fallback, malformed JSON, private mode, quota)
- [x] My-district hook: state synced to localStorage
- [x] DistrictsPage: star button per row, click pins to top, persists to localStorage
- [x] Full frontend suite: 2129/2129
- [ ] Live verify on https://ts.taverns.red after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)