### PR TITLE
feat(collector): FindAClubMerger + pipeline wiring (#429)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -314,6 +314,43 @@ jobs:
             | "| \(.districtId) | \(.clubCount) | \(.snapshotClubCount) | \(if .extraInFac > 0 then "+" else "" end)\(.extraInFac) |"' \
             /tmp/fac-output.json >> "$GITHUB_STEP_SUMMARY"
 
+      # ── Daily Step 3c: Find-A-Club snapshot merge (#429) ──
+      # Joins the raw FAC JSON written above into each district
+      # snapshot (charterDate / coordinates / address / contact /
+      # meeting fields). Idempotent — runs before Upload so the
+      # published snapshots carry the enrichment. Non-blocking; a
+      # merge failure must not stall the daily run because the
+      # underlying snapshot is still valid without enrichment.
+      # FAC-only clubs (ATOs / prospective — #489) are counted but
+      # NOT merged into clubPerformance.
+      - name: '[daily] Merge Find-A-Club into snapshots'
+        if: steps.mode.outputs.mode == 'daily' && steps.daily-fac-fetch.outcome == 'success'
+        id: daily-fac-merge
+        continue-on-error: true
+        run: |
+          SNAPSHOT_DATE="${{ steps.daily-scrape.outputs.snapshot_date }}"
+          if [ -z "${SNAPSHOT_DATE}" ]; then
+            SNAPSHOT_DATE="${{ steps.daily-scrape.outputs.date }}"
+          fi
+          ARGS="--fac-dir ./cache/find-a-club/${SNAPSHOT_DATE}"
+          ARGS="$ARGS --snapshot-dir ./cache/snapshots/${SNAPSHOT_DATE}"
+          ARGS="$ARGS --verbose"
+
+          echo "Running: npx collector-cli merge-find-a-club $ARGS"
+          npx collector-cli merge-find-a-club $ARGS | tee /tmp/fac-merge-output.json
+
+          echo "## 🔗 Find-A-Club Snapshot Merge (#429)" >> "$GITHUB_STEP_SUMMARY"
+          MATCHED=$(jq -r '.totalMatched' /tmp/fac-merge-output.json)
+          SNAP_ONLY=$(jq -r '.totalSnapshotOnly' /tmp/fac-merge-output.json)
+          FAC_ONLY=$(jq -r '.totalFacOnly' /tmp/fac-merge-output.json)
+          SUCCEEDED=$(jq -r '.succeeded' /tmp/fac-merge-output.json)
+          FAILED=$(jq -r '.failed' /tmp/fac-merge-output.json)
+          echo "- **Districts merged**: ${SUCCEEDED}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Districts failed**: ${FAILED}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Clubs enriched** (matched): ${MATCHED}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Snapshot-only** (no FAC match — typically suspended; #490): ${SNAP_ONLY}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **FAC-only** (ATOs / prospective; #489): ${FAC_ONLY}" >> "$GITHUB_STEP_SUMMARY"
+
       # ── Daily Step 4: Compute Analytics ──
       - name: '[daily] Compute Analytics'
         if: steps.mode.outputs.mode == 'daily'

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -1371,5 +1371,122 @@ export function createCLI(): Command {
       }
     )
 
