### PR TITLE
feat(clubs-table): status segmented filter with counts (#361 Clubs tab redesign)

### DIFF
--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -395,6 +395,126 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
             )}
           </div>
 
+          {/* Status segmented filter (#361) — All / Thriving / Vulnerable
+              / Intervention with counts, per design mockup. Sits above the
+              quick-filter chips so users can narrow by club health first,
+              then refine. */}
+          {(() => {
+            const statusFilter = getFilter('status')
+            const activeStatuses =
+              statusFilter && Array.isArray(statusFilter.value)
+                ? (statusFilter.value as string[])
+                : []
+            const isActive = (status: string) =>
+              activeStatuses.length === 1 && activeStatuses[0] === status
+            const isAllActive = activeStatuses.length === 0
+            const counts = {
+              all: clubs.length,
+              thriving: clubs.filter(c => c.currentStatus === 'thriving')
+                .length,
+              vulnerable: clubs.filter(c => c.currentStatus === 'vulnerable')
+                .length,
+              intervention: clubs.filter(
+                c => c.currentStatus === 'intervention-required'
+              ).length,
+            }
+            const setStatus = (status: string | null) => {
+              if (status === null) {
+                setFilter('status', null)
+              } else {
+                setFilter('status', {
+                  field: 'status',
+                  type: 'categorical',
+                  value: [status],
+                })
+              }
+            }
+            return (
+              <div
+                className="clubs-status-segmented"
+                role="tablist"
+                aria-label="Filter clubs by health status"
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={isAllActive}
+                  onClick={() => setStatus(null)}
+                  className={
+                    'clubs-status-segmented__btn' +
+                    (isAllActive ? ' clubs-status-segmented__btn--active' : '')
+                  }
+                >
+                  All{' '}
+                  <span className="clubs-status-segmented__count">
+                    {counts.all}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive('thriving')}
+                  onClick={() =>
+                    setStatus(isActive('thriving') ? null : 'thriving')
+                  }
+                  className={
+                    'clubs-status-segmented__btn' +
+                    (isActive('thriving')
+                      ? ' clubs-status-segmented__btn--active'
+                      : '')
+                  }
+                >
+                  Thriving{' '}
+                  <span className="clubs-status-segmented__count">
+                    {counts.thriving}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive('vulnerable')}
+                  onClick={() =>
+                    setStatus(isActive('vulnerable') ? null : 'vulnerable')
+                  }
+                  className={
+                    'clubs-status-segmented__btn' +
+                    (isActive('vulnerable')
+                      ? ' clubs-status-segmented__btn--active'
+                      : '')
+                  }
+                >
+                  Vulnerable{' '}
+                  <span className="clubs-status-segmented__count">
+                    {counts.vulnerable}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive('intervention-required')}
+                  onClick={() =>
+                    setStatus(
+                      isActive('intervention-required')
+                        ? null
+                        : 'intervention-required'
+                    )
+                  }
+                  className={
+                    'clubs-status-segmented__btn' +
+                    (isActive('intervention-required')
+                      ? ' clubs-status-segmented__btn--active'
+                      : '')
+                  }
+                >
+                  Intervention{' '}
+                  <span className="clubs-status-segmented__count">
+                    {counts.intervention}
+                  </span>
+                </button>
+              </div>
+            )
+          })()}
+
           <div className="clubs-quick-filters">
             <span className="clubs-quick-filters__label">Quick filters:</span>
 

--- a/frontend/src/components/__tests__/ClubsTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.test.tsx
@@ -559,7 +559,7 @@ describe('ClubsTable', () => {
         }),
       ]
 
-      render(
+      const { container } = render(
         <ClubsTable
           clubs={clubs}
           districtId="test-district"
@@ -567,7 +567,11 @@ describe('ClubsTable', () => {
         />
       )
 
-      expect(screen.getByText('Thriving')).toBeInTheDocument()
+      // 'Thriving' appears in the status segmented filter button (#361)
+      // and as the status badge on the table row. Scope to the table body.
+      const tbody = container.querySelector('tbody')
+      expect(tbody).toBeTruthy()
+      expect(tbody!.textContent).toMatch(/Thriving/)
     })
 
     it('should display "Vulnerable" status badge for vulnerable clubs', () => {
@@ -579,7 +583,7 @@ describe('ClubsTable', () => {
         }),
       ]
 
-      render(
+      const { container } = render(
         <ClubsTable
           clubs={clubs}
           districtId="test-district"
@@ -587,7 +591,9 @@ describe('ClubsTable', () => {
         />
       )
 
-      expect(screen.getByText('Vulnerable')).toBeInTheDocument()
+      const tbody = container.querySelector('tbody')
+      expect(tbody).toBeTruthy()
+      expect(tbody!.textContent).toMatch(/Vulnerable/)
     })
 
     it('should display "Intervention Required" status badge for intervention-required clubs', () => {

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -962,6 +962,69 @@
     font-weight: 600;
   }
 
+  /* Clubs tab segmented status filter (#361). Larger primary filter
+     above the quick-filter chip strip — All / Thriving / Vulnerable /
+     Intervention with counts. */
+  .clubs-status-segmented {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 2px;
+    margin-bottom: 12px;
+    padding: 2px;
+    background-color: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-md);
+  }
+
+  .clubs-status-segmented__btn {
+    appearance: none;
+    border: 0;
+    padding: 6px 12px;
+    border-radius: calc(var(--rds-radius-md) - 2px);
+    background-color: transparent;
+    color: var(--ink-2);
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: 13px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: background-color 120ms ease, color 120ms ease;
+  }
+
+  .clubs-status-segmented__btn:hover {
+    color: var(--ink);
+    background-color: var(--surface-3);
+  }
+
+  .clubs-status-segmented__btn--active {
+    background-color: var(--surface);
+    color: var(--loyal-500);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  }
+
+  .clubs-status-segmented__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    padding: 0 6px;
+    height: 18px;
+    border-radius: 999px;
+    background-color: var(--surface-3);
+    color: var(--ink-3);
+    font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+    font-weight: 500;
+    font-size: 11px;
+    line-height: 1;
+  }
+
+  .clubs-status-segmented__btn--active .clubs-status-segmented__count {
+    background-color: var(--loyal-50);
+    color: var(--loyal-500);
+  }
+
   /* Clubs tab quick-filter chip strip (#24 follow-up). Sits above the
      ClubsTable toolbar on the District detail Clubs tab. */
   .clubs-quick-filters {


### PR DESCRIPTION
## Summary
**Sprint 9 / Issue #361 — Clubs tab redesign.**

Adds the All / Thriving / Vulnerable / Intervention segmented filter from the design mockup. Sits above the existing quick-filter chip strip so users can filter by club health first, then refine with quick chips.

- Counts rendered next to each segment (e.g. 'Thriving 218'), live from the \`clubs\` prop
- Clicking a segment dispatches \`setFilter('status', { value: [key] })\` — same wiring as the existing column filter
- Clicking the active segment OR 'All' clears the status filter
- \`role=tablist\` + \`aria-selected\` for screen readers
- Subtle 'pressed pill' visual (loyal-blue text on raised surface) when active

## Test plan
- [x] ClubsTable tests scoped to table body (Thriving / Vulnerable text now appears in 2 surfaces)
- [x] Full frontend suite: 2138/2138
- [ ] Live verify on https://ts.taverns.red/district/61 → Clubs tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)