### PR TITLE
feat(district-overview): all 5 payment types in donut + larger-batch redesign approach (#360)

### DIFF
--- a/frontend/src/components/DistrictOverview.tsx
+++ b/frontend/src/components/DistrictOverview.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
+import { useDistrictRanking } from '../hooks/useDistrictRanking'
 import type { DistrictPerformanceTargets } from '../hooks/useDistrictAnalytics'
 import { LoadingSkeleton } from './LoadingSkeleton'
 import { ErrorDisplay, EmptyState } from './ErrorDisplay'
@@ -40,6 +41,10 @@ export const DistrictOverview: React.FC<DistrictOverviewProps> = ({
     isLoading: isLoadingAnalytics,
     error,
   } = useDistrictAnalytics(districtId, programYearStartDate, selectedDate)
+
+  // Fetch the district's row from rankings.json for district-level fields
+  // not carried in the per-club analytics (payment breakdowns).
+  const { ranking: districtRanking } = useDistrictRanking(districtId)
 
   // Get club counts from the new separate arrays
   const interventionRequiredClubsCount = React.useMemo(() => {
@@ -314,18 +319,11 @@ export const DistrictOverview: React.FC<DistrictOverviewProps> = ({
           />
           <PaymentCompositionDonut
             totalMembership={analytics.totalMembership}
-            newMembers={analytics.allClubs.reduce(
-              (sum, c) => sum + (c.newMembers ?? 0),
-              0
-            )}
-            aprilRenewals={analytics.allClubs.reduce(
-              (sum, c) => sum + (c.aprilRenewals ?? 0),
-              0
-            )}
-            octoberRenewals={analytics.allClubs.reduce(
-              (sum, c) => sum + (c.octoberRenewals ?? 0),
-              0
-            )}
+            newPayments={districtRanking?.newPayments ?? 0}
+            aprilPayments={districtRanking?.aprilPayments ?? 0}
+            octoberPayments={districtRanking?.octoberPayments ?? 0}
+            latePayments={districtRanking?.latePayments ?? 0}
+            charterPayments={districtRanking?.charterPayments ?? 0}
           />
         </div>
       )}

--- a/frontend/src/components/PaymentCompositionDonut.tsx
+++ b/frontend/src/components/PaymentCompositionDonut.tsx
@@ -7,11 +7,13 @@
 import React from 'react'
 
 interface PaymentCompositionDonutProps {
-  /** Number of currently-paid members (the cohort, not the events). */
+  /** Number of currently-paid members (the cohort — for the tooltip only). */
   totalMembership: number
-  newMembers: number
-  aprilRenewals: number
-  octoberRenewals: number
+  newPayments: number
+  aprilPayments: number
+  octoberPayments: number
+  latePayments: number
+  charterPayments: number
 }
 
 interface Segment {
@@ -27,36 +29,53 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS
 
 const PaymentCompositionDonut: React.FC<PaymentCompositionDonutProps> = ({
   totalMembership,
-  newMembers,
-  aprilRenewals,
-  octoberRenewals,
+  newPayments,
+  aprilPayments,
+  octoberPayments,
+  latePayments,
+  charterPayments,
 }) => {
   // Total PAYMENTS is the sum of payment events across the program year
-  // (a single member can show up in multiple buckets — paid as new, then
-  // renewed in April, then renewed in October). The previous version used
-  // totalMembership (= cohort count) as the denominator, which conflated
-  // two different metrics and produced percentages > 100%.
-  const totalPayments = newMembers + aprilRenewals + octoberRenewals
+  // (a single member can show up in multiple buckets). All 5 categories
+  // are sourced from the all-districts-rankings.json file.
+  const totalPayments =
+    newPayments +
+    aprilPayments +
+    octoberPayments +
+    latePayments +
+    charterPayments
   if (totalPayments <= 0) return null
 
   const segments: Segment[] = [
     {
       key: 'new',
       label: 'New member payments',
-      count: newMembers,
+      count: newPayments,
       color: 'var(--tm-loyal-blue, #004165)',
     },
     {
       key: 'april',
       label: 'April renewals',
-      count: aprilRenewals,
+      count: aprilPayments,
       color: 'var(--tm-loyal-blue-80, #3D7AA0)',
     },
     {
       key: 'october',
       label: 'October renewals',
-      count: octoberRenewals,
+      count: octoberPayments,
       color: 'rgb(22 163 74)',
+    },
+    {
+      key: 'late',
+      label: 'Late payments',
+      count: latePayments,
+      color: 'var(--tm-true-maroon, #772432)',
+    },
+    {
+      key: 'charter',
+      label: 'Charter payments',
+      count: charterPayments,
+      color: 'var(--yellow-500, #f59e0b)',
     },
   ].filter(s => s.count > 0)
 

--- a/frontend/src/hooks/useDistrictRanking.ts
+++ b/frontend/src/hooks/useDistrictRanking.ts
@@ -1,0 +1,30 @@
+/* useDistrictRanking — fetch the single district's row out of the shared
+   rankings.json cache. Returns null while loading or if not found.
+   Used to surface district-level fields that aren't carried in the
+   per-club analytics (e.g. payment breakdowns: new / april / october /
+   late / charter). */
+
+import { useQuery } from '@tanstack/react-query'
+import { fetchCdnRankings } from '../services/cdn'
+import type { DistrictRanking } from '../types/districts'
+
+export function useDistrictRanking(districtId: string | undefined): {
+  ranking: DistrictRanking | null
+  isLoading: boolean
+} {
+  const { data, isLoading } = useQuery({
+    queryKey: ['district-rankings', 'latest'],
+    queryFn: async () => {
+      const cdnData = await fetchCdnRankings()
+      return { rankings: cdnData.rankings, date: cdnData.date }
+    },
+    staleTime: 15 * 60 * 1000,
+  })
+
+  const ranking =
+    data?.rankings && districtId
+      ? (data.rankings.find(r => r.districtId === districtId) ?? null)
+      : null
+
+  return { ranking, isLoading }
+}


### PR DESCRIPTION
## Summary
Live user feedback: the Payment Composition donut showed only New / April / October — but Toastmasters tracks **five** payment categories (Late and Charter were missing).

## Root cause
The data was already in \`rankings.json\` (\`@toastmasters/shared-contracts\` types carry \`newPayments\`, \`aprilPayments\`, \`octoberPayments\`, \`latePayments\`, \`charterPayments\`). The previous donut was inferring buckets from per-club \`ClubTrend\` aggregates (\`newMembers / aprilRenewals / octoberRenewals\`) which is the **wrong source** — those fields are per-club partial data, not the district's payment-event roll-up.

## Fix
- New \`useDistrictRanking\` hook fetches the district's row from the shared rankings.json cache (no extra network — DistrictsPage already has the file cached via React Query)
- \`PaymentCompositionDonut\` prop API replaced: now takes the 5 explicit payment fields instead of inferring from per-club aggregates
- Two new segments: **Late payments** (true-maroon) + **Charter payments** (yellow-500), matching the design mockup
- Percentages sum to 100% by construction

## Approach going forward
Per user direction: shifting from slice-by-slice to **whole-tab PRs**. Sprint 8 (Overview tab #360) is now complete — KPI rank badge + Distinguished Composition + Payment Composition with all 5 types. Next PR will tackle a full tab.

## Test plan
- [x] Typecheck clean (new hook + new prop API)
- [ ] CI: full coverage suite
- [ ] Live verify on https://ts.taverns.red/district/61 — donut now has 5 wedges; legend shows all 5 categories; percentages sum to 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)