### PR TITLE
fix(fac): propagate FAC enrichment through ClubTrend so CHARTERED actually renders (#503)

### DIFF
--- a/frontend/src/hooks/useDistrictAnalytics.ts
+++ b/frontend/src/hooks/useDistrictAnalytics.ts
@@ -42,12 +42,30 @@ export interface ClubTrend {
   /** Club Success Plan submission status (2025-2026+). Undefined for pre-2025 data. */
   cspSubmitted?: boolean
   /**
-   * Charter date (ISO) — populated from the public Find-A-Club Search
-   * endpoint when the daily pipeline (#430) ran successfully. Absent
-   * when the endpoint hasn't been fetched yet for this snapshot.
-   * (#429 / #432)
+   * Find-A-Club enrichment fields (#429 / #432 / #503). All optional.
+   * Populated by FindAClubMerger from the public TI Find-A-Club Search
+   * endpoint and propagated through ClubHealthAnalyticsModule onto
+   * each ClubTrend in the analytics JSON. Absent until the daily
+   * pipeline has run with the merger active for the snapshot.
    */
   charterDate?: string
+  coordinates?: { lat: number; lng: number }
+  address?: {
+    street?: string
+    city?: string
+    region?: string
+    postalCode?: string
+    country?: string
+  }
+  email?: string
+  phone?: string
+  website?: string
+  facebookLink?: string
+  twitterLink?: string
+  meetingDay?: string
+  meetingTime?: string
+  allowsVirtualAttendance?: boolean
+  isProspective?: boolean
 }
 
 export interface DivisionAnalytics {

--- a/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.test.ts
+++ b/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.test.ts
@@ -561,6 +561,80 @@ describe('ClubHealthAnalyticsModule', () => {
     })
   })
 
