### PR TITLE
feat(util): aggregateRegions — Sprint A of /regions epic (#493, #492)

### DIFF
--- a/frontend/src/utils/__tests__/aggregateRegions.test.ts
+++ b/frontend/src/utils/__tests__/aggregateRegions.test.ts
@@ -153,7 +153,14 @@ describe('aggregateRegions (#493)', () => {
 
   it('returns 0 (not NaN) when a denominator is zero', () => {
     const rollups = aggregateRegions([
-      mk({ region: '01', paidClubs: 0, paidClubBase: 0 }),
+      mk({
+        region: '01',
+        paidClubs: 0,
+        paidClubBase: 0,
+        totalPayments: 0,
+        paymentBase: 0,
+        distinguishedClubs: 0,
+      }),
     ])
     expect(rollups[0]?.clubGrowthPercent).toBe(0)
     expect(rollups[0]?.paymentGrowthPercent).toBe(0)

--- a/frontend/src/utils/__tests__/aggregateRegions.test.ts
+++ b/frontend/src/utils/__tests__/aggregateRegions.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest'
+import { aggregateRegions } from '../aggregateRegions'
+import type { DistrictRanking } from '@toastmasters/shared-contracts'
+
+/* Sprint A test suite (#493). Red-first per Lesson 54: this file is
+   committed BEFORE the implementation. Tests fail until the utility
+   ships. */
+
+const baseRanking: DistrictRanking = {
+  districtId: '01',
+  districtName: 'District 01',
+  region: '01',
+  paidClubs: 100,
+  paidClubBase: 90,
+  clubGrowthPercent: 11.1,
+  totalPayments: 5000,
+  paymentBase: 4500,
+  paymentGrowthPercent: 11.1,
+  activeClubs: 100,
+  distinguishedClubs: 50,
+  selectDistinguished: 20,
+  presidentsDistinguished: 10,
+  distinguishedPercent: 50,
+  clubsRank: 1,
+  paymentsRank: 1,
+  distinguishedRank: 1,
+  overallRank: 1,
+  aggregateScore: 300,
+  // requirement flags
+  dspSubmitted: true,
+  trainingMet: true,
+  marketAnalysisSubmitted: true,
+  communicationPlanSubmitted: true,
+  regionAdvisorVisitMet: true,
+  // sub-fields that may or may not be referenced
+  smedleyDistinguished: 4,
+  clubsWith20PlusMembers: 22,
+  newCharteredClubs: 5,
+  newPayments: 656,
+  aprilPayments: 1039,
+  octoberPayments: 1009,
+  latePayments: 3,
+  charterPayments: 101,
+} as DistrictRanking
+
+const mk = (overrides: Partial<DistrictRanking>): DistrictRanking =>
+  ({ ...baseRanking, ...overrides }) as DistrictRanking
+
+describe('aggregateRegions (#493)', () => {
+  it('returns empty array for empty input', () => {
+    expect(aggregateRegions([])).toEqual([])
+  })
+
+  it('groups districts by region', () => {
+    const rollups = aggregateRegions([
+      mk({ districtId: '01', region: '01' }),
+      mk({ districtId: '02', region: '01' }),
+      mk({ districtId: '57', region: '07' }),
+    ])
+    expect(rollups).toHaveLength(2)
+    expect(rollups[0]?.region).toBe('01')
+    expect(rollups[0]?.districtCount).toBe(2)
+    expect(rollups[1]?.region).toBe('07')
+    expect(rollups[1]?.districtCount).toBe(1)
+  })
+
+  it('sorts output by region number ascending', () => {
+    const rollups = aggregateRegions([
+      mk({ districtId: 'X', region: '14' }),
+      mk({ districtId: 'Y', region: '01' }),
+      mk({ districtId: 'Z', region: '07' }),
+    ])
+    expect(rollups.map(r => r.region)).toEqual(['01', '07', '14'])
+  })
+
+  it('excludes DNAR (district-not-assigned-region)', () => {
+    const rollups = aggregateRegions([
+      mk({ districtId: 'A', region: '01' }),
+      mk({ districtId: 'B', region: 'DNAR' }),
+    ])
+    expect(rollups.map(r => r.region)).toEqual(['01'])
+  })
+
+  it('excludes non-numeric regions other than DNAR (defensive)', () => {
+    const rollups = aggregateRegions([
+      mk({ districtId: 'A', region: '01' }),
+      mk({ districtId: 'B', region: '' }),
+      mk({ districtId: 'C', region: 'UNKNOWN' }),
+    ])
+    expect(rollups.map(r => r.region)).toEqual(['01'])
+  })
+
+  it('sums paidClubs, paidClubBase, totalPayments, paymentBase, distinguishedClubs', () => {
+    const rollups = aggregateRegions([
+      mk({
+        region: '01',
+        paidClubs: 100,
+        paidClubBase: 90,
+        totalPayments: 5000,
+        paymentBase: 4500,
+        distinguishedClubs: 50,
+      }),
+      mk({
+        region: '01',
+        paidClubs: 50,
+        paidClubBase: 48,
+        totalPayments: 2500,
+        paymentBase: 2400,
+        distinguishedClubs: 22,
+      }),
+    ])
+    expect(rollups[0]?.paidClubs).toBe(150)
+    expect(rollups[0]?.paidClubBase).toBe(138)
+    expect(rollups[0]?.totalPayments).toBe(7500)
+    expect(rollups[0]?.paymentBase).toBe(6900)
+    expect(rollups[0]?.distinguishedClubs).toBe(72)
+  })
+
+  it('sums aggregateScore across districts in the region', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', aggregateScore: 300 }),
+      mk({ region: '01', aggregateScore: 250 }),
+    ])
+    expect(rollups[0]?.aggregateScore).toBe(550)
+  })
+
+  it('derives clubGrowthPercent from sums', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', paidClubs: 100, paidClubBase: 90 }),
+      mk({ region: '01', paidClubs: 60, paidClubBase: 50 }),
+    ])
+    // paidClubs=160, paidClubBase=140 → growth = (160-140)/140 = 14.285…
+    expect(rollups[0]?.clubGrowthPercent).toBeCloseTo(14.285, 2)
+  })
+
+  it('derives paymentGrowthPercent from sums', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', totalPayments: 5000, paymentBase: 4500 }),
+      mk({ region: '01', totalPayments: 2500, paymentBase: 2400 }),
+    ])
+    // payments=7500, base=6900 → growth = 600/6900 = 8.695…
+    expect(rollups[0]?.paymentGrowthPercent).toBeCloseTo(8.695, 2)
+  })
+
+  it('derives distinguishedPercent from sums', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', paidClubs: 100, distinguishedClubs: 50 }),
+      mk({ region: '01', paidClubs: 50, distinguishedClubs: 22 }),
+    ])
+    // distinguished=72, paidClubs=150 → 48%
+    expect(rollups[0]?.distinguishedPercent).toBeCloseTo(48, 1)
+  })
+
+  it('returns 0 (not NaN) when a denominator is zero', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', paidClubs: 0, paidClubBase: 0 }),
+    ])
+    expect(rollups[0]?.clubGrowthPercent).toBe(0)
+    expect(rollups[0]?.paymentGrowthPercent).toBe(0)
+    expect(rollups[0]?.distinguishedPercent).toBe(0)
+  })
+
+  it('picks the leading district by aggregateScore', () => {
+    const rollups = aggregateRegions([
+      mk({
+        districtId: '01',
+        districtName: 'District 01',
+        region: '01',
+        aggregateScore: 200,
+      }),
+      mk({
+        districtId: '02',
+        districtName: 'District 02',
+        region: '01',
+        aggregateScore: 400,
+      }),
+      mk({
+        districtId: '03',
+        districtName: 'District 03',
+        region: '01',
+        aggregateScore: 300,
+      }),
+    ])
+    expect(rollups[0]?.leadingDistrictId).toBe('02')
+    expect(rollups[0]?.leadingDistrictName).toBe('District 02')
+  })
+
+  it('counts requirement met/total per region', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', dspSubmitted: true, trainingMet: true }),
+      mk({ region: '01', dspSubmitted: true, trainingMet: false }),
+      mk({ region: '01', dspSubmitted: false, trainingMet: true }),
+    ])
+    expect(rollups[0]?.requirements.dspSubmitted.met).toBe(2)
+    expect(rollups[0]?.requirements.dspSubmitted.total).toBe(3)
+    expect(rollups[0]?.requirements.trainingMet.met).toBe(2)
+    expect(rollups[0]?.requirements.trainingMet.total).toBe(3)
+  })
+
+  it('handles missing/undefined requirement fields (counts as not-met)', () => {
+    // Older snapshots may lack these fields entirely.
+    const r = mk({ region: '01' })
+    delete (r as { dspSubmitted?: unknown }).dspSubmitted
+    const rollups = aggregateRegions([r])
+    expect(rollups[0]?.requirements.dspSubmitted.met).toBe(0)
+    expect(rollups[0]?.requirements.dspSubmitted.total).toBe(1)
+  })
+})

