### PR TITLE
feat(pipeline): wire fetch-find-a-club into daily pipeline (#429)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -261,6 +261,59 @@ jobs:
           echo "- **Club-trends files**: ${CT_COUNT}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Prev-year snapshots**: ${PREV_COUNT}" >> "$GITHUB_STEP_SUMMARY"
 
+      # ── Daily Step 3b: Find-A-Club enrichment fetch (#430) ──
+      # Hits the public TI Find-A-Club Search endpoint per district and
+      # writes raw JSON to ./cache/find-a-club/<date>/district_<id>.json.
+      # Non-blocking — TI's endpoint is public/unauth'd and could change
+      # or rate-limit at any time, so a failure here must NOT break the
+      # daily snapshot. `--compare-snapshot-dir` surfaces the FAC-vs-
+      # snapshot diff per district so we can watch for ATO/prospective
+      # clubs (extraInFac > 0) and pipeline drift.
+      # Snapshot merge + GCS upload are deliberate follow-up PRs after
+      # we observe a week of clean runs.
+      - name: '[daily] Fetch Find-A-Club enrichment'
+        if: steps.mode.outputs.mode == 'daily'
+        id: daily-fac-fetch
+        continue-on-error: true
+        run: |
+          SNAPSHOT_DATE="${{ steps.daily-scrape.outputs.snapshot_date }}"
+          if [ -z "${SNAPSHOT_DATE}" ]; then
+            SNAPSHOT_DATE="${{ steps.daily-scrape.outputs.date }}"
+          fi
+          DISTRICT_LIST="${{ steps.daily-config.outputs.districts }}"
+          ARGS="--districts ${DISTRICT_LIST} --include-undistricted --verbose"
+          ARGS="$ARGS --date ${SNAPSHOT_DATE}"
+          ARGS="$ARGS --compare-snapshot-dir ./cache/snapshots/${SNAPSHOT_DATE}"
+
+          echo "Running: npx collector-cli fetch-find-a-club $ARGS"
+          npx collector-cli fetch-find-a-club $ARGS | tee /tmp/fac-output.json
+
+          echo "## 🔍 Find-A-Club Enrichment (#430)" >> "$GITHUB_STEP_SUMMARY"
+          SUCCEEDED=$(jq '.succeeded' /tmp/fac-output.json)
+          FAILED=$(jq '.failed' /tmp/fac-output.json)
+          TOTAL_CLUBS=$(jq '.totalClubs' /tmp/fac-output.json)
+          EXTRA_IN_FAC=$(jq '.compare.totalExtraInFac // "n/a"' /tmp/fac-output.json)
+          SNAPSHOT_TOTAL=$(jq '.compare.totalSnapshotClubs // "n/a"' /tmp/fac-output.json)
+          echo "- **Districts succeeded**: ${SUCCEEDED}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Districts failed**: ${FAILED}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **FAC clubs total**: ${TOTAL_CLUBS}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Snapshot clubs total**: ${SNAPSHOT_TOTAL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Extra in FAC** (ATO / prospective): ${EXTRA_IN_FAC}" >> "$GITHUB_STEP_SUMMARY"
+
+          # Top 5 districts by extraInFac for quick visual scan.
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Top 5 districts by ATO/prospective surplus" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| District | FAC | Snapshot | Extra |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-----|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '.results
+            | map(select(.extraInFac != null))
+            | sort_by(.extraInFac)
+            | reverse
+            | .[0:5][]
+            | "| \(.districtId) | \(.clubCount) | \(.snapshotClubCount) | \(if .extraInFac > 0 then "+" else "" end)\(.extraInFac) |"' \
+            /tmp/fac-output.json >> "$GITHUB_STEP_SUMMARY"
+
       # ── Daily Step 4: Compute Analytics ──
       - name: '[daily] Compute Analytics'
         if: steps.mode.outputs.mode == 'daily'

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -1203,6 +1203,13 @@ export function createCLI(): Command {
       (value: string) => parseInt(value, 10),
       1100
     )
+    .option(
+      '--compare-snapshot-dir <dir>',
+      'For each district, also count clubPerformance entries in ' +
+        '<dir>/district_<id>.json and report the FAC-vs-snapshot diff. ' +
+        'Extra FAC entries are typically ATO/prospective clubs not yet ' +
+        'in the dashboard.'
+    )
     .option('-v, --verbose', 'Enable detailed logging output', false)
     .option('-c, --config <path>', 'Alternative configuration file path')
     .action(
@@ -1211,6 +1218,7 @@ export function createCLI(): Command {
         districts?: string[]
         includeUndistricted: boolean
         rateMs: number
+        compareSnapshotDir?: string
         verbose: boolean
         config?: string
       }) => {
@@ -1218,6 +1226,27 @@ export function createCLI(): Command {
           await import('./services/FindAClubService.js')
         const { writeFile, mkdir, readFile } = await import('fs/promises')
         const { join } = await import('path')
+
+        // Helper: count clubs in a snapshot file. Returns null if the
+        // file is missing or shape doesn't match.
+        const countSnapshotClubs = async (
+          districtId: string
+        ): Promise<number | null> => {
+          if (!options.compareSnapshotDir) return null
+          try {
+            const path = join(
+              options.compareSnapshotDir,
+              `district_${districtId}.json`
+            )
+            const raw = JSON.parse(await readFile(path, 'utf-8')) as {
+              data?: { clubPerformance?: unknown[] }
+            }
+            const cp = raw?.data?.clubPerformance
+            return Array.isArray(cp) ? cp.length : null
+          } catch {
+            return null
+          }
+        }
 
         const targetDate = options.date ?? getCurrentDateString()
         const resolvedConfig = resolveConfiguration({
@@ -1255,6 +1284,8 @@ export function createCLI(): Command {
           clubCount: number
           ok: boolean
           error?: string
+          snapshotClubCount?: number | null
+          extraInFac?: number | null
         }> = []
 
         for (const districtId of districts) {
@@ -1266,14 +1297,25 @@ export function createCLI(): Command {
               JSON.stringify(rawJson, null, 2),
               'utf-8'
             )
+            const snapshotClubCount = await countSnapshotClubs(districtId)
+            const extraInFac =
+              snapshotClubCount === null
+                ? null
+                : clubs.length - snapshotClubCount
             results.push({
               districtId,
               clubCount: clubs.length,
               ok: true,
+              ...(snapshotClubCount !== null && { snapshotClubCount }),
+              ...(extraInFac !== null && { extraInFac }),
             })
             if (options.verbose) {
+              const diff =
+                extraInFac !== null && snapshotClubCount !== null
+                  ? ` (snapshot=${snapshotClubCount}, extra=${extraInFac >= 0 ? '+' : ''}${extraInFac})`
+                  : ''
               console.error(
-                `[INFO] district ${districtId}: ${clubs.length} clubs → ${fileName}`
+                `[INFO] district ${districtId}: ${clubs.length} clubs${diff} → ${fileName}`
               )
             }
           } catch (err) {
@@ -1291,13 +1333,34 @@ export function createCLI(): Command {
           }
         }
 
+        const succeeded = results.filter(r => r.ok)
+        const withCompare = results.filter(
+          r => typeof r.extraInFac === 'number'
+        )
         const summary = {
           date: targetDate,
           outDir,
           totalDistricts: results.length,
-          succeeded: results.filter(r => r.ok).length,
+          succeeded: succeeded.length,
           failed: results.filter(r => !r.ok).length,
           totalClubs: results.reduce((sum, r) => sum + r.clubCount, 0),
+          // FAC-vs-snapshot diff aggregate (only when --compare-snapshot-dir
+          // was supplied). extraInFac > 0 means FAC has clubs the dashboard
+          // doesn't — typically ATO/prospective clubs.
+          compare:
+            withCompare.length > 0
+              ? {
+                  districtsCompared: withCompare.length,
+                  totalSnapshotClubs: withCompare.reduce(
+                    (sum, r) => sum + (r.snapshotClubCount ?? 0),
+                    0
+                  ),
+                  totalExtraInFac: withCompare.reduce(
+                    (sum, r) => sum + (r.extraInFac ?? 0),
+                    0
+                  ),
+                }
+              : undefined,
           results,
         }
         console.log(JSON.stringify(summary, null, 2))


### PR DESCRIPTION
## Summary

First of 3 phased rollouts after the Find-A-Club epic landed. Adds a non-blocking workflow step that fetches FAC data nightly and surfaces a FAC-vs-snapshot diff in the GitHub step summary, so we can observe reliability and ATO/prospective-club surplus for a week before deciding to merge or upload.

## What's in the box

### Workflow change (`.github/workflows/data-pipeline.yml`)

New step `[daily] Fetch Find-A-Club enrichment`, inserted between scrape and compute-analytics. Marked `continue-on-error: true` — a TI outage cannot break the daily snapshot. Passes the discovered district list + `--include-undistricted` + the snapshot dir for comparison. Posts a markdown table to `$GITHUB_STEP_SUMMARY` with the top-5 districts by prospective-club surplus.

### CLI flag (`fetch-find-a-club`)

New `--compare-snapshot-dir <dir>` flag. For each district, reads `<dir>/district_<id>.json`'s `data.clubPerformance` array and reports `clubCount` / `snapshotClubCount` / `extraInFac` per district, plus a `compare` aggregate.

## End-to-end verification

Local run against live TI for D61:

```
[INFO] district 61: 165 clubs (snapshot=161, extra=+4) → district_61.json
```

The +4 surplus is exactly the ATO / prospective-club pattern we expected — clubs that have submitted an Application To Organize but aren't yet in the dashboard's clubPerformance roster.

## What this PR deliberately doesn't do

Per the rollout checklist:

- **No snapshot merge** — raw JSON is written to `./cache/find-a-club/<date>/` and only used for the in-step diff summary. Snapshot enrichment (merging FAC fields into the published `district_<id>.json` files) is the next PR, after we've watched a week of clean runs.
- **No GCS upload** — local cache only, for the same reason. GCS upload lands with the snapshot-merge PR.
- **No analytics consumption** — frontend never reads FAC data in this PR. The Club hero CHARTERED eyebrow (#432) stays dormant until snapshot merge ships.

## Test plan

- [x] CLI tests: 32 files / 713 tests green
- [x] YAML lint clean (warnings only — line-length)
- [x] End-to-end against live TI: D61 returns 165 clubs (+4 extra-in-FAC)
- [ ] CI green
- [ ] First nightly run: watch `$GITHUB_STEP_SUMMARY` for per-district success rates and the prospective-club surplus pattern across all districts

🤖 Generated with [Claude Code](https://claude.com/claude-code)