### PR TITLE
fix(districts): drop Analytics chip + redundant district number, no-op #521 (#519 #520 #521)

### DIFF
--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -31,7 +31,7 @@ import { arrayToCSV, downloadCSV } from '../utils/csvExport'
  *  "District 57 Carolinas" but not "57". The D## chip already conveys
  *  the number, so showing it again is duplication. */
 const hasDescriptiveName = (name: string | undefined): boolean =>
-  !!name && !/^\d+$/.test(name)
+  !!name && !/^\d+$/.test(name.trim())
 
 const DistrictsPage: React.FC = () => {
   const navigate = useNavigate()

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -8,7 +8,6 @@ import {
 } from '../services/cdn'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
 import { AwardsRaceSection } from '../components/AwardsRaceSection'
-import { useDistricts } from '../hooks/useDistricts'
 import { LazyHistoricalRankChart as HistoricalRankChart } from '../components/LazyCharts'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
 import { ProgramYearSelector } from '../components/ProgramYearSelector'
@@ -27,6 +26,12 @@ import {
 import { formatDisplayDate } from '../utils/dateFormatting'
 import { DistrictRanking } from '../types/districts'
 import { arrayToCSV, downloadCSV } from '../utils/csvExport'
+
+/** A descriptive name is anything beyond the bare district number — e.g.
+ *  "District 57 Carolinas" but not "57". The D## chip already conveys
+ *  the number, so showing it again is duplication. */
+const hasDescriptiveName = (name: string | undefined): boolean =>
+  !!name && !/^\d+$/.test(name)
 
 const DistrictsPage: React.FC = () => {
   const navigate = useNavigate()
@@ -63,10 +68,6 @@ const DistrictsPage: React.FC = () => {
     return () => window.removeEventListener('keydown', handler)
   }, [])
 
-  // useDistricts call retained as a cache primer for the rest of the
-  // app; the tracked-IDs derivation that fed the Analytics chip was
-  // removed alongside the chip (#519).
-  useDistricts()
   // selectedRegions persists across visits (#416). Default = all (empty list,
   // which the existing useEffect inflates to all-known-regions on first
   // data render).
@@ -1091,21 +1092,16 @@ const DistrictsPage: React.FC = () => {
                           >
                             D{district.districtId}
                           </span>
-                          {/* #520 — skip the bare district name when it's
-                              purely numeric (TI CSV reality), since the
-                              D## chip already conveys the number. Richer
-                              names like "District 57 Carolinas" still
-                              render. */}
-                          {district.districtName &&
-                            !/^\d+$/.test(district.districtName) && (
-                              <span className="text-sm font-medium text-gray-900">
-                                {district.districtName}
-                              </span>
-                            )}
-                          {/* #519 — Analytics chip removed. The row is
-                              already a link into the district detail
-                              page; the chip added visual noise without
-                              disambiguating anything. */}
+                          {/* TI's CSV districtName is just the number ("86"
+                              for D86), which the chip already shows. Only
+                              render the name span when it carries
+                              additional information (e.g. "District 57
+                              Carolinas"). */}
+                          {hasDescriptiveName(district.districtName) && (
+                            <span className="text-sm font-medium text-gray-900">
+                              {district.districtName}
+                            </span>
+                          )}
                           {/* Competitive award winner badges (#331) */}
                           {competitiveAwards?.byDistrict?.[district.districtId]
                             ?.extensionIsWinner && (

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -63,13 +63,10 @@ const DistrictsPage: React.FC = () => {
     return () => window.removeEventListener('keydown', handler)
   }, [])
 
-  // Fetch tracked districts to show indicator badges
-  const { data: districtsData } = useDistricts()
-  const trackedDistrictIds = React.useMemo(() => {
-    const ids = new Set<string>()
-    districtsData?.districts?.forEach(d => ids.add(d.id))
-    return ids
-  }, [districtsData])
+  // useDistricts call retained as a cache primer for the rest of the
+  // app; the tracked-IDs derivation that fed the Analytics chip was
+  // removed alongside the chip (#519).
+  useDistricts()
   // selectedRegions persists across visits (#416). Default = all (empty list,
   // which the existing useEffect inflates to all-known-regions on first
   // data render).
@@ -1094,30 +1091,21 @@ const DistrictsPage: React.FC = () => {
                           >
                             D{district.districtId}
                           </span>
-                          <span className="text-sm font-medium text-gray-900">
-                            {district.districtName}
-                          </span>
-                          {trackedDistrictIds.has(district.districtId) && (
-                            <span
-                              title="Detailed analytics available"
-                              className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700"
-                            >
-                              <svg
-                                className="w-3 h-3 mr-0.5"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth={2}
-                                  d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
-                                />
-                              </svg>
-                              Analytics
-                            </span>
-                          )}
+                          {/* #520 — skip the bare district name when it's
+                              purely numeric (TI CSV reality), since the
+                              D## chip already conveys the number. Richer
+                              names like "District 57 Carolinas" still
+                              render. */}
+                          {district.districtName &&
+                            !/^\d+$/.test(district.districtName) && (
+                              <span className="text-sm font-medium text-gray-900">
+                                {district.districtName}
+                              </span>
+                            )}
+                          {/* #519 — Analytics chip removed. The row is
+                              already a link into the district detail
+                              page; the chip added visual noise without
+                              disambiguating anything. */}
                           {/* Competitive award winner badges (#331) */}
                           {competitiveAwards?.byDistrict?.[district.districtId]
                             ?.extensionIsWinner && (

--- a/frontend/src/pages/__tests__/DistrictsPage.row-cleanup.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.row-cleanup.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import DistrictsPage from '../DistrictsPage'
+import { fetchCdnRankings } from '../../services/cdn'
+import { renderWithProviders } from '../../__tests__/test-utils'
+
+/* RED tests for #519 + #520. Ranking row hygiene:
+
+   - #519 — drop the "Analytics" chip rendered on tracked districts. The
+     row is already a link into the district detail page; the chip adds
+     visual noise without disambiguating anything.
+
+   - #520 — drop the bare numeric district name that follows the D## chip
+     when the name is purely the district number (which is the prod
+     reality: TI's all-districts-rankings CSV's DISTRICT field is just
+     the number, so we end up rendering "D86" + "86" side-by-side).
+     If a district has a richer name (e.g. "District 57 Carolinas"),
+     keep it. */
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: [],
+    count: 0,
+    generatedAt: '2025-01-01T00:00:00Z',
+  }),
+  fetchCdnSnapshotIndex: vi.fn().mockResolvedValue({}),
+  fetchCdnRankings: vi.fn(),
+  fetchCdnManifest: vi.fn().mockResolvedValue({
+    latestSnapshotDate: '2025-11-22',
+    generatedAt: '2025-01-01T00:00:00Z',
+  }),
+  cdnAnalyticsUrl: vi.fn().mockReturnValue('https://cdn.taverns.red/test'),
+  fetchFromCdn: vi.fn(),
+}))
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: () => ({
+    data: {
+      districts: [
+        { id: '86', name: 'District 86' },
+        { id: '57', name: 'District 57' },
+      ],
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}))
+
+const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)
+
+const baseRanking = {
+  region: '1',
+  paidClubs: 100,
+  paidClubBase: 90,
+  clubGrowthPercent: 10,
+  totalPayments: 5000,
+  paymentBase: 4500,
+  paymentGrowthPercent: 10,
+  activeClubs: 100,
+  distinguishedClubs: 50,
+  selectDistinguished: 20,
+  presidentsDistinguished: 10,
+  distinguishedPercent: 50,
+  clubsRank: 1,
+  paymentsRank: 1,
+  distinguishedRank: 1,
+  aggregateScore: 300,
+}
+
+describe('DistrictsPage row cleanup (#519 #520)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('#519: does not render an "Analytics" chip on any ranking row', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        {
+          ...baseRanking,
+          districtId: '86',
+          // Tracked districts previously got an Analytics chip. We want
+          // it gone regardless of tracking state.
+          districtName: '86',
+        },
+      ],
+      date: '2025-11-22',
+    })
+
+    renderWithProviders(<DistrictsPage />)
+
+    // Wait for the row to render via the D## chip's stable test id.
+    await screen.findByTestId('district-number-chip-D86')
+
+    // Assert: no element with the literal "Analytics" label anywhere
+    // inside the row's district cell.
+    const analyticsBadges = screen.queryAllByText(/^Analytics$/i)
+    expect(analyticsBadges).toHaveLength(0)
+  })
+
+  it('#520: omits the bare district number when districtName is purely numeric (chip already conveys it)', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        {
+          ...baseRanking,
+          districtId: '86',
+          // Production data shape — districtName is just the number,
+          // so rendering it next to the D86 chip duplicates information.
+          districtName: '86',
+        },
+      ],
+      date: '2025-11-22',
+    })
+
+    renderWithProviders(<DistrictsPage />)
+
+    // The D## chip should render exactly once.
+    const chip = await screen.findByTestId('district-number-chip-D86')
+    expect(chip.textContent).toBe('D86')
+
+    // There should be no plain-text "86" sibling inside the same cell.
+    // queryAllByText finds DOM nodes whose entire text content is "86".
+    const bareEightySix = screen.queryAllByText('86', { selector: 'span' })
+    expect(bareEightySix).toHaveLength(0)
+  })
+
+  it('#520: keeps a richer district name when it is not purely numeric', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        {
+          ...baseRanking,
+          districtId: '57',
+          districtName: 'District 57 Carolinas',
+        },
+      ],
+      date: '2025-11-22',
+    })
+
+    renderWithProviders(<DistrictsPage />)
+    expect(await screen.findByText('District 57 Carolinas')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/DistrictsPage.row-cleanup.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.row-cleanup.test.tsx
@@ -1,21 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { screen, within } from '@testing-library/react'
 import DistrictsPage from '../DistrictsPage'
 import { fetchCdnRankings } from '../../services/cdn'
 import { renderWithProviders } from '../../__tests__/test-utils'
-
-/* RED tests for #519 + #520. Ranking row hygiene:
-
-   - #519 — drop the "Analytics" chip rendered on tracked districts. The
-     row is already a link into the district detail page; the chip adds
-     visual noise without disambiguating anything.
-
-   - #520 — drop the bare numeric district name that follows the D## chip
-     when the name is purely the district number (which is the prod
-     reality: TI's all-districts-rankings CSV's DISTRICT field is just
-     the number, so we end up rendering "D86" + "86" side-by-side).
-     If a district has a richer name (e.g. "District 57 Carolinas"),
-     keep it. */
 
 vi.mock('../../services/cdn', () => ({
   fetchCdnDates: vi.fn().mockResolvedValue({
@@ -31,19 +18,6 @@ vi.mock('../../services/cdn', () => ({
   }),
   cdnAnalyticsUrl: vi.fn().mockReturnValue('https://cdn.taverns.red/test'),
   fetchFromCdn: vi.fn(),
-}))
-
-vi.mock('../../hooks/useDistricts', () => ({
-  useDistricts: () => ({
-    data: {
-      districts: [
-        { id: '86', name: 'District 86' },
-        { id: '57', name: 'District 57' },
-      ],
-    },
-    isLoading: false,
-    isError: false,
-  }),
 }))
 
 const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)
@@ -68,62 +42,33 @@ const baseRanking = {
 }
 
 describe('DistrictsPage row cleanup (#519 #520)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  it('#519: does not render an "Analytics" chip on any ranking row', async () => {
+  it('does not render an "Analytics" chip on any ranking row', async () => {
     mockedFetchCdnRankings.mockResolvedValueOnce({
-      rankings: [
-        {
-          ...baseRanking,
-          districtId: '86',
-          // Tracked districts previously got an Analytics chip. We want
-          // it gone regardless of tracking state.
-          districtName: '86',
-        },
-      ],
+      rankings: [{ ...baseRanking, districtId: '86', districtName: '86' }],
       date: '2025-11-22',
     })
 
     renderWithProviders(<DistrictsPage />)
-
-    // Wait for the row to render via the D## chip's stable test id.
     await screen.findByTestId('district-number-chip-D86')
 
-    // Assert: no element with the literal "Analytics" label anywhere
-    // inside the row's district cell.
-    const analyticsBadges = screen.queryAllByText(/^Analytics$/i)
-    expect(analyticsBadges).toHaveLength(0)
+    expect(screen.queryAllByText(/^Analytics$/i)).toHaveLength(0)
   })
 
-  it('#520: omits the bare district number when districtName is purely numeric (chip already conveys it)', async () => {
+  it('omits the bare district number when districtName is purely numeric', async () => {
     mockedFetchCdnRankings.mockResolvedValueOnce({
-      rankings: [
-        {
-          ...baseRanking,
-          districtId: '86',
-          // Production data shape — districtName is just the number,
-          // so rendering it next to the D86 chip duplicates information.
-          districtName: '86',
-        },
-      ],
+      rankings: [{ ...baseRanking, districtId: '86', districtName: '86' }],
       date: '2025-11-22',
     })
 
     renderWithProviders(<DistrictsPage />)
-
-    // The D## chip should render exactly once.
     const chip = await screen.findByTestId('district-number-chip-D86')
     expect(chip.textContent).toBe('D86')
 
-    // There should be no plain-text "86" sibling inside the same cell.
-    // queryAllByText finds DOM nodes whose entire text content is "86".
-    const bareEightySix = screen.queryAllByText('86', { selector: 'span' })
-    expect(bareEightySix).toHaveLength(0)
+    const row = chip.closest('tr')!
+    expect(within(row).queryByText('86', { selector: 'span' })).toBeNull()
   })
 
-  it('#520: keeps a richer district name when it is not purely numeric', async () => {
+  it('keeps a richer district name when it is not purely numeric', async () => {
     mockedFetchCdnRankings.mockResolvedValueOnce({
       rankings: [
         {


### PR DESCRIPTION
## Summary

Three issues against the \`/districts\` ranking page, one PR:

- **#519** — removed the \"Analytics\" chip from each row. The row is already a link into the district detail page; the chip was visual noise.
- **#520** — skip the bare \`districtName\` span when it's purely numeric. TI's CSV \`DISTRICT\` field is just the number (\"86\" for D86), so the row was rendering \`D86 86\` side-by-side. New \`hasDescriptiveName(name)\` predicate; richer names like \"District 57 Carolinas\" still render.
- **#521** — verified no-op. There is no Trend column in \`DistrictsPage.tsx\`, and Region appears only as its own \`<td>\` cell, never as a row subline. The \"305 active clubs · Region 1\" copy in the linked screenshot was a draft artifact, not in the repo.

## Commits

1. \`test(districts): RED — Analytics chip + redundant district number (#519 #520)\` — 3 failing tests.
2. \`fix(districts): GREEN — drop Analytics chip + redundant district number (#519 #520 #521)\` — minimal code change to pass.
3. \`refactor(districts): /simplify pass — drop dead useDistricts call, hoist predicate, tighten tests (#519 #520)\` — three reviewer agents agreed: the retained \`useDistricts()\` cache-primer was dead weight, the changelog comment rotted, the regex reads cleaner as a named predicate, the test was brittle to unrelated \"86\" spans.
4. \`fix(districts): trim before numeric check in hasDescriptiveName (#520)\` — fresh-context reviewer caught a whitespace edge case; defensive \`.trim()\`.

## Test plan

- [x] 3 RED → 3 GREEN tests for the new behaviour
- [x] 2270/2270 frontend tests pass; TypeScript clean
- [x] /simplify pass applied (drop dead \`useDistricts()\` cache primer, hoist predicate, tighten tests)
- [x] Fresh-context reviewer ran independently — one Low finding fixed in commit 4
- [x] Award chips (Extension / 20-Plus / Retention) untouched and still render
- [ ] Visual: 375 / 768 / 1280 + dark mode after deploy

## Follow-ups filed

- **#522** — extract \`<DistrictChipAndName>\` to consolidate the same pattern (and same #520 bug) in \`RegionPage.tsx\` and the search-suggestions dropdown.

Closes #519, #520, #521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)