### PR TITLE
feat(district-overview): top-right rank badge on KPI cards (#360 — slice 1)

### DIFF
--- a/frontend/src/components/TargetProgressCard.tsx
+++ b/frontend/src/components/TargetProgressCard.tsx
@@ -184,9 +184,22 @@ export const TargetProgressCard: React.FC<TargetProgressCardProps> = ({
 
   return (
     <div
-      className={`${colors.gradient} rounded-lg p-4 border ${colors.border}`}
+      className={`${colors.gradient} rounded-lg p-4 border ${colors.border} relative`}
       data-testid="target-progress-card"
     >
+      {/* Top-right rank badge (#360 redesign parity) — promoted from the
+          bottom chip for higher visibility per design mockup. Renders only
+          when world rank data is available. */}
+      {rankings.worldRank !== null && rankings.totalDistricts > 0 && (
+        <span
+          className="absolute top-3 right-3 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-white/70 text-gray-700 border border-gray-200 backdrop-blur-sm"
+          data-testid="kpi-rank-badge"
+          title={`World rank ${rankings.worldRank} out of ${rankings.totalDistricts} districts`}
+        >
+          #{rankings.worldRank} of {rankings.totalDistricts}
+        </span>
+      )}
+
       {/* Header with title, value, and icon */}
       <div className="flex items-center justify-between">
         <div>


### PR DESCRIPTION
## Summary
**Sprint 8 / Issue #360 — first slice of the Overview tab redesign.**

Promotes the world rank from a small bottom chip to a prominent top-right pill per the design mockup (\`#1 of 117\`).

- Renders only when both \`worldRank\` and \`totalDistricts\` are available, so cards without ranking data (e.g. Total Members) stay clean.
- Existing 'World: #N' chip + percentile + region-rank chips at the bottom are preserved for context.
- New \`data-testid="kpi-rank-badge"\` for stable test targeting.
- Tooltip on hover shows the rank in plain English.

## Why ship as a slice
The full Overview redesign mockup also has:
- Stack-bar Distinguished Composition panel
- Donut-chart Payment Composition panel
- Net Member Change as a 5th KPI (instead of Total Members)
- Vs-all-117 sparkline panel
- Multi-Year Comparison table

Each of those is a focused PR. Shipping one slice at a time so you can react between iterations rather than reviewing a 2000-line redesign blob.

## Test plan
- [x] Full frontend suite: 2138/2138
- [ ] Live verify on https://ts.taverns.red/district/61 — confirm 'rank of 117' badge shows top-right of each KPI card

🤖 Generated with [Claude Code](https://claude.com/claude-code)