### PR TITLE
feat(a11y): WAI-ARIA tablist arrow-key nav + tabpanel linkage (#384)

### DIFF
--- a/frontend/src/components/DistrictDetailTabs.tsx
+++ b/frontend/src/components/DistrictDetailTabs.tsx
@@ -1,7 +1,19 @@
-import React from 'react'
+import React, { useRef } from 'react'
 
 /* District detail tab bar (#359). Pure presentational tablist — the
-   parent owns activeTab state and routing/URL sync. */
+   parent owns activeTab state and routing/URL sync.
+
+   WAI-ARIA tablist pattern (#384):
+   - role=tablist on the container, role=tab on each button
+   - Roving tabIndex: active tab is tabIndex=0, others are tabIndex=-1
+   - Arrow keys (←/→) move focus with wrap; Home/End jump to first/last
+   - Manual activation (Space/Enter) — focus moves on arrows but the
+     activeTab only changes when the user explicitly activates, because
+     tab content is heavy
+   - aria-controls links each tab to its tabpanel id; the parent renders
+     the panel with role=tabpanel + id + aria-labelledby. See
+     `tabIdFor` / `panelIdFor` exports.
+   Reference: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/ */
 
 export type DistrictTabId =
   | 'overview'
@@ -10,6 +22,9 @@ export type DistrictTabId =
   | 'trends'
   | 'analytics'
   | 'globalRankings'
+
+export const tabIdFor = (id: DistrictTabId) => `district-tab-${id}`
+export const panelIdFor = (id: DistrictTabId) => `district-tabpanel-${id}`
 
 interface DistrictDetailTabsProps {
   activeTab: DistrictTabId
@@ -41,10 +56,37 @@ export const DistrictDetailTabs: React.FC<DistrictDetailTabsProps> = ({
   clubsCount,
   divisionsCount,
 }) => {
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
+
   const handleClick = (tabId: DistrictTabId) => {
     if (tabId !== activeTab) {
       onTabChange(tabId)
     }
+  }
+
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    currentIndex: number
+  ) => {
+    let nextIndex = currentIndex
+    switch (event.key) {
+      case 'ArrowRight':
+        nextIndex = (currentIndex + 1) % TABS.length
+        break
+      case 'ArrowLeft':
+        nextIndex = (currentIndex - 1 + TABS.length) % TABS.length
+        break
+      case 'Home':
+        nextIndex = 0
+        break
+      case 'End':
+        nextIndex = TABS.length - 1
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+    tabRefs.current[nextIndex]?.focus()
   }
 
   return (
@@ -53,7 +95,7 @@ export const DistrictDetailTabs: React.FC<DistrictDetailTabsProps> = ({
       role="tablist"
       aria-label="District analysis tabs"
     >
-      {TABS.map(tab => {
+      {TABS.map((tab, index) => {
         const isActive = activeTab === tab.id
         const count =
           tab.countKey === 'clubsCount'
@@ -66,10 +108,17 @@ export const DistrictDetailTabs: React.FC<DistrictDetailTabsProps> = ({
         return (
           <button
             key={tab.id}
+            ref={el => {
+              tabRefs.current[index] = el
+            }}
             type="button"
             role="tab"
+            id={tabIdFor(tab.id)}
             aria-selected={isActive}
+            aria-controls={panelIdFor(tab.id)}
+            tabIndex={isActive ? 0 : -1}
             onClick={() => handleClick(tab.id)}
+            onKeyDown={event => handleKeyDown(event, index)}
             className={
               'district-detail-tabs__tab' +
               (isActive ? ' district-detail-tabs__tab--active' : '')

--- a/frontend/src/components/__tests__/DistrictDetailTabs.test.tsx
+++ b/frontend/src/components/__tests__/DistrictDetailTabs.test.tsx
@@ -99,6 +99,78 @@ describe('DistrictDetailTabs (#359)', () => {
     })
   })
 
+  describe('keyboard navigation (#384)', () => {
+    // WAI-ARIA tabs pattern: roving tabIndex, arrow keys move focus,
+    // Home/End jump, Space/Enter activate. Focus moves manually because
+    // tab content is heavy.
+    it('puts the active tab at tabIndex=0 and others at tabIndex=-1', () => {
+      renderTabs({ activeTab: 'clubs' })
+      const tablist = screen.getByRole('tablist')
+      const tabs = within(tablist).getAllByRole('tab')
+      tabs.forEach(t => {
+        const expected = t.getAttribute('aria-selected') === 'true' ? '0' : '-1'
+        expect(t).toHaveAttribute('tabindex', expected)
+      })
+    })
+
+    it('ArrowRight moves focus to the next tab (with wrap)', () => {
+      renderTabs({ activeTab: 'overview' })
+      const tablist = screen.getByRole('tablist')
+      const tabs = within(tablist).getAllByRole('tab')
+      tabs[0].focus()
+      fireEvent.keyDown(tabs[0], { key: 'ArrowRight' })
+      expect(tabs[1]).toHaveFocus()
+      // wrap at end
+      tabs[5].focus()
+      fireEvent.keyDown(tabs[5], { key: 'ArrowRight' })
+      expect(tabs[0]).toHaveFocus()
+    })
+
+    it('ArrowLeft moves focus to the previous tab (with wrap)', () => {
+      renderTabs({ activeTab: 'overview' })
+      const tablist = screen.getByRole('tablist')
+      const tabs = within(tablist).getAllByRole('tab')
+      tabs[2].focus()
+      fireEvent.keyDown(tabs[2], { key: 'ArrowLeft' })
+      expect(tabs[1]).toHaveFocus()
+      // wrap at start
+      tabs[0].focus()
+      fireEvent.keyDown(tabs[0], { key: 'ArrowLeft' })
+      expect(tabs[5]).toHaveFocus()
+    })
+
+    it('Home jumps focus to the first tab; End jumps to the last', () => {
+      renderTabs({ activeTab: 'overview' })
+      const tablist = screen.getByRole('tablist')
+      const tabs = within(tablist).getAllByRole('tab')
+      tabs[3].focus()
+      fireEvent.keyDown(tabs[3], { key: 'End' })
+      expect(tabs[5]).toHaveFocus()
+      fireEvent.keyDown(tabs[5], { key: 'Home' })
+      expect(tabs[0]).toHaveFocus()
+    })
+
+    it('does not change activeTab on arrow keys — manual activation only', () => {
+      const onTabChange = vi.fn()
+      renderTabs({ activeTab: 'overview', onTabChange })
+      const tablist = screen.getByRole('tablist')
+      const tabs = within(tablist).getAllByRole('tab')
+      tabs[0].focus()
+      fireEvent.keyDown(tabs[0], { key: 'ArrowRight' })
+      expect(onTabChange).not.toHaveBeenCalled()
+    })
+
+    it('each tab has aria-controls pointing at its tabpanel id', () => {
+      renderTabs()
+      const tablist = screen.getByRole('tablist')
+      const tabs = within(tablist).getAllByRole('tab')
+      tabs.forEach(t => {
+        const controls = t.getAttribute('aria-controls')
+        expect(controls).toMatch(/^district-tabpanel-/)
+      })
+    })
+  })
+
   describe('accessibility', () => {
     it('exposes a tablist landmark with an aria-label', () => {
       renderTabs()

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -2,7 +2,11 @@ import React, { useCallback, useMemo } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useDistricts } from '../hooks/useDistricts'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
-import { DistrictDetailTabs } from '../components/DistrictDetailTabs'
+import {
+  DistrictDetailTabs,
+  panelIdFor,
+  tabIdFor,
+} from '../components/DistrictDetailTabs'
 import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useAggregatedAnalytics } from '../hooks/useAggregatedAnalytics'
 import { useDistrictStatistics } from '../hooks/useMembershipData'
@@ -593,295 +597,345 @@ const DistrictDetailPage: React.FC = () => {
               />
             )}
 
-          {/* Tab Content */}
+          {/* Tab Content — each panel has a stable id + aria-labelledby
+              even when its body is conditionally rendered, so the
+              tablist's aria-controls always resolves (#384). */}
           <div className="space-y-4 sm:space-y-6">
-            {activeTab === 'overview' && districtId && hasOverviewData && (
-              <>
-                {/* District Overview - Now uses global date selector */}
-                {hasValidDates && effectiveProgramYear && (
-                  <DistrictOverview
-                    districtId={districtId}
-                    {...(effectiveEndDate && {
-                      selectedDate: effectiveEndDate,
-                    })}
-                    programYearStartDate={effectiveProgramYear.startDate}
-                    performanceTargets={performanceTargets ?? undefined}
-                    netMemberChange={
-                      // #170: prefer time-series member change (base membership based)
-                      timeSeries?.memberChange
+            <div
+              role="tabpanel"
+              id={panelIdFor('overview')}
+              aria-labelledby={tabIdFor('overview')}
+              hidden={activeTab !== 'overview'}
+            >
+              {activeTab === 'overview' && districtId && hasOverviewData && (
+                <>
+                  {/* District Overview - Now uses global date selector */}
+                  {hasValidDates && effectiveProgramYear && (
+                    <DistrictOverview
+                      districtId={districtId}
+                      {...(effectiveEndDate && {
+                        selectedDate: effectiveEndDate,
+                      })}
+                      programYearStartDate={effectiveProgramYear.startDate}
+                      performanceTargets={performanceTargets ?? undefined}
+                      netMemberChange={
+                        // #170: prefer time-series member change (base membership based)
+                        timeSeries?.memberChange
+                      }
+                    />
+                  )}
+
+                  {/* Distinguished District Trophy Case (#332) */}
+                  <DistinguishedDistrictTrophyCase
+                    status={distinguishedDistrictStatus}
+                    clubStrengthQualifies={clubStrengthResult?.qualifies}
+                    clubStrengthGrowth={clubStrengthResult?.growthPercent}
+                    leadershipExcellenceQualifies={
+                      leadershipExcellenceResult?.qualifies
+                    }
+                    leadershipExcellenceYears={
+                      leadershipExcellenceResult?.consecutiveYears
+                    }
+                    educationTrainingQualifies={
+                      officerAwardsResult?.educationTraining?.qualifies
+                    }
+                    clubGrowthQualifies={
+                      officerAwardsResult?.clubGrowth?.qualifies
                     }
                   />
-                )}
 
-                {/* Distinguished District Trophy Case (#332) */}
-                <DistinguishedDistrictTrophyCase
-                  status={distinguishedDistrictStatus}
-                  clubStrengthQualifies={clubStrengthResult?.qualifies}
-                  clubStrengthGrowth={clubStrengthResult?.growthPercent}
-                  leadershipExcellenceQualifies={
-                    leadershipExcellenceResult?.qualifies
-                  }
-                  leadershipExcellenceYears={
-                    leadershipExcellenceResult?.consecutiveYears
-                  }
-                  educationTrainingQualifies={
-                    officerAwardsResult?.educationTraining?.qualifies
-                  }
-                  clubGrowthQualifies={
-                    officerAwardsResult?.clubGrowth?.qualifies
-                  }
-                />
-
-                {/* Payment Composition + Distinguished Progress legacy
+                  {/* Payment Composition + Distinguished Progress legacy
                     sections retired in #472 — the new redesign panels in
                     DistrictOverview (DistinguishedCompositionBar +
                     PaymentCompositionDonut) cover the same data. */}
-              </>
-            )}
+                </>
+              )}
+            </div>
 
-            {activeTab === 'clubs' && districtId && (
-              <ClubsTable
-                clubs={allClubs}
-                districtId={districtId}
-                isLoading={isLoadingAnalytics}
-                onClubClick={handleClubClick}
-                initialSortField={initialSortField}
-                initialSortDirection={initialSortDir}
-                onSortChange={handleSortChange}
-                initialPage={initialPage}
-                onPageChange={handlePageChange}
-                initialFilterState={initialFilterState}
-                onFilterChange={handleFilterChange}
-              />
-            )}
+            <div
+              role="tabpanel"
+              id={panelIdFor('clubs')}
+              aria-labelledby={tabIdFor('clubs')}
+              hidden={activeTab !== 'clubs'}
+            >
+              {activeTab === 'clubs' && districtId && (
+                <ClubsTable
+                  clubs={allClubs}
+                  districtId={districtId}
+                  isLoading={isLoadingAnalytics}
+                  onClubClick={handleClubClick}
+                  initialSortField={initialSortField}
+                  initialSortDirection={initialSortDir}
+                  onSortChange={handleSortChange}
+                  initialPage={initialPage}
+                  onPageChange={handlePageChange}
+                  initialFilterState={initialFilterState}
+                  onFilterChange={handleFilterChange}
+                />
+              )}
+            </div>
 
-            {activeTab === 'divisions' && (
-              <>
-                {/* Division Performance Cards */}
-                {districtStatistics ? (
-                  <DivisionPerformanceCards
-                    districtSnapshot={districtStatistics}
-                    isLoading={isLoadingStatistics}
-                    snapshotTimestamp={districtStatistics.asOfDate}
-                  />
-                ) : (
-                  isLoadingStatistics && <LoadingSkeleton variant="card" />
-                )}
+            <div
+              role="tabpanel"
+              id={panelIdFor('divisions')}
+              aria-labelledby={tabIdFor('divisions')}
+              hidden={activeTab !== 'divisions'}
+            >
+              {activeTab === 'divisions' && (
+                <>
+                  {/* Division Performance Cards */}
+                  {districtStatistics ? (
+                    <DivisionPerformanceCards
+                      districtSnapshot={districtStatistics}
+                      isLoading={isLoadingStatistics}
+                      snapshotTimestamp={districtStatistics.asOfDate}
+                    />
+                  ) : (
+                    isLoadingStatistics && <LoadingSkeleton variant="card" />
+                  )}
 
-                {/* Distinguished Program criteria explainer (#362). Sits
+                  {/* Distinguished Program criteria explainer (#362). Sits
                     between the per-division cards and the
                     DivisionAreaRecognitionPanel so users see the rules
                     before reading any specific division's status. */}
-                <DistinguishedProgramCriteriaExplainer />
+                  <DistinguishedProgramCriteriaExplainer />
 
-                {/* Division and Area Recognition Panel */}
-                {districtStatistics ? (
-                  <DivisionAreaRecognitionPanel
-                    divisions={extractDivisionPerformance(districtStatistics)}
-                    isLoading={isLoadingStatistics}
-                  />
-                ) : (
-                  isLoadingStatistics && (
-                    <LoadingSkeleton variant="table" count={3} />
-                  )
-                )}
-              </>
-            )}
-
-            {activeTab === 'trends' && (
-              <>
-                {/* Membership Trend Chart */}
-                {aggregatedAnalytics ? (
-                  <LazyChart height="400px">
-                    <MembershipTrendChart
-                      membershipTrend={
-                        // #170: prefer time-series monthly data over inline 1-point trend
-                        timeSeries?.years[
-                          timeSeries.currentProgramYear
-                        ]?.dataPoints.map(dp => ({
-                          date: dp.date,
-                          count: dp.membership,
-                        })) ?? aggregatedAnalytics.trends.membership
-                      }
-                      isLoading={isLoadingAggregated}
-                      priorYearTrends={
-                        // #238: overlay prior years for YoY comparison
-                        timeSeries
-                          ? timeSeries.availableYears
-                              .filter(y => y !== timeSeries.currentProgramYear)
-                              .map(y => ({
-                                label: y,
-                                data:
-                                  timeSeries.years[y]?.dataPoints.map(dp => ({
-                                    date: dp.date,
-                                    count: dp.membership,
-                                  })) ?? [],
-                              }))
-                              .filter(yt => yt.data.length > 0)
-                          : undefined
-                      }
+                  {/* Division and Area Recognition Panel */}
+                  {districtStatistics ? (
+                    <DivisionAreaRecognitionPanel
+                      divisions={extractDivisionPerformance(districtStatistics)}
+                      isLoading={isLoadingStatistics}
                     />
-                  </LazyChart>
-                ) : (
-                  isLoadingAggregated && (
-                    <LoadingSkeleton variant="chart" height="400px" />
-                  )
-                )}
+                  ) : (
+                    isLoadingStatistics && (
+                      <LoadingSkeleton variant="table" count={3} />
+                    )
+                  )}
+                </>
+              )}
+            </div>
 
-                {/* Membership Payments Chart (#243) */}
-                {paymentsTrendData ? (
-                  <LazyChart height="450px">
-                    <MembershipPaymentsChart
-                      paymentsTrend={paymentsTrendData.currentYearTrend}
-                      multiYearData={
-                        // #243: Build multi-year payment data from time-series CDN
-                        // (analytics CDN only has current year payments)
-                        timeSeries
-                          ? ((): MultiYearPaymentData => {
-                              const currentPY = timeSeries.currentProgramYear
-                              const currentData =
-                                timeSeries.years[currentPY]?.dataPoints.map(
-                                  dp => ({
-                                    date: dp.date,
-                                    payments: dp.payments,
-                                    programYearDay: calculateProgramYearDay(
-                                      dp.date
-                                    ),
-                                  })
-                                ) ?? []
-                              const previousYears = timeSeries.availableYears
-                                .filter(y => y !== currentPY)
+            <div
+              role="tabpanel"
+              id={panelIdFor('trends')}
+              aria-labelledby={tabIdFor('trends')}
+              hidden={activeTab !== 'trends'}
+            >
+              {activeTab === 'trends' && (
+                <>
+                  {/* Membership Trend Chart */}
+                  {aggregatedAnalytics ? (
+                    <LazyChart height="400px">
+                      <MembershipTrendChart
+                        membershipTrend={
+                          // #170: prefer time-series monthly data over inline 1-point trend
+                          timeSeries?.years[
+                            timeSeries.currentProgramYear
+                          ]?.dataPoints.map(dp => ({
+                            date: dp.date,
+                            count: dp.membership,
+                          })) ?? aggregatedAnalytics.trends.membership
+                        }
+                        isLoading={isLoadingAggregated}
+                        priorYearTrends={
+                          // #238: overlay prior years for YoY comparison
+                          timeSeries
+                            ? timeSeries.availableYears
+                                .filter(
+                                  y => y !== timeSeries.currentProgramYear
+                                )
                                 .map(y => ({
                                   label: y,
                                   data:
                                     timeSeries.years[y]?.dataPoints.map(dp => ({
                                       date: dp.date,
+                                      count: dp.membership,
+                                    })) ?? [],
+                                }))
+                                .filter(yt => yt.data.length > 0)
+                            : undefined
+                        }
+                      />
+                    </LazyChart>
+                  ) : (
+                    isLoadingAggregated && (
+                      <LoadingSkeleton variant="chart" height="400px" />
+                    )
+                  )}
+
+                  {/* Membership Payments Chart (#243) */}
+                  {paymentsTrendData ? (
+                    <LazyChart height="450px">
+                      <MembershipPaymentsChart
+                        paymentsTrend={paymentsTrendData.currentYearTrend}
+                        multiYearData={
+                          // #243: Build multi-year payment data from time-series CDN
+                          // (analytics CDN only has current year payments)
+                          timeSeries
+                            ? ((): MultiYearPaymentData => {
+                                const currentPY = timeSeries.currentProgramYear
+                                const currentData =
+                                  timeSeries.years[currentPY]?.dataPoints.map(
+                                    dp => ({
+                                      date: dp.date,
                                       payments: dp.payments,
                                       programYearDay: calculateProgramYearDay(
                                         dp.date
                                       ),
-                                    })) ?? [],
-                                }))
-                                .filter(yt => yt.data.length > 0)
-                              return {
-                                currentYear: {
-                                  label: currentPY,
-                                  data: currentData,
-                                },
-                                previousYears,
-                              }
-                            })()
-                          : paymentsTrendData.multiYearData
-                      }
-                      statistics={
-                        // #269: Override YoY when time-series data provides
-                        // multi-year payment history (analytics CDN is current-year-only)
-                        (() => {
-                          const tsYoY = computePaymentYoYFromTimeSeries(
-                            timeSeries ?? null
-                          )
-                          if (tsYoY) {
-                            // Use time-series payments for consistency (#319)
-                            const tsPayments = getLatestPayments(
+                                    })
+                                  ) ?? []
+                                const previousYears = timeSeries.availableYears
+                                  .filter(y => y !== currentPY)
+                                  .map(y => ({
+                                    label: y,
+                                    data:
+                                      timeSeries.years[y]?.dataPoints.map(
+                                        dp => ({
+                                          date: dp.date,
+                                          payments: dp.payments,
+                                          programYearDay:
+                                            calculateProgramYearDay(dp.date),
+                                        })
+                                      ) ?? [],
+                                  }))
+                                  .filter(yt => yt.data.length > 0)
+                                return {
+                                  currentYear: {
+                                    label: currentPY,
+                                    data: currentData,
+                                  },
+                                  previousYears,
+                                }
+                              })()
+                            : paymentsTrendData.multiYearData
+                        }
+                        statistics={
+                          // #269: Override YoY when time-series data provides
+                          // multi-year payment history (analytics CDN is current-year-only)
+                          (() => {
+                            const tsYoY = computePaymentYoYFromTimeSeries(
                               timeSeries ?? null
                             )
-                            return {
-                              ...paymentsTrendData.statistics,
-                              ...(tsPayments !== null && {
-                                currentPayments: tsPayments,
-                              }),
-                              yearOverYearChange: tsYoY.yearOverYearChange,
-                              trendDirection: tsYoY.trendDirection,
+                            if (tsYoY) {
+                              // Use time-series payments for consistency (#319)
+                              const tsPayments = getLatestPayments(
+                                timeSeries ?? null
+                              )
+                              return {
+                                ...paymentsTrendData.statistics,
+                                ...(tsPayments !== null && {
+                                  currentPayments: tsPayments,
+                                }),
+                                yearOverYearChange: tsYoY.yearOverYearChange,
+                                trendDirection: tsYoY.trendDirection,
+                              }
                             }
-                          }
-                          return paymentsTrendData.statistics
-                        })()
-                      }
-                      isLoading={isLoadingPaymentsTrend}
+                            return paymentsTrendData.statistics
+                          })()
+                        }
+                        isLoading={isLoadingPaymentsTrend}
+                      />
+                    </LazyChart>
+                  ) : (
+                    isLoadingPaymentsTrend && (
+                      <LoadingSkeleton variant="chart" height="450px" />
+                    )
+                  )}
+
+                  {/* Year-Over-Year Comparison */}
+                  {aggregatedAnalytics ? (
+                    <LazyChart height="300px">
+                      <YearOverYearComparison
+                        {...(computeYearOverYear(timeSeries ?? null) && {
+                          yearOverYear: computeYearOverYear(
+                            timeSeries ?? null
+                          )!,
+                        })}
+                        currentYear={{
+                          // Use time-series membership when available (#319)
+                          // to match the membership chart above
+                          totalMembership:
+                            timeSeries?.currentMembership ??
+                            aggregatedAnalytics.summary.totalMembership,
+                          distinguishedClubs:
+                            aggregatedAnalytics.summary.distinguishedClubs
+                              .total,
+                          thrivingClubs:
+                            aggregatedAnalytics.summary.clubCounts.thriving,
+                          totalClubs:
+                            aggregatedAnalytics.summary.clubCounts.total,
+                        }}
+                        isLoading={isLoadingAggregated}
+                      />
+                    </LazyChart>
+                  ) : (
+                    isLoadingAggregated && (
+                      <LoadingSkeleton variant="chart" height="300px" />
+                    )
+                  )}
+                </>
+              )}
+            </div>
+
+            <div
+              role="tabpanel"
+              id={panelIdFor('analytics')}
+              aria-labelledby={tabIdFor('analytics')}
+              hidden={activeTab !== 'analytics'}
+            >
+              {activeTab === 'analytics' && (
+                <>
+                  {/* Top Growth Clubs */}
+                  {analytics ? (
+                    <TopGrowthClubs
+                      topGrowthClubs={analytics.topGrowthClubs}
+                      topDCPClubs={analytics.allClubs
+                        .filter(club => club.dcpGoalsTrend.length > 0)
+                        .map(club => ({
+                          clubId: club.clubId,
+                          clubName: club.clubName,
+                          goalsAchieved:
+                            club.dcpGoalsTrend[club.dcpGoalsTrend.length - 1]
+                              ?.goalsAchieved || 0,
+                          ...(club.distinguishedLevel &&
+                            [
+                              'Smedley',
+                              'President',
+                              'Select',
+                              'Distinguished',
+                            ].includes(club.distinguishedLevel) && {
+                              distinguishedLevel: club.distinguishedLevel as
+                                | 'Smedley'
+                                | 'President'
+                                | 'Select'
+                                | 'Distinguished',
+                            }),
+                        }))
+                        .sort((a, b) => b.goalsAchieved - a.goalsAchieved)
+                        .slice(0, 10)}
+                      isLoading={isLoadingAnalytics}
                     />
-                  </LazyChart>
-                ) : (
-                  isLoadingPaymentsTrend && (
-                    <LoadingSkeleton variant="chart" height="450px" />
-                  )
-                )}
+                  ) : (
+                    isLoadingAnalytics && <LoadingSkeleton variant="card" />
+                  )}
+                </>
+              )}
+            </div>
 
-                {/* Year-Over-Year Comparison */}
-                {aggregatedAnalytics ? (
-                  <LazyChart height="300px">
-                    <YearOverYearComparison
-                      {...(computeYearOverYear(timeSeries ?? null) && {
-                        yearOverYear: computeYearOverYear(timeSeries ?? null)!,
-                      })}
-                      currentYear={{
-                        // Use time-series membership when available (#319)
-                        // to match the membership chart above
-                        totalMembership:
-                          timeSeries?.currentMembership ??
-                          aggregatedAnalytics.summary.totalMembership,
-                        distinguishedClubs:
-                          aggregatedAnalytics.summary.distinguishedClubs.total,
-                        thrivingClubs:
-                          aggregatedAnalytics.summary.clubCounts.thriving,
-                        totalClubs:
-                          aggregatedAnalytics.summary.clubCounts.total,
-                      }}
-                      isLoading={isLoadingAggregated}
-                    />
-                  </LazyChart>
-                ) : (
-                  isLoadingAggregated && (
-                    <LoadingSkeleton variant="chart" height="300px" />
-                  )
-                )}
-              </>
-            )}
-
-            {activeTab === 'analytics' && (
-              <>
-                {/* Top Growth Clubs */}
-                {analytics ? (
-                  <TopGrowthClubs
-                    topGrowthClubs={analytics.topGrowthClubs}
-                    topDCPClubs={analytics.allClubs
-                      .filter(club => club.dcpGoalsTrend.length > 0)
-                      .map(club => ({
-                        clubId: club.clubId,
-                        clubName: club.clubName,
-                        goalsAchieved:
-                          club.dcpGoalsTrend[club.dcpGoalsTrend.length - 1]
-                            ?.goalsAchieved || 0,
-                        ...(club.distinguishedLevel &&
-                          [
-                            'Smedley',
-                            'President',
-                            'Select',
-                            'Distinguished',
-                          ].includes(club.distinguishedLevel) && {
-                            distinguishedLevel: club.distinguishedLevel as
-                              | 'Smedley'
-                              | 'President'
-                              | 'Select'
-                              | 'Distinguished',
-                          }),
-                      }))
-                      .sort((a, b) => b.goalsAchieved - a.goalsAchieved)
-                      .slice(0, 10)}
-                    isLoading={isLoadingAnalytics}
-                  />
-                ) : (
-                  isLoadingAnalytics && <LoadingSkeleton variant="card" />
-                )}
-              </>
-            )}
-
-            {activeTab === 'globalRankings' && districtId && (
-              <GlobalRankingsTab
-                districtId={districtId}
-                districtName={districtName}
-                selectedProgramYear={selectedProgramYear}
-              />
-            )}
+            <div
+              role="tabpanel"
+              id={panelIdFor('globalRankings')}
+              aria-labelledby={tabIdFor('globalRankings')}
+              hidden={activeTab !== 'globalRankings'}
+            >
+              {activeTab === 'globalRankings' && districtId && (
+                <GlobalRankingsTab
+                  districtId={districtId}
+                  districtName={districtName}
+                  selectedProgramYear={selectedProgramYear}
+                />
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Closes #384. Completes the WAI-ARIA tablist pattern on the District Detail page.

- Roving tabIndex (active = 0, others = -1)
- ←/→ move focus across siblings (with wrap); Home/End jump to first/last
- Space/Enter activate (manual activation — tab content is heavy)
- Each `<button role="tab">` has `aria-controls={panelId}` pointing at its `<div role="tabpanel">`
- Each tabpanel has `id` + `aria-labelledby` referencing its tab — panels always render structurally even though their contents stay lazy-conditional, so the `aria-controls` reference is always resolvable

Reference: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/

## Test plan

- [x] 6 new keyboard-navigation tests in `DistrictDetailTabs.test.tsx` (18/18 green, 1.31s)
- [x] Full suite: 131/131 files, 2140/2140 tests
- [ ] CI green
- [ ] Manual smoke: focus the active tab, ←/→ should move focus visibly with wrap; Home/End should jump; Space or Enter should switch panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)