### PR TITLE
feat(districts): persist sort/regions + 'what changed since last visit' diff strip (#416 #418)

### DIFF
--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import 'jest-axe/extend-expect'
-import { vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
 
 // Import brand CSS to make design tokens available in tests
 import '../styles/brand.css'
@@ -81,4 +81,12 @@ Object.defineProperty(window, 'localStorage', {
       Object.keys(store).forEach(k => delete store[k])
     }),
   },
+})
+
+// Clear localStorage between every test so persisted state from one test
+// (e.g. selectedRegions, my-district-id, sortBy) does not leak into the
+// next. Required after #416 (filter persistence) wired filter state to
+// localStorage on the Districts page.
+beforeEach(() => {
+  Object.keys(store).forEach(k => delete store[k])
 })

--- a/frontend/src/hooks/__tests__/usePersistedState.test.ts
+++ b/frontend/src/hooks/__tests__/usePersistedState.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { usePersistedState } from '../usePersistedState'
+import { storageKey } from '../../utils/localStorageStore'
+
+describe('usePersistedState (#416)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('returns the initial value when nothing is stored', () => {
+    const { result } = renderHook(() =>
+      usePersistedState<string>('greeting', 'hello')
+    )
+    expect(result.current[0]).toBe('hello')
+  })
+
+  it('returns the stored value when present', () => {
+    localStorage.setItem(storageKey('greeting'), JSON.stringify('hi'))
+    const { result } = renderHook(() =>
+      usePersistedState<string>('greeting', 'hello')
+    )
+    expect(result.current[0]).toBe('hi')
+  })
+
+  it('writes new values to localStorage', () => {
+    const { result } = renderHook(() => usePersistedState<number>('count', 0))
+    act(() => result.current[1](42))
+    expect(localStorage.getItem(storageKey('count'))).toBe('42')
+  })
+
+  it('supports the functional setter form', () => {
+    const { result } = renderHook(() => usePersistedState<number>('count', 0))
+    act(() => result.current[1](prev => prev + 5))
+    expect(result.current[0]).toBe(5)
+    act(() => result.current[1](prev => prev + 5))
+    expect(result.current[0]).toBe(10)
+    expect(localStorage.getItem(storageKey('count'))).toBe('10')
+  })
+
+  it('handles arrays and objects', () => {
+    const { result } = renderHook(() =>
+      usePersistedState<string[]>('regions', [])
+    )
+    act(() => result.current[1](['1', '7', '11']))
+    expect(result.current[0]).toEqual(['1', '7', '11'])
+    expect(
+      JSON.parse(localStorage.getItem(storageKey('regions')) ?? '[]')
+    ).toEqual(['1', '7', '11'])
+  })
+})

--- a/frontend/src/hooks/useLastVisit.ts
+++ b/frontend/src/hooks/useLastVisit.ts
@@ -1,0 +1,98 @@
+/* useLastVisit (#418) — track the snapshot date the user last saw, and
+   the rank of their pinned district at that time. Returns a diff vs
+   the current snapshot so the Districts page can surface a "what
+   changed since your last visit" strip.
+
+   We persist three things:
+     - lastSeenDate: the data?.date the user saw last
+     - lastSeenMyRank: their my-district's rank at that time
+
+   On every render we compare current → stored and return a diff. The
+   commit() function is called after the strip has been read and stamps
+   the current values forward. */
+
+import { useCallback, useMemo } from 'react'
+import { usePersistedState } from './usePersistedState'
+
+interface VisitSnapshot {
+  lastSeenDate: string | null
+  lastSeenMyRank: number | null
+  lastSeenMyDistrictId: string | null
+}
+
+interface VisitDiff {
+  /** True if the user has visited before AND the snapshot date has changed. */
+  isNewSnapshot: boolean
+  previousDate: string | null
+  /** Change in my-district rank (positive = moved up the leaderboard). */
+  myRankDelta: number | null
+}
+
+const EMPTY: VisitSnapshot = {
+  lastSeenDate: null,
+  lastSeenMyRank: null,
+  lastSeenMyDistrictId: null,
+}
+
+export function useLastVisit({
+  currentDate,
+  currentMyRank,
+  currentMyDistrictId,
+}: {
+  currentDate: string | null
+  currentMyRank: number | null
+  currentMyDistrictId: string | null
+}): { diff: VisitDiff; commit: () => void; clear: () => void } {
+  const [snapshot, setSnapshot] = usePersistedState<VisitSnapshot>(
+    'last-visit-snapshot',
+    EMPTY
+  )
+
+  const diff = useMemo<VisitDiff>(() => {
+    const isNewSnapshot =
+      !!snapshot.lastSeenDate &&
+      !!currentDate &&
+      snapshot.lastSeenDate !== currentDate
+
+    let myRankDelta: number | null = null
+    // Only compute a meaningful rank delta when the same district is the
+    // user's pinned one across both visits and we have ranks for both.
+    if (
+      snapshot.lastSeenMyDistrictId !== null &&
+      currentMyDistrictId !== null &&
+      snapshot.lastSeenMyDistrictId === currentMyDistrictId &&
+      typeof snapshot.lastSeenMyRank === 'number' &&
+      typeof currentMyRank === 'number'
+    ) {
+      // Lower rank number = better; positive delta = moved up.
+      myRankDelta = snapshot.lastSeenMyRank - currentMyRank
+    }
+
+    return {
+      isNewSnapshot,
+      previousDate: snapshot.lastSeenDate,
+      myRankDelta,
+    }
+  }, [
+    snapshot.lastSeenDate,
+    snapshot.lastSeenMyRank,
+    snapshot.lastSeenMyDistrictId,
+    currentDate,
+    currentMyRank,
+    currentMyDistrictId,
+  ])
+
+  const commit = useCallback(() => {
+    setSnapshot({
+      lastSeenDate: currentDate,
+      lastSeenMyRank: currentMyRank,
+      lastSeenMyDistrictId: currentMyDistrictId,
+    })
+  }, [setSnapshot, currentDate, currentMyRank, currentMyDistrictId])
+
+  const clear = useCallback(() => {
+    setSnapshot(EMPTY)
+  }, [setSnapshot])
+
+  return { diff, commit, clear }
+}

