### PR TITLE
feat(page+shell): /regions page + enable Regions nav — Sprint C of /regions epic (#496 #497 #492)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,9 @@ const AwardsPage = React.lazy(() => import('./pages/AwardsPage'))
 // Code-split: RegionPage — /region/:n landing (#423)
 const RegionPage = React.lazy(() => import('./pages/RegionPage'))
 
+// Code-split: RegionsPage — /regions overview (#496, epic #492)
+const RegionsPage = React.lazy(() => import('./pages/RegionsPage'))
+
 // Code-split: DivisionPage — /district/:districtId/division/:divId (#424)
 const DivisionPage = React.lazy(() => import('./pages/DivisionPage'))
 
@@ -114,6 +117,14 @@ const router = createBrowserRouter(
           element: (
             <Suspense fallback={<PageLoadingFallback />}>
               <RegionPage />
+            </Suspense>
+          ),
+        },
+        {
+          path: 'regions',
+          element: (
+            <Suspense fallback={<PageLoadingFallback />}>
+              <RegionsPage />
             </Suspense>
           ),
         },

--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -84,14 +84,16 @@ describe('AppShell (#354)', () => {
       ).toHaveAttribute('href', '/methodology')
     })
 
-    it('renders Regions as a disabled "soon" stub per design parity', () => {
-      // Design (screenshots/01-districts.png) shows Regions in the primary
-      // nav with a soon badge. Awards shipped (#371) so it is a real link.
+    it('renders Regions as an enabled nav link to /regions (#497)', () => {
+      // /regions overview shipped in epic #492; the previous "soon"
+      // stub is retired. Link must be a real router link with no
+      // aria-disabled / --soon styling.
       renderShell()
       const nav = screen.getByRole('navigation', { name: /primary/i })
       const regionsLink = within(nav).getByRole('link', { name: /regions/i })
-      expect(regionsLink).toHaveClass('app-shell-nav__link--soon')
-      expect(regionsLink).toHaveAttribute('aria-disabled', 'true')
+      expect(regionsLink).toHaveAttribute('href', '/regions')
+      expect(regionsLink).not.toHaveAttribute('aria-disabled')
+      expect(regionsLink).not.toHaveClass('app-shell-nav__link--soon')
     })
 
     it('renders the top-bar tools cluster (help link, avatar)', () => {

--- a/frontend/src/components/AppShell/AppShellTopBar.tsx
+++ b/frontend/src/components/AppShell/AppShellTopBar.tsx
@@ -22,15 +22,9 @@ const AppShellTopBar: React.FC = () => {
         <NavLink to="/" end className="app-shell-nav__link">
           Districts
         </NavLink>
-        <a
-          href="#regions"
-          aria-disabled="true"
-          tabIndex={-1}
-          onClick={e => e.preventDefault()}
-          className="app-shell-nav__link app-shell-nav__link--soon"
-        >
+        <NavLink to="/regions" className="app-shell-nav__link">
           Regions
-        </a>
+        </NavLink>
         {NAV_ITEMS.filter(i => i.to !== '/').map(item => (
           <NavLink
             key={item.to}

--- a/frontend/src/pages/RegionsPage.tsx
+++ b/frontend/src/pages/RegionsPage.tsx
@@ -1,0 +1,9 @@
+/* RegionsPage (#496) — overview of all 14 numbered regions.
+   Sprint C RED stub: signature only. GREEN implementation composes
+   RegionsLeaderboard + RegionGrid against rankings.json data. */
+
+const RegionsPage: React.FC = () => {
+  throw new Error('RegionsPage: not implemented (RED phase)')
+}
+
+export default RegionsPage

--- a/frontend/src/pages/RegionsPage.tsx
+++ b/frontend/src/pages/RegionsPage.tsx
@@ -1,9 +1,98 @@
+import React, { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchCdnRankings } from '../services/cdn'
+import { aggregateRegions } from '../utils/aggregateRegions'
+import { RegionsLeaderboard } from '../components/RegionsLeaderboard'
+import { RegionGrid } from '../components/RegionGrid'
+import { LoadingSkeleton } from '../components/LoadingSkeleton'
+import { EmptyState } from '../components/ErrorDisplay'
+
 /* RegionsPage (#496) — overview of all 14 numbered regions.
-   Sprint C RED stub: signature only. GREEN implementation composes
-   RegionsLeaderboard + RegionGrid against rankings.json data. */
+
+   Composes the Sprint A utility + Sprint B components against the
+   shared rankings.json feed. No new data; no pipeline changes; the
+   /regions surface is purely a client-side grouping of the existing
+   per-district feed.
+
+   DNAR (District-Not-Assigned-Region) districts are filtered OUT of
+   both the leaderboard and the grid. When non-zero, they're surfaced
+   as a small footnote so the count is visible without polluting the
+   leaderboard. */
 
 const RegionsPage: React.FC = () => {
-  throw new Error('RegionsPage: not implemented (RED phase)')
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['district-rankings', 'latest'],
+    queryFn: async () => {
+      const cdn = await fetchCdnRankings()
+      return { rankings: cdn.rankings, date: cdn.date }
+    },
+    staleTime: 15 * 60 * 1000,
+  })
+
+  const rollups = useMemo(
+    () => (data?.rankings ? aggregateRegions(data.rankings) : []),
+    [data]
+  )
+
+  const dnarCount = useMemo(
+    () =>
+      data?.rankings
+        ? data.rankings.filter(r => !/^\d+$/.test(r.region)).length
+        : 0,
+    [data]
+  )
+
+  if (isLoading) return <LoadingSkeleton variant="card" />
+  if (error || !data) {
+    return (
+      <EmptyState
+        title="Could not load regions"
+        message="The rankings file is unavailable. Try again in a moment."
+        icon="data"
+      />
+    )
+  }
+
+  return (
+    <div className="app-shell__page">
+      <header className="districts-page-header">
+        <div className="districts-page-header__intro">
+          <p className="districts-page-header__eyebrow">
+            All regions · 14 worldwide
+          </p>
+          <h1 className="districts-page-header__title">Regions</h1>
+          <p className="districts-page-header__lede">
+            Aggregate ranking of all 14 Toastmasters regions. Click any region
+            to drill into its districts.
+          </p>
+        </div>
+      </header>
+
+      <section className="my-6" aria-labelledby="regions-leaderboard-heading">
+        <h2 id="regions-leaderboard-heading" className="sr-only">
+          Region leaderboard
+        </h2>
+        <RegionsLeaderboard rollups={rollups} />
+      </section>
+
+      <section className="my-8" aria-labelledby="regions-grid-heading">
+        <h2
+          id="regions-grid-heading"
+          className="text-lg font-tm-headline text-gray-900 dark:text-gray-50 mb-3"
+        >
+          Region cards
+        </h2>
+        <RegionGrid rollups={rollups} />
+      </section>
+
+      {dnarCount > 0 && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-6 italic">
+          {dnarCount} district{dnarCount === 1 ? '' : 's'} not yet assigned to a
+          region — not shown above.
+        </p>
+      )}
+    </div>
+  )
 }
 
 export default RegionsPage

--- a/frontend/src/pages/__tests__/RegionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionsPage.test.tsx
@@ -9,8 +9,14 @@ import RegionsPage from '../RegionsPage'
 
 afterEach(() => cleanup())
 
-const mkRanking = (region: string, districtId: string, aggregateScore = 100) =>
-  ({
+// vi.mock is hoisted; inline the fixtures so they don't reference
+// the outer-scope mkRanking before initialization.
+vi.mock('../../services/cdn', () => {
+  const baseRanking = (
+    region: string,
+    districtId: string,
+    aggregateScore: number
+  ) => ({
     districtId,
     districtName: `District ${districtId}`,
     region,
@@ -43,20 +49,20 @@ const mkRanking = (region: string, districtId: string, aggregateScore = 100) =>
     octoberPayments: 300,
     latePayments: 0,
     charterPayments: 0,
-  }) as unknown as ReturnType<typeof Object>
-
-vi.mock('../../services/cdn', () => ({
-  fetchCdnRankings: vi.fn().mockResolvedValue({
-    date: '2026-05-12',
-    rankings: [
-      mkRanking('01', '01', 500),
-      mkRanking('01', '02', 400),
-      mkRanking('07', '57', 350),
-      mkRanking('07', '60', 300),
-      mkRanking('DNAR', '99', 50),
-    ],
-  }),
-}))
+  })
+  return {
+    fetchCdnRankings: vi.fn().mockResolvedValue({
+      date: '2026-05-12',
+      rankings: [
+        baseRanking('01', '01', 500),
+        baseRanking('01', '02', 400),
+        baseRanking('07', '57', 350),
+        baseRanking('07', '60', 300),
+        baseRanking('DNAR', '99', 50),
+      ],
+    }),
+  }
+})
 
 const renderPage = () => {
   const queryClient = new QueryClient({

--- a/frontend/src/pages/__tests__/RegionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionsPage.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import RegionsPage from '../RegionsPage'
+
+/* Sprint C test suite (#496, #492). Red-first per Lesson 54. */
+
+afterEach(() => cleanup())
+
+const mkRanking = (region: string, districtId: string, aggregateScore = 100) =>
+  ({
+    districtId,
+    districtName: `District ${districtId}`,
+    region,
+    paidClubs: 50,
+    paidClubBase: 48,
+    clubGrowthPercent: 4,
+    totalPayments: 2000,
+    paymentBase: 1900,
+    paymentGrowthPercent: 5,
+    activeClubs: 50,
+    distinguishedClubs: 20,
+    selectDistinguished: 5,
+    presidentsDistinguished: 3,
+    distinguishedPercent: 40,
+    clubsRank: 1,
+    paymentsRank: 1,
+    distinguishedRank: 1,
+    overallRank: 1,
+    aggregateScore,
+    smedleyDistinguished: 2,
+    dspSubmitted: true,
+    trainingMet: true,
+    marketAnalysisSubmitted: true,
+    communicationPlanSubmitted: true,
+    regionAdvisorVisitMet: true,
+    clubsWith20PlusMembers: 10,
+    newCharteredClubs: 1,
+    newPayments: 100,
+    aprilPayments: 200,
+    octoberPayments: 300,
+    latePayments: 0,
+    charterPayments: 0,
+  }) as unknown as ReturnType<typeof Object>
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnRankings: vi.fn().mockResolvedValue({
+    date: '2026-05-12',
+    rankings: [
+      mkRanking('01', '01', 500),
+      mkRanking('01', '02', 400),
+      mkRanking('07', '57', 350),
+      mkRanking('07', '60', 300),
+      mkRanking('DNAR', '99', 50),
+    ],
+  }),
+}))
+
+const renderPage = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/regions']}>
+        <Routes>
+          <Route path="/regions" element={<RegionsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('RegionsPage (#496)', () => {
+  it('renders the page header with eyebrow + h1 "Regions"', async () => {
+    renderPage()
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /^regions$/i })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the leaderboard table + grid sections', async () => {
+    renderPage()
+    // Wait for data to land
+    await screen.findByRole('table', { name: /region rankings/i })
+    // Leaderboard
+    expect(
+      screen.getByRole('table', { name: /region rankings/i })
+    ).toBeInTheDocument()
+    // Grid (find by Region label appearing in card eyebrow context)
+    expect(screen.getAllByText(/Region 01/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Region 07/).length).toBeGreaterThan(0)
+  })
+
+  it('excludes DNAR districts from the leaderboard', async () => {
+    renderPage()
+    await screen.findByRole('table', { name: /region rankings/i })
+    // DNAR (region "DNAR") must not appear
+    expect(screen.queryByText(/Region DNAR/)).not.toBeInTheDocument()
+  })
+
+  it('shows a DNAR footnote when DNAR districts exist in the data', async () => {
+    renderPage()
+    await screen.findByRole('table', { name: /region rankings/i })
+    // 1 DNAR district in the fixture → footnote should appear
+    expect(
+      screen.getByText(/1 district.*not.*assigned to a region/i)
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Sprint C of epic #492. Composes Sprint A's \`aggregateRegions\` and Sprint B's \`RegionsLeaderboard\` + \`RegionGrid\` into a real \`/regions\` page, and removes the "soon" stub from the Regions top-bar nav link.

Closes #492 once merged (all 5 sub-issues shipped: #493, #494, #495, #496, #497).

## Red → Green

1. \`test(page+shell): RED — RegionsPage tests + nav-link enablement test\` — page stubbed (throws), AppShell test updated to expect the enabled link state. 5 failing tests.
2. \`feat(page+shell): GREEN — RegionsPage composition + nav-link enabled\` — wires data + components together, swaps the disabled anchor for a NavLink to /regions. All tests pass.

## What ships

- \`frontend/src/pages/RegionsPage.tsx\` — header + leaderboard + grid + DNAR footnote
- New \`/regions\` route (lazy-loaded) in \`App.tsx\`
- \`AppShellTopBar.tsx\` — Regions nav link is now a real NavLink (no aria-disabled, no --soon class)
- Existing AppShell test updated to lock the new expectation

## Page composition

- Eyebrow: "All regions · 14 worldwide"
- H1: "Regions"
- Lede: "Aggregate ranking of all 14 Toastmasters regions. Click any region to drill into its districts."
- \`<RegionsLeaderboard rollups={...}>\` — sortable 6-column table, default sort aggregateScore desc
- \`<RegionGrid rollups={...}>\` — 14 KPI cards (1/2/3/4 cols by breakpoint)
- DNAR footnote shown only when at-least-one DNAR district exists

## Test plan

- [x] 4 RegionsPage tests green (header, table+grid render, DNAR exclusion, footnote)
- [x] AppShell test updated + passing — Regions link is real, no aria-disabled, no --soon
- [x] All prior AppShell + Sprint A + Sprint B tests still pass
- [ ] CI green
- [ ] Manual smoke: navigate to /regions, confirm 14 regions in both leaderboard and grid; click a card to land on /region/:n

## Epic acceptance — to be checked once this merges

- [ ] /regions route renders without console errors in light + dark mode
- [ ] All 14 numbered regions appear in both surfaces
- [ ] DNAR districts excluded (footnoted when non-zero)
- [ ] Clicking any row/card navigates to /region/:n
- [ ] Top-bar Regions link is enabled and lands on /regions
- [ ] All tests written red-first per Lesson 54

🤖 Generated with [Claude Code](https://claude.com/claude-code)