### PR TITLE
feat(anniversary): hero badge + clubs-table Years column (#445 #448 #443)

### DIFF
--- a/frontend/src/components/ClubAnniversaryBadge.tsx
+++ b/frontend/src/components/ClubAnniversaryBadge.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import type { ClubAnniversary } from '../utils/clubAnniversary'
+
+/* ClubAnniversaryBadge (#445) — quiet pill for non-milestone, gold
+   badge for milestone years, animated countdown when within ±30 days.
+   Sprint B RED stub. */
+
+export interface ClubAnniversaryBadgeProps {
+  anniversary: ClubAnniversary | null
+  /** Charter date in display form for the tooltip. */
+  charterDateLabel?: string
+}
+
+export const ClubAnniversaryBadge: React.FC<ClubAnniversaryBadgeProps> = () => {
+  throw new Error('ClubAnniversaryBadge: not implemented (RED phase, #445)')
+}

--- a/frontend/src/components/ClubAnniversaryBadge.tsx
+++ b/frontend/src/components/ClubAnniversaryBadge.tsx
@@ -1,9 +1,15 @@
 import React from 'react'
 import type { ClubAnniversary } from '../utils/clubAnniversary'
 
-/* ClubAnniversaryBadge (#445) — quiet pill for non-milestone, gold
-   badge for milestone years, animated countdown when within ±30 days.
-   Sprint B RED stub. */
+/* ClubAnniversaryBadge (#445) — anniversary display for the club hero.
+   Three visual modes:
+
+   - quiet pill: non-milestone, non-upcoming — "<N> years"
+   - milestone badge: 5-year increment — gold accent, "<N> Years"
+   - upcoming countdown: within ±30 days — "<Nth> anniversary in X days"
+     or "today!" on the exact day
+
+   Renders nothing when anniversary is null (missing charter date). */
 
 export interface ClubAnniversaryBadgeProps {
   anniversary: ClubAnniversary | null
@@ -11,6 +17,78 @@ export interface ClubAnniversaryBadgeProps {
   charterDateLabel?: string
 }
 
-export const ClubAnniversaryBadge: React.FC<ClubAnniversaryBadgeProps> = () => {
-  throw new Error('ClubAnniversaryBadge: not implemented (RED phase, #445)')
+const ordinalSuffix = (n: number): string => {
+  const mod100 = n % 100
+  if (mod100 >= 11 && mod100 <= 13) return 'th'
+  const mod10 = n % 10
+  if (mod10 === 1) return 'st'
+  if (mod10 === 2) return 'nd'
+  if (mod10 === 3) return 'rd'
+  return 'th'
+}
+
+export const ClubAnniversaryBadge: React.FC<ClubAnniversaryBadgeProps> = ({
+  anniversary,
+  charterDateLabel,
+}) => {
+  if (!anniversary) return null
+
+  const { years, isMilestone, daysUntilNext, isUpcoming, upcomingYears } =
+    anniversary
+
+  // Upcoming countdown wins over the quiet pill when within ±30 days.
+  if (isUpcoming) {
+    const ord = `${upcomingYears}${ordinalSuffix(upcomingYears)}`
+    const copy =
+      daysUntilNext === 0
+        ? `${ord} anniversary today!`
+        : `${ord} anniversary in ${daysUntilNext} day${daysUntilNext === 1 ? '' : 's'}`
+    return (
+      <span
+        data-milestone={isMilestone}
+        title={charterDateLabel}
+        className={
+          'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold ' +
+          (isMilestone
+            ? 'bg-yellow-100 text-yellow-900 ring-1 ring-yellow-400 dark:bg-yellow-900/40 dark:text-yellow-100 dark:ring-yellow-500'
+            : 'bg-blue-50 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100')
+        }
+      >
+        🎉 {copy}
+        {charterDateLabel && (
+          <span className="sr-only"> · Chartered {charterDateLabel}</span>
+        )}
+      </span>
+    )
+  }
+
+  // Milestone (steady-state milestone year, not in upcoming window).
+  if (isMilestone) {
+    return (
+      <span
+        data-milestone="true"
+        title={charterDateLabel}
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-900 ring-1 ring-yellow-400 dark:bg-yellow-900/40 dark:text-yellow-100 dark:ring-yellow-500"
+      >
+        🥇 {years} Years
+        {charterDateLabel && (
+          <span className="sr-only"> · Chartered {charterDateLabel}</span>
+        )}
+      </span>
+    )
+  }
+
+  // Quiet pill for everyone else.
+  return (
+    <span
+      data-milestone="false"
+      title={charterDateLabel}
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs text-gray-600 bg-gray-100 dark:bg-gray-700 dark:text-gray-300"
+    >
+      {years} years
+      {charterDateLabel && (
+        <span className="sr-only"> · Chartered {charterDateLabel}</span>
+      )}
+    </span>
+  )
 }

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -45,6 +45,9 @@ interface ClubsTableProps {
   onFilterChange?:
     | ((state: import('./filters/types').FilterState) => void)
     | undefined
+  /** Reference date for anniversary computation. Defaults to `new Date()`.
+   *  Tests inject a fixed date to keep year counts deterministic (#448). */
+  referenceDate?: Date
 }
 
 /**
@@ -91,6 +94,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   onPageChange,
   initialFilterState,
   onFilterChange,
+  referenceDate,
 }) => {
   const [sortField, setSortField] = useState<SortField>(
     initialSortField ?? 'name'
@@ -109,7 +113,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
     getFilter,
     hasActiveFilters,
     activeFilterCount,
-  } = useColumnFilters(clubs, initialFilterState)
+  } = useColumnFilters(clubs, initialFilterState, referenceDate)
 
   // Wrap setFilter to notify parent of changes for URL sync
   const setFilter = useCallback(
@@ -257,6 +261,12 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
         case 'clubStatus':
           aValue = a.clubStatus?.toLowerCase()
           bValue = b.clubStatus?.toLowerCase()
+          break
+        case 'yearsChartered':
+          // null (missing charterDate) falls through to the
+          // undefined-handling below, sorting to end either direction.
+          aValue = a.yearsChartered ?? undefined
+          bValue = b.yearsChartered ?? undefined
           break
         default:
           return 0
@@ -910,6 +920,15 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                         }
                       >
                         {club.newMembers}
+                      </span>
+                    ) : (
+                      <span className="text-gray-500">—</span>
+                    )}
+                  </td>
+                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
+                    {club.yearsChartered !== null ? (
+                      <span className="text-gray-900">
+                        {club.yearsChartered}
                       </span>
                     ) : (
                       <span className="text-gray-500">—</span>

--- a/frontend/src/components/__tests__/ClubAnniversaryBadge.test.tsx
+++ b/frontend/src/components/__tests__/ClubAnniversaryBadge.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ClubAnniversaryBadge } from '../ClubAnniversaryBadge'
+import type { ClubAnniversary } from '../../utils/clubAnniversary'
+
+/* Sprint B RED tests for #445. */
+
+afterEach(() => cleanup())
+
+const anniversary = (overrides: Partial<ClubAnniversary>): ClubAnniversary => ({
+  years: 3,
+  isMilestone: false,
+  daysUntilNext: 200,
+  isUpcoming: false,
+  upcomingYears: 4,
+  ...overrides,
+})
+
+describe('ClubAnniversaryBadge (#445)', () => {
+  it('renders nothing when anniversary is null (missing charter date)', () => {
+    const { container } = render(<ClubAnniversaryBadge anniversary={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a quiet pill for non-milestone, non-upcoming years', () => {
+    render(
+      <ClubAnniversaryBadge
+        anniversary={anniversary({ years: 7 })}
+        charterDateLabel="March 1987"
+      />
+    )
+    expect(screen.getByText(/7 years/i)).toBeInTheDocument()
+    // No upcoming countdown, no milestone gold.
+    expect(screen.queryByText(/anniversary in/i)).not.toBeInTheDocument()
+  })
+
+  it('elevates milestone years with the milestone class', () => {
+    const { container } = render(
+      <ClubAnniversaryBadge
+        anniversary={anniversary({ years: 25, isMilestone: true })}
+      />
+    )
+    const badge = container.querySelector('[data-milestone="true"]')
+    expect(badge).not.toBeNull()
+    expect(badge?.textContent).toMatch(/25 years/i)
+  })
+
+  it('shows upcoming countdown when isUpcoming is true and not yet on the day', () => {
+    render(
+      <ClubAnniversaryBadge
+        anniversary={anniversary({
+          years: 24,
+          upcomingYears: 25,
+          daysUntilNext: 20,
+          isUpcoming: true,
+        })}
+      />
+    )
+    expect(screen.getByText(/25th anniversary in 20 days/i)).toBeInTheDocument()
+  })
+
+  it('shows "today!" copy on the exact anniversary day', () => {
+    render(
+      <ClubAnniversaryBadge
+        anniversary={anniversary({
+          years: 25,
+          upcomingYears: 25,
+          daysUntilNext: 0,
+          isUpcoming: true,
+          isMilestone: true,
+        })}
+      />
+    )
+    expect(screen.getByText(/today/i)).toBeInTheDocument()
+  })
+
+  it('shows charter date in tooltip when charterDateLabel is provided', () => {
+    render(
+      <ClubAnniversaryBadge
+        anniversary={anniversary({ years: 39 })}
+        charterDateLabel="March 1, 1987"
+      />
+    )
+    // The label appears in the title attribute of the root element OR
+    // as visible text; either works for now.
+    expect(
+      screen.getByText(/March 1, 1987/i, { exact: false })
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/ClubsTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.test.tsx
@@ -492,7 +492,9 @@ describe('ClubsTable', () => {
   })
 
   describe('Table Column Structure', () => {
-    it('should render 10 columns in the table', () => {
+    // Years Chartered column was added in #448 (epic #443).
+    // 12 → 13 reflects that new column.
+    it('should render 13 columns in the table', () => {
       const clubs = [createMockClub()]
 
       render(
@@ -505,10 +507,10 @@ describe('ClubsTable', () => {
 
       const headerRow = screen.getAllByRole('row')[0]
       const headerCells = headerRow.querySelectorAll('th')
-      expect(headerCells.length).toBe(12)
+      expect(headerCells.length).toBe(13)
     })
 
-    it('should render 11 cells per data row', () => {
+    it('should render 13 cells per data row', () => {
       const clubs = [createMockClub()]
 
       render(
@@ -521,7 +523,54 @@ describe('ClubsTable', () => {
 
       const dataRow = screen.getAllByRole('row')[1]
       const cells = dataRow.querySelectorAll('td')
-      expect(cells.length).toBe(12)
+      expect(cells.length).toBe(13)
+    })
+  })
+
+  describe('Years Chartered column (#448)', () => {
+    // #448 — Years column shows whole years since charter, sortable;
+    // missing charterDate renders as em-dash, sorts to end.
+    const referenceDate = new Date('2026-05-12T00:00:00Z')
+
+    it('renders the Years header label', () => {
+      render(
+        <ClubsTable
+          clubs={[createMockClub({ charterDate: '1987-03-01' })]}
+          districtId="test-district"
+          isLoading={false}
+          referenceDate={referenceDate}
+        />
+      )
+      expect(
+        screen.getByRole('columnheader', { name: /years/i })
+      ).toBeInTheDocument()
+    })
+
+    it('displays the years count for a chartered club', () => {
+      render(
+        <ClubsTable
+          clubs={[createMockClub({ charterDate: '2016-05-12' })]}
+          districtId="test-district"
+          isLoading={false}
+          referenceDate={referenceDate}
+        />
+      )
+      // 2026-05-12 minus 2016-05-12 = 10 years (milestone)
+      const dataRow = screen.getAllByRole('row')[1]
+      expect(dataRow.textContent).toMatch(/\b10\b/)
+    })
+
+    it('renders em-dash for clubs without a charter date', () => {
+      render(
+        <ClubsTable
+          clubs={[createMockClub({ charterDate: undefined })]}
+          districtId="test-district"
+          isLoading={false}
+          referenceDate={referenceDate}
+        />
+      )
+      const dataRow = screen.getAllByRole('row')[1]
+      expect(dataRow.textContent).toContain('—')
     })
   })
 

--- a/frontend/src/components/filters/__tests__/FilterComponentConsistency.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterComponentConsistency.test.tsx
@@ -118,7 +118,9 @@ describe('Filter Component Consistency', () => {
         col => col.filterType === 'numeric'
       )
 
-      // Should have expected numeric columns
+      // Should have expected numeric columns. yearsChartered (#448) is
+      // numeric but display-only — it carries filterable: false because
+      // a years-since-charter range filter wasn't part of the epic.
       expect(numericColumns.map(c => c.field)).toEqual([
         'membership',
         'dcpGoals',
@@ -126,11 +128,17 @@ describe('Filter Component Consistency', () => {
         'octoberRenewals',
         'aprilRenewals',
         'newMembers',
+        'yearsChartered',
       ])
 
-      // Each numeric column should be filterable
+      // Each numeric column should be filterable, except the display-only
+      // yearsChartered column (#448).
       numericColumns.forEach(column => {
-        expect(column.filterable).toBe(true)
+        if (column.field === 'yearsChartered') {
+          expect(column.filterable).toBe(false)
+        } else {
+          expect(column.filterable).toBe(true)
+        }
       })
     })
   })

--- a/frontend/src/components/filters/types.ts
+++ b/frontend/src/components/filters/types.ts
@@ -20,6 +20,7 @@ export type SortField =
   | 'newMembers'
   | 'clubStatus'
   | 'membersNeeded'
+  | 'yearsChartered'
 
 /**
  * Sort direction types
@@ -128,6 +129,9 @@ export interface ProcessedClubTrend extends ClubTrend {
   latestDcpGoals: number
   distinguishedOrder: number // For proper Distinguished column sorting
   membersNeeded: number // For "Members Needed" column filtering/sorting
+  /** Whole years since charter, or null when charterDate is missing
+   *  or invalid. Powers the Years Chartered column (#448) + sorting. */
+  yearsChartered: number | null
 }
 
 /**
@@ -237,6 +241,13 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
     label: 'New',
     sortable: true,
     filterable: true,
+    filterType: 'numeric',
+  },
+  {
+    field: 'yearsChartered',
+    label: 'Years',
+    sortable: true,
+    filterable: false,
     filterType: 'numeric',
   },
 ]

--- a/frontend/src/hooks/useColumnFilters.ts
+++ b/frontend/src/hooks/useColumnFilters.ts
@@ -27,7 +27,8 @@ export {
  */
 export const useColumnFilters = (
   clubs: ClubTrend[],
-  initialFilterState?: FilterState
+  initialFilterState?: FilterState,
+  referenceDate?: Date
 ) => {
   const [filterState, setFilterState] = useState<FilterState>(
     initialFilterState ?? {}
@@ -37,8 +38,8 @@ export const useColumnFilters = (
    * Process clubs with computed properties for filtering
    */
   const processedClubs = useMemo((): ProcessedClubTrend[] => {
-    return processClubs(clubs)
-  }, [clubs])
+    return processClubs(clubs, referenceDate)
+  }, [clubs, referenceDate])
 
   /**
    * Apply a single filter to the club data

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -12,6 +12,8 @@ import {
 } from '../utils/programYear'
 import { formatDisplayDate } from '../utils/dateFormatting'
 import { formatCharterDate } from '../utils/formatCharterDate'
+import { getClubAnniversary } from '../utils/clubAnniversary'
+import { ClubAnniversaryBadge } from '../components/ClubAnniversaryBadge'
 import {
   isProvisionallyDistinguished,
   getConfirmedLevel,
@@ -453,6 +455,21 @@ const ClubDetailPage: React.FC = () => {
             </div>
 
             <div className="club-hero__pills">
+              {/* #445 — anniversary badge surfaces years chartered, milestones,
+                  and an upcoming countdown when within ±30 days. Returns null
+                  when charterDate is missing so layout stays clean. */}
+              {(() => {
+                if (!club.charterDate) return null
+                const charterLabel = formatCharterDate(club.charterDate)
+                return (
+                  <ClubAnniversaryBadge
+                    anniversary={getClubAnniversary(club.charterDate)}
+                    {...(charterLabel
+                      ? { charterDateLabel: charterLabel }
+                      : {})}
+                  />
+                )
+              })()}
               <span
                 className={
                   'club-hero__pill ' +

--- a/frontend/src/utils/__tests__/clubAnniversary.test.ts
+++ b/frontend/src/utils/__tests__/clubAnniversary.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest'
+import { getClubAnniversary } from '../clubAnniversary'
+
+/* Sprint A — RED tests for #444. */
+
+const ref = (iso: string) => new Date(`${iso}T12:00:00Z`)
+
+describe('getClubAnniversary (#444)', () => {
+  describe('null / invalid input', () => {
+    it('returns null for empty string', () => {
+      expect(getClubAnniversary('', ref('2026-05-12'))).toBeNull()
+    })
+
+    it('returns null for unparseable garbage', () => {
+      expect(getClubAnniversary('not a date', ref('2026-05-12'))).toBeNull()
+    })
+
+    it('returns null for out-of-band years (< 1900 or > current+10)', () => {
+      expect(getClubAnniversary('1800-01-01', ref('2026-05-12'))).toBeNull()
+      expect(getClubAnniversary('2099-01-01', ref('2026-05-12'))).toBeNull()
+    })
+  })
+
+  describe('whole-year arithmetic', () => {
+    it('returns years=0 when charter date is exactly today', () => {
+      const result = getClubAnniversary('2026-05-12', ref('2026-05-12'))
+      expect(result?.years).toBe(0)
+      expect(result?.daysUntilNext).toBe(0)
+      expect(result?.upcomingYears).toBe(0)
+    })
+
+    it('returns years=1 one year after charter, on the day', () => {
+      const result = getClubAnniversary('2025-05-12', ref('2026-05-12'))
+      expect(result?.years).toBe(1)
+      expect(result?.daysUntilNext).toBe(0)
+      expect(result?.upcomingYears).toBe(1)
+    })
+
+    it('returns years just BEFORE incrementing on the day before anniversary', () => {
+      const result = getClubAnniversary('2025-05-13', ref('2026-05-12'))
+      expect(result?.years).toBe(0) // not yet first anniversary
+      expect(result?.daysUntilNext).toBe(1)
+      expect(result?.upcomingYears).toBe(1)
+    })
+
+    it('returns 39 years for a 1987-03-01 club observed in 2026-05-12', () => {
+      const result = getClubAnniversary('1987-03-01', ref('2026-05-12'))
+      expect(result?.years).toBe(39)
+    })
+
+    it('accepts ISO datetimes (Z) as well as date-only strings', () => {
+      const a = getClubAnniversary('1987-03-01', ref('2026-05-12'))
+      const b = getClubAnniversary('1987-03-01T00:00:00Z', ref('2026-05-12'))
+      expect(a?.years).toBe(b?.years)
+    })
+
+    it('accepts Date objects', () => {
+      const result = getClubAnniversary(
+        new Date('1987-03-01T00:00:00Z'),
+        ref('2026-05-12')
+      )
+      expect(result?.years).toBe(39)
+    })
+  })
+
+  describe('milestone flag', () => {
+    it.each([
+      [5, true],
+      [10, true],
+      [15, true],
+      [20, true],
+      [25, true],
+      [30, true],
+      [40, true],
+      [50, true],
+      [60, true],
+      [75, true],
+      [100, true],
+    ])('marks %d years as a milestone', (y, expected) => {
+      const charter = `${2026 - y}-05-12`
+      const result = getClubAnniversary(charter, ref('2026-05-12'))
+      expect(result?.years).toBe(y)
+      expect(result?.isMilestone).toBe(expected)
+    })
+
+    it.each([
+      [1, false],
+      [3, false],
+      [7, false],
+      [35, false],
+      [45, false],
+      [55, false],
+      [65, false],
+      [70, false],
+      [80, false],
+      [85, false],
+      [90, false],
+      [95, false],
+    ])('does NOT mark %d years as a milestone', (y, expected) => {
+      const charter = `${2026 - y}-05-12`
+      const result = getClubAnniversary(charter, ref('2026-05-12'))
+      expect(result?.years).toBe(y)
+      expect(result?.isMilestone).toBe(expected)
+    })
+  })
+
+  describe('upcoming window (±30 days)', () => {
+    it('is upcoming exactly on the anniversary day', () => {
+      const result = getClubAnniversary('2020-05-12', ref('2026-05-12'))
+      expect(result?.isUpcoming).toBe(true)
+    })
+
+    it('is upcoming 30 days before the anniversary', () => {
+      const result = getClubAnniversary('2020-06-11', ref('2026-05-12'))
+      // 2026-06-11 is 30 days away
+      expect(result?.daysUntilNext).toBe(30)
+      expect(result?.isUpcoming).toBe(true)
+    })
+
+    it('is NOT upcoming 31 days before the anniversary', () => {
+      const result = getClubAnniversary('2020-06-12', ref('2026-05-12'))
+      expect(result?.daysUntilNext).toBe(31)
+      expect(result?.isUpcoming).toBe(false)
+    })
+
+    it('is upcoming within 30 days AFTER the anniversary (just passed)', () => {
+      // Charter 2020-04-12; ref 2026-05-12. Last anniversary was 2026-04-12,
+      // which is 30 days ago. daysUntilNext is to 2027-04-12 (~334 days).
+      // But the "upcoming" flag should consider proximity in either
+      // direction; per the AC: "within ±30 days of the reference date".
+      const result = getClubAnniversary('2020-04-12', ref('2026-05-12'))
+      expect(result?.isUpcoming).toBe(true)
+    })
+
+    it('is NOT upcoming 31 days after the anniversary', () => {
+      const result = getClubAnniversary('2020-04-11', ref('2026-05-12'))
+      expect(result?.isUpcoming).toBe(false)
+    })
+  })
+
+  describe('upcomingYears', () => {
+    it('equals years on the exact anniversary day', () => {
+      const result = getClubAnniversary('2020-05-12', ref('2026-05-12'))
+      expect(result?.years).toBe(6)
+      expect(result?.upcomingYears).toBe(6)
+    })
+
+    it('equals years + 1 before the anniversary', () => {
+      const result = getClubAnniversary('2020-05-13', ref('2026-05-12'))
+      expect(result?.years).toBe(5)
+      expect(result?.upcomingYears).toBe(6)
+    })
+
+    it('marks an upcoming MILESTONE even when current years is not a milestone', () => {
+      // Charter 2001-06-01; ref 2026-05-12. Current years = 24, but next
+      // anniversary (2026-06-01) is 20 days away → upcomingYears = 25
+      // → milestone via upcoming.
+      const result = getClubAnniversary('2001-06-01', ref('2026-05-12'))
+      expect(result?.years).toBe(24)
+      expect(result?.upcomingYears).toBe(25)
+      expect(result?.isUpcoming).toBe(true)
+      // Note: isMilestone reflects CURRENT years, not upcoming. UI uses
+      // upcomingYears + isMilestone of upcomingYears to gild "in 20 days"
+      // copy. Keep flags primitive; let UI compose.
+      expect(result?.isMilestone).toBe(false)
+    })
+  })
+
+  describe('Feb 29 leap-year clubs', () => {
+    // Toastmasters has been around since 1924; leap-year charters exist.
+    // On non-leap years the anniversary is observed on Feb 28 by
+    // convention — same approach the TI dashboard uses.
+    it('observes Feb 29 → Feb 28 in non-leap reference years', () => {
+      const result = getClubAnniversary('1972-02-29', ref('2025-02-28'))
+      expect(result?.years).toBe(53)
+      expect(result?.daysUntilNext).toBe(0)
+    })
+
+    it('observes Feb 29 on actual Feb 29 in leap reference years', () => {
+      const result = getClubAnniversary('1972-02-29', ref('2024-02-29'))
+      expect(result?.years).toBe(52)
+      expect(result?.daysUntilNext).toBe(0)
+    })
+  })
+})

--- a/frontend/src/utils/clubAnniversary.ts
+++ b/frontend/src/utils/clubAnniversary.ts
@@ -1,26 +1,136 @@
 /* clubAnniversary (#444) — derives years / milestone / proximity for
    a club from its charter date. Foundation utility for the
-   Anniversaries epic (#443). Sprint A RED stub. */
+   Anniversaries epic (#443). Every anniversary-related UI surface
+   consumes this function — UI does NOT compute years inline.
+
+   Charter-date inputs accepted from the FAC enrichment pipeline:
+   - ISO date  '1987-03-01'
+   - ISO datetime  '1987-03-01T00:00:00Z'
+   - JS Date object  new Date(...)
+
+   All date math is done in UTC to keep results deterministic across
+   timezones. */
 
 export interface ClubAnniversary {
   /** Whole years since charter, measured against referenceDate. */
   years: number
   /** True for 5-year increments per the Toastmasters recognition set:
-   *  5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100. */
+   *  5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100.
+   *  Note: 35, 45, 55, 65, 70, 80, 85, 90, 95 are NOT milestones —
+   *  TI doesn't issue recognition pins for those increments. */
   isMilestone: boolean
-  /** Days until the next anniversary. Zero on the exact day. Negative
-   *  values are not returned — daysUntilNext is always in [0, 365]. */
+  /** Days until the next anniversary. Zero on the exact day; never
+   *  negative (always in [0, ~365]). */
   daysUntilNext: number
-  /** True iff the next anniversary is within ±30 days of referenceDate. */
+  /** True iff the anniversary is within ±30 days of referenceDate
+   *  (either upcoming OR just passed in the prior 30 days). */
   isUpcoming: boolean
   /** Whole-year mark that the next anniversary will celebrate.
    *  Equal to years on the exact anniversary day; otherwise years + 1. */
   upcomingYears: number
 }
 
+const MILESTONE_YEARS: ReadonlySet<number> = new Set([
+  5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100,
+])
+
+const UPCOMING_WINDOW_DAYS = 30
+const MIN_YEAR = 1900
+
+const isLeapYear = (y: number): boolean =>
+  (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0
+
+/** Parse a charter input. Returns a UTC-midnight Date or null. */
+function parseCharter(input: string | Date): Date | null {
+  if (input instanceof Date) {
+    if (Number.isNaN(input.getTime())) return null
+    return new Date(
+      Date.UTC(input.getUTCFullYear(), input.getUTCMonth(), input.getUTCDate())
+    )
+  }
+  if (typeof input !== 'string') return null
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  // YYYY-MM-DD prefix is enough — drop time-of-day if present.
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(trimmed)
+  if (!match) return null
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  if (year < MIN_YEAR) return null
+  if (month < 1 || month > 12) return null
+  if (day < 1 || day > 31) return null
+  return new Date(Date.UTC(year, month - 1, day))
+}
+
+/** Build the observed anniversary date in a given UTC year. Feb 29
+ *  charters fall back to Feb 28 in non-leap years (TI convention). */
+function anniversaryInYear(charter: Date, year: number): Date {
+  const month = charter.getUTCMonth()
+  let day = charter.getUTCDate()
+  if (month === 1 && day === 29 && !isLeapYear(year)) day = 28
+  return new Date(Date.UTC(year, month, day))
+}
+
+/** UTC-day-truncate a date. */
+function utcDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
 export function getClubAnniversary(
-  _charterDate: string | Date,
-  _referenceDate?: Date
+  charterDate: string | Date,
+  referenceDate: Date = new Date()
 ): ClubAnniversary | null {
-  throw new Error('getClubAnniversary: not implemented (RED phase, #444)')
+  const charter = parseCharter(charterDate)
+  if (!charter) return null
+
+  const ref = utcDay(referenceDate)
+  const refYear = ref.getUTCFullYear()
+  // Reject implausible futures — guard against parser accidents.
+  if (charter.getUTCFullYear() > refYear + 10) return null
+
+  // Years count up the moment the anniversary date is reached (or
+  // passed) in the reference year.
+  const thisYearAnniv = anniversaryInYear(charter, refYear)
+  const alreadyPassed = ref.getTime() > thisYearAnniv.getTime()
+  const isExactDay = ref.getTime() === thisYearAnniv.getTime()
+  const baseYears = refYear - charter.getUTCFullYear()
+  const years = alreadyPassed || isExactDay ? baseYears : baseYears - 1
+
+  // daysUntilNext: 0 on the exact day, otherwise the gap to the next
+  // anniversary (this year if we're before it, next year if after).
+  const nextAnniv = alreadyPassed
+    ? anniversaryInYear(charter, refYear + 1)
+    : thisYearAnniv
+  const daysUntilNext = Math.round(
+    (nextAnniv.getTime() - ref.getTime()) / MS_PER_DAY
+  )
+
+  // Days since the previous anniversary (for the "just passed" half of
+  // the upcoming window). Zero on the exact day.
+  const prevAnniv =
+    alreadyPassed || isExactDay
+      ? thisYearAnniv
+      : anniversaryInYear(charter, refYear - 1)
+  const daysSincePrev = Math.round(
+    (ref.getTime() - prevAnniv.getTime()) / MS_PER_DAY
+  )
+
+  const isUpcoming =
+    daysUntilNext <= UPCOMING_WINDOW_DAYS ||
+    daysSincePrev <= UPCOMING_WINDOW_DAYS
+
+  // upcomingYears: years count on the upcoming anniversary day.
+  // Equal to years when today IS the anniversary; otherwise years + 1.
+  const upcomingYears = isExactDay ? years : years + 1
+
+  return {
+    years,
+    isMilestone: MILESTONE_YEARS.has(years),
+    daysUntilNext,
+    isUpcoming,
+    upcomingYears,
+  }
 }

--- a/frontend/src/utils/clubAnniversary.ts
+++ b/frontend/src/utils/clubAnniversary.ts
@@ -1,0 +1,26 @@
+/* clubAnniversary (#444) — derives years / milestone / proximity for
+   a club from its charter date. Foundation utility for the
+   Anniversaries epic (#443). Sprint A RED stub. */
+
+export interface ClubAnniversary {
+  /** Whole years since charter, measured against referenceDate. */
+  years: number
+  /** True for 5-year increments per the Toastmasters recognition set:
+   *  5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100. */
+  isMilestone: boolean
+  /** Days until the next anniversary. Zero on the exact day. Negative
+   *  values are not returned — daysUntilNext is always in [0, 365]. */
+  daysUntilNext: number
+  /** True iff the next anniversary is within ±30 days of referenceDate. */
+  isUpcoming: boolean
+  /** Whole-year mark that the next anniversary will celebrate.
+   *  Equal to years on the exact anniversary day; otherwise years + 1. */
+  upcomingYears: number
+}
+
+export function getClubAnniversary(
+  _charterDate: string | Date,
+  _referenceDate?: Date
+): ClubAnniversary | null {
+  throw new Error('getClubAnniversary: not implemented (RED phase, #444)')
+}

--- a/frontend/src/utils/columnFilterUtils.ts
+++ b/frontend/src/utils/columnFilterUtils.ts
@@ -10,6 +10,7 @@ import type {
   ColumnFilter,
   ProcessedClubTrend,
 } from '../components/filters/types'
+import { getClubAnniversary } from './clubAnniversary'
 import {
   deriveGoalContext,
   computeMembersToDistinguished,
@@ -61,13 +62,21 @@ export function getMembersNeeded(club: ClubTrend): number {
 /**
  * Process clubs with computed properties for filtering
  */
-export function processClubs(clubs: ClubTrend[]): ProcessedClubTrend[] {
+export function processClubs(
+  clubs: ClubTrend[],
+  referenceDate: Date = new Date()
+): ProcessedClubTrend[] {
   return clubs.map(club => ({
     ...club,
     latestMembership: getLatestMembership(club),
     latestDcpGoals: getLatestDcpGoals(club),
     distinguishedOrder: getDistinguishedOrder(club),
     membersNeeded: getMembersNeeded(club),
+    // #448 — Years Chartered column. null when charterDate is absent
+    // or invalid, which the table renders as em-dash and sorts to end.
+    yearsChartered: club.charterDate
+      ? (getClubAnniversary(club.charterDate, referenceDate)?.years ?? null)
+      : null,
   }))
 }
 


### PR DESCRIPTION
## Summary

Sprint B of the Club Anniversaries epic (#443). Surfaces years chartered on two surfaces:

- **Club hero (#445)** — `ClubAnniversaryBadge` next to health + DCP tier pills. Three visual modes:
  - quiet pill ("7 years") for steady-state non-milestone years
  - gold milestone badge ("🥇 25 Years") for 5/10/15/20/25/30/40/50/60/75/100
  - upcoming countdown ("🎉 25th anniversary in 20 days" / "today!") when within ±30 days
- **Clubs table (#448)** — new sortable "Years" column (display-only, no filter). Em-dash when charterDate missing.

Foundation utility `getClubAnniversary()` shipped in #444 / Sprint A (PR #491-equivalent commit `56f06706`).

## What's NOT here

- District-level upcoming-anniversaries panel (#446) — Sprint C
- District-level milestones callout (#447) — Sprint C

## Test plan

- [x] 6 RED + 6 GREEN tests for `ClubAnniversaryBadge`
- [x] 3 new + 2 updated tests for ClubsTable Years column
- [x] FilterComponentConsistency assertion updated to recognise yearsChartered as display-only numeric
- [x] All 2254 frontend tests pass
- [x] TypeScript clean
- [ ] Manual: visit a club detail page and confirm badge renders in hero
- [ ] Manual: confirm Years column sorts ascending/descending on districts page

Closes #445, #448. Part of #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)