### PR TITLE
fix(hooks): 5 setState-in-effect violations → render-phase sync (#340)

### DIFF
--- a/frontend/src/__tests__/validation/migrationValidation.test.tsx
+++ b/frontend/src/__tests__/validation/migrationValidation.test.tsx
@@ -99,13 +99,19 @@ const TestFunctionalComponent: React.FC<TestComponentProps> = ({
   )
 }
 
-// Component with hooks for testing
+// Component with hooks for testing. Tracks variant-prop changes via the
+// render-phase setState pattern instead of a useEffect mirror to avoid
+// the react-hooks/set-state-in-effect violation (#340). See React docs:
+// https://react.dev/reference/react/useState#storing-information-from-previous-renders
 const TestHooksComponent: React.FC<TestComponentProps> = props => {
   const [count, setCount] = React.useState(0)
-
-  React.useEffect(() => {
+  const [prevVariant, setPrevVariant] = React.useState<string | undefined>(
+    undefined
+  )
+  if (prevVariant !== props.variant) {
+    setPrevVariant(props.variant)
     setCount(prev => prev + 1)
-  }, [props.variant])
+  }
 
   return (
     <div data-testid="hooks-wrapper">

--- a/frontend/src/components/DateRangeSelector.tsx
+++ b/frontend/src/components/DateRangeSelector.tsx
@@ -20,10 +20,9 @@ export const DateRangeSelector = ({
 
   const [startDate, setStartDate] = useState(thirtyDaysAgo)
   const [endDate, setEndDate] = useState(today)
-  const [error, setError] = useState<string | null>(null)
 
-  // Validation using useMemo instead of useEffect
-  const validationError = useMemo(() => {
+  // Derived during render — no mirror-into-state effect (#340).
+  const error = useMemo(() => {
     if (!startDate || !endDate) {
       return 'Both start and end dates are required'
     }
@@ -46,17 +45,12 @@ export const DateRangeSelector = ({
     return null
   }, [startDate, endDate, maxDays])
 
-  // Update error state when validation changes
-  useEffect(() => {
-    setError(validationError)
-  }, [validationError])
-
   // Emit valid date ranges
   useEffect(() => {
-    if (!validationError && startDate && endDate) {
+    if (!error && startDate && endDate) {
       onDateRangeChange(startDate, endDate)
     }
-  }, [startDate, endDate, validationError, onDateRangeChange])
+  }, [startDate, endDate, error, onDateRangeChange])
 
   const handlePresetRange = (days: number) => {
     const end = new Date()

--- a/frontend/src/components/filters/CategoricalFilter.tsx
+++ b/frontend/src/components/filters/CategoricalFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { CategoricalFilterProps } from './types'
 
 /**
@@ -24,11 +24,16 @@ export const CategoricalFilter: React.FC<CategoricalFilterProps> = ({
   className = '',
 }) => {
   const [localSelected, setLocalSelected] = useState<string[]>(selectedValues)
-
-  // Update local selection when props change
-  useEffect(() => {
+  // Render-phase sync: when the parent resets selectedValues (e.g. "Clear
+  // all filters") propagate it to local state without setState-in-effect
+  // (#340). See React docs:
+  // https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  const [trackedSelected, setTrackedSelected] =
+    useState<string[]>(selectedValues)
+  if (selectedValues !== trackedSelected) {
+    setTrackedSelected(selectedValues)
     setLocalSelected(selectedValues)
-  }, [selectedValues])
+  }
 
   // Handle option toggle
   const handleToggle = (option: string) => {

--- a/frontend/src/components/filters/NumericFilter.tsx
+++ b/frontend/src/components/filters/NumericFilter.tsx
@@ -32,14 +32,15 @@ export const NumericFilter: React.FC<NumericFilterProps> = ({
   )
   const [error, setError] = useState<string>('')
 
-  // Sync local state with props when they change
-  React.useEffect(() => {
-    const newMin = value[0]?.toString() || ''
-    const newMax = value[1]?.toString() || ''
-
-    setLocalMin(newMin)
-    setLocalMax(newMax)
-  }, [value])
+  // Render-phase sync: when the parent updates `value` (e.g. external
+  // "Clear all filters"), propagate it to local inputs without
+  // setState-in-effect (#340).
+  const [trackedValue, setTrackedValue] = useState(value)
+  if (value !== trackedValue) {
+    setTrackedValue(value)
+    setLocalMin(value[0]?.toString() || '')
+    setLocalMax(value[1]?.toString() || '')
+  }
 
   // Validate and update filter
   const updateFilter = (minStr: string, maxStr: string) => {

--- a/frontend/src/components/filters/TextFilter.tsx
+++ b/frontend/src/components/filters/TextFilter.tsx
@@ -27,14 +27,17 @@ export const TextFilter: React.FC<TextFilterProps> = ({
   const [operator, setOperator] = useState<'contains' | 'startsWith'>(
     'contains'
   )
+  // Track the prop value to detect external resets (e.g. "Clear all").
+  // Render-phase sync avoids setState-in-effect (#340); see React docs:
+  // https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  const [trackedValue, setTrackedValue] = useState(value)
+  if (value !== trackedValue) {
+    setTrackedValue(value)
+    setLocalValue(value)
+  }
 
   // Debounce the local value with 300ms delay for performance optimization
   const debouncedValue = useDebounce(localValue, 300)
-
-  // Update local value when prop changes
-  useEffect(() => {
-    setLocalValue(value)
-  }, [value])
 
   // Call onChange when debounced value changes
   useEffect(() => {


### PR DESCRIPTION
## Summary

Closes #340. Replaces the "useEffect setState mirror" anti-pattern with React's official render-phase sync pattern in 5 files. Unblocks dependabot dev-deps bumps #334 and #335 once the eslint-plugin-react-hooks rule activates.

- **CategoricalFilter** — sync `selectedValues` prop → `localSelected`
- **TextFilter** — sync `value` prop → `localValue`
- **NumericFilter** — sync `value` prop → `localMin` / `localMax`
- **DateRangeSelector** — drop the mirrored `error` state entirely; derive via `useMemo` instead
- **migrationValidation.test.tsx** — `TestHooksComponent` tracks `prevVariant` so the variant-change counter still ticks without setState-in-effect

The 6th file the issue listed (`LandingPage.tsx`) no longer exists on main — its rendering path was restructured into `DistrictsPage`, so no-op there.

Pattern follows [React docs: "Storing information from previous renders"](https://react.dev/reference/react/useState#storing-information-from-previous-renders).

## Test plan

- [x] Local: 131/131 files, 2134/2134 tests green
- [x] Affected files (TextFilter.debouncing, migrationValidation): 41/41 tests pass
- [ ] CI green
- [ ] Rebase #334 / #335 (or their next regenerated equivalents) and confirm the eslint-plugin-react-hooks bump no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)