+  // Merge previously-fetched FAC raw JSON into district snapshots
+  // (#429 follow-up). Reads <fac-dir>/district_<id>.json + the
+  // corresponding <snapshot-dir>/district_<id>.json, applies the
+  // left-outer-join semantics from FindAClubMerger, writes the
+  // enriched snapshot back to <snapshot-dir>. Idempotent.
+  program
+    .command('merge-find-a-club')
+    .description(
+      'Merge previously-fetched Find-A-Club JSON into district snapshots (#429)'
+    )
+    .requiredOption(
+      '--fac-dir <dir>',
+      'Directory containing district_<id>.json files from fetch-find-a-club'
+    )
+    .requiredOption(
+      '--snapshot-dir <dir>',
+      'Directory containing district snapshot files (target — rewritten in-place)'
+    )
+    .option(
+      '--districts <list>',
+      'Comma-separated district IDs to merge (default: every district that has both a FAC file and a snapshot file)',
+      parseDistrictList
+    )
+    .option('-v, --verbose', 'Enable detailed logging output', false)
+    .action(
+      async (options: {
+        facDir: string
+        snapshotDir: string
+        districts?: string[]
+        verbose: boolean
+      }) => {
+        const { mergeFacIntoSnapshot } =
+          await import('./services/FindAClubMerger.js')
+        const { readFile, writeFile, readdir } = await import('fs/promises')
+        const { join } = await import('path')
+
+        // Discover districts when not specified: intersection of FAC
+        // and snapshot files.
+        let districts = options.districts ?? []
+        if (districts.length === 0) {
+          const FILE_PATTERN = /^district_(.+)\.json$/
+          const facFiles = (await readdir(options.facDir).catch(() => []))
+            .map(f => FILE_PATTERN.exec(f)?.[1])
+            .filter((id): id is string => Boolean(id))
+          const snapshotFiles = new Set(
+            (await readdir(options.snapshotDir).catch(() => []))
+              .map(f => FILE_PATTERN.exec(f)?.[1])
+              .filter((id): id is string => Boolean(id))
+          )
+          districts = facFiles.filter(id => snapshotFiles.has(id)).sort()
+        }
+
+        const results: Array<{
+          districtId: string
+          ok: boolean
+          matched?: number
+          snapshotOnly?: number
+          facOnly?: number
+          error?: string
+        }> = []
+
+        for (const districtId of districts) {
+          try {
+            const facPath = join(options.facDir, `district_${districtId}.json`)
+            const snapshotPath = join(
+              options.snapshotDir,
+              `district_${districtId}.json`
+            )
+            const facRaw = JSON.parse(await readFile(facPath, 'utf-8'))
+            const snapshot = JSON.parse(await readFile(snapshotPath, 'utf-8'))
+            const result = mergeFacIntoSnapshot(snapshot, facRaw)
+            await writeFile(
+              snapshotPath,
+              JSON.stringify(result.snapshot, null, 2),
+              'utf-8'
+            )
+            results.push({
+              districtId,
+              ok: true,
+              matched: result.matched,
+              snapshotOnly: result.snapshotOnly,
+              facOnly: result.facOnly,
+            })
+            if (options.verbose) {
+              console.error(
+                `[INFO] district ${districtId}: matched=${result.matched}, snapshot-only=${result.snapshotOnly}, fac-only=${result.facOnly}`
+              )
+            }
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err)
+            results.push({ districtId, ok: false, error: message })
+            if (options.verbose) {
+              console.error(`[ERROR] district ${districtId}: ${message}`)
+            }
+          }
+        }
+
+        const summary = {
+          totalDistricts: results.length,
+          succeeded: results.filter(r => r.ok).length,
+          failed: results.filter(r => !r.ok).length,
+          totalMatched: results.reduce((s, r) => s + (r.matched ?? 0), 0),
+          totalSnapshotOnly: results.reduce(
+            (s, r) => s + (r.snapshotOnly ?? 0),
+            0
+          ),
+          totalFacOnly: results.reduce((s, r) => s + (r.facOnly ?? 0), 0),
+          results,
+        }
+        console.log(JSON.stringify(summary, null, 2))
+
+        process.exit(
+          summary.failed === 0 ? ExitCode.SUCCESS : ExitCode.PARTIAL_FAILURE
+        )
+      }
+    )
+
   return program
 }