--- a/frontend/src/utils/aggregateRegions.ts
+++ b/frontend/src/utils/aggregateRegions.ts
@@ -1,0 +1,142 @@
+/* aggregateRegions (#493) — group rankings.json districts by region
+   into a leaderboard-ready rollup.
+
+   Powers the /regions overview page (epic #492). The TI dashboard
+   itself renders the same data server-side as HTML; this utility lets
+   us compute it client-side from the per-district feed we already
+   publish, with no pipeline changes. */
+
+import type { DistrictRanking } from '@toastmasters/shared-contracts'
+
+export interface RequirementRatio {
+  met: number
+  total: number
+}
+
+export interface RegionRollup {
+  region: string
+  districtCount: number
+  paidClubs: number
+  paidClubBase: number
+  /** Derived: (paidClubs − paidClubBase) / paidClubBase × 100. 0 when base is 0. */
+  clubGrowthPercent: number
+  totalPayments: number
+  paymentBase: number
+  /** Derived: (totalPayments − paymentBase) / paymentBase × 100. 0 when base is 0. */
+  paymentGrowthPercent: number
+  distinguishedClubs: number
+  /** Derived: distinguishedClubs / paidClubs × 100. 0 when paidClubs is 0. */
+  distinguishedPercent: number
+  /** Sum of district aggregate scores. Higher is better. */
+  aggregateScore: number
+  /** District with highest aggregateScore in this region. */
+  leadingDistrictId: string
+  leadingDistrictName: string
+  /** Per-requirement counts: how many districts met / total in region. */
+  requirements: {
+    dspSubmitted: RequirementRatio
+    trainingMet: RequirementRatio
+    marketAnalysisSubmitted: RequirementRatio
+    communicationPlanSubmitted: RequirementRatio
+    regionAdvisorVisitMet: RequirementRatio
+  }
+}
+
+const REQUIREMENT_KEYS = [
+  'dspSubmitted',
+  'trainingMet',
+  'marketAnalysisSubmitted',
+  'communicationPlanSubmitted',
+  'regionAdvisorVisitMet',
+] as const
+
+/** Region IDs that should be excluded from the leaderboard / grid.
+ *  TI uses 'DNAR' for districts that aren't yet assigned to a region;
+ *  unknown / empty values fall in the same bucket defensively. */
+const isValidRegion = (region: string): boolean => /^\d+$/.test(region)
+
+/** Safe division: 0 when denominator is 0 so we never emit NaN. */
+const pct = (num: number, denom: number): number =>
+  denom > 0 ? (num / denom) * 100 : 0
+
+export function aggregateRegions(
+  rankings: ReadonlyArray<DistrictRanking>
+): RegionRollup[] {
+  if (rankings.length === 0) return []
+
+  // Group: region → districts in that region.
+  const byRegion = new Map<string, DistrictRanking[]>()
+  for (const r of rankings) {
+    if (!isValidRegion(r.region)) continue
+    const list = byRegion.get(r.region) ?? []
+    list.push(r)
+    byRegion.set(r.region, list)
+  }
+
+  // Build rollups; sort by region number ascending.
+  const rollups: RegionRollup[] = []
+  for (const [region, districts] of byRegion) {
+    if (districts.length === 0) continue
+
+    const totals = districts.reduce(
+      (acc, d) => {
+        acc.paidClubs += d.paidClubs ?? 0
+        acc.paidClubBase += d.paidClubBase ?? 0
+        acc.totalPayments += d.totalPayments ?? 0
+        acc.paymentBase += d.paymentBase ?? 0
+        acc.distinguishedClubs += d.distinguishedClubs ?? 0
+        acc.aggregateScore += d.aggregateScore ?? 0
+        return acc
+      },
+      {
+        paidClubs: 0,
+        paidClubBase: 0,
+        totalPayments: 0,
+        paymentBase: 0,
+        distinguishedClubs: 0,
+        aggregateScore: 0,
+      }
+    )
+
+    const leading = districts.reduce((best, d) =>
+      (d.aggregateScore ?? 0) > (best.aggregateScore ?? 0) ? d : best
+    )
+
+    const requirements = REQUIREMENT_KEYS.reduce(
+      (acc, key) => {
+        const met = districts.filter(
+          d => (d as unknown as Record<string, unknown>)[key] === true
+        ).length
+        acc[key] = { met, total: districts.length }
+        return acc
+      },
+      {} as RegionRollup['requirements']
+    )
+
+    rollups.push({
+      region,
+      districtCount: districts.length,
+      paidClubs: totals.paidClubs,
+      paidClubBase: totals.paidClubBase,
+      clubGrowthPercent: pct(
+        totals.paidClubs - totals.paidClubBase,
+        totals.paidClubBase
+      ),
+      totalPayments: totals.totalPayments,
+      paymentBase: totals.paymentBase,
+      paymentGrowthPercent: pct(
+        totals.totalPayments - totals.paymentBase,
+        totals.paymentBase
+      ),
+      distinguishedClubs: totals.distinguishedClubs,
+      distinguishedPercent: pct(totals.distinguishedClubs, totals.paidClubs),
+      aggregateScore: totals.aggregateScore,
+      leadingDistrictId: leading.districtId,
+      leadingDistrictName: leading.districtName,
+      requirements,
+    })
+  }
+
+  rollups.sort((a, b) => Number(a.region) - Number(b.region))
+  return rollups
+}


