### PR TITLE
feat(util): getClubAnniversary — Sprint A of anniversaries epic (#444 #443)

### DIFF
--- a/frontend/src/utils/__tests__/clubAnniversary.test.ts
+++ b/frontend/src/utils/__tests__/clubAnniversary.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest'
+import { getClubAnniversary } from '../clubAnniversary'
+
+/* Sprint A — RED tests for #444. */
+
+const ref = (iso: string) => new Date(`${iso}T12:00:00Z`)
+
+describe('getClubAnniversary (#444)', () => {
+  describe('null / invalid input', () => {
+    it('returns null for empty string', () => {
+      expect(getClubAnniversary('', ref('2026-05-12'))).toBeNull()
+    })
+
+    it('returns null for unparseable garbage', () => {
+      expect(getClubAnniversary('not a date', ref('2026-05-12'))).toBeNull()
+    })
+
+    it('returns null for out-of-band years (< 1900 or > current+10)', () => {
+      expect(getClubAnniversary('1800-01-01', ref('2026-05-12'))).toBeNull()
+      expect(getClubAnniversary('2099-01-01', ref('2026-05-12'))).toBeNull()
+    })
+  })
+
+  describe('whole-year arithmetic', () => {
+    it('returns years=0 when charter date is exactly today', () => {
+      const result = getClubAnniversary('2026-05-12', ref('2026-05-12'))
+      expect(result?.years).toBe(0)
+      expect(result?.daysUntilNext).toBe(0)
+      expect(result?.upcomingYears).toBe(0)
+    })
+
+    it('returns years=1 one year after charter, on the day', () => {
+      const result = getClubAnniversary('2025-05-12', ref('2026-05-12'))
+      expect(result?.years).toBe(1)
+      expect(result?.daysUntilNext).toBe(0)
+      expect(result?.upcomingYears).toBe(1)
+    })
+
+    it('returns years just BEFORE incrementing on the day before anniversary', () => {
+      const result = getClubAnniversary('2025-05-13', ref('2026-05-12'))
+      expect(result?.years).toBe(0) // not yet first anniversary
+      expect(result?.daysUntilNext).toBe(1)
+      expect(result?.upcomingYears).toBe(1)
+    })
+
+    it('returns 39 years for a 1987-03-01 club observed in 2026-05-12', () => {
+      const result = getClubAnniversary('1987-03-01', ref('2026-05-12'))
+      expect(result?.years).toBe(39)
+    })
+
+    it('accepts ISO datetimes (Z) as well as date-only strings', () => {
+      const a = getClubAnniversary('1987-03-01', ref('2026-05-12'))
+      const b = getClubAnniversary('1987-03-01T00:00:00Z', ref('2026-05-12'))
+      expect(a?.years).toBe(b?.years)
+    })
+
+    it('accepts Date objects', () => {
+      const result = getClubAnniversary(
+        new Date('1987-03-01T00:00:00Z'),
+        ref('2026-05-12')
+      )
+      expect(result?.years).toBe(39)
+    })
+  })
+
+  describe('milestone flag', () => {
+    it.each([
+      [5, true],
+      [10, true],
+      [15, true],
+      [20, true],
+      [25, true],
+      [30, true],
+      [40, true],
+      [50, true],
+      [60, true],
+      [75, true],
+      [100, true],
+    ])('marks %d years as a milestone', (y, expected) => {
+      const charter = `${2026 - y}-05-12`
+      const result = getClubAnniversary(charter, ref('2026-05-12'))
+      expect(result?.years).toBe(y)
+      expect(result?.isMilestone).toBe(expected)
+    })
+
+    it.each([
+      [1, false],
+      [3, false],
+      [7, false],
+      [35, false],
+      [45, false],
+      [55, false],
+      [65, false],
+      [70, false],
+      [80, false],
+      [85, false],
+      [90, false],
+      [95, false],
+    ])('does NOT mark %d years as a milestone', (y, expected) => {
+      const charter = `${2026 - y}-05-12`
+      const result = getClubAnniversary(charter, ref('2026-05-12'))
+      expect(result?.years).toBe(y)
+      expect(result?.isMilestone).toBe(expected)
+    })
+  })
+
+  describe('upcoming window (±30 days)', () => {
+    it('is upcoming exactly on the anniversary day', () => {
+      const result = getClubAnniversary('2020-05-12', ref('2026-05-12'))
+      expect(result?.isUpcoming).toBe(true)
+    })
+
+    it('is upcoming 30 days before the anniversary', () => {
+      const result = getClubAnniversary('2020-06-11', ref('2026-05-12'))
+      // 2026-06-11 is 30 days away
+      expect(result?.daysUntilNext).toBe(30)
+      expect(result?.isUpcoming).toBe(true)
+    })
+
+    it('is NOT upcoming 31 days before the anniversary', () => {
+      const result = getClubAnniversary('2020-06-12', ref('2026-05-12'))
+      expect(result?.daysUntilNext).toBe(31)
+      expect(result?.isUpcoming).toBe(false)
+    })
+
+    it('is upcoming within 30 days AFTER the anniversary (just passed)', () => {
+      // Charter 2020-04-12; ref 2026-05-12. Last anniversary was 2026-04-12,
+      // which is 30 days ago. daysUntilNext is to 2027-04-12 (~334 days).
+      // But the "upcoming" flag should consider proximity in either
+      // direction; per the AC: "within ±30 days of the reference date".
+      const result = getClubAnniversary('2020-04-12', ref('2026-05-12'))
+      expect(result?.isUpcoming).toBe(true)
+    })
+
+    it('is NOT upcoming 31 days after the anniversary', () => {
+      const result = getClubAnniversary('2020-04-11', ref('2026-05-12'))
+      expect(result?.isUpcoming).toBe(false)
+    })
+  })
+
+  describe('upcomingYears', () => {
+    it('equals years on the exact anniversary day', () => {
+      const result = getClubAnniversary('2020-05-12', ref('2026-05-12'))
+      expect(result?.years).toBe(6)
+      expect(result?.upcomingYears).toBe(6)
+    })
+
+    it('equals years + 1 before the anniversary', () => {
+      const result = getClubAnniversary('2020-05-13', ref('2026-05-12'))
+      expect(result?.years).toBe(5)
+      expect(result?.upcomingYears).toBe(6)
+    })
+
+    it('marks an upcoming MILESTONE even when current years is not a milestone', () => {
+      // Charter 2001-06-01; ref 2026-05-12. Current years = 24, but next
+      // anniversary (2026-06-01) is 20 days away → upcomingYears = 25
+      // → milestone via upcoming.
+      const result = getClubAnniversary('2001-06-01', ref('2026-05-12'))
+      expect(result?.years).toBe(24)
+      expect(result?.upcomingYears).toBe(25)
+      expect(result?.isUpcoming).toBe(true)
+      // Note: isMilestone reflects CURRENT years, not upcoming. UI uses
+      // upcomingYears + isMilestone of upcomingYears to gild "in 20 days"
+      // copy. Keep flags primitive; let UI compose.
+      expect(result?.isMilestone).toBe(false)
+    })
+  })
+
+  describe('Feb 29 leap-year clubs', () => {
+    // Toastmasters has been around since 1924; leap-year charters exist.
+    // On non-leap years the anniversary is observed on Feb 28 by
+    // convention — same approach the TI dashboard uses.
+    it('observes Feb 29 → Feb 28 in non-leap reference years', () => {
+      const result = getClubAnniversary('1972-02-29', ref('2025-02-28'))
+      expect(result?.years).toBe(53)
+      expect(result?.daysUntilNext).toBe(0)
+    })
+
+    it('observes Feb 29 on actual Feb 29 in leap reference years', () => {
+      const result = getClubAnniversary('1972-02-29', ref('2024-02-29'))
+      expect(result?.years).toBe(52)
+      expect(result?.daysUntilNext).toBe(0)
+    })
+  })
+})

--- a/frontend/src/utils/clubAnniversary.ts
+++ b/frontend/src/utils/clubAnniversary.ts
@@ -1,26 +1,136 @@
 /* clubAnniversary (#444) — derives years / milestone / proximity for
    a club from its charter date. Foundation utility for the
-   Anniversaries epic (#443). Sprint A RED stub. */
+   Anniversaries epic (#443). Every anniversary-related UI surface
+   consumes this function — UI does NOT compute years inline.
+
+   Charter-date inputs accepted from the FAC enrichment pipeline:
+   - ISO date  '1987-03-01'
+   - ISO datetime  '1987-03-01T00:00:00Z'
+   - JS Date object  new Date(...)
+
+   All date math is done in UTC to keep results deterministic across
+   timezones. */
 
 export interface ClubAnniversary {
   /** Whole years since charter, measured against referenceDate. */
   years: number
   /** True for 5-year increments per the Toastmasters recognition set:
-   *  5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100. */
+   *  5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100.
+   *  Note: 35, 45, 55, 65, 70, 80, 85, 90, 95 are NOT milestones —
+   *  TI doesn't issue recognition pins for those increments. */
   isMilestone: boolean
-  /** Days until the next anniversary. Zero on the exact day. Negative
-   *  values are not returned — daysUntilNext is always in [0, 365]. */
+  /** Days until the next anniversary. Zero on the exact day; never
+   *  negative (always in [0, ~365]). */
   daysUntilNext: number
-  /** True iff the next anniversary is within ±30 days of referenceDate. */
+  /** True iff the anniversary is within ±30 days of referenceDate
+   *  (either upcoming OR just passed in the prior 30 days). */
   isUpcoming: boolean
   /** Whole-year mark that the next anniversary will celebrate.
    *  Equal to years on the exact anniversary day; otherwise years + 1. */
   upcomingYears: number
 }
 
+const MILESTONE_YEARS: ReadonlySet<number> = new Set([
+  5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100,
+])
+
+const UPCOMING_WINDOW_DAYS = 30
+const MIN_YEAR = 1900
+
+const isLeapYear = (y: number): boolean =>
+  (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0
+
+/** Parse a charter input. Returns a UTC-midnight Date or null. */
+function parseCharter(input: string | Date): Date | null {
+  if (input instanceof Date) {
+    if (Number.isNaN(input.getTime())) return null
+    return new Date(
+      Date.UTC(input.getUTCFullYear(), input.getUTCMonth(), input.getUTCDate())
+    )
+  }
+  if (typeof input !== 'string') return null
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  // YYYY-MM-DD prefix is enough — drop time-of-day if present.
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(trimmed)
+  if (!match) return null
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  if (year < MIN_YEAR) return null
+  if (month < 1 || month > 12) return null
+  if (day < 1 || day > 31) return null
+  return new Date(Date.UTC(year, month - 1, day))
+}
+
+/** Build the observed anniversary date in a given UTC year. Feb 29
+ *  charters fall back to Feb 28 in non-leap years (TI convention). */
+function anniversaryInYear(charter: Date, year: number): Date {
+  const month = charter.getUTCMonth()
+  let day = charter.getUTCDate()
+  if (month === 1 && day === 29 && !isLeapYear(year)) day = 28
+  return new Date(Date.UTC(year, month, day))
+}
+
+/** UTC-day-truncate a date. */
+function utcDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
 export function getClubAnniversary(
-  _charterDate: string | Date,
-  _referenceDate?: Date
+  charterDate: string | Date,
+  referenceDate: Date = new Date()
 ): ClubAnniversary | null {
-  throw new Error('getClubAnniversary: not implemented (RED phase, #444)')
+  const charter = parseCharter(charterDate)
+  if (!charter) return null
+
+  const ref = utcDay(referenceDate)
+  const refYear = ref.getUTCFullYear()
+  // Reject implausible futures — guard against parser accidents.
+  if (charter.getUTCFullYear() > refYear + 10) return null
+
+  // Years count up the moment the anniversary date is reached (or
+  // passed) in the reference year.
+  const thisYearAnniv = anniversaryInYear(charter, refYear)
+  const alreadyPassed = ref.getTime() > thisYearAnniv.getTime()
+  const isExactDay = ref.getTime() === thisYearAnniv.getTime()
+  const baseYears = refYear - charter.getUTCFullYear()
+  const years = alreadyPassed || isExactDay ? baseYears : baseYears - 1
+
+  // daysUntilNext: 0 on the exact day, otherwise the gap to the next
+  // anniversary (this year if we're before it, next year if after).
+  const nextAnniv = alreadyPassed
+    ? anniversaryInYear(charter, refYear + 1)
+    : thisYearAnniv
+  const daysUntilNext = Math.round(
+    (nextAnniv.getTime() - ref.getTime()) / MS_PER_DAY
+  )
+
+  // Days since the previous anniversary (for the "just passed" half of
+  // the upcoming window). Zero on the exact day.
+  const prevAnniv =
+    alreadyPassed || isExactDay
+      ? thisYearAnniv
+      : anniversaryInYear(charter, refYear - 1)
+  const daysSincePrev = Math.round(
+    (ref.getTime() - prevAnniv.getTime()) / MS_PER_DAY
+  )
+
+  const isUpcoming =
+    daysUntilNext <= UPCOMING_WINDOW_DAYS ||
+    daysSincePrev <= UPCOMING_WINDOW_DAYS
+
+  // upcomingYears: years count on the upcoming anniversary day.
+  // Equal to years when today IS the anniversary; otherwise years + 1.
+  const upcomingYears = isExactDay ? years : years + 1
+
+  return {
+    years,
+    isMilestone: MILESTONE_YEARS.has(years),
+    daysUntilNext,
+    isUpcoming,
+    upcomingYears,
+  }
 }

--- a/frontend/src/utils/clubAnniversary.ts
+++ b/frontend/src/utils/clubAnniversary.ts
@@ -1,0 +1,26 @@
+/* clubAnniversary (#444) — derives years / milestone / proximity for
+   a club from its charter date. Foundation utility for the
+   Anniversaries epic (#443). Sprint A RED stub. */
+
+export interface ClubAnniversary {
+  /** Whole years since charter, measured against referenceDate. */
+  years: number
+  /** True for 5-year increments per the Toastmasters recognition set:
+   *  5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100. */
+  isMilestone: boolean
+  /** Days until the next anniversary. Zero on the exact day. Negative
+   *  values are not returned — daysUntilNext is always in [0, 365]. */
+  daysUntilNext: number
+  /** True iff the next anniversary is within ±30 days of referenceDate. */
+  isUpcoming: boolean
+  /** Whole-year mark that the next anniversary will celebrate.
+   *  Equal to years on the exact anniversary day; otherwise years + 1. */
+  upcomingYears: number
+}
+
+export function getClubAnniversary(
+  _charterDate: string | Date,
+  _referenceDate?: Date
+): ClubAnniversary | null {
+  throw new Error('getClubAnniversary: not implemented (RED phase, #444)')
+}


### PR DESCRIPTION
## Summary

Sprint A of epic #443. Pure foundation utility — every anniversary-related UI consumes this function instead of recomputing years inline.

## Red → Green

1. \`test(util): RED — failing tests for getClubAnniversary\` — 42 tests, throwing stub
2. \`feat(util): GREEN — getClubAnniversary implementation\` — all 42 pass

## API

\`\`\`ts
export function getClubAnniversary(
  charterDate: string | Date,
  referenceDate?: Date
): ClubAnniversary | null

interface ClubAnniversary {
  years: number           // whole years since charter
  isMilestone: boolean    // 5/10/15/20/25/30/40/50/60/75/100 (TI recognition set)
  daysUntilNext: number   // 0..~365, never negative
  isUpcoming: boolean     // within ±30 days of anniversary (either direction)
  upcomingYears: number   // years count on the upcoming anniversary
}
\`\`\`

## Behaviour

- Returns null for missing / unparseable / out-of-band inputs (no throws)
- Accepts ISO date, ISO datetime (Z), and Date instances
- All math in UTC — deterministic across timezones
- Feb 29 charters fall back to Feb 28 in non-leap reference years (matches TI convention)
- Milestones use TI's actual recognition set — 35/45/55/65/70/80/85/90/95 are explicitly NOT milestones

## Test plan

- [x] 42 tests covering null inputs, whole-year arithmetic, exact-day vs day-before, milestone flag for 11 valid increments and 12 non-milestone increments, ±30-day upcoming window in both directions, upcomingYears semantics, Feb 29 leap-year fallback
- [ ] CI green

## Next sprints

- **B (#445 + #448)**: hero badge + clubs-table column
- **C (#446 + #447)**: District Detail upcoming panel + milestones callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)