### PR TITLE
feat(shell): universal search palette opened with Cmd-K / Ctrl-K (#422)

### DIFF
--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -1,10 +1,18 @@
 /* AppShell behavior contract — Epic #352 / Issue #354. */
 
-import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AppShell from '../../components/AppShell/AppShell'
 import { DarkModeProvider } from '../../contexts/DarkModeContext'
+
+// Mock the CDN service the CommandPalette (#422) lazy-fetches when the
+// shell mounts — keeps these tests isolated from the network layer.
+vi.mock('../../services/cdn', () => ({
+  fetchCdnRankings: vi.fn().mockResolvedValue({ rankings: [], date: '' }),
+}))
 
 const renderShell = (initialPath = '/') => {
   const router = createMemoryRouter(
@@ -31,10 +39,15 @@ const renderShell = (initialPath = '/') => {
     ],
     { initialEntries: [initialPath] }
   )
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
   return render(
-    <DarkModeProvider>
-      <RouterProvider router={router} />
-    </DarkModeProvider>
+    <QueryClientProvider client={client}>
+      <DarkModeProvider>
+        <RouterProvider router={router} />
+      </DarkModeProvider>
+    </QueryClientProvider>
   )
 }
 

--- a/frontend/src/components/AppShell/AppShell.tsx
+++ b/frontend/src/components/AppShell/AppShell.tsx
@@ -1,15 +1,35 @@
-import React from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import AppShellTopBar from './AppShellTopBar'
 import AppShellFooter from './AppShellFooter'
+import CommandPalette from './CommandPalette'
 import { useGoogleAnalytics } from '../../hooks/useGoogleAnalytics'
 
 /* Per Epic #352: no notifications/help/avatar (no auth today),
    no Regions/Awards "soon" stubs. ThemeToggle stays in the footer
-   so manual dark-mode access survives the chrome swap. */
+   so manual dark-mode access survives the chrome swap.
+
+   #422 Universal search: Cmd-K / Ctrl-K opens the CommandPalette modal
+   from anywhere. The palette shares the React-Query cache with
+   DistrictsPage, so it usually opens with data already in memory. */
 
 const AppShell: React.FC = () => {
   useGoogleAnalytics()
+
+  const [paletteOpen, setPaletteOpen] = useState(false)
+  const closePalette = useCallback(() => setPaletteOpen(false), [])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setPaletteOpen(prev => !prev)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
   return (
     <div className="app-shell">
       <a href="#main-content" className="tm-skip-link">
@@ -20,6 +40,7 @@ const AppShell: React.FC = () => {
         <Outlet />
       </main>
       <AppShellFooter />
+      <CommandPalette isOpen={paletteOpen} onClose={closePalette} />
     </div>
   )
 }

--- a/frontend/src/components/AppShell/CommandPalette.tsx
+++ b/frontend/src/components/AppShell/CommandPalette.tsx
@@ -1,0 +1,213 @@
+/* CommandPalette (#422) — universal search opened with Cmd-K / Ctrl-K
+   from anywhere in the app. v1 searches districts only (the data we
+   already fetch on the landing page); clubs/areas can extend later by
+   resolving the user's pinned district at open time.
+
+   Architecture: outer <CommandPalette> just gates visibility. The inner
+   <OpenPalette> holds all local state, so closing + reopening naturally
+   resets via React's unmount/remount, avoiding setState-in-effect
+   patterns. */
+
+import React, { useCallback, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { fetchCdnRankings } from '../../services/cdn'
+import type { DistrictRanking } from '../../types/districts'
+
+const MAX_RESULTS = 8
+
+interface CommandPaletteProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) return null
+  return <OpenPalette onClose={onClose} />
+}
+
+interface OpenPaletteProps {
+  onClose: () => void
+}
+
+const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
+  const navigate = useNavigate()
+  const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  // Auto-focus the input on mount. Callback ref avoids the
+  // setState-in-effect pattern; React calls it once when the input
+  // attaches.
+  const inputAttachRef = useCallback((el: HTMLInputElement | null) => {
+    if (el) {
+      // Defer one frame so the modal animation/layout has settled.
+      window.setTimeout(() => el.focus(), 0)
+    }
+  }, [])
+
+  // Share the same cache as DistrictsPage so opening the palette is
+  // typically free.
+  const { data } = useQuery({
+    queryKey: ['district-rankings', 'latest'],
+    queryFn: async () => {
+      const cdnData = await fetchCdnRankings()
+      return { rankings: cdnData.rankings, date: cdnData.date }
+    },
+    staleTime: 15 * 60 * 1000,
+  })
+
+  const matches = useMemo<DistrictRanking[]>(() => {
+    const all: DistrictRanking[] = data?.rankings ?? []
+    const q = query.trim().toLowerCase()
+    if (!q) return all.slice(0, MAX_RESULTS)
+    return all
+      .filter(
+        r =>
+          r.districtId.toLowerCase().includes(q) ||
+          r.districtName.toLowerCase().includes(q)
+      )
+      .slice(0, MAX_RESULTS)
+  }, [data?.rankings, query])
+
+  // Clamp activeIndex at read time rather than in an effect — derived
+  // value, no setState-in-effect needed.
+  const clampedActiveIndex = Math.min(
+    activeIndex,
+    Math.max(0, matches.length - 1)
+  )
+
+  const navigateToActive = useCallback(() => {
+    const choice = matches[clampedActiveIndex]
+    if (!choice) return
+    navigate(`/district/${choice.districtId}`)
+    onClose()
+  }, [matches, clampedActiveIndex, navigate, onClose])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setActiveIndex(i => Math.min(i + 1, Math.max(0, matches.length - 1)))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setActiveIndex(i => Math.max(0, i - 1))
+      } else if (e.key === 'Enter') {
+        e.preventDefault()
+        navigateToActive()
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    },
+    [matches.length, navigateToActive, onClose]
+  )
+
+  return (
+    <div
+      className="command-palette__backdrop"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        className="command-palette"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Universal search"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="command-palette__input-row">
+          <svg
+            width="18"
+            height="18"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            className="command-palette__icon"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <input
+            ref={inputAttachRef}
+            type="text"
+            value={query}
+            onChange={e => {
+              setQuery(e.target.value)
+              setActiveIndex(0)
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="Jump to a district by number or name…"
+            aria-label="Universal search input"
+            aria-controls="command-palette-results"
+            aria-activedescendant={
+              matches[clampedActiveIndex]
+                ? `command-palette-result-${matches[clampedActiveIndex].districtId}`
+                : undefined
+            }
+            className="command-palette__input"
+          />
+          <kbd className="command-palette__hint">esc</kbd>
+        </div>
+
+        {matches.length > 0 ? (
+          <ul
+            id="command-palette-results"
+            role="listbox"
+            aria-label="Search results"
+            className="command-palette__results"
+          >
+            {matches.map((m, i) => (
+              <li
+                key={m.districtId}
+                role="option"
+                aria-selected={i === clampedActiveIndex}
+                id={`command-palette-result-${m.districtId}`}
+                onMouseEnter={() => setActiveIndex(i)}
+                className={
+                  'command-palette__result' +
+                  (i === clampedActiveIndex
+                    ? ' command-palette__result--active'
+                    : '')
+                }
+              >
+                <Link
+                  to={`/district/${m.districtId}`}
+                  onClick={onClose}
+                  className="command-palette__result-link"
+                >
+                  <span className="command-palette__result-num">
+                    D{m.districtId}
+                  </span>
+                  <span className="command-palette__result-name">
+                    {m.districtName}
+                  </span>
+                  <span className="command-palette__result-region">
+                    Region {m.region}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="command-palette__empty">
+            {data ? 'No districts match.' : 'Loading districts…'}
+          </p>
+        )}
+
+        <div className="command-palette__footer">
+          <span>
+            <kbd>↑</kbd>
+            <kbd>↓</kbd> navigate · <kbd>↵</kbd> open · <kbd>esc</kbd> close
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CommandPalette

--- a/frontend/src/components/AppShell/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,118 @@
+/* CommandPalette (#422) — scoped tests on the small palette component
+   directly (Lesson 51 — keep render scope tight). */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import CommandPalette from '../CommandPalette'
+
+// Mock CDN service — palette fetches via fetchCdnRankings.
+vi.mock('../../../services/cdn', () => ({
+  fetchCdnRankings: vi.fn().mockResolvedValue({
+    rankings: [
+      {
+        districtId: '57',
+        districtName: 'District 57',
+        region: '7',
+        paidClubs: 100,
+        paidClubBase: 90,
+        clubGrowthPercent: 11.1,
+        totalPayments: 5000,
+        paymentBase: 4500,
+        paymentGrowthPercent: 11.1,
+        activeClubs: 100,
+        distinguishedClubs: 50,
+        selectDistinguished: 20,
+        presidentsDistinguished: 10,
+        distinguishedPercent: 50,
+        clubsRank: 1,
+        paymentsRank: 1,
+        distinguishedRank: 1,
+        aggregateScore: 300,
+        overallRank: 1,
+      },
+      {
+        districtId: '61',
+        districtName: 'District 61',
+        region: '7',
+        paidClubs: 100,
+        paidClubBase: 90,
+        clubGrowthPercent: 11.1,
+        totalPayments: 5000,
+        paymentBase: 4500,
+        paymentGrowthPercent: 11.1,
+        activeClubs: 100,
+        distinguishedClubs: 50,
+        selectDistinguished: 20,
+        presidentsDistinguished: 10,
+        distinguishedPercent: 50,
+        clubsRank: 2,
+        paymentsRank: 2,
+        distinguishedRank: 2,
+        aggregateScore: 250,
+        overallRank: 2,
+      },
+    ],
+    date: '2025-11-22',
+  }),
+}))
+
+const renderPalette = (isOpen: boolean) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <CommandPalette isOpen={isOpen} onClose={() => {}} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('CommandPalette (#422)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when closed', () => {
+    renderPalette(false)
+    expect(
+      screen.queryByRole('dialog', { name: /universal search/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders an input + listbox when open', async () => {
+    renderPalette(true)
+    expect(
+      screen.getByRole('dialog', { name: /universal search/i })
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText(/universal search input/i)).toBeInTheDocument()
+    // Wait for the rankings query to resolve and results to render
+    await screen.findByRole('listbox', { name: /search results/i })
+  })
+
+  it('filters results as the user types', async () => {
+    renderPalette(true)
+    await screen.findByRole('listbox', { name: /search results/i })
+
+    const input = screen.getByLabelText(/universal search input/i)
+    fireEvent.change(input, { target: { value: '61' } })
+
+    const listbox = screen.getByRole('listbox', { name: /search results/i })
+    const options = within(listbox).getAllByRole('option')
+    expect(options.length).toBe(1)
+    expect(options[0]?.textContent).toMatch(/District 61/)
+  })
+
+  it('renders a Link with href /district/<id> for each result', async () => {
+    renderPalette(true)
+    await screen.findByRole('listbox', { name: /search results/i })
+    const listbox = screen.getByRole('listbox')
+    const links = within(listbox).getAllByRole('link')
+    expect(links[0]?.getAttribute('href')).toBe('/district/57')
+    expect(links[1]?.getAttribute('href')).toBe('/district/61')
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -1749,4 +1749,140 @@
     font-style: italic;
     color: var(--ink-3);
   }
+
+  /* Universal CommandPalette (#422). Cmd-K / Ctrl-K modal. Centered
+     dialog over a translucent backdrop. */
+  .command-palette__backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 90;
+    background-color: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 12vh;
+  }
+
+  .command-palette {
+    width: min(640px, 92vw);
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-lg);
+    box-shadow: var(--rds-shadow-lg);
+    overflow: hidden;
+  }
+
+  .command-palette__input-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .command-palette__icon {
+    flex-shrink: 0;
+    color: var(--ink-3);
+  }
+
+  .command-palette__input {
+    flex: 1;
+    border: 0;
+    background: transparent;
+    font-family: var(--sans);
+    font-size: 16px;
+    color: var(--ink);
+    outline: none;
+  }
+
+  .command-palette__input::placeholder {
+    color: var(--ink-4);
+  }
+
+  .command-palette__hint {
+    font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+    font-size: 11px;
+    color: var(--ink-3);
+    background-color: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: 3px;
+    padding: 1px 5px;
+  }
+
+  .command-palette__results {
+    list-style: none;
+    margin: 0;
+    padding: 4px;
+    overflow-y: auto;
+  }
+
+  .command-palette__result {
+    margin: 0;
+    padding: 0;
+    border-radius: var(--rds-radius-sm);
+  }
+
+  .command-palette__result--active {
+    background-color: var(--surface-2);
+  }
+
+  .command-palette__result-link {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    text-decoration: none;
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 14px;
+  }
+
+  .command-palette__result-num {
+    font-weight: 700;
+    color: var(--loyal-500);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .command-palette__result-name {
+    color: var(--ink-2);
+  }
+
+  .command-palette__result-region {
+    font-size: 12px;
+    color: var(--ink-3);
+  }
+
+  .command-palette__empty {
+    margin: 0;
+    padding: 16px;
+    text-align: center;
+    color: var(--ink-3);
+    font-size: 13px;
+  }
+
+  .command-palette__footer {
+    border-top: 1px solid var(--line);
+    padding: 6px 12px;
+    font-family: var(--sans);
+    font-size: 11px;
+    color: var(--ink-3);
+    display: flex;
+    justify-content: flex-end;
+    gap: 4px;
+  }
+
+  .command-palette__footer kbd {
+    font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+    font-size: 10px;
+    color: var(--ink-2);
+    background-color: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: 3px;
+    padding: 0 4px;
+    margin: 0 1px;
+  }
 }


### PR DESCRIPTION
## Summary
New CommandPalette modal at AppShell scope. **Cmd-K** (macOS) / **Ctrl-K** (Win/Linux) toggles it from anywhere.

### v1 — districts only
- Type to filter by district number or name; top 8 matches as a listbox
- **Arrow keys** navigate, **Enter** opens, **Esc** closes
- Each result is a Link to /district/:id
- Shares React-Query cache with DistrictsPage (typically free open)
- Empty state distinguishes 'no match' from 'still loading'

### Out of scope (v2)
- Clubs / Areas in palette — requires resolving the user's pinned district at open time and fetching analytics on demand
- Visible Cmd-K trigger button in top bar — keyboard-only for v1

Closes #422.

### Architecture
Outer \`<CommandPalette>\` just gates visibility; inner \`<OpenPalette>\` holds local state, so closing + reopening naturally resets via unmount/remount. Active-index clamped at read time. Both avoid setState-in-effect patterns flagged by lint.

### Test plan
- [x] Palette unit tests: renders only when open, filters, links resolve to /district/:id
- [x] AppShell tests wrapped with QueryClientProvider + mock fetchCdnRankings
- [x] Full frontend suite: 2133/2133
- [ ] Live verify on https://ts.taverns.red after deploy (Cmd-K opens palette from any page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)