### PR TITLE
feat(district): upcoming anniversaries panel + milestones callout (#446 #447 #443)

### DIFF
--- a/frontend/src/components/MilestonesCallout.tsx
+++ b/frontend/src/components/MilestonesCallout.tsx
@@ -1,19 +1,265 @@
-import React from 'react'
+import React, { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import type { ClubTrend } from '../hooks/useDistrictAnalytics'
+import { MILESTONE_YEARS } from '../utils/clubAnniversary'
+import { getCurrentProgramYear } from '../utils/programYear'
 
 /* MilestonesCallout (#447) — district-level program-year milestone roster.
-   Groups clubs hitting a 5/10/15/.../100 year milestone within the current
-   program year (Jul 1 – Jun 30). STUB — implementation lands in GREEN. */
+   Groups clubs hitting a 5/10/15/.../100 year milestone within the
+   program year window (Jul 1 → Jun 30 inclusive). */
 
 export interface MilestonesCalloutProps {
   clubs: ClubTrend[]
-  /** Program year start year (e.g. 2025 for the 2025-2026 PY). Defaults
-   *  to the current PY. */
   programYearStart?: number
-  /** District id used for club detail links. */
   districtId?: string
 }
 
-export const MilestonesCallout: React.FC<MilestonesCalloutProps> = () => {
+interface MilestoneEntry {
+  club: ClubTrend
+  milestoneYears: number
+  anniversaryDate: Date
+}
+
+interface NextUpcomingEntry {
+  club: ClubTrend
+  milestoneYears: number
+  anniversaryDate: Date
+}
+
+/* Parse a Toastmasters charter date in UTC, supporting ISO YYYY-MM-DD and
+   the legacy /Date(ms)/ format the TI Find-A-Club endpoint returns. */
+const parseCharterUtc = (input: string): Date | null => {
+  const dotNetMatch = /^\/Date\((-?\d+)\)\/$/.exec(input)
+  if (dotNetMatch) {
+    const ms = Number(dotNetMatch[1])
+    if (!Number.isFinite(ms)) return null
+    const d = new Date(ms)
+    return new Date(
+      Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+    )
+  }
+  const isoMatch = /^(\d{4})-(\d{2})-(\d{2})/.exec(input)
+  if (isoMatch) {
+    const y = Number(isoMatch[1])
+    const m = Number(isoMatch[2]) - 1
+    const d = Number(isoMatch[3])
+    return new Date(Date.UTC(y, m, d))
+  }
   return null
+}
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+const formatAnniversaryDate = (d: Date): string =>
+  `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`
+
+const formatCharterMonth = (d: Date): string =>
+  `${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`
+
+/* Compute the anniversary date that falls inside the program year window.
+   Falls back to Feb 28 if the charter is Feb 29 and the anniversary year
+   is non-leap. Returns null when no anniversary falls in the window. */
+const anniversaryInProgramYear = (
+  charter: Date,
+  programYearStart: number
+): Date | null => {
+  const charterMonth = charter.getUTCMonth()
+  const charterDay = charter.getUTCDate()
+  // Anniversary year inside the window:
+  //   month >= 6 (Jul-Dec): in programYearStart
+  //   month <  6 (Jan-Jun): in programYearStart + 1
+  const annivYear = charterMonth >= 6 ? programYearStart : programYearStart + 1
+  let day = charterDay
+  if (charterMonth === 1 && charterDay === 29) {
+    const isLeap =
+      (annivYear % 4 === 0 && annivYear % 100 !== 0) || annivYear % 400 === 0
+    if (!isLeap) day = 28
+  }
+  return new Date(Date.UTC(annivYear, charterMonth, day))
+}
+
+export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
+  clubs,
+  programYearStart,
+  districtId,
+}) => {
+  const pyStart = programYearStart ?? getCurrentProgramYear().year
+
+  const { groups, nextUpcoming, pyLabel } = useMemo(() => {
+    const milestones: MilestoneEntry[] = []
+    const upcomingCandidates: NextUpcomingEntry[] = []
+
+    for (const club of clubs) {
+      if (!club.charterDate) continue
+      const charter = parseCharterUtc(club.charterDate)
+      if (!charter) continue
+      const annivInPy = anniversaryInProgramYear(charter, pyStart)
+      if (!annivInPy) continue
+      const yearsAtAnniv = annivInPy.getUTCFullYear() - charter.getUTCFullYear()
+      if (yearsAtAnniv <= 0) continue
+      if (MILESTONE_YEARS.has(yearsAtAnniv)) {
+        milestones.push({
+          club,
+          milestoneYears: yearsAtAnniv,
+          anniversaryDate: annivInPy,
+        })
+        continue
+      }
+      // Not a milestone in this PY — find the next future milestone
+      // anniversary so the empty state can point somewhere useful.
+      const charterMonth = charter.getUTCMonth()
+      const charterDay = charter.getUTCDate()
+      const today = new Date()
+      let candidateYear = today.getUTCFullYear()
+      while (candidateYear - charter.getUTCFullYear() <= 101) {
+        const years = candidateYear - charter.getUTCFullYear()
+        if (years > 0 && MILESTONE_YEARS.has(years)) {
+          const d = new Date(Date.UTC(candidateYear, charterMonth, charterDay))
+          if (d.getTime() >= today.getTime()) {
+            upcomingCandidates.push({
+              club,
+              milestoneYears: years,
+              anniversaryDate: d,
+            })
+            break
+          }
+        }
+        candidateYear += 1
+      }
+    }
+
+    // Group milestones by year, descending.
+    const grouped = new Map<number, MilestoneEntry[]>()
+    for (const entry of milestones) {
+      const arr = grouped.get(entry.milestoneYears) ?? []
+      arr.push(entry)
+      grouped.set(entry.milestoneYears, arr)
+    }
+    const groups = Array.from(grouped.entries())
+      .sort(([a], [b]) => b - a)
+      .map(([years, entries]) => ({
+        years,
+        entries: [...entries].sort(
+          (a, b) => a.anniversaryDate.getTime() - b.anniversaryDate.getTime()
+        ),
+      }))
+
+    const nextUpcoming =
+      upcomingCandidates.length > 0
+        ? upcomingCandidates.reduce((nearest, candidate) =>
+            candidate.anniversaryDate < nearest.anniversaryDate
+              ? candidate
+              : nearest
+          )
+        : null
+
+    const pyLabel = `${pyStart}-${(pyStart + 1).toString().slice(-2)}`
+
+    return { groups, nextUpcoming, pyLabel }
+  }, [clubs, pyStart])
+
+  if (groups.length === 0) {
+    return (
+      <section
+        aria-labelledby="milestones-heading"
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4 sm:p-6"
+      >
+        <h2
+          id="milestones-heading"
+          className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+        >
+          Milestones — Program Year {pyLabel}
+        </h2>
+        {nextUpcoming ? (
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+            No milestones in this program year — next milestone is{' '}
+            <Link
+              to={`/club/${nextUpcoming.club.clubId}${
+                districtId ? `?district=${districtId}` : ''
+              }`}
+              className="text-tm-loyal-blue hover:underline"
+            >
+              {nextUpcoming.club.clubName}
+            </Link>{' '}
+            at {nextUpcoming.milestoneYears} years on{' '}
+            {formatAnniversaryDate(nextUpcoming.anniversaryDate)}.
+          </p>
+        ) : (
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+            No milestones in this program year.
+          </p>
+        )}
+      </section>
+    )
+  }
+
+  return (
+    <section
+      aria-labelledby="milestones-heading"
+      className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4 sm:p-6"
+    >
+      <h2
+        id="milestones-heading"
+        className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+      >
+        Milestones — Program Year {pyLabel}
+      </h2>
+      <div className="mt-3 space-y-4">
+        {groups.map(group => (
+          <div key={group.years} data-testid="milestone-group">
+            <h3 className="text-sm font-semibold text-yellow-900 dark:text-yellow-200">
+              🥇 {group.years} Years
+            </h3>
+            <ul className="mt-1 divide-y divide-gray-200 dark:divide-gray-700">
+              {group.entries.map(entry => {
+                const charter = parseCharterUtc(
+                  entry.club.charterDate as string
+                )
+                return (
+                  <li
+                    key={entry.club.clubId}
+                    className="py-2 text-sm flex flex-wrap items-baseline gap-x-2"
+                  >
+                    <Link
+                      data-testid="milestone-club"
+                      to={`/club/${entry.club.clubId}${
+                        districtId ? `?district=${districtId}` : ''
+                      }`}
+                      className="font-medium text-tm-loyal-blue hover:underline"
+                    >
+                      {entry.club.clubName}
+                    </Link>
+                    {charter && (
+                      <span className="text-gray-500 dark:text-gray-400">
+                        · chartered {formatCharterMonth(charter)}
+                      </span>
+                    )}
+                    <span className="text-gray-500 dark:text-gray-400">
+                      · {entry.club.areaName}
+                    </span>
+                    <span className="text-gray-500 dark:text-gray-400">
+                      · {entry.club.divisionName}
+                    </span>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
 }

--- a/frontend/src/components/MilestonesCallout.tsx
+++ b/frontend/src/components/MilestonesCallout.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { ClubTrend } from '../hooks/useDistrictAnalytics'
+
+/* MilestonesCallout (#447) — district-level program-year milestone roster.
+   Groups clubs hitting a 5/10/15/.../100 year milestone within the current
+   program year (Jul 1 – Jun 30). STUB — implementation lands in GREEN. */
+
+export interface MilestonesCalloutProps {
+  clubs: ClubTrend[]
+  /** Program year start year (e.g. 2025 for the 2025-2026 PY). Defaults
+   *  to the current PY. */
+  programYearStart?: number
+  /** District id used for club detail links. */
+  districtId?: string
+}
+
+export const MilestonesCallout: React.FC<MilestonesCalloutProps> = () => {
+  return null
+}

--- a/frontend/src/components/UpcomingAnniversariesPanel.tsx
+++ b/frontend/src/components/UpcomingAnniversariesPanel.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import type { ClubTrend } from '../hooks/useDistrictAnalytics'
+
+/* UpcomingAnniversariesPanel (#446) — district-level recognition planner.
+   Lists clubs with anniversaries in the next 60 days, sorted by date
+   proximity. STUB — implementation lands in the GREEN commit. */
+
+export const UPCOMING_WINDOW_DAYS = 60
+
+export interface UpcomingAnniversariesPanelProps {
+  clubs: ClubTrend[]
+  /** Reference date for deterministic testing. Defaults to now. */
+  referenceDate?: Date
+  /** District id used for club detail links. */
+  districtId?: string
+  /** Initial visible row count before "Show all". */
+  initialRowLimit?: number
+}
+
+export const UpcomingAnniversariesPanel: React.FC<
+  UpcomingAnniversariesPanelProps
+> = () => {
+  return null
+}

--- a/frontend/src/components/UpcomingAnniversariesPanel.tsx
+++ b/frontend/src/components/UpcomingAnniversariesPanel.tsx
@@ -1,24 +1,199 @@
-import React from 'react'
+import React, { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import type { ClubTrend } from '../hooks/useDistrictAnalytics'
+import {
+  getClubAnniversary,
+  MILESTONE_YEARS,
+  type ClubAnniversary,
+} from '../utils/clubAnniversary'
 
 /* UpcomingAnniversariesPanel (#446) — district-level recognition planner.
-   Lists clubs with anniversaries in the next 60 days, sorted by date
-   proximity. STUB — implementation lands in the GREEN commit. */
+   Lists clubs with anniversaries in the next UPCOMING_WINDOW_DAYS days,
+   sorted by date proximity. */
 
 export const UPCOMING_WINDOW_DAYS = 60
+const DEFAULT_ROW_LIMIT = 5
 
 export interface UpcomingAnniversariesPanelProps {
   clubs: ClubTrend[]
-  /** Reference date for deterministic testing. Defaults to now. */
   referenceDate?: Date
-  /** District id used for club detail links. */
   districtId?: string
-  /** Initial visible row count before "Show all". */
   initialRowLimit?: number
 }
 
+interface Row {
+  club: ClubTrend
+  anniversary: ClubAnniversary
+}
+
+const ordinalSuffix = (n: number): string => {
+  const mod100 = n % 100
+  if (mod100 >= 11 && mod100 <= 13) return 'th'
+  const mod10 = n % 10
+  if (mod10 === 1) return 'st'
+  if (mod10 === 2) return 'nd'
+  if (mod10 === 3) return 'rd'
+  return 'th'
+}
+
+const buildRows = (
+  clubs: ClubTrend[],
+  referenceDate: Date | undefined
+): Row[] =>
+  clubs
+    .filter(c => !!c.charterDate)
+    .map(club => ({
+      club,
+      anniversary: getClubAnniversary(
+        club.charterDate as string,
+        referenceDate
+      ),
+    }))
+    .filter((r): r is Row => r.anniversary !== null)
+
 export const UpcomingAnniversariesPanel: React.FC<
   UpcomingAnniversariesPanelProps
-> = () => {
-  return null
+> = ({
+  clubs,
+  referenceDate,
+  districtId,
+  initialRowLimit = DEFAULT_ROW_LIMIT,
+}) => {
+  const [expanded, setExpanded] = useState(false)
+
+  const { upcoming, nextBeyondWindow } = useMemo(() => {
+    const all = buildRows(clubs, referenceDate)
+    const sorted = [...all].sort(
+      (a, b) => a.anniversary.daysUntilNext - b.anniversary.daysUntilNext
+    )
+    const upcoming = sorted.filter(
+      r => r.anniversary.daysUntilNext <= UPCOMING_WINDOW_DAYS
+    )
+    const nextBeyondWindow = upcoming.length === 0 ? (sorted[0] ?? null) : null
+    return { upcoming, nextBeyondWindow }
+  }, [clubs, referenceDate])
+
+  if (upcoming.length === 0) {
+    return (
+      <section
+        aria-labelledby="upcoming-anniversaries-heading"
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4 sm:p-6"
+      >
+        <h2
+          id="upcoming-anniversaries-heading"
+          className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+        >
+          Upcoming Anniversaries
+        </h2>
+        {nextBeyondWindow ? (
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+            All quiet on the anniversary front — next anniversary in{' '}
+            {nextBeyondWindow.anniversary.daysUntilNext} days at{' '}
+            <Link
+              to={`/club/${nextBeyondWindow.club.clubId}${
+                districtId ? `?district=${districtId}` : ''
+              }`}
+              className="text-tm-loyal-blue hover:underline"
+            >
+              {nextBeyondWindow.club.clubName}
+            </Link>
+            .
+          </p>
+        ) : (
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+            All quiet on the anniversary front — no charter dates available.
+          </p>
+        )}
+      </section>
+    )
+  }
+
+  const visible = expanded ? upcoming : upcoming.slice(0, initialRowLimit)
+  const hidden = upcoming.length - visible.length
+
+  return (
+    <section
+      aria-labelledby="upcoming-anniversaries-heading"
+      className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4 sm:p-6"
+    >
+      <h2
+        id="upcoming-anniversaries-heading"
+        className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+      >
+        Upcoming Anniversaries
+      </h2>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        Within the next {UPCOMING_WINDOW_DAYS} days
+      </p>
+      <ul className="mt-3 divide-y divide-gray-200 dark:divide-gray-700">
+        {visible.map(row => {
+          const { club, anniversary } = row
+          // For the upcoming panel, milestone means the UPCOMING anniversary
+          // year hits 5/10/15/... — distinct from isUpcomingMilestone,
+          // which fires on the CURRENT years count.
+          const isUpcomingMilestone = MILESTONE_YEARS.has(
+            anniversary.upcomingYears
+          )
+          const ord = `${anniversary.upcomingYears}${ordinalSuffix(
+            anniversary.upcomingYears
+          )}`
+          const dayCopy =
+            anniversary.daysUntilNext === 0
+              ? 'today'
+              : `in ${anniversary.daysUntilNext} day${
+                  anniversary.daysUntilNext === 1 ? '' : 's'
+                }`
+          return (
+            <li
+              key={club.clubId}
+              data-testid="upcoming-anniversary-row"
+              data-milestone={isUpcomingMilestone}
+              className={
+                'py-2 flex flex-wrap items-baseline gap-x-2 ' +
+                (isUpcomingMilestone
+                  ? 'bg-yellow-50/50 dark:bg-yellow-900/10 -mx-2 px-2 rounded'
+                  : '')
+              }
+            >
+              <Link
+                to={`/club/${club.clubId}${
+                  districtId ? `?district=${districtId}` : ''
+                }`}
+                className="font-medium text-tm-loyal-blue hover:underline"
+              >
+                {club.clubName}
+              </Link>
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                · {club.areaName}
+              </span>
+              <span
+                className={
+                  'text-sm ' +
+                  (isUpcomingMilestone
+                    ? 'font-semibold text-yellow-800 dark:text-yellow-200'
+                    : 'text-gray-700 dark:text-gray-300')
+                }
+              >
+                {ord} anniversary {dayCopy}
+              </span>
+              {isUpcomingMilestone && (
+                <span className="text-xs px-1.5 py-0.5 rounded-full bg-yellow-100 text-yellow-900 ring-1 ring-yellow-400 dark:bg-yellow-900/40 dark:text-yellow-100 dark:ring-yellow-500">
+                  🥇 milestone
+                </span>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+      {hidden > 0 && (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="mt-3 text-sm text-tm-loyal-blue hover:underline"
+        >
+          Show all ({upcoming.length})
+        </button>
+      )}
+    </section>
+  )
 }

--- a/frontend/src/components/__tests__/MilestonesCallout.test.tsx
+++ b/frontend/src/components/__tests__/MilestonesCallout.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import '@testing-library/jest-dom'
+import { MilestonesCallout } from '../MilestonesCallout'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+/* Sprint C RED tests for #447. Pinned to PY 2025-2026
+   (Jul 1 2025 → Jun 30 2026). */
+
+afterEach(() => cleanup())
+
+const PY_START = 2025
+
+const mkClub = (overrides: Partial<ClubTrend>): ClubTrend => ({
+  clubId: '0',
+  clubName: 'Test Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '01',
+  areaName: 'Area 01',
+  membershipTrend: [],
+  dcpGoalsTrend: [],
+  currentStatus: 'thriving',
+  riskFactors: [],
+  distinguishedLevel: 'NotDistinguished',
+  ...overrides,
+})
+
+const renderCallout = (clubs: ClubTrend[]) =>
+  render(
+    <MemoryRouter>
+      <MilestonesCallout
+        clubs={clubs}
+        programYearStart={PY_START}
+        districtId="61"
+      />
+    </MemoryRouter>
+  )
+
+describe('MilestonesCallout (#447)', () => {
+  it('renders empty state with the next upcoming milestone when no milestones fall in the program year', () => {
+    // Charter 2024-06-01 → will hit 5y on 2029-06-01 → outside PY 2025-2026
+    const clubs = [
+      mkClub({
+        clubId: '1',
+        clubName: 'Brand New Club',
+        charterDate: '2024-06-01',
+      }),
+    ]
+    renderCallout(clubs)
+    expect(screen.getByText(/no milestones/i)).toBeInTheDocument()
+    expect(screen.getByText(/Brand New Club/)).toBeInTheDocument()
+  })
+
+  it('lists milestone clubs grouped by milestone year in descending order', () => {
+    const clubs = [
+      // 25y milestone: charter 2000-08-15 → 25y on 2025-08-15 (in PY)
+      mkClub({
+        clubId: '1',
+        clubName: 'Twenty-Five Years Club',
+        charterDate: '2000-08-15',
+      }),
+      // 10y milestone: charter 2015-09-01 → 10y on 2025-09-01 (in PY)
+      mkClub({
+        clubId: '2',
+        clubName: 'Ten Years Club',
+        charterDate: '2015-09-01',
+      }),
+      // 50y milestone: charter 1975-11-12 → 50y on 2025-11-12 (in PY)
+      mkClub({
+        clubId: '3',
+        clubName: 'Fifty Years Club',
+        charterDate: '1975-11-12',
+      }),
+    ]
+    renderCallout(clubs)
+    const groups = screen.getAllByTestId('milestone-group')
+    expect(groups).toHaveLength(3)
+    // Descending order: 50 → 25 → 10
+    expect(within(groups[0]!).getByText(/50 Years/i)).toBeInTheDocument()
+    expect(within(groups[1]!).getByText(/25 Years/i)).toBeInTheDocument()
+    expect(within(groups[2]!).getByText(/10 Years/i)).toBeInTheDocument()
+    expect(
+      within(groups[0]!).getByText(/Fifty Years Club/i)
+    ).toBeInTheDocument()
+    expect(
+      within(groups[1]!).getByText(/Twenty-Five Years Club/i)
+    ).toBeInTheDocument()
+    expect(within(groups[2]!).getByText(/Ten Years Club/i)).toBeInTheDocument()
+  })
+
+  it('within a group, sorts clubs by anniversary date ascending', () => {
+    // Two 10y milestones: 2015-09-01 (earlier) and 2015-12-20 (later)
+    const clubs = [
+      mkClub({
+        clubId: '1',
+        clubName: 'December Anniversary',
+        charterDate: '2015-12-20',
+      }),
+      mkClub({
+        clubId: '2',
+        clubName: 'September Anniversary',
+        charterDate: '2015-09-01',
+      }),
+    ]
+    renderCallout(clubs)
+    const group = screen.getByTestId('milestone-group')
+    const clubLinks = within(group).getAllByTestId('milestone-club')
+    expect(clubLinks[0]).toHaveTextContent(/September Anniversary/)
+    expect(clubLinks[1]).toHaveTextContent(/December Anniversary/)
+  })
+
+  it('respects program year boundaries — Jul 1 inclusive, Jun 30 inclusive', () => {
+    // PY 2025-2026 = 2025-07-01 → 2026-06-30
+    const clubs = [
+      // Charter 2020-07-01 → 5y on 2025-07-01 (PY start, inclusive)
+      mkClub({
+        clubId: '1',
+        clubName: 'PY Start Club',
+        charterDate: '2020-07-01',
+      }),
+      // Charter 2020-06-30 → 5y on 2025-06-30 (one day before PY → excluded)
+      mkClub({
+        clubId: '2',
+        clubName: 'Before PY Club',
+        charterDate: '2020-06-30',
+      }),
+      // Charter 2021-06-30 → 5y on 2026-06-30 (PY end, inclusive)
+      mkClub({
+        clubId: '3',
+        clubName: 'PY End Club',
+        charterDate: '2021-06-30',
+      }),
+      // Charter 2021-07-01 → 5y on 2026-07-01 (one day after PY → excluded)
+      mkClub({
+        clubId: '4',
+        clubName: 'After PY Club',
+        charterDate: '2021-07-01',
+      }),
+    ]
+    renderCallout(clubs)
+    expect(screen.getByText(/PY Start Club/)).toBeInTheDocument()
+    expect(screen.getByText(/PY End Club/)).toBeInTheDocument()
+    expect(screen.queryByText(/Before PY Club/)).toBeNull()
+    expect(screen.queryByText(/After PY Club/)).toBeNull()
+  })
+
+  it('skips clubs without a charterDate', () => {
+    const clubs = [
+      mkClub({ clubId: '1', clubName: 'No Charter' }),
+      mkClub({
+        clubId: '2',
+        clubName: 'Has Charter',
+        charterDate: '2000-08-15',
+      }),
+    ]
+    renderCallout(clubs)
+    expect(screen.queryByText(/No Charter/)).toBeNull()
+    expect(screen.getByText(/Has Charter/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/UpcomingAnniversariesPanel.test.tsx
+++ b/frontend/src/components/__tests__/UpcomingAnniversariesPanel.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import '@testing-library/jest-dom'
+import { UpcomingAnniversariesPanel } from '../UpcomingAnniversariesPanel'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+/* Sprint C RED tests for #446. Reference date pinned to 2026-05-15 so
+   tests don't drift with calendar time. */
+
+afterEach(() => cleanup())
+
+const REF = new Date('2026-05-15T12:00:00Z')
+
+const mkClub = (overrides: Partial<ClubTrend>): ClubTrend => ({
+  clubId: '0',
+  clubName: 'Test Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '01',
+  areaName: 'Area 01',
+  membershipTrend: [],
+  dcpGoalsTrend: [],
+  currentStatus: 'thriving',
+  riskFactors: [],
+  distinguishedLevel: 'NotDistinguished',
+  ...overrides,
+})
+
+const renderPanel = (
+  clubs: ClubTrend[],
+  props: { initialRowLimit?: number } = {}
+) =>
+  render(
+    <MemoryRouter>
+      <UpcomingAnniversariesPanel
+        clubs={clubs}
+        referenceDate={REF}
+        districtId="61"
+        {...props}
+      />
+    </MemoryRouter>
+  )
+
+describe('UpcomingAnniversariesPanel (#446)', () => {
+  it('renders empty state with a forward-looking next anniversary when no clubs are within the 60-day window', () => {
+    // Club's anniversary is 200 days away — outside the window.
+    const clubs = [
+      mkClub({
+        clubId: '1',
+        clubName: 'Far Future Club',
+        // 200 days after 2026-05-15 ≈ 2026-12-01 → use a charter 200d earlier
+        // We pick a clear date well outside ±60.
+        charterDate: '2000-12-01',
+      }),
+    ]
+    renderPanel(clubs)
+    expect(screen.getByText(/all quiet/i)).toBeInTheDocument()
+    expect(screen.getByText(/Far Future Club/i)).toBeInTheDocument()
+  })
+
+  it('lists clubs whose next anniversary falls within 60 days, sorted by daysUntilNext ascending', () => {
+    const clubs = [
+      mkClub({
+        clubId: '1',
+        clubName: 'Three Weeks Away',
+        // 21 days after 2026-05-15 → 2026-06-05
+        charterDate: '2010-06-05',
+      }),
+      mkClub({
+        clubId: '2',
+        clubName: 'Five Days Away',
+        // 5 days after 2026-05-15 → 2026-05-20
+        charterDate: '2015-05-20',
+      }),
+      mkClub({
+        clubId: '3',
+        clubName: 'Outside Window',
+        charterDate: '2010-12-01',
+      }),
+    ]
+    renderPanel(clubs)
+    const rows = screen.getAllByTestId('upcoming-anniversary-row')
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toHaveTextContent(/Five Days Away/)
+    expect(rows[1]).toHaveTextContent(/Three Weeks Away/)
+  })
+
+  it('caps the visible list to initialRowLimit by default and reveals the rest after "Show all"', () => {
+    // 6 clubs all within window → only 5 visible initially
+    const clubs = Array.from({ length: 6 }, (_, i) =>
+      mkClub({
+        clubId: String(i + 1),
+        clubName: `Club ${i + 1}`,
+        // Spread anniversaries 5-30 days out from REF.
+        charterDate: new Date(REF.getTime() + (5 + i * 5) * 24 * 60 * 60 * 1000)
+          .toISOString()
+          .slice(0, 10),
+      })
+    )
+    renderPanel(clubs, { initialRowLimit: 5 })
+    expect(screen.getAllByTestId('upcoming-anniversary-row')).toHaveLength(5)
+    fireEvent.click(screen.getByRole('button', { name: /show all/i }))
+    expect(screen.getAllByTestId('upcoming-anniversary-row')).toHaveLength(6)
+  })
+
+  it('visually elevates milestone anniversaries with data-milestone="true"', () => {
+    const clubs = [
+      mkClub({
+        clubId: '1',
+        clubName: 'Twenty-Five Year Club',
+        // Charter exactly 25y minus 10d before REF (so 25y anniv ≈ 10d away,
+        // upcoming milestone). REF = 2026-05-15, charter = 2001-05-25.
+        charterDate: '2001-05-25',
+      }),
+    ]
+    renderPanel(clubs)
+    expect(
+      screen
+        .getByText(/Twenty-Five Year Club/i)
+        .closest('[data-milestone="true"]')
+    ).not.toBeNull()
+  })
+
+  it('skips clubs without a charterDate', () => {
+    const clubs = [
+      mkClub({ clubId: '1', clubName: 'No Charter' }),
+      mkClub({
+        clubId: '2',
+        clubName: 'Has Charter',
+        charterDate: '2015-05-20',
+      }),
+    ]
+    renderPanel(clubs)
+    expect(screen.queryByText(/No Charter/)).toBeNull()
+    expect(screen.getByText(/Has Charter/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -35,6 +35,8 @@ import {
 } from '../utils/filterUrlCodec'
 import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
 import { DistrictOverview } from '../components/DistrictOverview'
+import { UpcomingAnniversariesPanel } from '../components/UpcomingAnniversariesPanel'
+import { MilestonesCallout } from '../components/MilestonesCallout'
 import DataAsOfBanner from '../components/DataAsOfBanner'
 import { DistinguishedDistrictTrophyCase } from '../components/DistinguishedDistrictTrophyCase'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
@@ -645,6 +647,15 @@ const DistrictDetailPage: React.FC = () => {
                       officerAwardsResult?.clubGrowth?.qualifies
                     }
                   />
+
+                  {/* Club Anniversaries (#443 epic). Two surfaces:
+                    - Upcoming anniversaries within 60 days (#446)
+                    - Milestone clubs in the current program year (#447) */}
+                  <UpcomingAnniversariesPanel
+                    clubs={allClubs}
+                    districtId={districtId}
+                  />
+                  <MilestonesCallout clubs={allClubs} districtId={districtId} />
 
                   {/* Payment Composition + Distinguished Progress legacy
                     sections retired in #472 — the new redesign panels in

--- a/frontend/src/utils/clubAnniversary.ts
+++ b/frontend/src/utils/clubAnniversary.ts
@@ -30,7 +30,7 @@ export interface ClubAnniversary {
   upcomingYears: number
 }
 
-const MILESTONE_YEARS: ReadonlySet<number> = new Set([
+export const MILESTONE_YEARS: ReadonlySet<number> = new Set([
   5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100,
 ])
 

--- a/tasks/lessons/055-anniversary-isMilestone-vs-upcomingYears.md
+++ b/tasks/lessons/055-anniversary-isMilestone-vs-upcomingYears.md
@@ -1,0 +1,55 @@
+# Lesson 55 — `isMilestone` fires on `years`, not `upcomingYears`
+
+**Date:** 2026-05-12
+**Sprint:** /sprint 443-448 (Club Anniversaries epic, Sprint C)
+**PR:** #507
+
+## What happened
+
+The `UpcomingAnniversariesPanel.test.tsx` test "visually elevates milestone
+anniversaries with `data-milestone='true'`" failed against the first GREEN
+implementation. The test charter date `2001-05-25` against REF
+`2026-05-15` produces:
+
+- `years: 24` (anniversary hasn't happened yet this year)
+- `upcomingYears: 25`
+- `isMilestone: false` (because `MILESTONE_YEARS.has(24)` is false)
+
+The panel was using `anniversary.isMilestone` directly, so a club ten days
+away from its 25-year milestone was rendered as a non-milestone row. From
+a recognition standpoint that is exactly backwards — the whole point of
+the upcoming panel is to surface those clubs **before** the milestone
+date.
+
+## Root cause
+
+`getClubAnniversary()` is the foundation utility (#444). It returns
+`isMilestone` based on **current `years` count**, which is the right
+default for "is the club CURRENTLY at a milestone year." But for "upcoming
+panel" semantics — "is the next anniversary a milestone" — that flag is
+wrong by one year for ~365 days a year.
+
+## How to apply
+
+Two consumers of the same utility, two different milestone questions:
+
+- **ClubAnniversaryBadge** (hero / steady-state display): `isMilestone`
+  correctly fires for the year the club is currently celebrating.
+- **UpcomingAnniversariesPanel** (forward-looking recognition planner):
+  derive the flag locally from `MILESTONE_YEARS.has(upcomingYears)`.
+
+`MILESTONE_YEARS` is now exported from `clubAnniversary.ts` for exactly
+this reason — consumers with different temporal framing recompute the
+flag themselves rather than asking the utility to take a side.
+
+**Why this is a lesson, not just a bug fix:** the temptation when adding
+a new consumer is to extend the utility ("just add an `isUpcomingMilestone`
+field"). That balloons the contract for every caller. Letting consumers
+derive their own framing keeps the utility tight and forces the question
+"which `years` count do I actually care about?" to surface at the call
+site.
+
+## Related
+
+- `frontend/src/components/UpcomingAnniversariesPanel.tsx:130-136`
+- `frontend/src/utils/clubAnniversary.ts:33` — `MILESTONE_YEARS` export


### PR DESCRIPTION
## Summary

Sprint C of the Club Anniversaries epic (#443). Adds two district-level recognition surfaces to the Overview tab, below the Distinguished District Trophy Case.

- **UpcomingAnniversariesPanel (#446)** — clubs whose next anniversary is within the next 60 days, sorted by date proximity. Compact 5-row default with "Show all". Milestone (5/10/15/.../100y) rows visually elevated. Empty state surfaces the next anniversary outside the window so directors still have a forward-looking signal.
- **MilestonesCallout (#447)** — clubs hitting a milestone anniversary within the current program year (Jul 1 → Jun 30 inclusive), grouped by milestone year descending (50y before 25y before 10y). Within a group, clubs sort by anniversary date ascending. Empty state walks forward to find the next future milestone for any club.

## Implementation notes

- `MILESTONE_YEARS` exported from `clubAnniversary.ts` so both surfaces consume the same definition.
- UpcomingAnniversariesPanel derives its own milestone flag from `upcomingYears` (not `anniversary.isMilestone`), because the latter fires on the CURRENT years count — which is N-1 when the anniversary hasn't happened yet.
- MilestonesCallout uses custom anniversary-in-PY math rather than `getClubAnniversary` because PY-window semantics differ from from-today semantics.
- Both panels handle missing charterDate gracefully (skip the club).
- Feb 29 charter dates fall back to Feb 28 in non-leap years (defensive — not yet tested).

## Stacking

Sprint C is chained onto Sprint B (#506). Base branch is the Sprint B branch so the diff reads cleanly. Will rebase to main after Sprint B merges.

## Test plan

- [x] 5 RED + 5 GREEN tests for UpcomingAnniversariesPanel
- [x] 5 RED + 5 GREEN tests for MilestonesCallout
- [x] Both panels GREEN; full suite 2262/2264 (the 2 failures repro only under heavy parallelism — both pass in isolation and were not introduced by this change)
- [x] TypeScript clean
- [ ] Manual: verify both panels render on district detail Overview tab
- [ ] Manual: verify mobile responsive at 375px

Closes #446, #447. Part of #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)