### PR TITLE
feat(districts): orientation strip below lede (#415)

### DIFF
--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -504,6 +504,14 @@ const DistrictsPage: React.FC = () => {
               Compare district performance across paid clubs, payments, and
               distinguished clubs.
             </p>
+            {/* Orientation strip (#415) — orients first-time visitors. */}
+            <p className="districts-page-header__orientation">
+              Each row below is one of the 117 Toastmasters districts worldwide.
+              Click a district to drill into its clubs, divisions, and trends.
+              Use the search bar (or press <kbd>/</kbd>) to jump to a district
+              by number or name. Star (★) a district to keep it pinned at the
+              top across visits.
+            </p>
           </div>
           <div className="districts-page-header__actions">
             <DataFreshnessBadge />

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -325,6 +325,31 @@
     max-width: 60ch;
   }
 
+  /* Orientation strip (#415) — first-time-visitor primer below the lede.
+     Quieter than the lede but still legible. Inline `kbd` styling carries
+     the keyboard-shortcut hint. */
+  .districts-page-header__orientation {
+    margin: 8px 0 0;
+    font-family: var(--sans);
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--ink-3);
+    max-width: 70ch;
+  }
+
+  .districts-page-header__orientation kbd {
+    display: inline-block;
+    padding: 0 5px;
+    margin: 0 1px;
+    font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+    font-size: 11px;
+    color: var(--ink-2);
+    background-color: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: 3px;
+    vertical-align: 1px;
+  }
+
   .districts-page-header__actions {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary
First-time-visitor primer paragraph below the page lede on the Districts landing.

> Each row below is one of the 117 Toastmasters districts worldwide. Click a district to drill into its clubs, divisions, and trends. Use the search bar (or press \`/\`) to jump to a district by number or name. Star (★) a district to keep it pinned at the top across visits.

Visual treatment quieter than the lede (13px, \`--ink-3\`, 70ch max-width). Inline \`kbd\` styling carries the keyboard-shortcut hint.

Closes #415.

## Out of scope (deferred)
**#418 'what changed since last visit' diff strip** — depends on Sprint 16's localStorage primitive landing first. Will follow as a separate small PR once #458 merges.

## Test plan
- [x] Full frontend suite: 2118/2118
- [ ] Live verify on https://ts.taverns.red after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)