--- a/packages/collector-cli/src/services/FindAClubMerger.ts
+++ b/packages/collector-cli/src/services/FindAClubMerger.ts
@@ -1,0 +1,159 @@
+/**
+ * FindAClubMerger — joins a district snapshot's \`clubPerformance\`
+ * array with the FAC fetch output for that district, copying the
+ * optional enrichment fields onto each matched club.
+ *
+ * Semantics (#429 follow-up):
+ *
+ *   - Snapshot is the spine. For every club in \`clubPerformance\`,
+ *     look up the FAC record by \`Club Number\` (8-char zero-padded).
+ *   - Matched: copy charterDate / coordinates / address / email / etc.
+ *   - Snapshot-only: leave as-is. The FAC fields are all optional, so
+ *     a missing match is a no-op. Most of the 410 'missing from FAC'
+ *     clubs land here — see #490 for the pattern investigation.
+ *   - FAC-only (ATOs / prospective): NOT merged into clubPerformance —
+ *     they have no membership / DCP / status, would break analytics.
+ *     Captured separately in the merge result so callers can decide
+ *     whether to surface them. See #489 for the UI-placement design.
+ *
+ * The merger is pure data: takes parsed objects in, returns a new
+ * snapshot. No I/O. The CLI command in cli.ts handles file reads /
+ * writes around it.
+ */
+
+import {
+  TI_CLUB_NUMBER_KEY,
+  type FacRawResponse,
+  type DistrictSnapshot,
+  type EnrichedClub,
+  type MergeResult,
+} from '../types/findAClub.js'
+import { normaliseTiClub } from './FindAClubService.js'
+
+/** 8-char zero-pad a club number from anywhere (CSV row, FAC payload). */
+export function normaliseClubNumber(raw: unknown): string | null {
+  if (raw == null) return null
+  const s = typeof raw === 'number' ? String(raw) : String(raw).trim()
+  if (!s) return null
+  // Strip non-digits; clubPerformance rows occasionally have stray
+  // whitespace, leading apostrophes from CSV import quirks, etc.
+  const digits = s.replace(/\D/g, '')
+  if (!digits) return null
+  return digits.padStart(8, '0')
+}
+
+/**
+ * Merge a FAC fetch result into a district snapshot.
+ *
+ * Idempotent: running twice with the same inputs produces the same
+ * output. Re-runs overwrite previously-merged fields with the latest
+ * FAC values (which is what we want — TI's registry is the source of
+ * truth for the enrichment fields).
+ */
+export function mergeFacIntoSnapshot(
+  snapshot: DistrictSnapshot,
+  fac: FacRawResponse
+): MergeResult {
+  const cp = snapshot.data?.clubPerformance
+  if (!Array.isArray(cp)) {
+    return {
+      snapshot,
+      matched: 0,
+      snapshotOnly: 0,
+      facOnly: 0,
+      facOnlyClubs: [],
+    }
+  }
+
+  // Build the FAC lookup keyed by 8-char club number.
+  const facByClubId = new Map<string, ReturnType<typeof normaliseTiClub>>()
+  const facClubs = Array.isArray(fac?.Clubs) ? fac.Clubs : []
+  for (const raw of facClubs) {
+    if (typeof raw !== 'object' || raw === null) continue
+    // normaliseTiClub takes a parsed TiClub (Zod-validated); at runtime
+    // it tolerates the unknown shape because every field is optional
+    // and it bails on missing Id. The cast keeps TS happy without
+    // re-validating shape we already trust from the fetch step.
+    const enriched = normaliseTiClub(
+      raw as Parameters<typeof normaliseTiClub>[0]
+    )
+    if (enriched && enriched.clubId) {
+      facByClubId.set(enriched.clubId, enriched)
+    }
+  }
+
+  let matched = 0
+  let snapshotOnly = 0
+  const matchedIds = new Set<string>()
+
+  // Mutating the snapshot in-place would couple us to JSON.parse'd
+  // shapes; clone the array so callers can hold onto the original
+  // for diffing.
+  const enrichedClubs: EnrichedClub[] = cp.map(rawRow => {
+    if (typeof rawRow !== 'object' || rawRow === null) {
+      snapshotOnly += 1
+      return rawRow as EnrichedClub
+    }
+    const row = rawRow as Record<string, unknown>
+    const clubId = normaliseClubNumber(row[TI_CLUB_NUMBER_KEY])
+    if (!clubId) {
+      snapshotOnly += 1
+      return rawRow as EnrichedClub
+    }
+    const facHit = facByClubId.get(clubId)
+    if (!facHit) {
+      snapshotOnly += 1
+      return rawRow as EnrichedClub
+    }
+    matched += 1
+    matchedIds.add(clubId)
+    // Spread the FAC enrichment alongside the existing snapshot fields.
+    // Snapshot fields win on collision — TI dashboard is canonical for
+    // DCP / payments / status; FAC is only authoritative for the
+    // optional enrichment fields it adds.
+    return {
+      ...row,
+      ...(facHit.charterDate && { charterDate: facHit.charterDate }),
+      ...(facHit.coordinates && { coordinates: facHit.coordinates }),
+      ...(facHit.address && { address: facHit.address }),
+      ...(facHit.email && { email: facHit.email }),
+      ...(facHit.phone && { phone: facHit.phone }),
+      ...(facHit.website && { website: facHit.website }),
+      ...(facHit.facebookLink && { facebookLink: facHit.facebookLink }),
+      ...(facHit.twitterLink && { twitterLink: facHit.twitterLink }),
+      ...(facHit.meetingDay && { meetingDay: facHit.meetingDay }),
+      ...(facHit.meetingTime && { meetingTime: facHit.meetingTime }),
+      ...(typeof facHit.allowsVirtualAttendance === 'boolean' && {
+        allowsVirtualAttendance: facHit.allowsVirtualAttendance,
+      }),
+      ...(typeof facHit.isProspective === 'boolean' && {
+        isProspective: facHit.isProspective,
+      }),
+    }
+  })
+
+  // FAC-only clubs: in FAC but not in snapshot. These are typically
+  // ATOs / prospective (#489). We don't merge them into clubPerformance
+  // (would corrupt analytics), but we do return them so callers can
+  // surface them separately or log the count.
+  const facOnlyClubs: NonNullable<ReturnType<typeof normaliseTiClub>>[] = []
+  for (const [clubId, enriched] of facByClubId) {
+    if (!matchedIds.has(clubId) && enriched) {
+      facOnlyClubs.push(enriched)
+    }
+  }
+
+  return {
+    snapshot: {
+      ...snapshot,
+      data: {
+        ...snapshot.data,
+        clubPerformance: enrichedClubs,
+      },
+    },
+    matched,
+    snapshotOnly,
+    facOnly: facOnlyClubs.length,
+    facOnlyClubs,
+  }
+}

