### PR TITLE
feat(district): Education Levels rollup on Analytics tab (#426)

### DIFF
--- a/frontend/src/components/EducationLevelsCard.tsx
+++ b/frontend/src/components/EducationLevelsCard.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { Tooltip, InfoIcon } from './Tooltip'
+import type { EducationLevelsTotals } from '../utils/extractEducationLevels'
+
+/* Education Levels rollup card (#426).
+
+   Shows the four bucketed education-award totals for the program year
+   alongside the participation rate (clubs with ≥1 award / total clubs).
+   No per-Pathway breakdown — TI doesn't publish that in the district
+   dashboard, so we don't fake one.
+
+   Skipped from render when total === 0 (per the issue: "Skip if data
+   is empty for the snapshot"). */
+
+interface EducationLevelsCardProps {
+  totals: EducationLevelsTotals
+  /** Show a Loading skeleton instead of the totals. */
+  isLoading?: boolean
+}
+
+const LEVELS: ReadonlyArray<{
+  key: keyof Pick<
+    EducationLevelsTotals,
+    'level1' | 'level2' | 'level3' | 'level4PathDtm'
+  >
+  label: string
+  description: string
+}> = [
+  {
+    key: 'level1',
+    label: 'Level 1',
+    description: 'Mastering Fundamentals — first speech project completed.',
+  },
+  {
+    key: 'level2',
+    label: 'Level 2',
+    description:
+      'Learning Your Style — two speech projects + Add. Level 2 awards.',
+  },
+  {
+    key: 'level3',
+    label: 'Level 3',
+    description: 'Increasing Knowledge — three speech projects completed.',
+  },
+  {
+    key: 'level4PathDtm',
+    label: 'Level 4+ · Path · DTM',
+    description:
+      'Bundled per TI: Level 4 awards, complete Pathway completions, and Distinguished Toastmaster awards. TI does not break out individual pathways in the district dashboard.',
+  },
+]
+
+export const EducationLevelsCard: React.FC<EducationLevelsCardProps> = ({
+  totals,
+  isLoading = false,
+}) => {
+  if (isLoading) {
+    return (
+      <section
+        className="bg-white rounded-lg p-4 border border-gray-200 dark:bg-gray-800 dark:border-gray-700"
+        aria-busy="true"
+        aria-label="Loading education levels rollup"
+      >
+        <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+          Education Levels
+        </p>
+        <p className="text-xs text-gray-500 mt-2">Loading…</p>
+      </section>
+    )
+  }
+
+  if (totals.total === 0) return null
+
+  const participationPct =
+    totals.totalClubs > 0
+      ? Math.round((totals.contributingClubs / totals.totalClubs) * 100)
+      : 0
+
+  return (
+    <section
+      className="bg-white rounded-lg p-4 border border-gray-200 dark:bg-gray-800 dark:border-gray-700"
+      aria-labelledby="education-levels-card-title"
+      aria-label="education levels"
+    >
+      <header className="mb-3">
+        <h3
+          id="education-levels-card-title"
+          className="flex items-center gap-1 text-sm font-semibold text-gray-800 dark:text-gray-100"
+        >
+          Education Levels
+          <Tooltip content="Total education awards earned this program year, summed across all clubs. Source: clubPerformance.csv columns Level 1s, Level 2s, Level 3s, and the bundled Level 4 / Path Completion / DTM column. TI does not publish per-Pathway breakdowns in the district dashboard.">
+            <InfoIcon />
+          </Tooltip>
+        </h3>
+        <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
+          <strong className="text-gray-900 dark:text-gray-50">
+            {totals.total.toLocaleString()}
+          </strong>{' '}
+          total awards · {totals.contributingClubs}/{totals.totalClubs} clubs
+          earned ≥ 1 ({participationPct}%)
+        </p>
+      </header>
+      <ul className="space-y-2" role="list">
+        {LEVELS.map(spec => {
+          const count = totals[spec.key]
+          const pct =
+            totals.total > 0 ? Math.round((count / totals.total) * 100) : 0
+          return (
+            <li
+              key={spec.key}
+              className="grid grid-cols-[6.5rem_1fr_5rem] items-center gap-2 text-xs"
+            >
+              <span className="flex items-center gap-1 text-gray-700 dark:text-gray-200">
+                {spec.label}
+                <Tooltip content={spec.description}>
+                  <InfoIcon />
+                </Tooltip>
+              </span>
+              <span
+                className="h-2 rounded-full bg-tm-loyal-blue/80 dark:bg-tm-loyal-blue/60"
+                aria-hidden="true"
+                style={{ width: `${pct}%` }}
+              />
+              <span className="text-right text-gray-700 dark:text-gray-200">
+                <strong className="text-gray-900 dark:text-gray-50">
+                  {count.toLocaleString()}
+                </strong>{' '}
+                <span className="text-gray-500 dark:text-gray-400">{pct}%</span>
+              </span>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/components/__tests__/EducationLevelsCard.test.tsx
+++ b/frontend/src/components/__tests__/EducationLevelsCard.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import type { ReactElement } from 'react'
+import { EducationLevelsCard } from '../EducationLevelsCard'
+import type { EducationLevelsTotals } from '../../utils/extractEducationLevels'
+
+// Provider-free unit-test render (#473): card has no router / query.
+const renderCard = (ui: ReactElement) => render(ui)
+
+const empty: EducationLevelsTotals = {
+  level1: 0,
+  level2: 0,
+  level3: 0,
+  level4PathDtm: 0,
+  total: 0,
+  contributingClubs: 0,
+  totalClubs: 0,
+}
+
+describe('EducationLevelsCard (#426)', () => {
+  afterEach(() => cleanup())
+
+  it('renders the four labelled rows with counts and percentages', () => {
+    const totals: EducationLevelsTotals = {
+      level1: 4,
+      level2: 2,
+      level3: 3,
+      level4PathDtm: 1,
+      total: 10,
+      contributingClubs: 5,
+      totalClubs: 8,
+    }
+    renderCard(<EducationLevelsCard totals={totals} />)
+    const card = screen.getByLabelText(/education levels/i, {
+      selector: 'section',
+    })
+    expect(within(card).getByText(/level 1$/i)).toBeInTheDocument()
+    expect(within(card).getByText(/level 2$/i)).toBeInTheDocument()
+    expect(within(card).getByText(/level 3$/i)).toBeInTheDocument()
+    expect(
+      within(card).getByText(/level 4\+ · path · dtm/i)
+    ).toBeInTheDocument()
+
+    // Total + participation summary
+    expect(within(card).getByText('10')).toBeInTheDocument()
+    expect(within(card).getByText(/5\/8 clubs earned/)).toBeInTheDocument()
+    expect(within(card).getByText(/63%\)/)).toBeInTheDocument()
+  })
+
+  it('renders nothing when the snapshot has zero awards', () => {
+    const { container } = renderCard(<EducationLevelsCard totals={empty} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows a loading state when isLoading is true', () => {
+    renderCard(<EducationLevelsCard totals={empty} isLoading />)
+    expect(screen.getByLabelText(/loading education levels/i)).toHaveAttribute(
+      'aria-busy',
+      'true'
+    )
+  })
+
+  it('computes per-row percentages from total', () => {
+    const totals: EducationLevelsTotals = {
+      level1: 50,
+      level2: 25,
+      level3: 15,
+      level4PathDtm: 10,
+      total: 100,
+      contributingClubs: 10,
+      totalClubs: 10,
+    }
+    renderCard(<EducationLevelsCard totals={totals} />)
+    // Bars set inline width; assert by text first to keep the test robust.
+    expect(screen.getByText('50%')).toBeInTheDocument()
+    expect(screen.getByText('25%')).toBeInTheDocument()
+    expect(screen.getByText('15%')).toBeInTheDocument()
+    expect(screen.getByText('10%')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -46,6 +46,8 @@ import {
   LazyYearOverYearComparison as YearOverYearComparison,
 } from '../components/LazyCharts'
 import { TopGrowthClubs } from '../components/TopGrowthClubs'
+import { EducationLevelsCard } from '../components/EducationLevelsCard'
+import { extractEducationLevels } from '../utils/extractEducationLevels'
 import { DivisionPerformanceCards } from '../components/DivisionPerformanceCards'
 import DistinguishedProgramCriteriaExplainer from '../components/DistinguishedProgramCriteriaExplainer'
 import { DivisionAreaRecognitionPanel } from '../components/DivisionAreaRecognitionPanel'
@@ -917,6 +919,22 @@ const DistrictDetailPage: React.FC = () => {
                     />
                   ) : (
                     isLoadingAnalytics && <LoadingSkeleton variant="card" />
+                  )}
+
+                  {/* Education Levels rollup (#426) — sums Level 1/2/3
+                      and the bundled Level 4 / Path / DTM column across
+                      all clubs in the district. */}
+                  {districtStatistics ? (
+                    <EducationLevelsCard
+                      totals={extractEducationLevels(districtStatistics)}
+                    />
+                  ) : (
+                    isLoadingStatistics && (
+                      <EducationLevelsCard
+                        totals={extractEducationLevels(null)}
+                        isLoading
+                      />
+                    )
                   )}
                 </>
               )}

--- a/frontend/src/utils/__tests__/extractEducationLevels.test.ts
+++ b/frontend/src/utils/__tests__/extractEducationLevels.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { extractEducationLevels } from '../extractEducationLevels'
+
+describe('extractEducationLevels (#426)', () => {
+  it('returns zeros for an unrecognised input', () => {
+    expect(extractEducationLevels(null)).toEqual({
+      level1: 0,
+      level2: 0,
+      level3: 0,
+      level4PathDtm: 0,
+      total: 0,
+      contributingClubs: 0,
+      totalClubs: 0,
+    })
+    expect(extractEducationLevels(undefined)).toEqual({
+      level1: 0,
+      level2: 0,
+      level3: 0,
+      level4PathDtm: 0,
+      total: 0,
+      contributingClubs: 0,
+      totalClubs: 0,
+    })
+    expect(extractEducationLevels({})).toEqual({
+      level1: 0,
+      level2: 0,
+      level3: 0,
+      level4PathDtm: 0,
+      total: 0,
+      contributingClubs: 0,
+      totalClubs: 0,
+    })
+  })
+
+  it('sums the four reportable buckets across all clubs', () => {
+    const snapshot = {
+      data: {
+        clubPerformance: [
+          {
+            'Club Name': 'A',
+            'Level 1s': 3,
+            'Level 2s': 2,
+            'Level 3s': 1,
+            'Level 4s, Path Completions, or DTM Awards': 1,
+          },
+          {
+            'Club Name': 'B',
+            'Level 1s': 0,
+            'Level 2s': 1,
+            'Level 3s': 0,
+            'Level 4s, Path Completions, or DTM Awards': 0,
+          },
+        ],
+      },
+    }
+    const result = extractEducationLevels(snapshot)
+    expect(result.level1).toBe(3)
+    expect(result.level2).toBe(3)
+    expect(result.level3).toBe(1)
+    expect(result.level4PathDtm).toBe(1)
+    expect(result.total).toBe(8)
+    expect(result.contributingClubs).toBe(2)
+    expect(result.totalClubs).toBe(2)
+  })
+
+  it('includes Add. Level columns and the bundled Level 4 column', () => {
+    const snapshot = {
+      data: {
+        clubPerformance: [
+          {
+            'Club Name': 'A',
+            'Level 2s': 1,
+            'Add. Level 2s': 2,
+            'Level 4s, Path Completions, or DTM Awards': 1,
+            'Add. Level 4s, Path Completions, or DTM award': 1,
+          },
+        ],
+      },
+    }
+    const result = extractEducationLevels(snapshot)
+    expect(result.level2).toBe(3)
+    expect(result.level4PathDtm).toBe(2)
+  })
+
+  it('handles snapshots that lack the .data wrapper (unwrapped)', () => {
+    const snapshot = {
+      clubPerformance: [
+        {
+          'Club Name': 'A',
+          'Level 1s': 5,
+        },
+      ],
+    }
+    const result = extractEducationLevels(snapshot)
+    expect(result.level1).toBe(5)
+    expect(result.total).toBe(5)
+  })
+
+  it('parses string numerics from the raw CSV pipeline', () => {
+    const snapshot = {
+      data: {
+        clubPerformance: [
+          {
+            'Level 1s': '4',
+            'Level 2s': '2',
+          },
+        ],
+      },
+    }
+    const result = extractEducationLevels(snapshot)
+    expect(result.level1).toBe(4)
+    expect(result.level2).toBe(2)
+  })
+
+  it('counts only clubs that contributed at least one award', () => {
+    const snapshot = {
+      data: {
+        clubPerformance: [
+          { 'Club Name': 'A', 'Level 1s': 1 },
+          { 'Club Name': 'B' }, // zero awards
+          { 'Club Name': 'C', 'Level 3s': 2 },
+        ],
+      },
+    }
+    const result = extractEducationLevels(snapshot)
+    expect(result.contributingClubs).toBe(2)
+    expect(result.totalClubs).toBe(3)
+  })
+
+  it('ignores non-numeric garbage', () => {
+    const snapshot = {
+      data: {
+        clubPerformance: [
+          {
+            'Level 1s': 'n/a',
+            'Level 2s': null,
+            'Level 3s': '',
+            'Level 4s, Path Completions, or DTM Awards': 'NaN',
+          },
+        ],
+      },
+    }
+    const result = extractEducationLevels(snapshot)
+    expect(result.total).toBe(0)
+  })
+})

--- a/frontend/src/utils/extractEducationLevels.ts
+++ b/frontend/src/utils/extractEducationLevels.ts
@@ -1,0 +1,113 @@
+/* Education Levels rollup (#426).
+
+   Aggregates per-club education awards from a district snapshot into the
+   four reportable buckets that Toastmasters publishes:
+
+   - Level 1s
+   - Level 2s
+   - Level 3s
+   - Level 4s, Path Completions, or DTM Awards
+
+   The raw CSV bundles Level 4 + Path Completion + DTM into a single
+   column — TI doesn't publicly break out per-Pathway completions in the
+   district dashboard, so we report the bundle as-is rather than invent
+   a breakdown. The issue's "11 Pathway" ask isn't achievable from
+   public data without a per-member feed (see issue #426 comment).
+
+   The "Add. Level Xs" columns also exist in the CSV; they are
+   additional/secondary awards earned by clubs that already have a
+   primary level award. We include them in the totals so the rollup
+   reflects total awards, not unique clubs. */
+
+export interface EducationLevelsTotals {
+  level1: number
+  level2: number
+  level3: number
+  /** Level 4s + Path Completions + DTM Awards bundled — TI publishes
+   *  these in a single column. */
+  level4PathDtm: number
+  /** Total of all four buckets. */
+  total: number
+  /** Number of clubs that contributed at least one award. */
+  contributingClubs: number
+  /** Total clubs in the snapshot (denominator for participation %). */
+  totalClubs: number
+}
+
+const PRIMARY_KEYS = {
+  level1: ['Level 1s'],
+  level2: ['Level 2s', 'Add. Level 2s', 'Add Level 2s'],
+  level3: ['Level 3s'],
+  level4PathDtm: [
+    'Level 4s, Path Completions, or DTM Awards',
+    'Level 4s',
+    'Add. Level 4s, Path Completions, or DTM award',
+    'Add. Level 4s',
+  ],
+} as const
+
+const toNumber = (raw: unknown): number => {
+  if (raw == null || raw === '') return 0
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : 0
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const sumForKeys = (
+  club: Record<string, unknown>,
+  keys: ReadonlyArray<string>
+): number => keys.reduce((acc, key) => acc + toNumber(club[key]), 0)
+
+export function extractEducationLevels(
+  districtSnapshot: unknown
+): EducationLevelsTotals {
+  const empty: EducationLevelsTotals = {
+    level1: 0,
+    level2: 0,
+    level3: 0,
+    level4PathDtm: 0,
+    total: 0,
+    contributingClubs: 0,
+    totalClubs: 0,
+  }
+
+  if (typeof districtSnapshot !== 'object' || districtSnapshot === null) {
+    return empty
+  }
+
+  const rawSnapshot = districtSnapshot as Record<string, unknown>
+  const snapshot =
+    typeof rawSnapshot['data'] === 'object' && rawSnapshot['data'] !== null
+      ? (rawSnapshot['data'] as Record<string, unknown>)
+      : rawSnapshot
+
+  const clubPerformanceRaw = snapshot['clubPerformance']
+  if (!Array.isArray(clubPerformanceRaw)) return empty
+
+  const totals = { level1: 0, level2: 0, level3: 0, level4PathDtm: 0 }
+  let contributingClubs = 0
+
+  for (const clubRaw of clubPerformanceRaw) {
+    if (typeof clubRaw !== 'object' || clubRaw === null) continue
+    const club = clubRaw as Record<string, unknown>
+
+    const l1 = sumForKeys(club, PRIMARY_KEYS.level1)
+    const l2 = sumForKeys(club, PRIMARY_KEYS.level2)
+    const l3 = sumForKeys(club, PRIMARY_KEYS.level3)
+    const l4 = sumForKeys(club, PRIMARY_KEYS.level4PathDtm)
+
+    totals.level1 += l1
+    totals.level2 += l2
+    totals.level3 += l3
+    totals.level4PathDtm += l4
+
+    if (l1 + l2 + l3 + l4 > 0) contributingClubs += 1
+  }
+
+  return {
+    ...totals,
+    total: totals.level1 + totals.level2 + totals.level3 + totals.level4PathDtm,
+    contributingClubs,
+    totalClubs: clubPerformanceRaw.length,
+  }
+}


### PR DESCRIPTION
## Summary

Partially closes #426. Adds an `EducationLevelsCard` on the District Detail Analytics tab that sums per-club education awards into the four reportable buckets TI publishes.

## Scope decisions

The issue asked for two things; one is achievable from public data, one is not:

- **Education Levels rollup** ✅ — Level 1s, Level 2s (incl. Add. Level 2s), Level 3s, and the bundled Level 4 / Path Completion / DTM column. Sourced from \`clubPerformance.csv\` already in the district snapshot. Card auto-hides when total === 0.
- **Per-Pathway breakdown** ❌ — TI's district dashboard does NOT publish per-pathway completion counts. Level 4 + every Pathway completion + DTM all collapse into a single CSV column. The card's info tooltip says so explicitly so we don't fake a breakdown.
- **Global rollup on Districts page** ❌ deferred — \`/v1/rankings.json\` doesn't carry education-award fields, so cross-district aggregation would need new data plumbing. Per-district ships now; can revisit if the global view earns the data work.

## Test plan

- [x] 7 utility tests + 4 component tests = 11 new tests
- [x] Full suite: 133/133 files, 2151/2151 tests green
- [x] \`npm run build\` succeeds
- [ ] CI green
- [ ] Manual smoke on /district/61?tab=analytics — card renders beneath TopGrowthClubs, the four bars are proportional, info tooltips explain the per-Pathway scope limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)