+  describe('Find-A-Club Enrichment Propagation (#503)', () => {
+    // Regression: snapshots produced by the daily pipeline carry FAC
+    // enrichment fields (charterDate / coordinates / address / email /
+    // etc.) on each ClubStatistics row after FindAClubMerger runs.
+    // Analytics must forward these onto ClubTrend so the frontend
+    // Club hero (which reads from the analytics JSON) can render the
+    // CHARTERED eyebrow.
+    it('forwards charterDate from ClubStatistics to ClubTrend', () => {
+      const module = new ClubHealthAnalyticsModule()
+      const club = {
+        ...createMockClub({ clubId: '1' }),
+        charterDate: '1987-02-15',
+      }
+      const snapshot = createMockSnapshot('2024-01-15', [club])
+
+      const result = module.generateClubHealthData([snapshot])
+
+      expect(result.allClubs[0]?.charterDate).toBe('1987-02-15')
+    })
+
+    it('forwards coordinates / address / contact / meeting fields', () => {
+      const module = new ClubHealthAnalyticsModule()
+      const enriched = {
+        ...createMockClub({ clubId: '1' }),
+        charterDate: '1987-02-15',
+        coordinates: { lat: 45.42, lng: -75.69 },
+        address: {
+          street: '300 Ottawa Ave',
+          city: 'Ottawa',
+          region: 'ON',
+          postalCode: 'K1A 0A0',
+          country: 'Canada',
+        },
+        email: 'officers-180@toastmastersclubs.org',
+        phone: '+13039128450',
+        website: 'http://180.toastmastersclubs.org/',
+        facebookLink: 'https://www.facebook.com/test',
+        meetingDay: 'Tuesday',
+        meetingTime: '7:00 pm',
+        allowsVirtualAttendance: false,
+        isProspective: false,
+      }
+      const snapshot = createMockSnapshot('2024-01-15', [enriched])
+
+      const result = module.generateClubHealthData([snapshot])
+      const out = result.allClubs[0]
+
+      expect(out?.charterDate).toBe('1987-02-15')
+      expect(out?.coordinates).toEqual({ lat: 45.42, lng: -75.69 })
+      expect(out?.address?.city).toBe('Ottawa')
+      expect(out?.email).toBe('officers-180@toastmastersclubs.org')
+      expect(out?.phone).toBe('+13039128450')
+      expect(out?.website).toBe('http://180.toastmastersclubs.org/')
+      expect(out?.facebookLink).toBe('https://www.facebook.com/test')
+      expect(out?.meetingDay).toBe('Tuesday')
+      expect(out?.meetingTime).toBe('7:00 pm')
+      expect(out?.allowsVirtualAttendance).toBe(false)
+      expect(out?.isProspective).toBe(false)
+    })
+
+    it('leaves FAC fields undefined when ClubStatistics has none (graceful absence)', () => {
+      const module = new ClubHealthAnalyticsModule()
+      const bare = createMockClub({ clubId: '1' })
+      const snapshot = createMockSnapshot('2024-01-15', [bare])
+
+      const result = module.generateClubHealthData([snapshot])
+      const out = result.allClubs[0]
+
+      expect(out?.charterDate).toBeUndefined()
+      expect(out?.coordinates).toBeUndefined()
+      expect(out?.email).toBeUndefined()
+    })
+  })
+
   describe('Payment Field Extraction (Requirement 2.4)', () => {
     it('should extract all payment fields when present', () => {
       const module = new ClubHealthAnalyticsModule()

--- a/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
@@ -222,6 +222,25 @@ export class ClubHealthAnalyticsModule {
         clubStatus: club.clubStatus,
         // CSP submission status — use getCSPStatus() to normalize undefined → true for pre-2025
         cspSubmitted: getCSPStatus(club),
+        // Find-A-Club enrichment (#503). Propagate any FAC fields the
+        // merger wrote onto ClubStatistics. All optional — present
+        // only when FAC matched the club.
+        ...(club.charterDate && { charterDate: club.charterDate }),
+        ...(club.coordinates && { coordinates: club.coordinates }),
+        ...(club.address && { address: club.address }),
+        ...(club.email && { email: club.email }),
+        ...(club.phone && { phone: club.phone }),
+        ...(club.website && { website: club.website }),
+        ...(club.facebookLink && { facebookLink: club.facebookLink }),
+        ...(club.twitterLink && { twitterLink: club.twitterLink }),
+        ...(club.meetingDay && { meetingDay: club.meetingDay }),
+        ...(club.meetingTime && { meetingTime: club.meetingTime }),
+        ...(typeof club.allowsVirtualAttendance === 'boolean' && {
+          allowsVirtualAttendance: club.allowsVirtualAttendance,
+        }),
+        ...(typeof club.isProspective === 'boolean' && {
+          isProspective: club.isProspective,
+        }),
       })
     }
 

--- a/packages/analytics-core/src/interfaces.ts
+++ b/packages/analytics-core/src/interfaces.ts
@@ -74,6 +74,28 @@ export interface ClubStatistics {
 
   // Exact list of 10 boolean flags representing which DCP goals were achieved
   dcpGoalsAchieved?: boolean[]
+
+  // Find-A-Club enrichment (#429 / #503). All optional — populated by
+  // FindAClubMerger from the public TI Find-A-Club Search endpoint.
+  // Analytics propagates these onto ClubTrend so the frontend Club
+  // hero can render CHARTERED + meeting / contact info.
+  coordinates?: { lat: number; lng: number }
+  address?: {
+    street?: string
+    city?: string
+    region?: string
+    postalCode?: string
+    country?: string
+  }
+  email?: string
+  phone?: string
+  website?: string
+  facebookLink?: string
+  twitterLink?: string
+  meetingDay?: string
+  meetingTime?: string
+  allowsVirtualAttendance?: boolean
+  isProspective?: boolean
 }
 
 /**

--- a/packages/analytics-core/src/types/clubHealth.ts
+++ b/packages/analytics-core/src/types/clubHealth.ts
@@ -98,6 +98,28 @@ export interface ClubTrend {
 
   /** Club Success Plan submission status (2025-2026+). Undefined for pre-2025 data. (#288) */
   cspSubmitted?: boolean
+
+  // Find-A-Club enrichment (#429 / #503). All optional — propagated
+  // from ClubStatistics by analytics. Surfaces in the Club hero
+  // CHARTERED eyebrow + future map / contact panels.
+  charterDate?: string
+  coordinates?: { lat: number; lng: number }
+  address?: {
+    street?: string
+    city?: string
+    region?: string
+    postalCode?: string
+    country?: string
+  }
+  email?: string
+  phone?: string
+  website?: string
+  facebookLink?: string
+  twitterLink?: string
+  meetingDay?: string
+  meetingTime?: string
+  allowsVirtualAttendance?: boolean
+  isProspective?: boolean
 }
 
 /**

--- a/packages/analytics-core/src/types/core.ts
+++ b/packages/analytics-core/src/types/core.ts
@@ -144,6 +144,32 @@ export interface ClubTrend {
 
   // Club operational status (Requirement 1.8)
   clubStatus?: string
+
+  // CSP submission status — already on ClubStatistics, surfaced here
+  // so /district/:id/club/:cid can render it (#290 / pre-existing).
+  cspSubmitted?: boolean
+
+  // Find-A-Club enrichment (#429 / #503). All optional — propagated
+  // from ClubStatistics by analytics. Surfaces in the Club hero
+  // CHARTERED eyebrow + future map / contact panels.
+  charterDate?: string
+  coordinates?: { lat: number; lng: number }
+  address?: {
+    street?: string
+    city?: string
+    region?: string
+    postalCode?: string
+    country?: string
+  }
+  email?: string
+  phone?: string
+  website?: string
+  facebookLink?: string
+  twitterLink?: string
+  meetingDay?: string
+  meetingTime?: string
+  allowsVirtualAttendance?: boolean
+  isProspective?: boolean
 }
 
 /**

--- a/packages/collector-cli/src/services/FindAClubMerger.ts
+++ b/packages/collector-cli/src/services/FindAClubMerger.ts
@@ -86,6 +86,34 @@ export function mergeFacIntoSnapshot(
   let snapshotOnly = 0
   const matchedIds = new Set<string>()
 
+  // Build a flat enrichment-by-clubId map. The same enrichment object is
+  // applied to BOTH .data.clubPerformance[] (raw scraped records keyed
+  // by 'Club Number') and .data.clubs[] (parsed ClubStatisticsFile
+  // keyed by clubId). analytics-core reads from .clubs, so the latter
+  // is what reaches the frontend (#503).
+  const enrichmentByClubId = new Map<string, Record<string, unknown>>()
+  for (const [clubId, facHit] of facByClubId) {
+    if (!facHit) continue
+    const enrichment: Record<string, unknown> = {}
+    if (facHit.charterDate) enrichment['charterDate'] = facHit.charterDate
+    if (facHit.coordinates) enrichment['coordinates'] = facHit.coordinates
+    if (facHit.address) enrichment['address'] = facHit.address
+    if (facHit.email) enrichment['email'] = facHit.email
+    if (facHit.phone) enrichment['phone'] = facHit.phone
+    if (facHit.website) enrichment['website'] = facHit.website
+    if (facHit.facebookLink) enrichment['facebookLink'] = facHit.facebookLink
+    if (facHit.twitterLink) enrichment['twitterLink'] = facHit.twitterLink
+    if (facHit.meetingDay) enrichment['meetingDay'] = facHit.meetingDay
+    if (facHit.meetingTime) enrichment['meetingTime'] = facHit.meetingTime
+    if (typeof facHit.allowsVirtualAttendance === 'boolean') {
+      enrichment['allowsVirtualAttendance'] = facHit.allowsVirtualAttendance
+    }
+    if (typeof facHit.isProspective === 'boolean') {
+      enrichment['isProspective'] = facHit.isProspective
+    }
+    enrichmentByClubId.set(clubId, enrichment)
+  }
+
   // Mutating the snapshot in-place would couple us to JSON.parse'd
   // shapes; clone the array so callers can hold onto the original
   // for diffing.
@@ -107,30 +135,32 @@ export function mergeFacIntoSnapshot(
     }
     matched += 1
     matchedIds.add(clubId)
+    const enrichment = enrichmentByClubId.get(clubId) ?? {}
     // Spread the FAC enrichment alongside the existing snapshot fields.
     // Snapshot fields win on collision — TI dashboard is canonical for
     // DCP / payments / status; FAC is only authoritative for the
     // optional enrichment fields it adds.
-    return {
-      ...row,
-      ...(facHit.charterDate && { charterDate: facHit.charterDate }),
-      ...(facHit.coordinates && { coordinates: facHit.coordinates }),
-      ...(facHit.address && { address: facHit.address }),
-      ...(facHit.email && { email: facHit.email }),
-      ...(facHit.phone && { phone: facHit.phone }),
-      ...(facHit.website && { website: facHit.website }),
-      ...(facHit.facebookLink && { facebookLink: facHit.facebookLink }),
-      ...(facHit.twitterLink && { twitterLink: facHit.twitterLink }),
-      ...(facHit.meetingDay && { meetingDay: facHit.meetingDay }),
-      ...(facHit.meetingTime && { meetingTime: facHit.meetingTime }),
-      ...(typeof facHit.allowsVirtualAttendance === 'boolean' && {
-        allowsVirtualAttendance: facHit.allowsVirtualAttendance,
-      }),
-      ...(typeof facHit.isProspective === 'boolean' && {
-        isProspective: facHit.isProspective,
-      }),
-    }
+    return { ...row, ...enrichment }
   })
+
+  // Also enrich the parsed .data.clubs[] array if present. This is the
+  // array analytics-core reads to build ClubTrend, so it's the path
+  // by which charterDate etc. reach the frontend Club hero (#503).
+  const parsedClubsRaw = (
+    snapshot.data as Record<string, unknown> | undefined
+  )?.['clubs']
+  let enrichedParsedClubs: unknown[] | undefined
+  if (Array.isArray(parsedClubsRaw)) {
+    enrichedParsedClubs = parsedClubsRaw.map(raw => {
+      if (typeof raw !== 'object' || raw === null) return raw
+      const parsed = raw as Record<string, unknown>
+      const clubId =
+        typeof parsed['clubId'] === 'string' ? parsed['clubId'] : null
+      if (!clubId) return raw
+      const enrichment = enrichmentByClubId.get(clubId)
+      return enrichment ? { ...parsed, ...enrichment } : raw
+    })
+  }
 
   // FAC-only clubs: in FAC but not in snapshot. These are typically
   // ATOs / prospective (#489). We don't merge them into clubPerformance
@@ -149,6 +179,12 @@ export function mergeFacIntoSnapshot(
       data: {
         ...snapshot.data,
         clubPerformance: enrichedClubs,
+        // Only spread .clubs[] back when we actually had one to enrich.
+        // Undefined when the snapshot lacked the parsed array (older
+        // shape) so we don't fabricate it.
+        ...(enrichedParsedClubs !== undefined && {
+          clubs: enrichedParsedClubs,
+        }),
       },
     },
     matched,

--- a/packages/collector-cli/src/services/__tests__/FindAClubMerger.test.ts
+++ b/packages/collector-cli/src/services/__tests__/FindAClubMerger.test.ts
@@ -86,6 +86,130 @@ describe('normaliseClubNumber', () => {
   })
 })
 
+describe('mergeFacIntoSnapshot — clubs[] propagation (#503)', () => {
+  // Critical regression: the merger originally only wrote onto
+  // .data.clubPerformance[] (raw scraped records). But analytics-core
+  // builds ClubTrend from .data.clubs[] (parsed ClubStatisticsFile),
+  // so FAC enrichment never reached the analytics JSON the frontend
+  // reads. The merger must update BOTH arrays.
+  it('enriches the .data.clubs[] entry that matches by clubId', () => {
+    const result = mergeFacIntoSnapshot(
+      {
+        districtId: '61',
+        data: {
+          clubPerformance: [ottawaSnapshotRow],
+          // parsed ClubStatisticsFile shape — what analytics-core reads
+          clubs: [
+            {
+              clubId: '00000180',
+              clubName: 'Causeurs Ottawa Speakers Club',
+              divisionId: 'A',
+              divisionName: 'Division A',
+              areaId: 'A1',
+              areaName: 'Area A1',
+              membershipCount: 23,
+              membershipBase: 20,
+              paymentsCount: 5,
+              dcpGoals: 5,
+              status: 'Distinguished',
+              octoberRenewals: 3,
+              aprilRenewals: 2,
+              newMembers: 1,
+              clubStatus: 'Active',
+            },
+          ],
+        },
+      },
+      { Clubs: [ottawaFacClub] }
+    )
+
+    expect(result.matched).toBe(1)
+    const parsedClubs = (result.snapshot.data?.['clubs'] ?? []) as Array<
+      Record<string, unknown>
+    >
+    expect(parsedClubs).toHaveLength(1)
+    expect(parsedClubs[0]?.['clubId']).toBe('00000180')
+    // Parsed snapshot fields preserved
+    expect(parsedClubs[0]?.['clubName']).toBe('Causeurs Ottawa Speakers Club')
+    expect(parsedClubs[0]?.['membershipCount']).toBe(23)
+    // FAC enrichment landed on .clubs[]
+    expect(parsedClubs[0]?.['charterDate']).toBe('1976-04-01')
+    expect(parsedClubs[0]?.['coordinates']).toEqual({
+      lat: 45.42,
+      lng: -75.69,
+    })
+    expect(parsedClubs[0]?.['email']).toBe('officers-180@toastmastersclubs.org')
+    expect(parsedClubs[0]?.['meetingDay']).toBe('Tuesday')
+  })
+
+  it('leaves .data.clubs[] alone for snapshot-only clubs (no FAC match)', () => {
+    const result = mergeFacIntoSnapshot(
+      {
+        districtId: '61',
+        data: {
+          clubPerformance: [ottawaSnapshotRow, suspendedSnapshotOnly],
+          clubs: [
+            {
+              clubId: '00000180',
+              clubName: 'Causeurs',
+              divisionId: 'A',
+              divisionName: 'A',
+              areaId: 'A1',
+              areaName: 'A1',
+              membershipCount: 23,
+              membershipBase: 20,
+              paymentsCount: 5,
+              dcpGoals: 5,
+              status: 'Distinguished',
+              octoberRenewals: 3,
+              aprilRenewals: 2,
+              newMembers: 1,
+            },
+            {
+              clubId: '00099999',
+              clubName: 'Suspended',
+              divisionId: 'B',
+              divisionName: 'B',
+              areaId: 'B1',
+              areaName: 'B1',
+              membershipCount: 0,
+              membershipBase: 15,
+              paymentsCount: 0,
+              dcpGoals: 0,
+              status: 'Suspended',
+              octoberRenewals: 0,
+              aprilRenewals: 0,
+              newMembers: 0,
+            },
+          ],
+        },
+      },
+      { Clubs: [ottawaFacClub] }
+    )
+    const parsedClubs = (result.snapshot.data?.['clubs'] ?? []) as Array<
+      Record<string, unknown>
+    >
+    // Suspended club must NOT acquire FAC fields
+    expect(parsedClubs[1]?.['clubId']).toBe('00099999')
+    expect(parsedClubs[1]?.['charterDate']).toBeUndefined()
+  })
+
+  it('handles snapshots without a .clubs[] array (defensive)', () => {
+    // Older snapshots may only have .clubPerformance — merger must
+    // still work and not throw.
+    const result = mergeFacIntoSnapshot(
+      {
+        districtId: '61',
+        data: { clubPerformance: [ottawaSnapshotRow] },
+      },
+      { Clubs: [ottawaFacClub] }
+    )
+    expect(result.matched).toBe(1)
+    // .clubs[] absent → nothing to update → no crash
+    expect(result.snapshot.data?.['clubs']).toBeUndefined()
+  })
+})
+
 describe('mergeFacIntoSnapshot', () => {
   it('enriches a matched club with FAC fields without losing snapshot fields', () => {
     const result = mergeFacIntoSnapshot(


### PR DESCRIPTION
## Summary

Closes #503. Fixes the gap that made the Find-A-Club enrichment chain (#429 / #483 / #484 / #485 / #491) ship without ever actually displaying anything in the UI — the FAC fields were merged into the snapshot but never made it into the analytics JSON the frontend reads.

## Red → Green

Per Lesson 54:

1. \`test(fac): RED — FAC fields must propagate through merger.clubs[] and analytics ClubTrend\`
2. \`fix(fac): GREEN — propagate FAC enrichment through analytics ClubTrend\`

## The bug

\`FindAClubMerger\` wrote FAC fields onto \`snapshot.data.clubPerformance[]\` (raw scraped records). But \`analytics-core\` builds \`ClubTrend\` from \`snapshot.data.clubs[]\` (parsed \`ClubStatisticsFile\`). So FAC enrichment never reached the analytics JSON file the Club hero actually reads. Verified live: \`analytics/district_61_analytics.json\`'s \`allClubs[0]\` had no charterDate / coordinates / address.

## The fix (two parts)

### 1. Merger writes BOTH arrays

\`FindAClubMerger\` now also enriches \`snapshot.data.clubs[]\` when present, matching by \`clubId\`. Defensive: absent \`.clubs[]\` is left alone (older snapshot shape).

### 2. Analytics propagates FAC fields

Added optional FAC fields to:

- \`analytics-core/src/interfaces.ts\` — \`ClubStatistics\` (the parsed snapshot type)
- \`analytics-core/src/types/clubHealth.ts\` — \`ClubTrend\` (the emitted analytics shape)
- \`analytics-core/src/types/core.ts\` — sibling ClubTrend (used by vulnerableClubs)
- \`frontend/src/hooks/useDistrictAnalytics.ts\` — frontend \`ClubTrend\` for consumers

\`ClubHealthAnalyticsModule\` propagates the fields from \`ClubStatistics\` onto \`ClubTrend\` during construction, with \`...(field && { field })\` spreads so absent fields stay absent (no \`undefined\` pollution).

## Test plan

- [x] 3 new merger tests (clubs[] enrichment, snapshot-only safety, absent-clubs[] defensive)
- [x] 3 new analytics tests (charterDate propagation, full FAC field set, graceful absence)
- [x] All collector-cli + analytics-core + shared-contracts suites still green (728 + 761 + 127 tests)
- [x] Frontend typecheck clean
- [ ] CI green
- [ ] **First nightly run after merge will produce enriched analytics JSON**; the Club hero CHARTERED eyebrow will start rendering for matched clubs

## Related

- #503 — this issue
- #432 — original CHARTERED eyebrow story (UI component already correct, just starved of data)
- #491 — merger (worked end-to-end as far as the snapshot, but stopped there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)