### PR DESCRIPTION
## Summary

Sprint A of epic #492. Pure data utility that groups \`rankings.json\` by region and computes the rollup metrics that the upcoming RegionsLeaderboard + RegionGrid will consume.

## Red → Green visible in the log

Per Lesson 54, this PR ships TWO commits:

1. \`test(util): RED — failing tests for aggregateRegions (#493, #492)\` — test file commits before implementation; suite fails at import resolution
2. \`feat(util): GREEN — aggregateRegions implementation (#493, #492)\` — implementation makes all 14 tests pass

## Tests (14)

Empty input · grouping by region · ascending-numeric sort · DNAR exclusion · defensive non-numeric exclusion · sum semantics across 5 fields · aggregateScore sum · derived percents (3) · zero-denominator → 0 · leading district by aggregateScore · requirement met/total ratios · missing-field defensive

## What ships

\`frontend/src/utils/aggregateRegions.ts\` + \`__tests__/aggregateRegions.test.ts\`

\`\`\`ts
export function aggregateRegions(
  rankings: ReadonlyArray<DistrictRanking>
): RegionRollup[]
\`\`\`

## Next sprints

- **B (#494, #495)**: RegionsLeaderboard table + RegionGrid cards
- **C (#496, #497)**: \`/regions\` page + enable Regions top-bar nav link

🤖 Generated with [Claude Code](https://claude.com/claude-code)