### PR TITLE
fix(anniversary): every multiple of 5 is a milestone, unbounded (#509)

### DIFF
--- a/frontend/src/components/MilestonesCallout.tsx
+++ b/frontend/src/components/MilestonesCallout.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import type { ClubTrend } from '../hooks/useDistrictAnalytics'
-import { MILESTONE_YEARS } from '../utils/clubAnniversary'
+import { isMilestoneYear } from '../utils/clubAnniversary'
 import { getCurrentProgramYear } from '../utils/programYear'
 
 /* MilestonesCallout (#447) — district-level program-year milestone roster.
@@ -110,7 +110,7 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
       if (!annivInPy) continue
       const yearsAtAnniv = annivInPy.getUTCFullYear() - charter.getUTCFullYear()
       if (yearsAtAnniv <= 0) continue
-      if (MILESTONE_YEARS.has(yearsAtAnniv)) {
+      if (isMilestoneYear(yearsAtAnniv)) {
         milestones.push({
           club,
           milestoneYears: yearsAtAnniv,
@@ -126,7 +126,7 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
       let candidateYear = today.getUTCFullYear()
       while (candidateYear - charter.getUTCFullYear() <= 101) {
         const years = candidateYear - charter.getUTCFullYear()
-        if (years > 0 && MILESTONE_YEARS.has(years)) {
+        if (isMilestoneYear(years)) {
           const d = new Date(Date.UTC(candidateYear, charterMonth, charterDay))
           if (d.getTime() >= today.getTime()) {
             upcomingCandidates.push({

--- a/frontend/src/components/UpcomingAnniversariesPanel.tsx
+++ b/frontend/src/components/UpcomingAnniversariesPanel.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import type { ClubTrend } from '../hooks/useDistrictAnalytics'
 import {
   getClubAnniversary,
-  MILESTONE_YEARS,
+  isMilestoneYear,
   type ClubAnniversary,
 } from '../utils/clubAnniversary'
 
@@ -131,9 +131,7 @@ export const UpcomingAnniversariesPanel: React.FC<
           // For the upcoming panel, milestone means the UPCOMING anniversary
           // year hits 5/10/15/... — distinct from isUpcomingMilestone,
           // which fires on the CURRENT years count.
-          const isUpcomingMilestone = MILESTONE_YEARS.has(
-            anniversary.upcomingYears
-          )
+          const isUpcomingMilestone = isMilestoneYear(anniversary.upcomingYears)
           const ord = `${anniversary.upcomingYears}${ordinalSuffix(
             anniversary.upcomingYears
           )}`

--- a/frontend/src/utils/__tests__/clubAnniversary.test.ts
+++ b/frontend/src/utils/__tests__/clubAnniversary.test.ts
@@ -64,6 +64,9 @@ describe('getClubAnniversary (#444)', () => {
   })
 
   describe('milestone flag', () => {
+    // #509 — every multiple of 5 from 5 through 100 is a milestone.
+    // Districts recognize 35/45/55/65/70/etc. anniversaries even though
+    // TI doesn't issue recognition pins for those exact increments.
     it.each([
       [5, true],
       [10, true],
@@ -71,10 +74,19 @@ describe('getClubAnniversary (#444)', () => {
       [20, true],
       [25, true],
       [30, true],
+      [35, true],
       [40, true],
+      [45, true],
       [50, true],
+      [55, true],
       [60, true],
+      [65, true],
+      [70, true],
       [75, true],
+      [80, true],
+      [85, true],
+      [90, true],
+      [95, true],
       [100, true],
     ])('marks %d years as a milestone', (y, expected) => {
       const charter = `${2026 - y}-05-12`
@@ -87,15 +99,9 @@ describe('getClubAnniversary (#444)', () => {
       [1, false],
       [3, false],
       [7, false],
-      [35, false],
-      [45, false],
-      [55, false],
-      [65, false],
-      [70, false],
-      [80, false],
-      [85, false],
-      [90, false],
-      [95, false],
+      [11, false],
+      [42, false],
+      [99, false],
     ])('does NOT mark %d years as a milestone', (y, expected) => {
       const charter = `${2026 - y}-05-12`
       const result = getClubAnniversary(charter, ref('2026-05-12'))

--- a/frontend/src/utils/clubAnniversary.ts
+++ b/frontend/src/utils/clubAnniversary.ts
@@ -14,10 +14,11 @@
 export interface ClubAnniversary {
   /** Whole years since charter, measured against referenceDate. */
   years: number
-  /** True for 5-year increments per the Toastmasters recognition set:
-   *  5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100.
-   *  Note: 35, 45, 55, 65, 70, 80, 85, 90, 95 are NOT milestones —
-   *  TI doesn't issue recognition pins for those increments. */
+  /** True for every multiple of 5 years (5, 10, 15, ... unbounded above).
+   *  Districts recognize every 5-year anniversary; TI's recognition-pin
+   *  schedule is more selective but irrelevant for district-level planning.
+   *  Note: TI was founded in 1924, so 105+y milestones start appearing
+   *  in 2029 — keep this rule unbounded. */
   isMilestone: boolean
   /** Days until the next anniversary. Zero on the exact day; never
    *  negative (always in [0, ~365]). */
@@ -30,9 +31,10 @@ export interface ClubAnniversary {
   upcomingYears: number
 }
 
-export const MILESTONE_YEARS: ReadonlySet<number> = new Set([
-  5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100,
-])
+/** True for every multiple of 5 years from 5 upward. See ClubAnniversary
+ *  doc-comment for rationale. */
+export const isMilestoneYear = (years: number): boolean =>
+  Number.isInteger(years) && years >= 5 && years % 5 === 0
 
 const UPCOMING_WINDOW_DAYS = 30
 const MIN_YEAR = 1900
@@ -128,7 +130,7 @@ export function getClubAnniversary(
 
   return {
     years,
-    isMilestone: MILESTONE_YEARS.has(years),
+    isMilestone: isMilestoneYear(years),
     daysUntilNext,
     isUpcoming,
     upcomingYears,

--- a/tasks/lessons/055-anniversary-isMilestone-vs-upcomingYears.md
+++ b/tasks/lessons/055-anniversary-isMilestone-vs-upcomingYears.md
@@ -38,9 +38,12 @@ Two consumers of the same utility, two different milestone questions:
 - **UpcomingAnniversariesPanel** (forward-looking recognition planner):
   derive the flag locally from `MILESTONE_YEARS.has(upcomingYears)`.
 
-`MILESTONE_YEARS` is now exported from `clubAnniversary.ts` for exactly
+`isMilestoneYear()` is exported from `clubAnniversary.ts` for exactly
 this reason — consumers with different temporal framing recompute the
-flag themselves rather than asking the utility to take a side.
+flag themselves rather than asking the utility to take a side. (Originally
+exported as the Set `MILESTONE_YEARS`; later refactored to a predicate
+function in #509 once the rule shifted to "every multiple of 5,
+unbounded" — TI was founded in 1924 so 105+y milestones appear in 2029.)
 
 **Why this is a lesson, not just a bug fix:** the temptation when adding
 a new consumer is to extend the utility ("just add an `isUpcomingMilestone`
@@ -51,5 +54,6 @@ site.
 
 ## Related
 
-- `frontend/src/components/UpcomingAnniversariesPanel.tsx:130-136`
-- `frontend/src/utils/clubAnniversary.ts:33` — `MILESTONE_YEARS` export
+- `frontend/src/components/UpcomingAnniversariesPanel.tsx` — `isMilestoneYear(anniversary.upcomingYears)`
+- `frontend/src/utils/clubAnniversary.ts` — `isMilestoneYear()` export
+- #509 — widening the rule from TI's recognition-pin schedule to every-multiple-of-5


### PR DESCRIPTION
## Summary

District 61 has clubs hitting 65 and 70 years that weren't showing up on the anniversary surfaces because MILESTONE_YEARS was capped at TI's recognition-pin schedule (5/10/15/20/25/30/40/50/60/75/100). Per founder, every 5-year mark is a milestone for district-level recognition planning. Also: TI was founded in 1924, so 105+y milestones start appearing in 2029 — the rule must be unbounded above.

## Changes

- Replaces \`MILESTONE_YEARS\` Set with \`isMilestoneYear(years)\` predicate (\`years >= 5 && years % 5 === 0\`).
- Updates \`UpcomingAnniversariesPanel\` and \`MilestonesCallout\` to use the predicate.
- Tightens \`clubAnniversary.test.ts\` to require 35/45/55/65/70/80/85/90/95 to be milestones.
- Amends Lesson 55 to note the refactor + rationale.

## Test plan

- [x] 20 GREEN tests for milestone-flag predicate (every multiple of 5 from 5 to 100)
- [x] 6 GREEN tests for non-milestone years (1, 3, 7, 11, 42, 99)
- [x] All 61 anniversary-related tests pass
- [x] TypeScript clean

Closes #509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)