### PR TITLE
fix(regions): Borda-count region scoring + /methodology section (#501)

### DIFF
--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -15,16 +15,17 @@ const SECTIONS: ReadonlyArray<{ id: string; num: string; title: string }> = [
   { id: 'data-source', num: '01', title: 'Data source & access' },
   { id: 'refresh-cadence', num: '02', title: 'Refresh cadence' },
   { id: 'borda-count', num: '03', title: 'Borda count scoring' },
-  { id: 'dcp-tiers', num: '04', title: 'DCP tier definitions' },
-  { id: 'club-health', num: '05', title: 'Club health classifications' },
+  { id: 'regions-borda', num: '04', title: 'Region-level scoring' },
+  { id: 'dcp-tiers', num: '05', title: 'DCP tier definitions' },
+  { id: 'club-health', num: '06', title: 'Club health classifications' },
   {
     id: 'district-membership-trend',
-    num: '06',
+    num: '07',
     title: 'District Membership Trend',
   },
-  { id: 'glossary', num: '07', title: 'Glossary' },
-  { id: 'caveats', num: '08', title: 'Caveats & known issues' },
-  { id: 'changelog', num: '09', title: 'Changelog' },
+  { id: 'glossary', num: '08', title: 'Glossary' },
+  { id: 'caveats', num: '09', title: 'Caveats & known issues' },
+  { id: 'changelog', num: '10', title: 'Changelog' },
 ]
 
 const MethodologyPage: React.FC = () => {
@@ -130,9 +131,60 @@ const MethodologyPage: React.FC = () => {
         </p>
       </section>
 
-      <section id="dcp-tiers" className="methodology-section">
+      <section id="regions-borda" className="methodology-section">
         <h2 className="methodology-section__title">
           <span className="methodology-section__num">04</span>
+          Region-level scoring
+        </h2>
+        <p>
+          The{' '}
+          <Link to="/regions" className="methodology-link">
+            Regions overview
+          </Link>{' '}
+          ranks all 14 numbered Toastmasters regions using the same Borda count
+          method described above for districts, but with{' '}
+          <strong>per-region growth-percent values</strong> in three categories:
+        </p>
+        <ul>
+          <li>
+            <strong>Paid Clubs growth</strong> — sum of paid clubs across the
+            region's districts, divided by the sum of paid-club bases, minus
+            one.
+          </li>
+          <li>
+            <strong>Payments growth</strong> — sum of total payments across the
+            region's districts, divided by the sum of payment bases, minus one.
+          </li>
+          <li>
+            <strong>Distinguished share</strong> — sum of distinguished clubs
+            across the region, divided by the sum of paid clubs.
+          </li>
+        </ul>
+        <p>
+          Regions are ranked separately in each category. With N=14 regions,
+          rank #1 in a category gets 14 points, rank #14 gets 1. The region
+          <strong> aggregate score</strong> is the sum of points across the
+          three ranks — a number between 3 and 42. This mirrors the district
+          aggregate above so the framing transfers, and (unlike a raw sum of
+          district scores) it{' '}
+          <em>isn't biased by how many districts a region happens to have</em>.
+        </p>
+        <p className="methodology-source">
+          Implementation: <code>frontend/src/utils/aggregateRegions.ts</code> (
+          <code>rankBy</code>). Tested in{' '}
+          <code>frontend/src/utils/__tests__/aggregateRegions.test.ts</code>.
+          The DNAR sentinel (district-not-assigned-region) is excluded from the
+          ranking; its districts surface as a footnote on{' '}
+          <Link to="/regions" className="methodology-link">
+            /regions
+          </Link>{' '}
+          only when non-zero.
+        </p>
+      </section>
+
+      <section id="dcp-tiers" className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">05</span>
           DCP tier definitions
         </h2>
         <p>Distinguished Club Program tiers, in ascending order:</p>
@@ -181,7 +233,7 @@ const MethodologyPage: React.FC = () => {
 
       <section id="club-health" className="methodology-section">
         <h2 className="methodology-section__title">
-          <span className="methodology-section__num">05</span>
+          <span className="methodology-section__num">06</span>
           Club health classifications
         </h2>
         <p>
@@ -227,7 +279,7 @@ const MethodologyPage: React.FC = () => {
 
       <section id="district-membership-trend" className="methodology-section">
         <h2 className="methodology-section__title">
-          <span className="methodology-section__num">06</span>
+          <span className="methodology-section__num">07</span>
           District Membership Trend
         </h2>
         <p>
@@ -272,7 +324,7 @@ const MethodologyPage: React.FC = () => {
 
       <section id="glossary" className="methodology-section">
         <h2 className="methodology-section__title">
-          <span className="methodology-section__num">07</span>
+          <span className="methodology-section__num">08</span>
           Glossary
         </h2>
         <dl className="methodology-glossary">
@@ -310,7 +362,7 @@ const MethodologyPage: React.FC = () => {
 
       <section id="caveats" className="methodology-section">
         <h2 className="methodology-section__title">
-          <span className="methodology-section__num">08</span>
+          <span className="methodology-section__num">09</span>
           Caveats &amp; known issues
         </h2>
         <ul>
@@ -344,7 +396,7 @@ const MethodologyPage: React.FC = () => {
 
       <section id="changelog" className="methodology-section">
         <h2 className="methodology-section__title">
-          <span className="methodology-section__num">09</span>
+          <span className="methodology-section__num">10</span>
           Changelog
         </h2>
         <p>

--- a/frontend/src/utils/__tests__/aggregateRegions.test.ts
+++ b/frontend/src/utils/__tests__/aggregateRegions.test.ts
@@ -116,12 +116,93 @@ describe('aggregateRegions (#493)', () => {
     expect(rollups[0]?.distinguishedClubs).toBe(72)
   })
 
-  it('sums aggregateScore across districts in the region', () => {
+  // #501: aggregateScore is now a region-level Borda count of growth-
+  // percent ranks across 3 categories, NOT a sum of district scores.
+  // With N regions, rank #1 in a category gets N points, #N gets 1.
+  it('aggregateScore is a region-level Borda count (3 ranks × N points)', () => {
+    // 3 regions with distinct growth-percent profiles in each category.
+    // Region A: clubs=top (3pts), payments=mid (2pts), distinguished=top (3pts) → 8
+    // Region B: clubs=mid (2pts), payments=top (3pts), distinguished=mid (2pts) → 7
+    // Region C: clubs=bot (1pt), payments=bot (1pt), distinguished=bot (1pt) → 3
     const rollups = aggregateRegions([
-      mk({ region: '01', aggregateScore: 300 }),
-      mk({ region: '01', aggregateScore: 250 }),
+      // Region 01 — strongest clubs growth (10%), strongest distinguished
+      mk({
+        region: '01',
+        paidClubs: 110,
+        paidClubBase: 100,
+        totalPayments: 1050,
+        paymentBase: 1000,
+        distinguishedClubs: 50,
+      }),
+      // Region 02 — strongest payments growth (10%), mid clubs & dist
+      mk({
+        region: '02',
+        paidClubs: 105,
+        paidClubBase: 100,
+        totalPayments: 1100,
+        paymentBase: 1000,
+        distinguishedClubs: 30,
+      }),
+      // Region 03 — weakest on all three
+      mk({
+        region: '03',
+        paidClubs: 101,
+        paidClubBase: 100,
+        totalPayments: 1010,
+        paymentBase: 1000,
+        distinguishedClubs: 20,
+      }),
     ])
-    expect(rollups[0]?.aggregateScore).toBe(550)
+
+    const byRegion = Object.fromEntries(rollups.map(r => [r.region, r]))
+    // With N=3: rank #1 → 3 points, #2 → 2 points, #3 → 1 point
+    expect(byRegion['01']?.aggregateScore).toBe(3 + 2 + 3) // 8
+    expect(byRegion['02']?.aggregateScore).toBe(2 + 3 + 2) // 7
+    expect(byRegion['03']?.aggregateScore).toBe(1 + 1 + 1) // 3
+  })
+
+  it('exposes per-category ranks (clubsRank, paymentsRank, distinguishedRank)', () => {
+    const rollups = aggregateRegions([
+      mk({
+        region: '01',
+        paidClubs: 110,
+        paidClubBase: 100, // 10% growth — top
+        totalPayments: 1050,
+        paymentBase: 1000, // 5% growth
+        distinguishedClubs: 50,
+      }),
+      mk({
+        region: '02',
+        paidClubs: 105,
+        paidClubBase: 100, // 5% growth
+        totalPayments: 1100,
+        paymentBase: 1000, // 10% growth — top
+        distinguishedClubs: 30,
+      }),
+    ])
+    const byRegion = Object.fromEntries(rollups.map(r => [r.region, r]))
+    expect(byRegion['01']?.clubsRank).toBe(1)
+    expect(byRegion['01']?.paymentsRank).toBe(2)
+    expect(byRegion['02']?.clubsRank).toBe(2)
+    expect(byRegion['02']?.paymentsRank).toBe(1)
+  })
+
+  it('single-region input → all ranks = 1, aggregateScore = 3', () => {
+    const rollups = aggregateRegions([mk({ region: '01' })])
+    expect(rollups[0]?.clubsRank).toBe(1)
+    expect(rollups[0]?.paymentsRank).toBe(1)
+    expect(rollups[0]?.distinguishedRank).toBe(1)
+    expect(rollups[0]?.aggregateScore).toBe(3)
+  })
+
+  it('DNAR is excluded from ranking (no rank inflation)', () => {
+    const rollups = aggregateRegions([
+      mk({ region: '01' }),
+      mk({ region: 'DNAR' }), // must not occupy a rank slot
+    ])
+    // Only one valid region → ranks all 1, aggregateScore = 3
+    expect(rollups).toHaveLength(1)
+    expect(rollups[0]?.aggregateScore).toBe(3)
   })
 
   it('derives clubGrowthPercent from sums', () => {

--- a/frontend/src/utils/aggregateRegions.ts
+++ b/frontend/src/utils/aggregateRegions.ts
@@ -27,9 +27,19 @@ export interface RegionRollup {
   distinguishedClubs: number
   /** Derived: distinguishedClubs / paidClubs × 100. 0 when paidClubs is 0. */
   distinguishedPercent: number
-  /** Sum of district aggregate scores. Higher is better. */
+  /** Region's rank by clubGrowthPercent. 1 = best across all regions. */
+  clubsRank: number
+  /** Region's rank by paymentGrowthPercent. 1 = best. */
+  paymentsRank: number
+  /** Region's rank by distinguishedPercent. 1 = best. */
+  distinguishedRank: number
+  /** Region-level Borda count (#501): sum of points across the 3
+   *  category ranks, where rank #1 gets N points and rank #N gets 1.
+   *  With 14 regions the max possible is 42 (1st in all three). This
+   *  mirrors the district-level Borda described on /methodology and
+   *  is unbiased by region size. */
   aggregateScore: number
-  /** District with highest aggregateScore in this region. */
+  /** District with highest district-level aggregateScore in this region. */
   leadingDistrictId: string
   leadingDistrictName: string
   /** Per-requirement counts: how many districts met / total in region. */
@@ -59,6 +69,28 @@ const isValidRegion = (region: string): boolean => /^\d+$/.test(region)
 const pct = (num: number, denom: number): number =>
   denom > 0 ? (num / denom) * 100 : 0
 
+/** Assign ranks (1 = highest value) across rollups for a metric. Stable
+ *  for ties: insertion order within an equal-value group is preserved. */
+function rankBy<
+  K extends
+    | 'clubGrowthPercent'
+    | 'paymentGrowthPercent'
+    | 'distinguishedPercent',
+>(rollups: ReadonlyArray<RegionRollup>, metric: K): Map<string, number> {
+  const indexed = rollups.map((r, idx) => ({
+    region: r.region,
+    value: r[metric],
+    idx,
+  }))
+  indexed.sort((a, b) => {
+    if (b.value !== a.value) return b.value - a.value
+    return a.idx - b.idx // stable tie-break
+  })
+  const ranks = new Map<string, number>()
+  indexed.forEach((entry, i) => ranks.set(entry.region, i + 1))
+  return ranks
+}
+
 export function aggregateRegions(
   rankings: ReadonlyArray<DistrictRanking>
 ): RegionRollup[] {
@@ -73,8 +105,13 @@ export function aggregateRegions(
     byRegion.set(r.region, list)
   }
 
-  // Build rollups; sort by region number ascending.
-  const rollups: RegionRollup[] = []
+  // First pass: compute the derived totals + growth percents for each
+  // region. aggregateScore + per-category ranks come in the second pass
+  // because they depend on cross-region ordering.
+  const initial: Omit<
+    RegionRollup,
+    'clubsRank' | 'paymentsRank' | 'distinguishedRank' | 'aggregateScore'
+  >[] = []
   for (const [region, districts] of byRegion) {
     if (districts.length === 0) continue
 
@@ -85,7 +122,6 @@ export function aggregateRegions(
         acc.totalPayments += d.totalPayments ?? 0
         acc.paymentBase += d.paymentBase ?? 0
         acc.distinguishedClubs += d.distinguishedClubs ?? 0
-        acc.aggregateScore += d.aggregateScore ?? 0
         return acc
       },
       {
@@ -94,7 +130,6 @@ export function aggregateRegions(
         totalPayments: 0,
         paymentBase: 0,
         distinguishedClubs: 0,
-        aggregateScore: 0,
       }
     )
 
@@ -113,7 +148,7 @@ export function aggregateRegions(
       {} as RegionRollup['requirements']
     )
 
-    rollups.push({
+    initial.push({
       region,
       districtCount: districts.length,
       paidClubs: totals.paidClubs,
@@ -130,12 +165,37 @@ export function aggregateRegions(
       ),
       distinguishedClubs: totals.distinguishedClubs,
       distinguishedPercent: pct(totals.distinguishedClubs, totals.paidClubs),
-      aggregateScore: totals.aggregateScore,
       leadingDistrictId: leading.districtId,
       leadingDistrictName: leading.districtName,
       requirements,
     })
   }
+
+  // Second pass: rank regions in each of the 3 growth categories, then
+  // sum the Borda points (N = number of valid regions). With N regions,
+  // rank #1 → N points, rank #N → 1 point. Region aggregateScore = sum
+  // across the 3 categories. Mirrors the district-level Borda described
+  // at /methodology#borda-count (#501).
+  const N = initial.length
+  const placeholder = initial as RegionRollup[]
+  const clubsRanks = rankBy(placeholder, 'clubGrowthPercent')
+  const paymentsRanks = rankBy(placeholder, 'paymentGrowthPercent')
+  const distinguishedRanks = rankBy(placeholder, 'distinguishedPercent')
+
+  const rollups: RegionRollup[] = initial.map(r => {
+    const clubsRank = clubsRanks.get(r.region) ?? N
+    const paymentsRank = paymentsRanks.get(r.region) ?? N
+    const distinguishedRank = distinguishedRanks.get(r.region) ?? N
+    const aggregateScore =
+      N - clubsRank + 1 + (N - paymentsRank + 1) + (N - distinguishedRank + 1)
+    return {
+      ...r,
+      clubsRank,
+      paymentsRank,
+      distinguishedRank,
+      aggregateScore,
+    }
+  })
 
   rollups.sort((a, b) => Number(a.region) - Number(b.region))
   return rollups


### PR DESCRIPTION
## Summary

Closes #501. Replaces the size-biased "sum of district scores" with a true region-level Borda count, and documents the formula on \`/methodology\`.

## Red → Green

Per Lesson 54:

1. \`test(util): RED — region-level Borda count expectations\` — 4 failing tests describing the new semantics
2. \`fix(util+docs): GREEN — region-level Borda count + /methodology section\` — implementation + methodology page update

## What changed

### Scoring (the methodology fix the user called out)

The 14 regions are now ranked separately in three categories by **growth percent** — exactly mirroring district-level Borda:

- \`clubGrowthPercent\` (paid clubs / paid-club base, summed across the region's districts)
- \`paymentGrowthPercent\` (payments / payment base, summed)
- \`distinguishedPercent\` (distinguished clubs / paid clubs, summed)

With N=14 regions, rank #1 in a category earns 14 points, rank #14 earns 1. Region \`aggregateScore\` is the sum across the three ranks — a number between **3 and 42**. Unbiased by region size.

\`RegionRollup\` gains three new fields exposing the per-category ranks: \`clubsRank\`, \`paymentsRank\`, \`distinguishedRank\`.

### Methodology page

New \`#regions-borda\` section (#04 in the TOC, inserted between \`#borda-count\` and \`#dcp-tiers\`) explains the formula in the same framing as the district Borda section, cross-links \`/regions\`, and explicitly notes the size-bias the old approach had. Existing section numbers shifted by one.

## Test plan

- [x] 17 tests pass — 4 new for Borda semantics, 13 preserved
- [x] Methodology page + RegionsPage tests still pass (28 total)
- [x] Typecheck clean
- [ ] CI green
- [ ] Manual smoke: \`/regions\` leaderboard re-orders to reflect the corrected scoring; rankings now between 3 and 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)