### PR TITLE
feat(district-overview): Distinguished Composition stack-bar (#360 slice 2)

### DIFF
--- a/frontend/src/__tests__/integration/journeys/03-DcpProgressFlow.test.tsx
+++ b/frontend/src/__tests__/integration/journeys/03-DcpProgressFlow.test.tsx
@@ -88,12 +88,15 @@ describe('Journey 03: The DCP Progress Flow', () => {
     )
     expect(memPaymentsCard).toBeInTheDocument()
 
-    const distClubsCard = await screen.findByText(
+    // The Overview redesign (#360 slice 2) adds a 'Distinguished Clubs ·
+    // Composition' panel, so 'Distinguished Clubs' now appears multiple
+    // times on the page. The KPI card is the FIRST occurrence.
+    const distClubsCards = await screen.findAllByText(
       /Distinguished Clubs/i,
       {},
       { timeout: 5000 }
     )
-    expect(distClubsCard).toBeInTheDocument()
+    expect(distClubsCards.length).toBeGreaterThan(0)
 
     // Step 3: Verify DCP badge details (Smedley, Presidents, Select) within the Distinguished Clubs card region
     const smedleyBadge = await screen.findByText(

--- a/frontend/src/components/DistinguishedCompositionBar.tsx
+++ b/frontend/src/components/DistinguishedCompositionBar.tsx
@@ -1,0 +1,131 @@
+/* DistinguishedCompositionBar (#360 redesign) — single stacked bar
+   showing the breakdown of clubs in each Distinguished tier vs
+   not-yet-distinguished, with a legend. Replaces the legacy stack of
+   per-tier badges; same data, denser visual. */
+
+import React from 'react'
+
+interface DistinguishedCompositionBarProps {
+  smedley: number
+  presidents: number
+  select: number
+  distinguished: number
+  totalClubs: number
+}
+
+interface Segment {
+  key: string
+  label: string
+  count: number
+  /** Tailwind/inline background class for the bar segment. */
+  bgClassName: string
+  /** Display swatch in the legend (must visually match bg). */
+  swatchClassName: string
+}
+
+const DistinguishedCompositionBar: React.FC<
+  DistinguishedCompositionBarProps
+> = ({ smedley, presidents, select, distinguished, totalClubs }) => {
+  if (totalClubs <= 0) return null
+
+  const distinguishedTotal = smedley + presidents + select + distinguished
+  const notYet = Math.max(0, totalClubs - distinguishedTotal)
+
+  const segments: Segment[] = [
+    {
+      key: 'smedley',
+      label: 'Smedley',
+      count: smedley,
+      bgClassName: 'bg-tm-true-maroon',
+      swatchClassName: 'bg-tm-true-maroon',
+    },
+    {
+      key: 'presidents',
+      label: "President's",
+      count: presidents,
+      bgClassName: 'bg-tm-loyal-blue',
+      swatchClassName: 'bg-tm-loyal-blue',
+    },
+    {
+      key: 'select',
+      label: 'Select',
+      count: select,
+      bgClassName: 'bg-tm-loyal-blue-80',
+      swatchClassName: 'bg-tm-loyal-blue-80',
+    },
+    {
+      key: 'distinguished',
+      label: 'Distinguished',
+      count: distinguished,
+      bgClassName: 'bg-green-600',
+      swatchClassName: 'bg-green-600',
+    },
+    {
+      key: 'notYet',
+      label: 'Not yet',
+      count: notYet,
+      bgClassName: 'bg-gray-200',
+      swatchClassName: 'bg-gray-200 border border-gray-300',
+    },
+  ]
+
+  const distinguishedPct =
+    totalClubs > 0 ? Math.round((distinguishedTotal / totalClubs) * 100) : 0
+
+  return (
+    <section
+      className="redesign-panel"
+      aria-labelledby="distinguished-composition-heading"
+      data-testid="distinguished-composition"
+    >
+      <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <h2
+          id="distinguished-composition-heading"
+          className="text-lg font-semibold text-gray-900 font-tm-headline"
+        >
+          Distinguished Clubs · Composition
+        </h2>
+        <span className="text-sm text-gray-600 font-tm-body">
+          {distinguishedTotal} of {totalClubs} paid ({distinguishedPct}%)
+        </span>
+      </div>
+
+      <div
+        className="flex w-full h-7 rounded-md overflow-hidden border border-gray-200"
+        role="img"
+        aria-label={`Distinguished club composition: Smedley ${smedley}, President's ${presidents}, Select ${select}, Distinguished ${distinguished}, Not yet ${notYet}, total ${totalClubs}`}
+      >
+        {segments.map(seg => {
+          if (seg.count === 0) return null
+          const widthPct = (seg.count / totalClubs) * 100
+          return (
+            <div
+              key={seg.key}
+              className={`${seg.bgClassName} flex items-center justify-center text-[11px] font-medium text-white`}
+              style={{ width: `${widthPct}%`, minWidth: 0 }}
+              title={`${seg.label}: ${seg.count}`}
+            >
+              {widthPct >= 4 ? seg.count : ''}
+            </div>
+          )
+        })}
+      </div>
+
+      <ul className="mt-3 flex flex-wrap gap-3 list-none text-xs font-tm-body text-gray-700">
+        {segments.map(seg => (
+          <li key={seg.key} className="inline-flex items-center gap-1.5">
+            <span
+              aria-hidden="true"
+              className={`inline-block w-3 h-3 rounded-sm ${seg.swatchClassName}`}
+            />
+            <span>
+              {seg.label} · {seg.count}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export default DistinguishedCompositionBar

--- a/frontend/src/components/DistrictOverview.tsx
+++ b/frontend/src/components/DistrictOverview.tsx
@@ -4,6 +4,7 @@ import type { DistrictPerformanceTargets } from '../hooks/useDistrictAnalytics'
 import { LoadingSkeleton } from './LoadingSkeleton'
 import { ErrorDisplay, EmptyState } from './ErrorDisplay'
 import { TargetProgressCard } from './TargetProgressCard'
+import DistinguishedCompositionBar from './DistinguishedCompositionBar'
 
 interface DistrictOverviewProps {
   districtId: string
@@ -294,6 +295,19 @@ export const DistrictOverview: React.FC<DistrictOverviewProps> = ({
                 {analytics.allClubs.length === 1 ? '' : 's'}
               </span>
             }
+          />
+        </div>
+      )}
+
+      {/* Distinguished Composition stack-bar (#360 redesign slice 2). */}
+      {!isLoading && !error && analytics && analytics.allClubs.length > 0 && (
+        <div className="mt-4">
+          <DistinguishedCompositionBar
+            smedley={analytics.distinguishedClubs.smedley}
+            presidents={analytics.distinguishedClubs.presidents}
+            select={analytics.distinguishedClubs.select}
+            distinguished={analytics.distinguishedClubs.distinguished}
+            totalClubs={analytics.allClubs.length}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
**Slice 2 of the Overview tab redesign (#360).**

Adds the 'Distinguished Clubs · Composition' panel from the design mockup.

- New \`DistinguishedCompositionBar\` component — single stacked bar with Smedley / President's / Select / Distinguished / Not-yet segments + legend
- Same data as the existing per-tier badges (\`analytics.distinguishedClubs.*\`), presented as a denser visual scan
- Segment width proportional to count; segments < 4% wide hide their number to avoid label crowding
- WCAG-friendly: full \`aria-label\` on the bar, swatches \`aria-hidden\`

Integration test \`03-DcpProgressFlow\` updated: 'Distinguished Clubs' now appears in two surfaces (KPI card + composition heading) so the query uses \`findAllByText\`.

## Test plan
- [x] Full frontend suite: 2138/2138
- [ ] Live verify on https://ts.taverns.red/district/61

🤖 Generated with [Claude Code](https://claude.com/claude-code)