--- a/frontend/src/hooks/usePersistedState.ts
+++ b/frontend/src/hooks/usePersistedState.ts
@@ -1,0 +1,19 @@
+/* usePersistedState (#416) — useState that mirrors its value to the
+   versioned localStorage primitive. Read once on mount, write on every
+   change. Same shape as useState. */
+
+import { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import { readJson, writeJson } from '../utils/localStorageStore'
+
+export function usePersistedState<T>(
+  storageName: string,
+  initial: T
+): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(() => readJson(storageName, initial))
+
+  useEffect(() => {
+    writeJson(storageName, value)
+  }, [storageName, value])
+
+  return [value, setValue]
+}

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -15,6 +15,8 @@ import { ProgramYearSelector } from '../components/ProgramYearSelector'
 import { useRankHistory } from '../hooks/useRankHistory'
 import InfoTooltip from '../components/InfoTooltip'
 import { useMyDistrict } from '../hooks/useMyDistrict'
+import { usePersistedState } from '../hooks/usePersistedState'
+import { useLastVisit } from '../hooks/useLastVisit'
 import DataFreshnessBadge from '../components/DataFreshnessBadge'
 import { LazyComparisonPanel as ComparisonPanel } from '../components/LazyCharts'
 import {
@@ -28,9 +30,11 @@ import { arrayToCSV, downloadCSV } from '../utils/csvExport'
 
 const DistrictsPage: React.FC = () => {
   const navigate = useNavigate()
-  const [sortBy, setSortBy] = useState<
+  // sortBy persists across visits (#416). Default 'aggregate'.
+  const [sortBy, setSortBy] = usePersistedState<
     'aggregate' | 'clubs' | 'payments' | 'distinguished'
-  >('aggregate')
+  >('districts-sort-by', 'aggregate')
+  // Intentionally NOT persisted — search query should reset between visits.
   const [searchQuery, setSearchQuery] = useState<string>('')
   const [pinnedDistrictIds, setPinnedDistrictIds] = useState<Set<string>>(
     new Set()
@@ -66,7 +70,13 @@ const DistrictsPage: React.FC = () => {
     districtsData?.districts?.forEach(d => ids.add(d.id))
     return ids
   }, [districtsData])
-  const [selectedRegions, setSelectedRegions] = useState<string[]>([])
+  // selectedRegions persists across visits (#416). Default = all (empty list,
+  // which the existing useEffect inflates to all-known-regions on first
+  // data render).
+  const [selectedRegions, setSelectedRegions] = usePersistedState<string[]>(
+    'districts-selected-regions',
+    []
+  )
 
   // Use URL-synced program year and date (#272)
   const {
@@ -284,6 +294,28 @@ const DistrictsPage: React.FC = () => {
         r.districtName.toLowerCase().includes(query)
     )
   }, [rankedRankings, searchQuery])
+
+  // 'What changed since last visit' diff strip (#418). Compares the
+  // current snapshot date + my-district rank to the previous-visit
+  // snapshot stored in localStorage.
+  const myDistrictCurrentRank = React.useMemo(() => {
+    if (!myDistrictId) return null
+    const row = rankedRankings.find(r => r.districtId === myDistrictId)
+    return row?.displayRank ?? null
+  }, [rankedRankings, myDistrictId])
+
+  const { diff: lastVisitDiff, commit: commitLastVisit } = useLastVisit({
+    currentDate: data?.date ?? null,
+    currentMyRank: myDistrictCurrentRank,
+    currentMyDistrictId: myDistrictId,
+  })
+
+  // Stamp the current visit forward whenever the snapshot date changes,
+  // so the next visit reads it as the previous one. The effect runs once
+  // per data load.
+  React.useEffect(() => {
+    if (data?.date) commitLastVisit()
+  }, [data?.date, commitLastVisit])
 
   // Sticky-pin 'my district' to the top of the rankings table (#417).
   // Reorder ONLY for visual placement; ranks stay correct.
@@ -528,6 +560,42 @@ const DistrictsPage: React.FC = () => {
               by number or name. Star (★) a district to keep it pinned at the
               top across visits.
             </p>
+            {/* What changed since last visit (#418) — only renders when the
+                user has visited before AND the snapshot date has changed.
+                Quiet, no dismiss control needed (it self-clears next visit). */}
+            {lastVisitDiff.isNewSnapshot && (
+              <p
+                className="districts-page-header__diff-strip"
+                data-testid="last-visit-diff-strip"
+              >
+                <span aria-hidden="true">📍</span>
+                <span>
+                  New snapshot since your last visit
+                  {lastVisitDiff.previousDate && (
+                    <>
+                      {' '}
+                      (<time>{lastVisitDiff.previousDate}</time>).
+                    </>
+                  )}
+                  {lastVisitDiff.myRankDelta !== null &&
+                    lastVisitDiff.myRankDelta !== 0 && (
+                      <>
+                        {' '}
+                        Your district moved{' '}
+                        <strong>
+                          {lastVisitDiff.myRankDelta > 0
+                            ? `up ${lastVisitDiff.myRankDelta}`
+                            : `down ${Math.abs(lastVisitDiff.myRankDelta)}`}
+                        </strong>{' '}
+                        {Math.abs(lastVisitDiff.myRankDelta) === 1
+                          ? 'place'
+                          : 'places'}
+                        .
+                      </>
+                    )}
+                </span>
+              </p>
+            )}
           </div>
           <div className="districts-page-header__actions">
             <DataFreshnessBadge />

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -350,6 +350,34 @@
     vertical-align: 1px;
   }
 
+  /* "What changed since last visit" diff strip (#418). Loyal-blue tinted
+     pill that surfaces only when the user has visited before AND the
+     snapshot date has changed. */
+  .districts-page-header__diff-strip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin: 12px 0 0;
+    padding: 6px 12px;
+    background-color: var(--loyal-50);
+    border: 1px solid var(--loyal-200);
+    border-radius: var(--rds-radius-sm);
+    font-family: var(--sans);
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--loyal-600);
+  }
+
+  .districts-page-header__diff-strip strong {
+    color: var(--loyal-700);
+    font-weight: 700;
+  }
+
+  .districts-page-header__diff-strip time {
+    font-variant-numeric: tabular-nums;
+    color: var(--loyal-500);
+  }
+
   .districts-page-header__actions {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary

### #416 Filter / sort persistence
- New \`usePersistedState<T>(key, initial)\` hook on top of \`localStorageStore\` primitive (#420). Same shape as useState; reads on mount, writes on every change. 5 unit tests.
- DistrictsPage \`sortBy\` now persists; \`selectedRegions\` also persists.
- \`searchQuery\` deliberately NOT persisted — fresh slate per visit.

### #418 'What changed since last visit' diff strip
- New \`useLastVisit\` hook tracks (lastSeenDate, lastSeenMyRank, lastSeenMyDistrictId) via the same primitive.
- Districts page renders a quiet loyal-blue pill below the orientation strip ONLY when the user has visited before AND the snapshot date has changed. Shows 'Your district moved up/down N places' when a pinned district's rank shifted.
- Self-clears (commits the current visit forward) so it stays accurate.

Closes #416, #418.

## Test infra
\`setup.ts\` now clears the mock localStorage between every test so persisted state from one test doesn't leak into the next.

## Test plan
- [x] usePersistedState: 5 unit tests (initial, stored, write, functional setter, arrays/objects)
- [x] Existing DistrictsPage tests pass under new persistence wiring
- [x] Full frontend suite: 2134/2134
- [ ] Live verify on https://ts.taverns.red after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)