--- a/packages/collector-cli/src/services/__tests__/FindAClubMerger.test.ts
+++ b/packages/collector-cli/src/services/__tests__/FindAClubMerger.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest'
+import {
+  mergeFacIntoSnapshot,
+  normaliseClubNumber,
+} from '../FindAClubMerger.js'
+
+/* Fixtures based on the real shapes — TI Find-A-Club response and a
+   district snapshot's clubPerformance row. Kept minimal — only the
+   fields the merger actually reads / writes. */
+
+const ottawaFacClub = {
+  Identification: { Id: { Value: '00000180' } },
+  Address: {
+    Street: '300 Ottawa Ave',
+    City: 'Ottawa',
+    PrimaryRegion: { Value: 'ON' },
+    PostalCode: 'K1A 0A0',
+    Coordinates: { Latitude: 45.42, Longitude: -75.69 },
+  },
+  CountryName: 'Canada',
+  CharterDate: '/Date(197190000000)/',
+  Email: 'officers-180@toastmastersclubs.org',
+  Website: 'http://180.toastmastersclubs.org/',
+  MeetingDay: 'Tuesday',
+  MeetingTime: '7:00 pm',
+  AllowsVirtualAttendance: false,
+  IsProspective: false,
+}
+
+const ottawaSnapshotRow = {
+  'Club Number': '00000180',
+  'Club Name': 'Causeurs Ottawa Speakers Club',
+  Division: 'A',
+  Area: 'A1',
+  'Club Status': 'Active',
+  'Mem. Base': '20',
+  'Active Members': '23',
+  'Goals Met': '5',
+}
+
+const suspendedSnapshotOnly = {
+  'Club Number': '00099999',
+  'Club Name': 'Suspended Toastmasters',
+  Division: 'B',
+  Area: 'B1',
+  'Club Status': 'Suspended',
+  'Mem. Base': '15',
+  'Active Members': '0',
+}
+
+const prospectiveFacOnlyClub = {
+  Identification: { Id: { Value: '00088888' } },
+  Address: {
+    Street: '12 New Way',
+    City: 'Toronto',
+    PrimaryRegion: { Value: 'ON' },
+  },
+  CharterDate: null,
+  CountryName: 'Canada',
+  IsProspective: true,
+}
+
+describe('normaliseClubNumber', () => {
+  it('zero-pads numeric strings to 8 chars', () => {
+    expect(normaliseClubNumber('180')).toBe('00000180')
+    expect(normaliseClubNumber('1399')).toBe('00001399')
+    expect(normaliseClubNumber('12345678')).toBe('12345678')
+  })
+
+  it('zero-pads numeric inputs', () => {
+    expect(normaliseClubNumber(180)).toBe('00000180')
+  })
+
+  it('strips non-digits before padding (handles CSV quirks)', () => {
+    expect(normaliseClubNumber("'180")).toBe('00000180')
+    expect(normaliseClubNumber('Club 180')).toBe('00000180')
+    expect(normaliseClubNumber('  00000180  ')).toBe('00000180')
+  })
+
+  it('returns null for inputs without digits', () => {
+    expect(normaliseClubNumber('')).toBeNull()
+    expect(normaliseClubNumber('   ')).toBeNull()
+    expect(normaliseClubNumber(null)).toBeNull()
+    expect(normaliseClubNumber(undefined)).toBeNull()
+    expect(normaliseClubNumber('abc')).toBeNull()
+  })
+})
+
+describe('mergeFacIntoSnapshot', () => {
+  it('enriches a matched club with FAC fields without losing snapshot fields', () => {
+    const result = mergeFacIntoSnapshot(
+      {
+        districtId: '61',
+        data: { clubPerformance: [ottawaSnapshotRow] },
+      },
+      { Clubs: [ottawaFacClub] }
+    )
+
+    expect(result.matched).toBe(1)
+    expect(result.snapshotOnly).toBe(0)
+    expect(result.facOnly).toBe(0)
+
+    const merged = (result.snapshot.data?.clubPerformance ?? [])[0] as Record<
+      string,
+      unknown
+    >
+    // Snapshot fields preserved
+    expect(merged['Club Number']).toBe('00000180')
+    expect(merged['Club Name']).toBe('Causeurs Ottawa Speakers Club')
+    expect(merged['Club Status']).toBe('Active')
+    expect(merged['Goals Met']).toBe('5')
+    // FAC fields layered on
+    expect(merged['charterDate']).toBe('1976-04-01')
+    expect(merged['coordinates']).toEqual({ lat: 45.42, lng: -75.69 })
+    expect(merged['address']).toEqual({
+      street: '300 Ottawa Ave',
+      city: 'Ottawa',
+      region: 'ON',
+      postalCode: 'K1A 0A0',
+      country: 'Canada',
+    })
+    expect(merged['email']).toBe('officers-180@toastmastersclubs.org')
+    expect(merged['meetingDay']).toBe('Tuesday')
+  })
+
+  it('leaves snapshot-only rows untouched and counts them', () => {
+    const result = mergeFacIntoSnapshot(
+      {
+        districtId: '61',
+        data: {
+          clubPerformance: [ottawaSnapshotRow, suspendedSnapshotOnly],
+        },
+      },
+      { Clubs: [ottawaFacClub] }
+    )
+
+    expect(result.matched).toBe(1)
+    expect(result.snapshotOnly).toBe(1)
+    expect(result.facOnly).toBe(0)
+
+    const suspended = (result.snapshot.data?.clubPerformance ??
+      [])[1] as Record<string, unknown>
+    expect(suspended).toEqual(suspendedSnapshotOnly)
+    expect(suspended['charterDate']).toBeUndefined()
+  })
+
+  it('captures FAC-only clubs (ATOs / prospective) separately, not in clubPerformance', () => {
+    const result = mergeFacIntoSnapshot(
+      {
+        districtId: '61',
+        data: { clubPerformance: [ottawaSnapshotRow] },
+      },
+      { Clubs: [ottawaFacClub, prospectiveFacOnlyClub] }
+    )
+
+    expect(result.matched).toBe(1)
+    expect(result.facOnly).toBe(1)
+    expect(result.facOnlyClubs).toHaveLength(1)
+    expect(result.facOnlyClubs[0]?.clubId).toBe('00088888')
+    expect(result.facOnlyClubs[0]?.isProspective).toBe(true)
+    // The prospective club must NOT have been merged into clubPerformance
+    expect(result.snapshot.data?.clubPerformance).toHaveLength(1)
+  })
+
+  it('is idempotent — merging twice produces the same enriched output', () => {
+    const input = {
+      districtId: '61',
+      data: { clubPerformance: [ottawaSnapshotRow] },
+    }
+    const fac = { Clubs: [ottawaFacClub] }
+    const once = mergeFacIntoSnapshot(input, fac)
+    const twice = mergeFacIntoSnapshot(once.snapshot, fac)
+    expect(twice.snapshot.data?.clubPerformance).toEqual(
+      once.snapshot.data?.clubPerformance
+    )
+    expect(twice.matched).toBe(1)
+  })
+
+  it('handles FAC = null (TI returned no clubs) by leaving snapshot untouched', () => {
+    const result = mergeFacIntoSnapshot(
+      {
+        districtId: '61',
+        data: { clubPerformance: [ottawaSnapshotRow] },
+      },
+      { Clubs: null }
+    )
+
+    expect(result.matched).toBe(0)
+    expect(result.snapshotOnly).toBe(1)
+    expect(result.facOnly).toBe(0)
+    expect((result.snapshot.data?.clubPerformance ?? [])[0]).toEqual(
+      ottawaSnapshotRow
+    )
+  })
+
+  it('handles snapshot with no clubPerformance array (defensive)', () => {
+    const result = mergeFacIntoSnapshot(
+      { districtId: '61', data: {} },
+      { Clubs: [ottawaFacClub] }
+    )
+    expect(result.matched).toBe(0)
+    expect(result.snapshotOnly).toBe(0)
+    // FAC-only counting requires the matched-id set to know what was
+    // joined; when there's no snapshot side, EVERY FAC club is
+    // technically unmatched. But the contract is 'FAC-only = clubs
+    // we DELIBERATELY chose not to merge into clubPerformance', so
+    // this case returns 0 (defensive: don't surprise callers by
+    // creating a prospective-clubs list for a clubPerformance-less
+    // snapshot).
+    expect(result.facOnly).toBe(0)
+  })
+
+  it('matches across CSV-quoting variants of Club Number (suspended/active rows)', () => {
+    const result = mergeFacIntoSnapshot(
+      {
+        districtId: '61',
+        data: {
+          clubPerformance: [
+            { ...ottawaSnapshotRow, 'Club Number': '180' }, // unpadded
+            { ...ottawaSnapshotRow, 'Club Number': "'00000180" }, // leading apostrophe
+          ],
+        },
+      },
+      { Clubs: [ottawaFacClub] }
+    )
+    // Both rows are the same club; both should match.
+    expect(result.matched).toBe(2)
+  })
+})

