### PR TITLE
chore(shell): remove notification bell stub (#411)

### DIFF
--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -94,17 +94,15 @@ describe('AppShell (#354)', () => {
       expect(regionsLink).toHaveAttribute('aria-disabled', 'true')
     })
 
-    it('renders the top-bar tools cluster (notifications stub, help link, avatar)', () => {
-      // Design shows a bell + ? + JS avatar on the right side of the
-      // top bar. The notifications bell + avatar remain visual stubs
-      // until auth lands; the help icon is now a Link to /methodology
-      // (#410) so users have one-click access to the canonical
-      // definitions.
+    it('renders the top-bar tools cluster (help link, avatar)', () => {
+      // Bell stub was removed in #411 — a non-functional icon erodes
+      // trust. The help icon is a Link to /methodology (#410); the
+      // avatar remains a visual stub until auth lands.
       renderShell()
       const header = screen.getByRole('banner')
       expect(
-        within(header).getByRole('button', { name: /notifications/i })
-      ).toBeInTheDocument()
+        within(header).queryByRole('button', { name: /notifications/i })
+      ).not.toBeInTheDocument()
       // The text 'How it works' appears twice in the header — as the
       // primary nav link AND as the help icon's aria-label. Scope the
       // help icon assertion to the tools cluster (everything outside the

--- a/frontend/src/components/AppShell/AppShellTopBar.tsx
+++ b/frontend/src/components/AppShell/AppShellTopBar.tsx
@@ -44,25 +44,8 @@ const AppShellTopBar: React.FC = () => {
       </nav>
 
       <div className="app-shell-tools">
-        <button
-          type="button"
-          className="app-shell-icon-btn"
-          aria-label="Notifications"
-          title="Notifications"
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 16 16"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            aria-hidden="true"
-          >
-            <path d="M3 13h10l-1.5-2v-3.5a3.5 3.5 0 0 0-7 0V11L3 13Z" />
-            <path d="M6.5 13.5a1.5 1.5 0 0 0 3 0" />
-          </svg>
-        </button>
+        {/* Bell stub removed per #411 — a non-functional icon erodes
+            trust. Re-add when there's real notification content. */}
         <Link
           to="/methodology"
           className="app-shell-icon-btn"


### PR DESCRIPTION
## Summary

Closes #411. Removes the non-functional bell icon from `AppShellTopBar` per Option A in the issue — a stub icon erodes trust. The slot will return when there's real notification content to ship (snapshot freshness, dependabot alerts, etc.).

## Test plan

- [x] `AppShell.test.tsx` updated: asserts bell is gone, help link + avatar remain
- [x] Full suite: 131/131 files, 2140/2140 tests
- [ ] CI green
- [ ] Manual smoke: top bar shows brand · nav · `?` help · `TS` avatar — no bell

🤖 Generated with [Claude Code](https://claude.com/claude-code)