### PR TITLE
fix(anniversary): tighter, denser layout per design handoff (#511)

### DIFF
--- a/frontend/src/components/MilestonesCallout.tsx
+++ b/frontend/src/components/MilestonesCallout.tsx
@@ -4,9 +4,8 @@ import type { ClubTrend } from '../hooks/useDistrictAnalytics'
 import { isMilestoneYear } from '../utils/clubAnniversary'
 import { getCurrentProgramYear } from '../utils/programYear'
 
-/* MilestonesCallout (#447) — district-level program-year milestone roster.
-   Groups clubs hitting a 5/10/15/.../100 year milestone within the
-   program year window (Jul 1 → Jun 30 inclusive). */
+/* MilestonesCallout (#447 / #511) — district-level program-year
+   milestone roster. Tight, single-line groups per milestone year. */
 
 export interface MilestonesCalloutProps {
   clubs: ClubTrend[]
@@ -26,8 +25,6 @@ interface NextUpcomingEntry {
   anniversaryDate: Date
 }
 
-/* Parse a Toastmasters charter date in UTC, supporting ISO YYYY-MM-DD and
-   the legacy /Date(ms)/ format the TI Find-A-Club endpoint returns. */
 const parseCharterUtc = (input: string): Date | null => {
   const dotNetMatch = /^\/Date\((-?\d+)\)\/$/.exec(input)
   if (dotNetMatch) {
@@ -49,38 +46,29 @@ const parseCharterUtc = (input: string): Date | null => {
 }
 
 const MONTHS = [
-  'January',
-  'February',
-  'March',
-  'April',
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
   'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
 ]
 
-const formatAnniversaryDate = (d: Date): string =>
-  `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`
-
-const formatCharterMonth = (d: Date): string =>
+const formatShortDate = (d: Date): string =>
   `${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`
 
-/* Compute the anniversary date that falls inside the program year window.
-   Falls back to Feb 28 if the charter is Feb 29 and the anniversary year
-   is non-leap. Returns null when no anniversary falls in the window. */
 const anniversaryInProgramYear = (
   charter: Date,
   programYearStart: number
 ): Date | null => {
   const charterMonth = charter.getUTCMonth()
   const charterDay = charter.getUTCDate()
-  // Anniversary year inside the window:
-  //   month >= 6 (Jul-Dec): in programYearStart
-  //   month <  6 (Jan-Jun): in programYearStart + 1
   const annivYear = charterMonth >= 6 ? programYearStart : programYearStart + 1
   let day = charterDay
   if (charterMonth === 1 && charterDay === 29) {
@@ -98,7 +86,7 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
 }) => {
   const pyStart = programYearStart ?? getCurrentProgramYear().year
 
-  const { groups, nextUpcoming, pyLabel } = useMemo(() => {
+  const { groups, nextUpcoming, pyLabel, totalCount } = useMemo(() => {
     const milestones: MilestoneEntry[] = []
     const upcomingCandidates: NextUpcomingEntry[] = []
 
@@ -118,8 +106,6 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
         })
         continue
       }
-      // Not a milestone in this PY — find the next future milestone
-      // anniversary so the empty state can point somewhere useful.
       const charterMonth = charter.getUTCMonth()
       const charterDay = charter.getUTCDate()
       const today = new Date()
@@ -141,7 +127,6 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
       }
     }
 
-    // Group milestones by year, descending.
     const grouped = new Map<number, MilestoneEntry[]>()
     for (const entry of milestones) {
       const arr = grouped.get(entry.milestoneYears) ?? []
@@ -167,39 +152,38 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
         : null
 
     const pyLabel = `${pyStart}-${(pyStart + 1).toString().slice(-2)}`
+    const totalCount = milestones.length
 
-    return { groups, nextUpcoming, pyLabel }
+    return { groups, nextUpcoming, pyLabel, totalCount }
   }, [clubs, pyStart])
+
+  const clubHref = (clubId: string) =>
+    `/club/${clubId}${districtId ? `?district=${districtId}` : ''}`
 
   if (groups.length === 0) {
     return (
-      <section
-        aria-labelledby="milestones-heading"
-        className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4 sm:p-6"
-      >
-        <h2
-          id="milestones-heading"
-          className="text-lg font-semibold text-gray-900 dark:text-gray-100"
-        >
-          Milestones — Program Year {pyLabel}
-        </h2>
+      <section aria-labelledby="milestones-heading" className="redesign-panel">
+        <h3 id="milestones-heading" className="redesign-panel__header">
+          Milestones · PY {pyLabel}
+        </h3>
         {nextUpcoming ? (
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-            No milestones in this program year — next milestone is{' '}
+          <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+            None this PY — next is{' '}
             <Link
-              to={`/club/${nextUpcoming.club.clubId}${
-                districtId ? `?district=${districtId}` : ''
-              }`}
+              to={clubHref(nextUpcoming.club.clubId)}
               className="text-tm-loyal-blue hover:underline"
             >
               {nextUpcoming.club.clubName}
             </Link>{' '}
-            at {nextUpcoming.milestoneYears} years on{' '}
-            {formatAnniversaryDate(nextUpcoming.anniversaryDate)}.
+            at{' '}
+            <strong className="font-semibold text-gray-700 dark:text-gray-200">
+              {nextUpcoming.milestoneYears}y
+            </strong>{' '}
+            in {formatShortDate(nextUpcoming.anniversaryDate)}.
           </p>
         ) : (
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-            No milestones in this program year.
+          <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+            None this PY.
           </p>
         )}
       </section>
@@ -207,59 +191,52 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
   }
 
   return (
-    <section
-      aria-labelledby="milestones-heading"
-      className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4 sm:p-6"
-    >
-      <h2
-        id="milestones-heading"
-        className="text-lg font-semibold text-gray-900 dark:text-gray-100"
-      >
-        Milestones — Program Year {pyLabel}
-      </h2>
-      <div className="mt-3 space-y-4">
-        {groups.map(group => (
-          <div key={group.years} data-testid="milestone-group">
-            <h3 className="text-sm font-semibold text-yellow-900 dark:text-yellow-200">
-              🥇 {group.years} Years
-            </h3>
-            <ul className="mt-1 divide-y divide-gray-200 dark:divide-gray-700">
-              {group.entries.map(entry => {
-                const charter = parseCharterUtc(
-                  entry.club.charterDate as string
-                )
-                return (
-                  <li
-                    key={entry.club.clubId}
-                    className="py-2 text-sm flex flex-wrap items-baseline gap-x-2"
-                  >
-                    <Link
-                      data-testid="milestone-club"
-                      to={`/club/${entry.club.clubId}${
-                        districtId ? `?district=${districtId}` : ''
-                      }`}
-                      className="font-medium text-tm-loyal-blue hover:underline"
-                    >
-                      {entry.club.clubName}
-                    </Link>
-                    {charter && (
-                      <span className="text-gray-500 dark:text-gray-400">
-                        · chartered {formatCharterMonth(charter)}
-                      </span>
-                    )}
-                    <span className="text-gray-500 dark:text-gray-400">
-                      · {entry.club.areaName}
-                    </span>
-                    <span className="text-gray-500 dark:text-gray-400">
-                      · {entry.club.divisionName}
-                    </span>
-                  </li>
-                )
-              })}
-            </ul>
-          </div>
-        ))}
+    <section aria-labelledby="milestones-heading" className="redesign-panel">
+      <div className="flex items-baseline justify-between gap-2 mb-2">
+        <h3 id="milestones-heading" className="redesign-panel__header !mb-0">
+          Milestones · PY {pyLabel}
+        </h3>
+        <span className="text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400 font-tm-body">
+          {totalCount} club{totalCount === 1 ? '' : 's'}
+        </span>
       </div>
+      <ul className="divide-y divide-gray-100 dark:divide-gray-800 -mx-1">
+        {groups.map(group => (
+          <li
+            key={group.years}
+            data-testid="milestone-group"
+            className="flex items-baseline gap-3 px-2 py-1.5 text-sm font-tm-body"
+          >
+            <span className="w-10 shrink-0 tabular-nums text-xs font-bold text-tm-true-maroon">
+              {group.years} Years
+            </span>
+            <span className="flex-1 min-w-0 flex flex-wrap gap-x-2 gap-y-0.5">
+              {group.entries.map((entry, i) => (
+                <span
+                  key={entry.club.clubId}
+                  className="inline-flex items-baseline gap-1"
+                >
+                  <Link
+                    data-testid="milestone-club"
+                    to={clubHref(entry.club.clubId)}
+                    className="text-tm-loyal-blue hover:underline truncate"
+                  >
+                    {entry.club.clubName}
+                  </Link>
+                  <span className="text-[11px] text-gray-500 dark:text-gray-400 tabular-nums">
+                    {formatShortDate(entry.anniversaryDate)}
+                  </span>
+                  {i < group.entries.length - 1 && (
+                    <span aria-hidden="true" className="text-gray-300">
+                      ·
+                    </span>
+                  )}
+                </span>
+              ))}
+            </span>
+          </li>
+        ))}
+      </ul>
     </section>
   )
 }

--- a/frontend/src/components/UpcomingAnniversariesPanel.tsx
+++ b/frontend/src/components/UpcomingAnniversariesPanel.tsx
@@ -7,9 +7,9 @@ import {
   type ClubAnniversary,
 } from '../utils/clubAnniversary'
 
-/* UpcomingAnniversariesPanel (#446) — district-level recognition planner.
-   Lists clubs with anniversaries in the next UPCOMING_WINDOW_DAYS days,
-   sorted by date proximity. */
+/* UpcomingAnniversariesPanel (#446 / #511) — district-level recognition
+   planner. Tight, dense rows of clubs whose next anniversary is within
+   UPCOMING_WINDOW_DAYS days, sorted by date proximity. */
 
 export const UPCOMING_WINDOW_DAYS = 60
 const DEFAULT_ROW_LIMIT = 5
@@ -73,35 +73,38 @@ export const UpcomingAnniversariesPanel: React.FC<
     return { upcoming, nextBeyondWindow }
   }, [clubs, referenceDate])
 
+  const clubHref = (clubId: string) =>
+    `/club/${clubId}${districtId ? `?district=${districtId}` : ''}`
+
   if (upcoming.length === 0) {
     return (
       <section
         aria-labelledby="upcoming-anniversaries-heading"
-        className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4 sm:p-6"
+        className="redesign-panel"
       >
-        <h2
+        <h3
           id="upcoming-anniversaries-heading"
-          className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+          className="redesign-panel__header"
         >
-          Upcoming Anniversaries
-        </h2>
+          Upcoming anniversaries
+        </h3>
         {nextBeyondWindow ? (
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-            All quiet on the anniversary front — next anniversary in{' '}
-            {nextBeyondWindow.anniversary.daysUntilNext} days at{' '}
+          <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+            All quiet — next in{' '}
+            <strong className="font-semibold text-gray-700 dark:text-gray-200">
+              {nextBeyondWindow.anniversary.daysUntilNext}d
+            </strong>{' '}
+            at{' '}
             <Link
-              to={`/club/${nextBeyondWindow.club.clubId}${
-                districtId ? `?district=${districtId}` : ''
-              }`}
+              to={clubHref(nextBeyondWindow.club.clubId)}
               className="text-tm-loyal-blue hover:underline"
             >
               {nextBeyondWindow.club.clubName}
             </Link>
-            .
           </p>
         ) : (
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-            All quiet on the anniversary front — no charter dates available.
+          <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+            All quiet — no charter dates available.
           </p>
         )}
       </section>
@@ -114,23 +117,25 @@ export const UpcomingAnniversariesPanel: React.FC<
   return (
     <section
       aria-labelledby="upcoming-anniversaries-heading"
-      className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4 sm:p-6"
+      className="redesign-panel"
     >
-      <h2
-        id="upcoming-anniversaries-heading"
-        className="text-lg font-semibold text-gray-900 dark:text-gray-100"
-      >
-        Upcoming Anniversaries
-      </h2>
-      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-        Within the next {UPCOMING_WINDOW_DAYS} days
-      </p>
-      <ul className="mt-3 divide-y divide-gray-200 dark:divide-gray-700">
+      <div className="flex items-baseline justify-between gap-2 mb-2">
+        <h3
+          id="upcoming-anniversaries-heading"
+          className="redesign-panel__header !mb-0"
+        >
+          Upcoming anniversaries
+        </h3>
+        <span className="text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400 font-tm-body">
+          Next {UPCOMING_WINDOW_DAYS}d · {upcoming.length}
+        </span>
+      </div>
+      <ul className="divide-y divide-gray-100 dark:divide-gray-800 -mx-1">
         {visible.map(row => {
           const { club, anniversary } = row
-          // For the upcoming panel, milestone means the UPCOMING anniversary
-          // year hits 5/10/15/... — distinct from isUpcomingMilestone,
-          // which fires on the CURRENT years count.
+          // Milestone for this row = milestone on the UPCOMING year count.
+          // anniversary.isMilestone fires on the CURRENT count (N-1 until
+          // the day-of), so the panel computes its own flag.
           const isUpcomingMilestone = isMilestoneYear(anniversary.upcomingYears)
           const ord = `${anniversary.upcomingYears}${ordinalSuffix(
             anniversary.upcomingYears
@@ -138,47 +143,48 @@ export const UpcomingAnniversariesPanel: React.FC<
           const dayCopy =
             anniversary.daysUntilNext === 0
               ? 'today'
-              : `in ${anniversary.daysUntilNext} day${
-                  anniversary.daysUntilNext === 1 ? '' : 's'
-                }`
+              : `${anniversary.daysUntilNext}d`
           return (
             <li
               key={club.clubId}
               data-testid="upcoming-anniversary-row"
               data-milestone={isUpcomingMilestone}
               className={
-                'py-2 flex flex-wrap items-baseline gap-x-2 ' +
+                'flex items-center gap-2 px-2 py-1.5 text-sm font-tm-body ' +
                 (isUpcomingMilestone
-                  ? 'bg-yellow-50/50 dark:bg-yellow-900/10 -mx-2 px-2 rounded'
-                  : '')
+                  ? 'border-l-2 border-tm-happy-yellow bg-tm-happy-yellow/10'
+                  : 'border-l-2 border-transparent')
               }
             >
-              <Link
-                to={`/club/${club.clubId}${
-                  districtId ? `?district=${districtId}` : ''
-                }`}
-                className="font-medium text-tm-loyal-blue hover:underline"
-              >
-                {club.clubName}
-              </Link>
-              <span className="text-sm text-gray-500 dark:text-gray-400">
-                · {club.areaName}
-              </span>
               <span
                 className={
-                  'text-sm ' +
-                  (isUpcomingMilestone
-                    ? 'font-semibold text-yellow-800 dark:text-yellow-200'
+                  'w-10 shrink-0 text-right tabular-nums text-xs font-semibold ' +
+                  (anniversary.daysUntilNext <= 7
+                    ? 'text-tm-true-maroon'
                     : 'text-gray-700 dark:text-gray-300')
                 }
               >
-                {ord} anniversary {dayCopy}
+                {dayCopy}
               </span>
-              {isUpcomingMilestone && (
-                <span className="text-xs px-1.5 py-0.5 rounded-full bg-yellow-100 text-yellow-900 ring-1 ring-yellow-400 dark:bg-yellow-900/40 dark:text-yellow-100 dark:ring-yellow-500">
-                  🥇 milestone
-                </span>
-              )}
+              <Link
+                to={clubHref(club.clubId)}
+                className="flex-1 min-w-0 truncate text-tm-loyal-blue hover:underline"
+              >
+                {club.clubName}
+              </Link>
+              <span className="hidden sm:inline text-xs text-gray-500 dark:text-gray-400 truncate max-w-[8rem]">
+                {club.areaName}
+              </span>
+              <span
+                className={
+                  'shrink-0 tabular-nums text-xs font-semibold ' +
+                  (isUpcomingMilestone
+                    ? 'text-tm-true-maroon'
+                    : 'text-gray-600 dark:text-gray-300')
+                }
+              >
+                {ord}
+              </span>
             </li>
           )
         })}
@@ -187,7 +193,7 @@ export const UpcomingAnniversariesPanel: React.FC<
         <button
           type="button"
           onClick={() => setExpanded(true)}
-          className="mt-3 text-sm text-tm-loyal-blue hover:underline"
+          className="mt-2 text-xs font-semibold text-tm-loyal-blue hover:underline font-tm-body"
         >
           Show all ({upcoming.length})
         </button>

--- a/frontend/src/components/__tests__/MilestonesCallout.test.tsx
+++ b/frontend/src/components/__tests__/MilestonesCallout.test.tsx
@@ -49,7 +49,8 @@ describe('MilestonesCallout (#447)', () => {
       }),
     ]
     renderCallout(clubs)
-    expect(screen.getByText(/no milestones/i)).toBeInTheDocument()
+    // Copy was tightened in #511 ("None this PY — next is ...").
+    expect(screen.getByText(/none this py/i)).toBeInTheDocument()
     expect(screen.getByText(/Brand New Club/)).toBeInTheDocument()
   })
 

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -648,14 +648,19 @@ const DistrictDetailPage: React.FC = () => {
                     }
                   />
 
-                  {/* Club Anniversaries (#443 epic). Two surfaces:
-                    - Upcoming anniversaries within 60 days (#446)
-                    - Milestone clubs in the current program year (#447) */}
-                  <UpcomingAnniversariesPanel
-                    clubs={allClubs}
-                    districtId={districtId}
-                  />
-                  <MilestonesCallout clubs={allClubs} districtId={districtId} />
+                  {/* Club Anniversaries (#443 epic, layout #511). Side-by-side
+                    on md+ so they share a row in the Overview tab; stack on
+                    mobile. */}
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
+                    <UpcomingAnniversariesPanel
+                      clubs={allClubs}
+                      districtId={districtId}
+                    />
+                    <MilestonesCallout
+                      clubs={allClubs}
+                      districtId={districtId}
+                    />
+                  </div>
 
                   {/* Payment Composition + Distinguished Progress legacy
                     sections retired in #472 — the new redesign panels in


### PR DESCRIPTION
## Summary

The original panels were verbose: large emoji badges, multi-line rows, separate sub-headings, vertical stack wasting horizontal space on wide screens. Tightened to match the \`redesign-panel\` visual language used elsewhere on the Overview tab.

## Changes

- **Use \`redesign-panel\` class** (14px serif heading, --surface bg, 18px pad) for visual consistency.
- **Side-by-side** via parent 2-col grid in DistrictDetailPage; stacks on mobile.
- **UpcomingAnniversariesPanel**: single-line rows with a 4-column rhythm — \`countdown · club · area · ordinal\`. Milestone rows get a thin happy-yellow left border + faint bg tint instead of a separate badge chip. Rows under 7 days flagged in maroon.
- **MilestonesCallout**: each milestone year now a single line — "65 Years" maroon label, then comma-separated club links with short \`MMM YYYY\` dates inline. No more sublists with charter month + area + division.
- Empty-state copy compressed.

## Test plan

- [x] Test selectors are semantic (\`data-testid\` + role) so layout passes through cleanly
- [x] One test copy regex updated ("None this PY" replaces "no milestones")
- [x] 10/10 panel tests pass
- [x] TypeScript clean
- [ ] Visual: 375 / 768 / 1280 + dark mode after deploy

Closes #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)