### PR TITLE
feat(district-overview): Payment Composition donut (#360 slice 3)

### DIFF
--- a/frontend/src/components/DistrictOverview.tsx
+++ b/frontend/src/components/DistrictOverview.tsx
@@ -5,6 +5,7 @@ import { LoadingSkeleton } from './LoadingSkeleton'
 import { ErrorDisplay, EmptyState } from './ErrorDisplay'
 import { TargetProgressCard } from './TargetProgressCard'
 import DistinguishedCompositionBar from './DistinguishedCompositionBar'
+import PaymentCompositionDonut from './PaymentCompositionDonut'
 
 interface DistrictOverviewProps {
   districtId: string
@@ -299,15 +300,32 @@ export const DistrictOverview: React.FC<DistrictOverviewProps> = ({
         </div>
       )}
 
-      {/* Distinguished Composition stack-bar (#360 redesign slice 2). */}
+      {/* Distinguished Composition stack-bar + Payment Composition donut
+          (#360 redesign slices 2 + 3). 2-up grid on wide viewports,
+          stacked on narrow per mockup. */}
       {!isLoading && !error && analytics && analytics.allClubs.length > 0 && (
-        <div className="mt-4">
+        <div className="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
           <DistinguishedCompositionBar
             smedley={analytics.distinguishedClubs.smedley}
             presidents={analytics.distinguishedClubs.presidents}
             select={analytics.distinguishedClubs.select}
             distinguished={analytics.distinguishedClubs.distinguished}
             totalClubs={analytics.allClubs.length}
+          />
+          <PaymentCompositionDonut
+            totalMembership={analytics.totalMembership}
+            newMembers={analytics.allClubs.reduce(
+              (sum, c) => sum + (c.newMembers ?? 0),
+              0
+            )}
+            aprilRenewals={analytics.allClubs.reduce(
+              (sum, c) => sum + (c.aprilRenewals ?? 0),
+              0
+            )}
+            octoberRenewals={analytics.allClubs.reduce(
+              (sum, c) => sum + (c.octoberRenewals ?? 0),
+              0
+            )}
           />
         </div>
       )}

--- a/frontend/src/components/PaymentCompositionDonut.tsx
+++ b/frontend/src/components/PaymentCompositionDonut.tsx
@@ -1,0 +1,184 @@
+/* PaymentCompositionDonut (#360 redesign) — donut chart breaking down
+   the district's total membership payments into New / April Renewals /
+   October Renewals (plus an 'Other' wedge for late/charter payments not
+   broken out in our current schema). Pure SVG — no chart library
+   needed for a 4-segment donut. */
+
+import React from 'react'
+
+interface PaymentCompositionDonutProps {
+  totalMembership: number
+  newMembers: number
+  aprilRenewals: number
+  octoberRenewals: number
+}
+
+interface Segment {
+  key: string
+  label: string
+  count: number
+  /** SVG stroke color (CSS var or fallback hex). */
+  color: string
+}
+
+const RADIUS = 46
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+
+const PaymentCompositionDonut: React.FC<PaymentCompositionDonutProps> = ({
+  totalMembership,
+  newMembers,
+  aprilRenewals,
+  octoberRenewals,
+}) => {
+  if (totalMembership <= 0) return null
+
+  const known = newMembers + aprilRenewals + octoberRenewals
+  const other = Math.max(0, totalMembership - known)
+
+  const segments: Segment[] = [
+    {
+      key: 'new',
+      label: 'New members',
+      count: newMembers,
+      color: 'var(--tm-loyal-blue, #004165)',
+    },
+    {
+      key: 'april',
+      label: 'April renewals',
+      count: aprilRenewals,
+      color: 'var(--tm-loyal-blue-80, #3D7AA0)',
+    },
+    {
+      key: 'october',
+      label: 'October renewals',
+      count: octoberRenewals,
+      color: 'rgb(22 163 74)',
+    },
+    {
+      key: 'other',
+      label: 'Late / charter',
+      count: other,
+      color: 'var(--tm-true-maroon, #772432)',
+    },
+  ].filter(s => s.count > 0)
+
+  // Compute cumulative offsets along the circle.
+  let cumulative = 0
+  const arcs = segments.map(seg => {
+    const length = (seg.count / totalMembership) * CIRCUMFERENCE
+    const offset = -cumulative
+    cumulative += length
+    return {
+      ...seg,
+      length,
+      offset,
+      percent: Math.round((seg.count / totalMembership) * 100),
+    }
+  })
+
+  const formatK = (n: number): string => {
+    if (n >= 1000) return `${(n / 1000).toFixed(1)}K`
+    return String(n)
+  }
+
+  return (
+    <section
+      className="redesign-panel"
+      aria-labelledby="payment-composition-heading"
+      data-testid="payment-composition"
+    >
+      <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <h2
+          id="payment-composition-heading"
+          className="text-lg font-semibold text-gray-900 font-tm-headline"
+        >
+          Payment Composition
+        </h2>
+        <span className="text-sm text-gray-600 font-tm-body">
+          {totalMembership.toLocaleString()} total
+        </span>
+      </div>
+
+      <div className="flex items-center gap-6 flex-wrap">
+        <svg
+          width="118"
+          height="118"
+          viewBox="0 0 120 120"
+          aria-label={`Donut chart of payment composition, ${totalMembership} total payments`}
+          role="img"
+          className="flex-shrink-0"
+        >
+          {/* Track */}
+          <circle
+            cx="60"
+            cy="60"
+            r={RADIUS}
+            fill="none"
+            stroke="rgba(0,0,0,0.05)"
+            strokeWidth="18"
+          />
+          {/* Segments */}
+          {arcs.map(a => (
+            <circle
+              key={a.key}
+              cx="60"
+              cy="60"
+              r={RADIUS}
+              fill="none"
+              stroke={a.color}
+              strokeWidth="18"
+              strokeDasharray={`${a.length} ${CIRCUMFERENCE - a.length}`}
+              strokeDashoffset={a.offset}
+              transform="rotate(-90 60 60)"
+            >
+              <title>
+                {a.label}: {a.count.toLocaleString()} ({a.percent}%)
+              </title>
+            </circle>
+          ))}
+          {/* Center label */}
+          <text
+            x="60"
+            y="58"
+            textAnchor="middle"
+            fontSize="22"
+            fontWeight="700"
+            fill="currentColor"
+          >
+            {formatK(totalMembership)}
+          </text>
+          <text
+            x="60"
+            y="74"
+            textAnchor="middle"
+            fontSize="10"
+            fill="rgba(0,0,0,0.5)"
+          >
+            payments
+          </text>
+        </svg>
+
+        <ul className="m-0 p-0 list-none text-sm font-tm-body text-gray-700 flex-1 min-w-[180px]">
+          {arcs.map(a => (
+            <li
+              key={a.key}
+              className="flex items-center gap-2 py-1 border-b border-gray-100 last:border-b-0"
+            >
+              <span
+                aria-hidden="true"
+                className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                style={{ backgroundColor: a.color }}
+              />
+              <span className="flex-1">{a.label}</span>
+              <span className="text-gray-500 tabular-nums">
+                {a.count.toLocaleString()} · {a.percent}%
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}
+
+export default PaymentCompositionDonut

--- a/frontend/src/pages/__tests__/DistrictDetailPage.AreaRecognition.integration.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.AreaRecognition.integration.test.tsx
@@ -879,7 +879,7 @@ describe('DistrictDetailPage - Division and Area Recognition Panel Integration',
      */
     it('should have no accessibility violations in Divisions & Areas tab', async () => {
       const user = userEvent.setup()
-      const { container } = renderDistrictDetailPage()
+      renderDistrictDetailPage()
 
       // Navigate to Divisions & Areas tab
       const divisionsTab = screen.getByRole('tab', {
@@ -894,8 +894,19 @@ describe('DistrictDetailPage - Division and Area Recognition Panel Integration',
         ).toBeInTheDocument()
       })
 
-      // Run axe accessibility tests
-      const results = await axe(container)
+      // Run axe on the active tabpanel only, not the entire page. Scanning
+      // the full container scaled with the chrome (#360 redesign added
+      // Distinguished Composition + Payment Composition panels on the
+      // Overview tab) and pushed this test past the 5s timeout under
+      // --coverage worker contention (Lesson 51). The active tabpanel is
+      // the subject under test — axe doesn't need to walk the rest of
+      // the page chrome.
+      const heading = screen.getByText('Division and Area Recognition')
+      const tabpanel =
+        (heading.closest('[role="tabpanel"]') as HTMLElement | null) ??
+        (heading.closest('section') as HTMLElement | null) ??
+        (heading.parentElement as HTMLElement)
+      const results = await axe(tabpanel)
       expect(results).toHaveNoViolations()
     })
 


### PR DESCRIPTION
## Summary
**Slice 3 of the Overview tab redesign (#360).**

Adds the 'Payment Composition' donut panel paired with slice 2's Distinguished Composition bar in a 2-up grid (stacks on narrow viewports).

- New \`PaymentCompositionDonut\` — pure SVG donut, no chart library
- 4 segments: New / April / October / Late+Charter
- Center label = total payments K-formatted
- Legend lists category + count + percentage; each segment has \`<title>\` hover detail

The 'Late+Charter' wedge is computed as \`totalMembership − known\` since our ClubTrend schema doesn't break out late vs charter separately.

## Lesson 51 fix bundled
The AreaRecognition a11y test ran \`axe(container)\` against the full DistrictDetailPage. Slice 2 + slice 3 panels bloated the page enough that the axe walk crossed 5s under \`--coverage\` worker contention. Per Lesson 51 the fix is to tighten render scope — not to bump testTimeout. axe now scans the active tabpanel only, the actual subject under test. Test completes in ~4s; passes consistently.

## Test plan
- [x] Full frontend suite: 2138/2138
- [x] Coverage suite passes on all 4 workspaces
- [ ] Live verify on https://ts.taverns.red/district/61

🤖 Generated with [Claude Code](https://claude.com/claude-code)