### PR TITLE
feat(components): RegionsLeaderboard + RegionGrid — Sprint B of /regions epic (#494 #495 #492)

### DIFF
--- a/frontend/src/components/RegionGrid.tsx
+++ b/frontend/src/components/RegionGrid.tsx
@@ -1,0 +1,14 @@
+import type { RegionRollup } from '../utils/aggregateRegions'
+
+/* RegionGrid (#495) — 14 region KPI cards under the leaderboard.
+   Sprint B RED stub: signature only; implementation comes in the GREEN
+   commit. The stub lets the test file resolve its import + lets the
+   pre-commit typecheck pass without bypassing it. */
+
+export interface RegionGridProps {
+  rollups: ReadonlyArray<RegionRollup>
+}
+
+export const RegionGrid: React.FC<RegionGridProps> = () => {
+  throw new Error('RegionGrid: not implemented (RED phase)')
+}

--- a/frontend/src/components/RegionGrid.tsx
+++ b/frontend/src/components/RegionGrid.tsx
@@ -1,14 +1,102 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { Tooltip } from './Tooltip'
 import type { RegionRollup } from '../utils/aggregateRegions'
 
-/* RegionGrid (#495) — 14 region KPI cards under the leaderboard.
-   Sprint B RED stub: signature only; implementation comes in the GREEN
-   commit. The stub lets the test file resolve its import + lets the
-   pre-commit typecheck pass without bypassing it. */
+/* RegionGrid (#495) — 14 region KPI cards below the leaderboard.
+   Each card is a single clickable link to /region/:n. The
+   requirements ribbon surfaces TI's 5 region-level requirements
+   (DSP / Training / Mkt Plan / Comm Plan / RA Mtgs) with a small
+   tooltip showing the met/total ratio per indicator. */
 
 export interface RegionGridProps {
   rollups: ReadonlyArray<RegionRollup>
 }
 
-export const RegionGrid: React.FC<RegionGridProps> = () => {
-  throw new Error('RegionGrid: not implemented (RED phase)')
+const REQUIREMENT_LABELS: ReadonlyArray<{
+  key: keyof RegionRollup['requirements']
+  label: string
+}> = [
+  { key: 'dspSubmitted', label: 'DSP' },
+  { key: 'trainingMet', label: 'Training' },
+  { key: 'marketAnalysisSubmitted', label: 'Mkt Plan' },
+  { key: 'communicationPlanSubmitted', label: 'Comm Plan' },
+  { key: 'regionAdvisorVisitMet', label: 'RA Mtgs' },
+]
+
+export const RegionGrid: React.FC<RegionGridProps> = ({ rollups }) => {
+  if (rollups.length === 0) return null
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      {rollups.map(r => (
+        <Link
+          key={r.region}
+          to={`/region/${r.region}`}
+          aria-label={`Region ${r.region} — ${r.districtCount} districts`}
+          className="block bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 hover:border-tm-loyal-blue dark:hover:border-blue-400 hover:shadow-sm transition-all focus-visible:outline-2 focus-visible:outline-tm-loyal-blue"
+        >
+          <header className="mb-3">
+            <p className="text-xs font-semibold uppercase tracking-wider text-tm-loyal-blue dark:text-blue-300">
+              Region {r.region}
+            </p>
+            <h3 className="text-sm font-tm-headline text-gray-900 dark:text-gray-50 mt-1">
+              leader: {r.leadingDistrictName}
+            </h3>
+          </header>
+
+          <ul className="grid grid-cols-3 gap-2 text-xs mb-3" role="list">
+            <li>
+              <span className="block text-gray-500 dark:text-gray-400">
+                {r.districtCount} districts
+              </span>
+            </li>
+            <li>
+              <span className="block text-gray-900 dark:text-gray-100 font-semibold tabular-nums">
+                {r.paidClubs.toLocaleString()}
+              </span>
+              <span className="block text-gray-500 dark:text-gray-400">
+                paid clubs
+              </span>
+            </li>
+            <li>
+              <span className="block text-gray-900 dark:text-gray-100 font-semibold tabular-nums">
+                {Math.round(r.distinguishedPercent)}%
+              </span>
+              <span className="block text-gray-500 dark:text-gray-400">
+                distinguished
+              </span>
+            </li>
+          </ul>
+
+          <div
+            className="flex items-center gap-1 pt-3 border-t border-gray-100 dark:border-gray-700"
+            aria-label="Requirements ribbon"
+          >
+            {REQUIREMENT_LABELS.map(({ key, label }) => {
+              const ratio = r.requirements[key]
+              const met = ratio.met > 0
+              return (
+                <Tooltip
+                  key={key}
+                  content={`${label}: ${ratio.met}/${ratio.total} districts`}
+                >
+                  <span
+                    data-requirement={key}
+                    data-met={met}
+                    className={
+                      'inline-block w-2 h-2 rounded-full ' +
+                      (met
+                        ? 'bg-green-500 dark:bg-green-400'
+                        : 'bg-gray-300 dark:bg-gray-600')
+                    }
+                  />
+                </Tooltip>
+              )
+            })}
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
 }

--- a/frontend/src/components/RegionsLeaderboard.tsx
+++ b/frontend/src/components/RegionsLeaderboard.tsx
@@ -1,0 +1,14 @@
+import type { RegionRollup } from '../utils/aggregateRegions'
+
+/* RegionsLeaderboard (#494) — sortable table for the /regions overview.
+   Sprint B RED stub: signature only; implementation comes in the GREEN
+   commit. The stub lets the test file resolve its import + lets the
+   pre-commit typecheck pass without bypassing it. */
+
+export interface RegionsLeaderboardProps {
+  rollups: ReadonlyArray<RegionRollup>
+}
+
+export const RegionsLeaderboard: React.FC<RegionsLeaderboardProps> = () => {
+  throw new Error('RegionsLeaderboard: not implemented (RED phase)')
+}

--- a/frontend/src/components/RegionsLeaderboard.tsx
+++ b/frontend/src/components/RegionsLeaderboard.tsx
@@ -1,14 +1,157 @@
+import React, { useState, useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import type { RegionRollup } from '../utils/aggregateRegions'
 
 /* RegionsLeaderboard (#494) — sortable table for the /regions overview.
-   Sprint B RED stub: signature only; implementation comes in the GREEN
-   commit. The stub lets the test file resolve its import + lets the
-   pre-commit typecheck pass without bypassing it. */
+   14 region rows × six columns. Default sort: aggregateScore desc
+   ("which region is winning right now"). Reuses Tailwind utility
+   classes for visual consistency with the DistrictsPage rankings
+   table — same chip + hover affordance. */
 
 export interface RegionsLeaderboardProps {
   rollups: ReadonlyArray<RegionRollup>
 }
 
-export const RegionsLeaderboard: React.FC<RegionsLeaderboardProps> = () => {
-  throw new Error('RegionsLeaderboard: not implemented (RED phase)')
+type SortKey =
+  | 'region'
+  | 'districtCount'
+  | 'paidClubs'
+  | 'totalPayments'
+  | 'distinguishedClubs'
+  | 'aggregateScore'
+
+type SortDir = 'asc' | 'desc'
+
+const COLUMNS: ReadonlyArray<{
+  key: SortKey
+  label: string
+  align: 'left' | 'right'
+}> = [
+  { key: 'region', label: 'Region', align: 'left' },
+  { key: 'districtCount', label: 'Districts', align: 'right' },
+  { key: 'paidClubs', label: 'Paid Clubs', align: 'right' },
+  { key: 'totalPayments', label: 'Payments', align: 'right' },
+  { key: 'distinguishedClubs', label: 'Distinguished', align: 'right' },
+  { key: 'aggregateScore', label: 'Score', align: 'right' },
+]
+
+const compareBy = (key: SortKey, a: RegionRollup, b: RegionRollup): number => {
+  if (key === 'region') return Number(a.region) - Number(b.region)
+  return (a[key] ?? 0) - (b[key] ?? 0)
+}
+
+export const RegionsLeaderboard: React.FC<RegionsLeaderboardProps> = ({
+  rollups,
+}) => {
+  const [sortKey, setSortKey] = useState<SortKey>('aggregateScore')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  const sorted = useMemo(() => {
+    const copy = [...rollups]
+    copy.sort((a, b) => {
+      const cmp = compareBy(sortKey, a, b)
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+    return copy
+  }, [rollups, sortKey, sortDir])
+
+  if (rollups.length === 0) {
+    return (
+      <p className="text-sm text-gray-500 italic px-4 py-6">
+        No regions to display.
+      </p>
+    )
+  }
+
+  const handleHeaderClick = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir(prev => (prev === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      // Default direction per column: region → asc (numeric), others → desc.
+      setSortDir(key === 'region' ? 'asc' : 'desc')
+    }
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table
+        className="w-full text-sm font-tm-body"
+        aria-label="Region rankings"
+      >
+        <thead className="border-b border-gray-200 dark:border-gray-700">
+          <tr>
+            {COLUMNS.map(col => {
+              const isActive = col.key === sortKey
+              const arrow = isActive ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''
+              return (
+                <th
+                  key={col.key}
+                  scope="col"
+                  className={
+                    'px-4 py-3 cursor-pointer select-none text-xs font-medium uppercase tracking-wider text-gray-600 dark:text-gray-300 ' +
+                    (col.align === 'right' ? 'text-right' : 'text-left')
+                  }
+                  aria-sort={
+                    isActive
+                      ? sortDir === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none'
+                  }
+                  onClick={() => handleHeaderClick(col.key)}
+                >
+                  {col.label}
+                  {arrow}
+                </th>
+              )
+            })}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+          {sorted.map(r => (
+            <tr
+              key={r.region}
+              className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+            >
+              <td className="px-4 py-3 text-left">
+                <Link
+                  to={`/region/${r.region}`}
+                  className="flex items-center gap-3 text-tm-loyal-blue hover:underline"
+                >
+                  <span
+                    className="inline-block px-2 py-0.5 text-xs font-mono rounded bg-tm-loyal-blue/10 text-tm-loyal-blue dark:bg-tm-loyal-blue/30 dark:text-blue-200"
+                    aria-hidden="true"
+                  >
+                    Region {r.region}
+                  </span>
+                  <span className="text-gray-700 dark:text-gray-200 text-xs">
+                    leader: {r.leadingDistrictName}
+                  </span>
+                </Link>
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums text-gray-700 dark:text-gray-200">
+                {r.districtCount}
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums text-gray-700 dark:text-gray-200">
+                {r.paidClubs.toLocaleString()}
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums text-gray-700 dark:text-gray-200">
+                {r.totalPayments.toLocaleString()}
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums text-gray-700 dark:text-gray-200">
+                {r.distinguishedClubs.toLocaleString()}
+                <span className="text-gray-500 dark:text-gray-400 ml-1">
+                  · {Math.round(r.distinguishedPercent)}%
+                </span>
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums font-semibold text-gray-900 dark:text-gray-50">
+                {r.aggregateScore.toLocaleString()}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
 }

--- a/frontend/src/components/__tests__/RegionGrid.test.tsx
+++ b/frontend/src/components/__tests__/RegionGrid.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { RegionGrid } from '../RegionGrid'
+import type { RegionRollup } from '../../utils/aggregateRegions'
+
+/* Sprint B test suite (#495, #492). Red-first per Lesson 54. */
+
+afterEach(() => cleanup())
+
+const renderWithRouter = (ui: ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>)
+
+const mkRollup = (overrides: Partial<RegionRollup>): RegionRollup => ({
+  region: '01',
+  districtCount: 8,
+  paidClubs: 500,
+  paidClubBase: 480,
+  clubGrowthPercent: 4.16,
+  totalPayments: 12000,
+  paymentBase: 11000,
+  paymentGrowthPercent: 9.09,
+  distinguishedClubs: 200,
+  distinguishedPercent: 40,
+  aggregateScore: 1500,
+  leadingDistrictId: '01',
+  leadingDistrictName: 'District 01',
+  requirements: {
+    dspSubmitted: { met: 7, total: 8 },
+    trainingMet: { met: 8, total: 8 },
+    marketAnalysisSubmitted: { met: 6, total: 8 },
+    communicationPlanSubmitted: { met: 7, total: 8 },
+    regionAdvisorVisitMet: { met: 8, total: 8 },
+  },
+  ...overrides,
+})
+
+const twoRollups: RegionRollup[] = [
+  mkRollup({ region: '01', leadingDistrictName: 'District 01' }),
+  mkRollup({ region: '07', leadingDistrictName: 'District 57' }),
+]
+
+describe('RegionGrid (#495)', () => {
+  it('renders one card per rollup', () => {
+    renderWithRouter(<RegionGrid rollups={twoRollups} />)
+    const cards = screen.getAllByRole('link', { name: /region/i })
+    expect(cards.length).toBe(2)
+  })
+
+  it('each card shows the region label as an eyebrow', () => {
+    renderWithRouter(<RegionGrid rollups={twoRollups} />)
+    expect(screen.getByText(/Region 01/)).toBeInTheDocument()
+    expect(screen.getByText(/Region 07/)).toBeInTheDocument()
+  })
+
+  it('each card shows the leading district name', () => {
+    renderWithRouter(<RegionGrid rollups={twoRollups} />)
+    expect(screen.getByText(/District 01/)).toBeInTheDocument()
+    expect(screen.getByText(/District 57/)).toBeInTheDocument()
+  })
+
+  it('each card links to /region/:n', () => {
+    renderWithRouter(<RegionGrid rollups={twoRollups} />)
+    const links = screen.getAllByRole('link', { name: /region/i })
+    const hrefs = links.map(a => a.getAttribute('href'))
+    expect(hrefs).toContain('/region/01')
+    expect(hrefs).toContain('/region/07')
+  })
+
+  it('shows districtCount, paidClubs, distinguishedPercent on each card', () => {
+    renderWithRouter(
+      <RegionGrid
+        rollups={[
+          mkRollup({
+            region: '01',
+            districtCount: 8,
+            paidClubs: 500,
+            distinguishedPercent: 40,
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText(/8 districts/i)).toBeInTheDocument()
+    expect(screen.getByText(/500/)).toBeInTheDocument()
+    expect(screen.getByText(/40%/)).toBeInTheDocument()
+  })
+
+  it('renders the 5-dot requirements ribbon', () => {
+    renderWithRouter(<RegionGrid rollups={twoRollups} />)
+    const card = screen.getAllByRole('link', { name: /region/i })[0]
+    const ribbon = within(card as HTMLElement).getByLabelText(
+      /requirements ribbon/i
+    )
+    // 5 requirement indicators (DSP/Training/Mkt/Comm/RA)
+    const dots = ribbon.querySelectorAll('[data-requirement]')
+    expect(dots.length).toBe(5)
+  })
+
+  it('requirement-ribbon dots carry data-met="true" when met > 0, else false', () => {
+    renderWithRouter(
+      <RegionGrid
+        rollups={[
+          mkRollup({
+            region: '01',
+            requirements: {
+              dspSubmitted: { met: 5, total: 8 },
+              trainingMet: { met: 0, total: 8 },
+              marketAnalysisSubmitted: { met: 5, total: 8 },
+              communicationPlanSubmitted: { met: 5, total: 8 },
+              regionAdvisorVisitMet: { met: 5, total: 8 },
+            },
+          }),
+        ]}
+      />
+    )
+    const card = screen.getByRole('link', { name: /region/i })
+    const ribbon = within(card as HTMLElement).getByLabelText(
+      /requirements ribbon/i
+    )
+    const trainingDot = ribbon.querySelector('[data-requirement="trainingMet"]')
+    expect(trainingDot).toHaveAttribute('data-met', 'false')
+    const dspDot = ribbon.querySelector('[data-requirement="dspSubmitted"]')
+    expect(dspDot).toHaveAttribute('data-met', 'true')
+  })
+
+  it('renders nothing when given an empty rollups array', () => {
+    const { container } = renderWithRouter(<RegionGrid rollups={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/frontend/src/components/__tests__/RegionsLeaderboard.test.tsx
+++ b/frontend/src/components/__tests__/RegionsLeaderboard.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  within,
+} from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { RegionsLeaderboard } from '../RegionsLeaderboard'
+import type { RegionRollup } from '../../utils/aggregateRegions'
+
+/* Sprint B test suite (#494, #492). Red-first per Lesson 54. */
+
+afterEach(() => cleanup())
+
+const renderWithRouter = (ui: ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>)
+
+const mkRollup = (overrides: Partial<RegionRollup>): RegionRollup => ({
+  region: '01',
+  districtCount: 8,
+  paidClubs: 500,
+  paidClubBase: 480,
+  clubGrowthPercent: 4.16,
+  totalPayments: 12000,
+  paymentBase: 11000,
+  paymentGrowthPercent: 9.09,
+  distinguishedClubs: 200,
+  distinguishedPercent: 40,
+  aggregateScore: 1500,
+  leadingDistrictId: '01',
+  leadingDistrictName: 'District 01',
+  requirements: {
+    dspSubmitted: { met: 7, total: 8 },
+    trainingMet: { met: 8, total: 8 },
+    marketAnalysisSubmitted: { met: 6, total: 8 },
+    communicationPlanSubmitted: { met: 7, total: 8 },
+    regionAdvisorVisitMet: { met: 8, total: 8 },
+  },
+  ...overrides,
+})
+
+const sampleRollups: RegionRollup[] = [
+  mkRollup({ region: '01', aggregateScore: 1500, leadingDistrictId: '01' }),
+  mkRollup({ region: '02', aggregateScore: 2200, leadingDistrictId: '20' }),
+  mkRollup({ region: '03', aggregateScore: 900, leadingDistrictId: '99' }),
+]
+
+describe('RegionsLeaderboard (#494)', () => {
+  it('renders one table row per region', () => {
+    renderWithRouter(<RegionsLeaderboard rollups={sampleRollups} />)
+    const tbody = screen.getByRole('table').querySelector('tbody')
+    expect(tbody?.querySelectorAll('tr').length).toBe(3)
+  })
+
+  it('renders the expected column headers', () => {
+    renderWithRouter(<RegionsLeaderboard rollups={sampleRollups} />)
+    expect(
+      screen.getByRole('columnheader', { name: /region/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /districts/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /paid clubs/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /payments/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /distinguished/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /score/i })
+    ).toBeInTheDocument()
+  })
+
+  it('defaults to sorting by aggregateScore descending', () => {
+    renderWithRouter(<RegionsLeaderboard rollups={sampleRollups} />)
+    const tbody = screen.getByRole('table').querySelector('tbody')
+    const regionTexts = Array.from(tbody?.querySelectorAll('tr') ?? []).map(
+      tr => tr.textContent
+    )
+    // Score order: 2200 (02), 1500 (01), 900 (03)
+    expect(regionTexts[0]).toMatch(/Region 02/)
+    expect(regionTexts[1]).toMatch(/Region 01/)
+    expect(regionTexts[2]).toMatch(/Region 03/)
+  })
+
+  it('clicking a column header reorders by that column', () => {
+    renderWithRouter(<RegionsLeaderboard rollups={sampleRollups} />)
+    fireEvent.click(screen.getByRole('columnheader', { name: /^region/i }))
+    const tbody = screen.getByRole('table').querySelector('tbody')
+    const regionTexts = Array.from(tbody?.querySelectorAll('tr') ?? []).map(
+      tr => tr.textContent
+    )
+    // After clicking Region header → ascending by region number
+    expect(regionTexts[0]).toMatch(/Region 01/)
+    expect(regionTexts[2]).toMatch(/Region 03/)
+  })
+
+  it('clicking the same header twice reverses the sort direction', () => {
+    renderWithRouter(<RegionsLeaderboard rollups={sampleRollups} />)
+    const regionHeader = screen.getByRole('columnheader', { name: /^region/i })
+    fireEvent.click(regionHeader) // asc
+    fireEvent.click(regionHeader) // desc
+    const tbody = screen.getByRole('table').querySelector('tbody')
+    const regionTexts = Array.from(tbody?.querySelectorAll('tr') ?? []).map(
+      tr => tr.textContent
+    )
+    expect(regionTexts[0]).toMatch(/Region 03/)
+    expect(regionTexts[2]).toMatch(/Region 01/)
+  })
+
+  it('each row is a link to /region/:n', () => {
+    renderWithRouter(<RegionsLeaderboard rollups={sampleRollups} />)
+    const tbody = screen.getByRole('table').querySelector('tbody')
+    const links = within(tbody as HTMLElement).getAllByRole('link')
+    const hrefs = links.map(a => a.getAttribute('href'))
+    expect(hrefs).toContain('/region/01')
+    expect(hrefs).toContain('/region/02')
+    expect(hrefs).toContain('/region/03')
+  })
+
+  it('renders the leading district name in the region cell', () => {
+    renderWithRouter(
+      <RegionsLeaderboard
+        rollups={[
+          mkRollup({
+            region: '07',
+            leadingDistrictId: '57',
+            leadingDistrictName: 'District 57',
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText(/District 57/)).toBeInTheDocument()
+  })
+
+  it('shows distinguished as count + percent', () => {
+    renderWithRouter(
+      <RegionsLeaderboard
+        rollups={[
+          mkRollup({ distinguishedClubs: 200, distinguishedPercent: 40 }),
+        ]}
+      />
+    )
+    // Component should render '200' AND '40%' somewhere in the row
+    expect(screen.getByText(/200/)).toBeInTheDocument()
+    expect(screen.getByText(/40%/)).toBeInTheDocument()
+  })
+
+  it('renders empty state when no rollups are provided', () => {
+    renderWithRouter(<RegionsLeaderboard rollups={[]} />)
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(screen.getByText(/no regions/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/utils/__tests__/aggregateRegions.test.ts
+++ b/frontend/src/utils/__tests__/aggregateRegions.test.ts
@@ -153,7 +153,14 @@ describe('aggregateRegions (#493)', () => {
 
   it('returns 0 (not NaN) when a denominator is zero', () => {
     const rollups = aggregateRegions([
-      mk({ region: '01', paidClubs: 0, paidClubBase: 0 }),
+      mk({
+        region: '01',
+        paidClubs: 0,
+        paidClubBase: 0,
+        totalPayments: 0,
+        paymentBase: 0,
+        distinguishedClubs: 0,
+      }),
     ])
     expect(rollups[0]?.clubGrowthPercent).toBe(0)
     expect(rollups[0]?.paymentGrowthPercent).toBe(0)

--- a/frontend/src/utils/__tests__/aggregateRegions.test.ts
+++ b/frontend/src/utils/__tests__/aggregateRegions.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest'
+import { aggregateRegions } from '../aggregateRegions'
+import type { DistrictRanking } from '@toastmasters/shared-contracts'
+
+/* Sprint A test suite (#493). Red-first per Lesson 54: this file is
+   committed BEFORE the implementation. Tests fail until the utility
+   ships. */
+
+const baseRanking: DistrictRanking = {
+  districtId: '01',
+  districtName: 'District 01',
+  region: '01',
+  paidClubs: 100,
+  paidClubBase: 90,
+  clubGrowthPercent: 11.1,
+  totalPayments: 5000,
+  paymentBase: 4500,
+  paymentGrowthPercent: 11.1,
+  activeClubs: 100,
+  distinguishedClubs: 50,
+  selectDistinguished: 20,
+  presidentsDistinguished: 10,
+  distinguishedPercent: 50,
+  clubsRank: 1,
+  paymentsRank: 1,
+  distinguishedRank: 1,
+  overallRank: 1,
+  aggregateScore: 300,
+  // requirement flags
+  dspSubmitted: true,
+  trainingMet: true,
+  marketAnalysisSubmitted: true,
+  communicationPlanSubmitted: true,
+  regionAdvisorVisitMet: true,
+  // sub-fields that may or may not be referenced
+  smedleyDistinguished: 4,
+  clubsWith20PlusMembers: 22,
+  newCharteredClubs: 5,
+  newPayments: 656,
+  aprilPayments: 1039,
+  octoberPayments: 1009,
+  latePayments: 3,
+  charterPayments: 101,
+} as DistrictRanking
+
+const mk = (overrides: Partial<DistrictRanking>): DistrictRanking =>
+  ({ ...baseRanking, ...overrides }) as DistrictRanking
+
+describe('aggregateRegions (#493)', () => {
+  it('returns empty array for empty input', () => {
+    expect(aggregateRegions([])).toEqual([])
+  })
+
+  it('groups districts by region', () => {
+    const rollups = aggregateRegions([
+      mk({ districtId: '01', region: '01' }),
+      mk({ districtId: '02', region: '01' }),
+      mk({ districtId: '57', region: '07' }),
+    ])
+    expect(rollups).toHaveLength(2)
+    expect(rollups[0]?.region).toBe('01')
+    expect(rollups[0]?.districtCount).toBe(2)
+    expect(rollups[1]?.region).toBe('07')
+    expect(rollups[1]?.districtCount).toBe(1)
+  })
+
+  it('sorts output by region number ascending', () => {
+    const rollups = aggregateRegions([
+      mk({ districtId: 'X', region: '14' }),
+      mk({ districtId: 'Y', region: '01' }),
+      mk({ districtId: 'Z', region: '07' }),
+    ])
+    expect(rollups.map(r => r.region)).toEqual(['01', '07', '14'])
+  })
+
+  it('excludes DNAR (district-not-assigned-region)', () => {
+    const rollups = aggregateRegions([
+      mk({ districtId: 'A', region: '01' }),
+      mk({ districtId: 'B', region: 'DNAR' }),
+    ])
+    expect(rollups.map(r => r.region)).toEqual(['01'])
+  })
+
+  it('excludes non-numeric regions other than DNAR (defensive)', () => {
+    const rollups = aggregateRegions([
+      mk({ districtId: 'A', region: '01' }),
+      mk({ districtId: 'B', region: '' }),
+      mk({ districtId: 'C', region: 'UNKNOWN' }),
+    ])
+    expect(rollups.map(r => r.region)).toEqual(['01'])
+  })
+
+  it('sums paidClubs, paidClubBase, totalPayments, paymentBase, distinguishedClubs', () => {
+    const rollups = aggregateRegions([
+      mk({
+        region: '01',
+        paidClubs: 100,
+        paidClubBase: 90,
+        totalPayments: 5000,
+        paymentBase: 4500,
+        distinguishedClubs: 50,
+      }),
+      mk({
+        region: '01',
+        paidClubs: 50,
+        paidClubBase: 48,
+        totalPayments: 2500,
+        paymentBase: 2400,
+        distinguishedClubs: 22,
+      }),
+    ])
+    expect(rollups[0]?.paidClubs).toBe(150)
+    expect(rollups[0]?.paidClubBase).toBe(138)
+    expect(rollups[0]?.totalPayments).toBe(7500)
+    expect(rollups[0]?.paymentBase).toBe(6900)
+    expect(rollups[0]?.distinguishedClubs).toBe(72)
+  })
+
+  it('sums aggregateScore across districts in the region', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', aggregateScore: 300 }),
+      mk({ region: '01', aggregateScore: 250 }),
+    ])
+    expect(rollups[0]?.aggregateScore).toBe(550)
+  })
+
+  it('derives clubGrowthPercent from sums', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', paidClubs: 100, paidClubBase: 90 }),
+      mk({ region: '01', paidClubs: 60, paidClubBase: 50 }),
+    ])
+    // paidClubs=160, paidClubBase=140 → growth = (160-140)/140 = 14.285…
+    expect(rollups[0]?.clubGrowthPercent).toBeCloseTo(14.285, 2)
+  })
+
+  it('derives paymentGrowthPercent from sums', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', totalPayments: 5000, paymentBase: 4500 }),
+      mk({ region: '01', totalPayments: 2500, paymentBase: 2400 }),
+    ])
+    // payments=7500, base=6900 → growth = 600/6900 = 8.695…
+    expect(rollups[0]?.paymentGrowthPercent).toBeCloseTo(8.695, 2)
+  })
+
+  it('derives distinguishedPercent from sums', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', paidClubs: 100, distinguishedClubs: 50 }),
+      mk({ region: '01', paidClubs: 50, distinguishedClubs: 22 }),
+    ])
+    // distinguished=72, paidClubs=150 → 48%
+    expect(rollups[0]?.distinguishedPercent).toBeCloseTo(48, 1)
+  })
+
+  it('returns 0 (not NaN) when a denominator is zero', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', paidClubs: 0, paidClubBase: 0 }),
+    ])
+    expect(rollups[0]?.clubGrowthPercent).toBe(0)
+    expect(rollups[0]?.paymentGrowthPercent).toBe(0)
+    expect(rollups[0]?.distinguishedPercent).toBe(0)
+  })
+
+  it('picks the leading district by aggregateScore', () => {
+    const rollups = aggregateRegions([
+      mk({
+        districtId: '01',
+        districtName: 'District 01',
+        region: '01',
+        aggregateScore: 200,
+      }),
+      mk({
+        districtId: '02',
+        districtName: 'District 02',
+        region: '01',
+        aggregateScore: 400,
+      }),
+      mk({
+        districtId: '03',
+        districtName: 'District 03',
+        region: '01',
+        aggregateScore: 300,
+      }),
+    ])
+    expect(rollups[0]?.leadingDistrictId).toBe('02')
+    expect(rollups[0]?.leadingDistrictName).toBe('District 02')
+  })
+
+  it('counts requirement met/total per region', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01', dspSubmitted: true, trainingMet: true }),
+      mk({ region: '01', dspSubmitted: true, trainingMet: false }),
+      mk({ region: '01', dspSubmitted: false, trainingMet: true }),
+    ])
+    expect(rollups[0]?.requirements.dspSubmitted.met).toBe(2)
+    expect(rollups[0]?.requirements.dspSubmitted.total).toBe(3)
+    expect(rollups[0]?.requirements.trainingMet.met).toBe(2)
+    expect(rollups[0]?.requirements.trainingMet.total).toBe(3)
+  })
+
+  it('handles missing/undefined requirement fields (counts as not-met)', () => {
+    // Older snapshots may lack these fields entirely.
+    const r = mk({ region: '01' })
+    delete (r as { dspSubmitted?: unknown }).dspSubmitted
+    const rollups = aggregateRegions([r])
+    expect(rollups[0]?.requirements.dspSubmitted.met).toBe(0)
+    expect(rollups[0]?.requirements.dspSubmitted.total).toBe(1)
+  })
+})

--- a/frontend/src/utils/aggregateRegions.ts
+++ b/frontend/src/utils/aggregateRegions.ts
@@ -1,0 +1,142 @@
+/* aggregateRegions (#493) — group rankings.json districts by region
+   into a leaderboard-ready rollup.
+
+   Powers the /regions overview page (epic #492). The TI dashboard
+   itself renders the same data server-side as HTML; this utility lets
+   us compute it client-side from the per-district feed we already
+   publish, with no pipeline changes. */
+
+import type { DistrictRanking } from '@toastmasters/shared-contracts'
+
+export interface RequirementRatio {
+  met: number
+  total: number
+}
+
+export interface RegionRollup {
+  region: string
+  districtCount: number
+  paidClubs: number
+  paidClubBase: number
+  /** Derived: (paidClubs − paidClubBase) / paidClubBase × 100. 0 when base is 0. */
+  clubGrowthPercent: number
+  totalPayments: number
+  paymentBase: number
+  /** Derived: (totalPayments − paymentBase) / paymentBase × 100. 0 when base is 0. */
+  paymentGrowthPercent: number
+  distinguishedClubs: number
+  /** Derived: distinguishedClubs / paidClubs × 100. 0 when paidClubs is 0. */
+  distinguishedPercent: number
+  /** Sum of district aggregate scores. Higher is better. */
+  aggregateScore: number
+  /** District with highest aggregateScore in this region. */
+  leadingDistrictId: string
+  leadingDistrictName: string
+  /** Per-requirement counts: how many districts met / total in region. */
+  requirements: {
+    dspSubmitted: RequirementRatio
+    trainingMet: RequirementRatio
+    marketAnalysisSubmitted: RequirementRatio
+    communicationPlanSubmitted: RequirementRatio
+    regionAdvisorVisitMet: RequirementRatio
+  }
+}
+
+const REQUIREMENT_KEYS = [
+  'dspSubmitted',
+  'trainingMet',
+  'marketAnalysisSubmitted',
+  'communicationPlanSubmitted',
+  'regionAdvisorVisitMet',
+] as const
+
+/** Region IDs that should be excluded from the leaderboard / grid.
+ *  TI uses 'DNAR' for districts that aren't yet assigned to a region;
+ *  unknown / empty values fall in the same bucket defensively. */
+const isValidRegion = (region: string): boolean => /^\d+$/.test(region)
+
+/** Safe division: 0 when denominator is 0 so we never emit NaN. */
+const pct = (num: number, denom: number): number =>
+  denom > 0 ? (num / denom) * 100 : 0
+
+export function aggregateRegions(
+  rankings: ReadonlyArray<DistrictRanking>
+): RegionRollup[] {
+  if (rankings.length === 0) return []
+
+  // Group: region → districts in that region.
+  const byRegion = new Map<string, DistrictRanking[]>()
+  for (const r of rankings) {
+    if (!isValidRegion(r.region)) continue
+    const list = byRegion.get(r.region) ?? []
+    list.push(r)
+    byRegion.set(r.region, list)
+  }
+
+  // Build rollups; sort by region number ascending.
+  const rollups: RegionRollup[] = []
+  for (const [region, districts] of byRegion) {
+    if (districts.length === 0) continue
+
+    const totals = districts.reduce(
+      (acc, d) => {
+        acc.paidClubs += d.paidClubs ?? 0
+        acc.paidClubBase += d.paidClubBase ?? 0
+        acc.totalPayments += d.totalPayments ?? 0
+        acc.paymentBase += d.paymentBase ?? 0
+        acc.distinguishedClubs += d.distinguishedClubs ?? 0
+        acc.aggregateScore += d.aggregateScore ?? 0
+        return acc
+      },
+      {
+        paidClubs: 0,
+        paidClubBase: 0,
+        totalPayments: 0,
+        paymentBase: 0,
+        distinguishedClubs: 0,
+        aggregateScore: 0,
+      }
+    )
+
+    const leading = districts.reduce((best, d) =>
+      (d.aggregateScore ?? 0) > (best.aggregateScore ?? 0) ? d : best
+    )
+
+    const requirements = REQUIREMENT_KEYS.reduce(
+      (acc, key) => {
+        const met = districts.filter(
+          d => (d as unknown as Record<string, unknown>)[key] === true
+        ).length
+        acc[key] = { met, total: districts.length }
+        return acc
+      },
+      {} as RegionRollup['requirements']
+    )
+
+    rollups.push({
+      region,
+      districtCount: districts.length,
+      paidClubs: totals.paidClubs,
+      paidClubBase: totals.paidClubBase,
+      clubGrowthPercent: pct(
+        totals.paidClubs - totals.paidClubBase,
+        totals.paidClubBase
+      ),
+      totalPayments: totals.totalPayments,
+      paymentBase: totals.paymentBase,
+      paymentGrowthPercent: pct(
+        totals.totalPayments - totals.paymentBase,
+        totals.paymentBase
+      ),
+      distinguishedClubs: totals.distinguishedClubs,
+      distinguishedPercent: pct(totals.distinguishedClubs, totals.paidClubs),
+      aggregateScore: totals.aggregateScore,
+      leadingDistrictId: leading.districtId,
+      leadingDistrictName: leading.districtName,
+      requirements,
+    })
+  }
+
+  rollups.sort((a, b) => Number(a.region) - Number(b.region))
+  return rollups
+}


### PR DESCRIPTION
## Summary

Sprint B of epic #492. Builds the two display components for the upcoming \`/regions\` overview, both consuming \`RegionRollup[]\` from \`aggregateRegions\` (Sprint A, #498).

## Red → Green visible

Per Lesson 54, this PR ships TWO commits:

1. \`test(components): RED — stubs + failing tests…\` — components stubbed (throw on use) + 17 failing tests
2. \`feat(components): GREEN — RegionsLeaderboard + RegionGrid…\` — implementations make all 17 tests pass

Practical compromise documented in the RED commit: full-empty stubs are committed alongside the test file so pre-commit \`typecheck\` doesn't reject the RED commit on import resolution. The stub bodies throw — tests fail at runtime instead of compile-time. Net effect is the same: separate commit boundaries show the work order.

## RegionsLeaderboard (#494)

- Sortable table, 6 columns (Region · Districts · Paid Clubs · Payments · Distinguished · Score)
- Default sort: aggregateScore **descending**
- Click any column header to re-sort; click same header to reverse direction; Region defaults to ascending-numeric
- Each row is a \`<Link to=\"/region/:n\">\`
- \`aria-sort\` on active column header
- Empty-state copy when zero rollups

9 tests cover sort, header order, link hrefs, and empty state.

## RegionGrid (#495)

- Responsive grid: 1 / 2 / 3 / 4 cols by breakpoint
- Per card: Region N eyebrow, leader name, three-stat KPI strip (districtCount · paidClubs · distinguishedPercent), 5-dot requirements ribbon
- Ribbon dots carry \`data-requirement="<key>"\` + \`data-met="true|false"\` so tests can assert structure
- Tooltips on dots show \`met/total\` per requirement
- Whole card is a single \`<Link>\` — no nested interactive elements

8 tests cover render count, eyebrow, leading-district, hrefs, KPI display, ribbon structure, ribbon met-flags, empty state.

## Test plan

- [x] 17/17 tests green (\`RegionsLeaderboard.test.tsx\` 9, \`RegionGrid.test.tsx\` 8)
- [x] Typecheck clean
- [ ] CI green
- [ ] Sprint A (#498) merged first ✓

Sprint C (#496, #497) follows: wire both into \`/regions\` page + enable the Regions top-bar nav link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)