### PR TITLE
fix(district-overview): payment donut denominator is payments, not members (#360)

### DIFF
--- a/frontend/src/components/PaymentCompositionDonut.tsx
+++ b/frontend/src/components/PaymentCompositionDonut.tsx
@@ -7,6 +7,7 @@
 import React from 'react'
 
 interface PaymentCompositionDonutProps {
+  /** Number of currently-paid members (the cohort, not the events). */
   totalMembership: number
   newMembers: number
   aprilRenewals: number
@@ -30,15 +31,18 @@ const PaymentCompositionDonut: React.FC<PaymentCompositionDonutProps> = ({
   aprilRenewals,
   octoberRenewals,
 }) => {
-  if (totalMembership <= 0) return null
-
-  const known = newMembers + aprilRenewals + octoberRenewals
-  const other = Math.max(0, totalMembership - known)
+  // Total PAYMENTS is the sum of payment events across the program year
+  // (a single member can show up in multiple buckets — paid as new, then
+  // renewed in April, then renewed in October). The previous version used
+  // totalMembership (= cohort count) as the denominator, which conflated
+  // two different metrics and produced percentages > 100%.
+  const totalPayments = newMembers + aprilRenewals + octoberRenewals
+  if (totalPayments <= 0) return null
 
   const segments: Segment[] = [
     {
       key: 'new',
-      label: 'New members',
+      label: 'New member payments',
       count: newMembers,
       color: 'var(--tm-loyal-blue, #004165)',
     },
@@ -54,25 +58,19 @@ const PaymentCompositionDonut: React.FC<PaymentCompositionDonutProps> = ({
       count: octoberRenewals,
       color: 'rgb(22 163 74)',
     },
-    {
-      key: 'other',
-      label: 'Late / charter',
-      count: other,
-      color: 'var(--tm-true-maroon, #772432)',
-    },
   ].filter(s => s.count > 0)
 
   // Compute cumulative offsets along the circle.
   let cumulative = 0
   const arcs = segments.map(seg => {
-    const length = (seg.count / totalMembership) * CIRCUMFERENCE
+    const length = (seg.count / totalPayments) * CIRCUMFERENCE
     const offset = -cumulative
     cumulative += length
     return {
       ...seg,
       length,
       offset,
-      percent: Math.round((seg.count / totalMembership) * 100),
+      percent: Math.round((seg.count / totalPayments) * 100),
     }
   })
 
@@ -94,8 +92,11 @@ const PaymentCompositionDonut: React.FC<PaymentCompositionDonutProps> = ({
         >
           Payment Composition
         </h2>
-        <span className="text-sm text-gray-600 font-tm-body">
-          {totalMembership.toLocaleString()} total
+        <span
+          className="text-sm text-gray-600 font-tm-body"
+          title={`${totalPayments.toLocaleString()} payment events across ${totalMembership.toLocaleString()} current members`}
+        >
+          {totalPayments.toLocaleString()} payment events
         </span>
       </div>
 
@@ -104,7 +105,7 @@ const PaymentCompositionDonut: React.FC<PaymentCompositionDonutProps> = ({
           width="118"
           height="118"
           viewBox="0 0 120 120"
-          aria-label={`Donut chart of payment composition, ${totalMembership} total payments`}
+          aria-label={`Donut chart of payment composition, ${totalPayments} total payment events`}
           role="img"
           className="flex-shrink-0"
         >


### PR DESCRIPTION
## Summary
Live user feedback: the Payment Composition donut's percentages summed to >200% and the '2,664 total' label conflated member count with payment count.

**Root cause**: I used \`analytics.totalMembership\` (current paid members — a cohort count) as the denominator for payment events (\`newMembers + aprilRenewals + octoberRenewals\` — an event count where one member can appear in multiple buckets across a program year).

## Fix
- Denominator is now \`totalPayments\` (sum of payment events from the three known buckets)
- Center label still shows the K-formatted total payments
- Header chip now reads 'N payment events' (was 'N total') with a tooltip explaining the relationship to member count
- 'New members' segment relabeled 'New member payments' so the unit matches the others
- Dropped the made-up 'Late / charter' wedge — we don't actually have those fields in ClubTrend; we were filling it with the (incorrect) remainder

Percentages now sum to 100% as expected.

## Test plan
- [x] Unit test: changed component renders 3 segments summing to 100%
- [ ] CI: full coverage suite + lighthouse
- [ ] Live verify on https://ts.taverns.red/district/61 — confirm percentages add to 100, header says 'payment events'

🤖 Generated with [Claude Code](https://claude.com/claude-code)