--- a/packages/collector-cli/src/types/findAClub.ts
+++ b/packages/collector-cli/src/types/findAClub.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared types for the Find-A-Club merge pipeline.
+ *
+ * Kept separate from the FindAClubService schema so the merger can be
+ * unit-tested with simple typed fixtures without spinning up Zod
+ * parsing.
+ */
+
+import type { ClubEnrichment } from '../services/FindAClubService.js'
+
+export const TI_CLUB_NUMBER_KEY = 'Club Number'
+
+/** Raw response from the FAC fetch (subset — only the fields we read). */
+export interface FacRawResponse {
+  Clubs: unknown[] | null
+  district?: string | null
+}
+
+/** District snapshot shape (subset — only the fields we read/write). */
+export interface DistrictSnapshot {
+  districtId?: string
+  data?: {
+    clubPerformance?: unknown[]
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+
+/** A clubPerformance row with optional FAC enrichment fields layered on. */
+export type EnrichedClub = Record<string, unknown> & Partial<ClubEnrichment>
+
+/** Output of mergeFacIntoSnapshot. */
+export interface MergeResult {
+  snapshot: DistrictSnapshot
+  matched: number
+  snapshotOnly: number
+  facOnly: number
+  /** FAC clubs that had no matching snapshot row (typically ATO /
+   *  prospective). NOT merged into snapshot.data.clubPerformance —
+   *  callers can surface them separately. See #489. */
+  facOnlyClubs: ClubEnrichment[]
+}

--- a/tasks/lessons/054-tdd-slipped-when-pre-push-disabled.md
+++ b/tasks/lessons/054-tdd-slipped-when-pre-push-disabled.md
@@ -1,0 +1,15 @@
+# 🗓️ 2026-05-12 — Lesson 54: TDD discipline slipped the moment the pre-push gate went away
+
+**Discovery:** During the Find-A-Club epic and its bug-audit follow-ups (PRs #483–#491), I shipped a steady stream of well-tested code — but the tests were never red. I wrote `FindAClubMerger.ts` first, then 11 tests after. Same pattern for `FindAClubService.ts`, `EducationLevelsCard.tsx`, the 6 bug fixes in #487. Tests existed, suites were green, CI passed. Looked like TDD. Wasn't TDD. The user called it out: "Feels like we're letting TDD slip now that pre-push is disabled."
+
+**Proof:** The session before pre-push was disabled (#483) shows commit pairs like `test(division-criteria): strip provider wrappers from unit-test (#473)` followed by behaviour-preserving code edits — red-test-first cadence was visible in the commit log. The session after pre-push was disabled shows single combined commits like `feat(collector): FindAClubMerger + pipeline wiring (#429)` with both implementation and tests in one shot. The commit boundary stopped reflecting the work order.
+
+**Root cause:** Pre-push acted as an implicit forcing function. Every push had to pass coverage; if I shipped code without tests, the gate noticed. Once it was disabled (#482), the visible feedback loop went away — CI takes 5–10 minutes and runs in the background. The mental cost of "did I actually fail this test first?" went up; the visible cost of skipping the discipline went down. Both signals point one direction: cheat.
+
+**Rule:** When a forcing function gets disabled, treat that as an _active risk_, not a neutral configuration change. Either (a) replace the forcing function with an explicit habit + commit-log audit, or (b) measure the discipline going forward via something else (e.g. a lint that flags PRs where every commit touches both `src/` and `__tests__/`). Don't assume "I'll remember." I didn't.
+
+**Fix:** Going forward, every new code change ships as at least two commits: `test(...): <failing test for behaviour X>` then `feat/fix(...): implement X to pass the test`. Commit boundaries become the discipline's audit trail. If the test isn't actually red at the first commit, that's a smell — either the test is wrong or the behaviour already exists.
+
+**Warning:** Tests-after still produce green suites and pass CI. They don't catch the cases where the test was over-fitted to the implementation already in front of me. The whole point of red-first is to write the test from the user-perceivable behaviour, BEFORE the implementation pollutes my view of "what's reasonable to assert." That's the part that quietly degrades when TDD slips into test-after.
+
+**rules.md candidate:** "R-N: every behaviour change ships as ≥2 commits — a failing test first, then the implementation. Verify red status before the implementation commit lands."


### PR DESCRIPTION
## Summary

Closes the Find-A-Club enrichment chain end-to-end. Joins per-district FAC raw JSON onto each snapshot's \`clubPerformance\` array via a left-outer-join from snapshot, before upload.

### How the merge handles each cohort

- **Matched** (snapshot row has a FAC counterpart): row gets optional FAC fields layered on — \`charterDate\`, \`coordinates\`, \`address\`, \`email\`, \`phone\`, \`website\`, \`facebookLink\`, \`meetingDay/Time\`, \`allowsVirtualAttendance\`, \`isProspective\`.
- **Snapshot-only** (no FAC match — most of the −410 from yesterday's data): row left as-is. Schema fields are optional; missing match is a no-op. Pattern investigation: #490.
- **FAC-only** (ATOs / prospective — the small + cohort): captured in \`MergeResult.facOnlyClubs\`, NOT merged into \`clubPerformance\` (would corrupt analytics). UI placement: #489.

### Idempotency

Re-runs overwrite previously-merged fields with the latest FAC values — TI registry is canonical for the enrichment fields; snapshot remains canonical for DCP / payments / status.

## End-to-end smoke

D61 on the 2026-05-11 snapshot:
\`\`\`
[INFO] district 61: matched=157, snapshot-only=4, fac-only=8
\`\`\`
Verified enrichment on club #00000180 (Causeurs Ottawa Speakers Club): charterDate \`1987-03-01\`, coordinates (45.42, -75.69), full address + email + meeting info — all in the merged snapshot file.

## What this PR ships

- \`packages/collector-cli/src/services/FindAClubMerger.ts\` (pure data, no I/O)
- \`packages/collector-cli/src/types/findAClub.ts\`
- New \`merge-find-a-club\` CLI command (reads / writes snapshot files in place)
- Pipeline step 3c in \`.github/workflows/data-pipeline.yml\` between FAC fetch and Compute Analytics, \`continue-on-error: true\`, gated on FAC fetch success

## Test plan

- [x] 11 new merger tests (normalisation, match/snapshot-only/FAC-only, idempotency, null Clubs handling, CSV-quoting variants)
- [x] Full collector-cli suite: 33 files / 725 tests
- [x] End-to-end smoke against live D61 (157+4+8 = 165 FAC / 161 snapshot, matches our prior observation)
- [ ] CI green
- [ ] First nightly run will show whether merged snapshots upload cleanly to GCS

## Related issues

- #489 — design UI placement for ATOs / prospective clubs (FAC-only cohort)
- #490 — investigate why 410 dashboard clubs are missing from FAC (snapshot-only cohort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)