### PR TITLE
feat(region): rollup KPIs + rank column + linkified chip — Sprint A of epic #513 (#514 #515 #518)

### DIFF
--- a/frontend/src/components/TargetProgressCard.tsx
+++ b/frontend/src/components/TargetProgressCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import { Tooltip, InfoIcon } from './Tooltip'
 import { isLevelAchieved } from '../utils/targetProgressHelpers'
 
@@ -255,24 +256,44 @@ export const TargetProgressCard: React.FC<TargetProgressCardProps> = ({
           </span>
         </Tooltip>
 
-        {/* Region Rank - only show if region is known (Requirement 8.3) */}
-        {rankings.region && (
-          <Tooltip
-            content={
+        {/* Region Rank - only show if region is known (Requirement 8.3).
+            #518: wrap in a Link to /region/:n when the region string
+            contains digits. Falls back to a plain span for non-numeric
+            regions (no route to send the user to). */}
+        {rankings.region &&
+          (() => {
+            const digits = String(rankings.region).match(/\d+/)?.[0]
+            const tooltipContent =
               rankings.regionRank !== null
                 ? `District's rank within ${rankings.region} region (1 = best)`
                 : `Regional ranking data unavailable for ${rankings.region}`
-            }
-          >
-            <span
-              className="px-2 py-1 rounded-sm bg-gray-100 text-gray-700"
-              data-testid="region-rank"
-            >
-              {rankings.region}:{' '}
-              {rankings.regionRank !== null ? `#${rankings.regionRank}` : '—'}
-            </span>
-          </Tooltip>
-        )}
+            const label = (
+              <>
+                {rankings.region}:{' '}
+                {rankings.regionRank !== null ? `#${rankings.regionRank}` : '—'}
+              </>
+            )
+            const sharedClasses =
+              'px-2 py-1 rounded-sm bg-gray-100 text-gray-700'
+            return (
+              <Tooltip content={tooltipContent}>
+                {digits ? (
+                  <Link
+                    to={`/region/${digits}`}
+                    className={`${sharedClasses} hover:bg-gray-200`}
+                    data-testid="region-rank"
+                    aria-label={`View Region ${digits} overview`}
+                  >
+                    {label}
+                  </Link>
+                ) : (
+                  <span className={sharedClasses} data-testid="region-rank">
+                    {label}
+                  </span>
+                )}
+              </Tooltip>
+            )
+          })()}
       </div>
 
       {/* Target Progress Bars */}

--- a/frontend/src/components/TargetProgressCard.tsx
+++ b/frontend/src/components/TargetProgressCard.tsx
@@ -147,6 +147,46 @@ function ordinalSuffix(n: number): string {
   return `${n}th`
 }
 
+interface RegionRankChipProps {
+  region: string
+  regionRank: number | null
+}
+
+const RegionRankChip: React.FC<RegionRankChipProps> = ({
+  region,
+  regionRank,
+}) => {
+  const digits = String(region).match(/\d+/)?.[0]
+  const tooltipContent =
+    regionRank !== null
+      ? `District's rank within ${region} region (1 = best)`
+      : `Regional ranking data unavailable for ${region}`
+  const label = (
+    <>
+      {region}: {regionRank !== null ? `#${regionRank}` : '—'}
+    </>
+  )
+  const sharedClasses = 'px-2 py-1 rounded-sm bg-gray-100 text-gray-700'
+  return (
+    <Tooltip content={tooltipContent}>
+      {digits ? (
+        <Link
+          to={`/region/${digits}`}
+          className={`${sharedClasses} hover:bg-gray-200`}
+          data-testid="region-rank"
+          aria-label={`View Region ${digits} overview`}
+        >
+          {label}
+        </Link>
+      ) : (
+        <span className={sharedClasses} data-testid="region-rank">
+          {label}
+        </span>
+      )}
+    </Tooltip>
+  )
+}
+
 /**
  * Format world percentile as ordinal (e.g., "12th percentile") (#305)
  */
@@ -256,44 +296,15 @@ export const TargetProgressCard: React.FC<TargetProgressCardProps> = ({
           </span>
         </Tooltip>
 
-        {/* Region Rank - only show if region is known (Requirement 8.3).
-            #518: wrap in a Link to /region/:n when the region string
-            contains digits. Falls back to a plain span for non-numeric
-            regions (no route to send the user to). */}
-        {rankings.region &&
-          (() => {
-            const digits = String(rankings.region).match(/\d+/)?.[0]
-            const tooltipContent =
-              rankings.regionRank !== null
-                ? `District's rank within ${rankings.region} region (1 = best)`
-                : `Regional ranking data unavailable for ${rankings.region}`
-            const label = (
-              <>
-                {rankings.region}:{' '}
-                {rankings.regionRank !== null ? `#${rankings.regionRank}` : '—'}
-              </>
-            )
-            const sharedClasses =
-              'px-2 py-1 rounded-sm bg-gray-100 text-gray-700'
-            return (
-              <Tooltip content={tooltipContent}>
-                {digits ? (
-                  <Link
-                    to={`/region/${digits}`}
-                    className={`${sharedClasses} hover:bg-gray-200`}
-                    data-testid="region-rank"
-                    aria-label={`View Region ${digits} overview`}
-                  >
-                    {label}
-                  </Link>
-                ) : (
-                  <span className={sharedClasses} data-testid="region-rank">
-                    {label}
-                  </span>
-                )}
-              </Tooltip>
-            )
-          })()}
+        {/* Region Rank chip — link to /region/:n when the region string
+            contains digits, otherwise a plain span (no route exists for
+            "Unknown" / non-numeric regions). */}
+        {rankings.region && (
+          <RegionRankChip
+            region={rankings.region}
+            regionRank={rankings.regionRank}
+          />
+        )}
       </div>
 
       {/* Target Progress Bars */}

--- a/frontend/src/components/__tests__/TargetProgressCard.test.tsx
+++ b/frontend/src/components/__tests__/TargetProgressCard.test.tsx
@@ -463,18 +463,21 @@ describe('TargetProgressCard', () => {
 
       expect(screen.getByTestId('target-progress-card')).toBeInTheDocument()
 
-      // Rerender with green color scheme
+      // Rerender with green color scheme. Wrap the rerender tree in
+      // MemoryRouter manually — rerender bypasses the wrapper helper.
       rerender(
-        <TargetProgressCard
-          title="Test Metric"
-          icon={<TestIcon />}
-          current={60}
-          base={100}
-          targets={standardTargets}
-          achievedLevel="distinguished"
-          rankings={standardRankings}
-          colorScheme="green"
-        />
+        <MemoryRouter>
+          <TargetProgressCard
+            title="Test Metric"
+            icon={<TestIcon />}
+            current={60}
+            base={100}
+            targets={standardTargets}
+            achievedLevel="distinguished"
+            rankings={standardRankings}
+            colorScheme="green"
+          />
+        </MemoryRouter>
       )
 
       expect(screen.getByTestId('target-progress-card')).toBeInTheDocument()

--- a/frontend/src/components/__tests__/TargetProgressCard.test.tsx
+++ b/frontend/src/components/__tests__/TargetProgressCard.test.tsx
@@ -12,11 +12,13 @@
 
 import { describe, it, expect, afterEach } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 
-// Provider-free unit-test render (#473): the component under test
-// uses no router / no React Query, so wrapping each render in a
-// fresh QueryClient + memory router was pure contention amplifier.
-const renderWithProviders = (ui: React.ReactElement) => render(ui)
+// Router-only wrapper (#518): the component now contains a <Link>
+// when region is numeric. Still no QueryClient — see #473 for why
+// provider bloat is contention amplifier.
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>)
 const cleanupAllResources = () => cleanup()
 import {
   TargetProgressCard,
@@ -324,6 +326,52 @@ describe('TargetProgressCard', () => {
 
       // World rank should still be displayed
       expect(screen.getByTestId('world-rank')).toBeInTheDocument()
+    })
+
+    // #518 — Region chip links to /region/:n. The href must use the
+    // bare numeric region (digits only) regardless of whether the
+    // display label is "1" or "Region 1".
+    it('renders the region rank chip as a link to /region/{digits}', () => {
+      renderWithProviders(
+        <TargetProgressCard
+          title="Test Metric"
+          icon={<TestIcon />}
+          current={60}
+          base={100}
+          targets={standardTargets}
+          achievedLevel="distinguished"
+          rankings={standardRankings}
+          colorScheme="blue"
+        />
+      )
+
+      const regionRank = screen.getByTestId('region-rank')
+      expect(regionRank.tagName).toBe('A')
+      expect(regionRank).toHaveAttribute('href', '/region/1')
+    })
+
+    it('does not wrap the chip in a link when region has no digits', () => {
+      const oddRegion: MetricRankings = {
+        ...standardRankings,
+        region: 'Unknown',
+      }
+      renderWithProviders(
+        <TargetProgressCard
+          title="Test Metric"
+          icon={<TestIcon />}
+          current={60}
+          base={100}
+          targets={standardTargets}
+          achievedLevel="distinguished"
+          rankings={oddRegion}
+          colorScheme="blue"
+        />
+      )
+
+      // With a non-numeric region, fall back to a plain span — there is
+      // no /region/Unknown route to send the user to.
+      const regionRank = screen.getByTestId('region-rank')
+      expect(regionRank.tagName).toBe('SPAN')
     })
   })
 

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -10,6 +10,7 @@ import { fetchCdnRankings } from '../services/cdn'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 import type { DistrictRanking } from '../types/districts'
+import { computeTiedRanks } from '../utils/tieRankingUtils'
 
 const RegionPage: React.FC = () => {
   const { n } = useParams<{ n: string }>()
@@ -31,8 +32,15 @@ const RegionPage: React.FC = () => {
     data?.rankings && region
       ? data.rankings
           .filter(r => r.region === region)
-          .sort((a, b) => (a.overallRank ?? 0) - (b.overallRank ?? 0))
+          .sort((a, b) => (b.aggregateScore ?? 0) - (a.aggregateScore ?? 0))
       : []
+
+  // #515 — rank each district within the region by aggregateScore desc.
+  // Ties share the same rank (competition ranking via computeTiedRanks).
+  const regionRanks = computeTiedRanks(
+    regionDistricts,
+    d => d.aggregateScore ?? 0
+  )
 
   if (isLoading) {
     return <LoadingSkeleton variant="card" />
@@ -125,6 +133,9 @@ const RegionPage: React.FC = () => {
             <thead>
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Region Rank
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   District
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -142,37 +153,51 @@ const RegionPage: React.FC = () => {
               </tr>
             </thead>
             <tbody>
-              {regionDistricts.map(d => (
-                <tr
-                  key={d.districtId}
-                  className="cursor-pointer"
-                  onClick={() => navigate(`/district/${d.districtId}`)}
-                >
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span
-                      className="districts-rankings-table__district-chip"
-                      aria-hidden="true"
+              {regionDistricts.map((d, i) => {
+                const rank = regionRanks[i]
+                return (
+                  <tr
+                    key={d.districtId}
+                    className="cursor-pointer"
+                    onClick={() => navigate(`/district/${d.districtId}`)}
+                  >
+                    <td
+                      data-testid="region-rank-cell"
+                      className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-900 tabular-nums"
                     >
-                      D{d.districtId}
-                    </span>
-                    <span className="ml-3 text-sm font-medium text-gray-900">
-                      {d.districtName}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    #{d.overallRank}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900">
-                    {d.paidClubs}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900">
-                    {d.distinguishedClubs}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
-                    {d.aggregateScore}
-                  </td>
-                </tr>
-              ))}
+                      #{rank?.rank}
+                      {rank?.isTied && (
+                        <span className="ml-1 text-xs text-gray-400 font-normal">
+                          (tied)
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <span
+                        className="districts-rankings-table__district-chip"
+                        aria-hidden="true"
+                      >
+                        D{d.districtId}
+                      </span>
+                      <span className="ml-3 text-sm font-medium text-gray-900">
+                        {d.districtName}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      #{d.overallRank}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900">
+                      {d.paidClubs}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900">
+                      {d.distinguishedClubs}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
+                      {d.aggregateScore}
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
         </div>

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -12,6 +12,47 @@ import { EmptyState } from '../components/ErrorDisplay'
 import type { DistrictRanking } from '../types/districts'
 import { computeTiedRanks } from '../utils/tieRankingUtils'
 
+/* #514 — KPI card with base → current → Δ → ±% rhythm. Used in the
+   Region page's totals strip. Negative deltas render in maroon. */
+const KpiCard: React.FC<{
+  label: string
+  base: number
+  current: number
+}> = ({ label, base, current }) => {
+  const delta = current - base
+  const percent = base === 0 ? null : ((current - base) / base) * 100
+  const sign = delta >= 0 ? '+' : ''
+  const deltaTone = delta >= 0 ? 'text-green-700' : 'text-tm-true-maroon'
+  return (
+    <div className="districts-kpi-card" aria-label={`${label} KPI`}>
+      <p className="districts-kpi-card__label">{label}</p>
+      <div className="districts-kpi-card__value">
+        {current.toLocaleString()}
+      </div>
+      <p className="text-xs text-gray-500 tabular-nums mt-1">
+        <span data-testid="kpi-base">Base {base.toLocaleString()}</span> ·{' '}
+        <span data-testid="kpi-delta" className={`font-semibold ${deltaTone}`}>
+          {sign}
+          {delta.toLocaleString()}
+        </span>
+        {percent !== null && (
+          <>
+            {' '}
+            ·{' '}
+            <span
+              data-testid="kpi-percent"
+              className={`font-semibold ${deltaTone}`}
+            >
+              {sign}
+              {percent.toFixed(1)}%
+            </span>
+          </>
+        )}
+      </p>
+    </div>
+  )
+}
+
 const RegionPage: React.FC = () => {
   const { n } = useParams<{ n: string }>()
   const navigate = useNavigate()
@@ -73,11 +114,19 @@ const RegionPage: React.FC = () => {
   const totals = regionDistricts.reduce(
     (acc, d) => {
       acc.paidClubs += d.paidClubs ?? 0
+      acc.paidClubBase += d.paidClubBase ?? 0
       acc.totalPayments += d.totalPayments ?? 0
+      acc.paymentBase += d.paymentBase ?? 0
       acc.distinguishedClubs += d.distinguishedClubs ?? 0
       return acc
     },
-    { paidClubs: 0, totalPayments: 0, distinguishedClubs: 0 }
+    {
+      paidClubs: 0,
+      paidClubBase: 0,
+      totalPayments: 0,
+      paymentBase: 0,
+      distinguishedClubs: 0,
+    }
   )
 
   return (
@@ -101,30 +150,30 @@ const RegionPage: React.FC = () => {
         style={{ marginBottom: 24 }}
         aria-label="Region totals"
       >
-        <div className="districts-kpi-card">
+        <div className="districts-kpi-card" aria-label="Districts KPI">
           <p className="districts-kpi-card__label">Districts</p>
           <div className="districts-kpi-card__value">
             {regionDistricts.length}
           </div>
         </div>
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Paid Clubs</p>
-          <div className="districts-kpi-card__value">
-            {totals.paidClubs.toLocaleString()}
-          </div>
-        </div>
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Payments</p>
-          <div className="districts-kpi-card__value">
-            {totals.totalPayments.toLocaleString()}
-          </div>
-        </div>
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Distinguished Clubs</p>
-          <div className="districts-kpi-card__value">
-            {totals.distinguishedClubs.toLocaleString()}
-          </div>
-        </div>
+        <KpiCard
+          label="Paid Clubs"
+          base={totals.paidClubBase}
+          current={totals.paidClubs}
+        />
+        <KpiCard
+          label="Payments"
+          base={totals.paymentBase}
+          current={totals.totalPayments}
+        />
+        {/* Distinguished is year-cumulative — every July 1 the count
+            resets to zero. Treating base as 0 is semantically correct
+            and makes Δ equal to the current count. */}
+        <KpiCard
+          label="Distinguished Clubs"
+          base={0}
+          current={totals.distinguishedClubs}
+        />
       </div>
 
       <div className="districts-rankings-table-wrap">

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -12,13 +12,16 @@ import { EmptyState } from '../components/ErrorDisplay'
 import type { DistrictRanking } from '../types/districts'
 import { computeTiedRanks } from '../utils/tieRankingUtils'
 
-/* #514 — KPI card with base → current → Δ → ±% rhythm. Used in the
-   Region page's totals strip. Negative deltas render in maroon. */
-const KpiCard: React.FC<{
+interface KpiCardProps {
   label: string
   base: number
   current: number
-}> = ({ label, base, current }) => {
+}
+
+/** KPI card with a base → current → Δ → ±% rhythm. Negative deltas
+ *  render in maroon. Percent is omitted when base is 0 (avoid /0; the
+ *  Distinguished case in particular relies on this). */
+const KpiCard: React.FC<KpiCardProps> = ({ label, base, current }) => {
   const delta = current - base
   const percent = base === 0 ? null : ((current - base) / base) * 100
   const sign = delta >= 0 ? '+' : ''
@@ -76,8 +79,8 @@ const RegionPage: React.FC = () => {
           .sort((a, b) => (b.aggregateScore ?? 0) - (a.aggregateScore ?? 0))
       : []
 
-  // #515 — rank each district within the region by aggregateScore desc.
-  // Ties share the same rank (competition ranking via computeTiedRanks).
+  // Rank within the region by aggregateScore desc. Ties share rank
+  // (competition ranking via computeTiedRanks).
   const regionRanks = computeTiedRanks(
     regionDistricts,
     d => d.aggregateScore ?? 0
@@ -203,7 +206,7 @@ const RegionPage: React.FC = () => {
             </thead>
             <tbody>
               {regionDistricts.map((d, i) => {
-                const rank = regionRanks[i]
+                const rank = regionRanks[i]!
                 return (
                   <tr
                     key={d.districtId}
@@ -214,8 +217,8 @@ const RegionPage: React.FC = () => {
                       data-testid="region-rank-cell"
                       className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-900 tabular-nums"
                     >
-                      #{rank?.rank}
-                      {rank?.isTied && (
+                      #{rank.rank}
+                      {rank.isTied && (
                         <span className="ml-1 text-xs text-gray-400 font-normal">
                           (tied)
                         </span>

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -54,6 +54,130 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+describe('RegionPage KPI strip — base / current / Δ / ±% (#514 #513)', () => {
+  it('shows current totals (existing behaviour)', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({
+          districtId: '60',
+          region: '2',
+          paidClubs: 150,
+          paidClubBase: 140,
+          totalPayments: 6000,
+          paymentBase: 5500,
+          distinguishedClubs: 50,
+        }),
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          paidClubs: 200,
+          paidClubBase: 190,
+          totalPayments: 8000,
+          paymentBase: 7000,
+          distinguishedClubs: 70,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('2')
+
+    // Paid Clubs card shows current total 350 = 150 + 200.
+    const paidClubsCard = await screen.findByLabelText(/paid clubs kpi/i)
+    expect(within(paidClubsCard).getByText('350')).toBeInTheDocument()
+  })
+
+  it('shows base, delta and ±% for Paid Clubs and Payments', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({
+          districtId: '60',
+          region: '2',
+          paidClubs: 150,
+          paidClubBase: 140,
+          totalPayments: 6000,
+          paymentBase: 5500,
+          distinguishedClubs: 50,
+        }),
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          paidClubs: 200,
+          paidClubBase: 190,
+          totalPayments: 8000,
+          paymentBase: 7000,
+          distinguishedClubs: 70,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('2')
+
+    // Paid Clubs: base 330, current 350, Δ +20, +6.1%
+    const paidCard = await screen.findByLabelText(/paid clubs kpi/i)
+    expect(within(paidCard).getByTestId('kpi-base').textContent).toContain(
+      '330'
+    )
+    expect(within(paidCard).getByTestId('kpi-delta').textContent).toContain(
+      '+20'
+    )
+    expect(within(paidCard).getByTestId('kpi-percent').textContent).toMatch(
+      /\+6\.1%/
+    )
+
+    // Payments: base 12500, current 14000, Δ +1500, +12.0%
+    const paymentsCard = screen.getByLabelText(/payments kpi/i)
+    expect(within(paymentsCard).getByTestId('kpi-base').textContent).toContain(
+      '12,500'
+    )
+    expect(within(paymentsCard).getByTestId('kpi-delta').textContent).toContain(
+      '+1,500'
+    )
+    expect(within(paymentsCard).getByTestId('kpi-percent').textContent).toMatch(
+      /\+12\.0%/
+    )
+  })
+
+  it('treats Distinguished Clubs as year-cumulative — base 0, delta = current', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          distinguishedClubs: 48,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('2')
+
+    const card = await screen.findByLabelText(/distinguished clubs kpi/i)
+    expect(within(card).getByTestId('kpi-base').textContent).toContain('0')
+    expect(within(card).getByTestId('kpi-delta').textContent).toContain('+48')
+  })
+
+  it('renders negative deltas in red (Δ < 0)', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          paidClubs: 130,
+          paidClubBase: 140,
+          totalPayments: 5000,
+          paymentBase: 5500,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('2')
+
+    const paidCard = await screen.findByLabelText(/paid clubs kpi/i)
+    const delta = within(paidCard).getByTestId('kpi-delta')
+    expect(delta.textContent).toContain('-10')
+    expect(delta).toHaveClass('text-tm-true-maroon')
+  })
+})
+
 describe('RegionPage rank-within-region column (#515 #513)', () => {
   it('renders a "Region Rank" column header on the district table', async () => {
     mockedFetchCdnRankings.mockResolvedValueOnce({

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import RegionPage from '../RegionPage'
+import { fetchCdnRankings } from '../../services/cdn'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnRankings: vi.fn(),
+}))
+
+const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)
+
+const mkRanking = (overrides: Record<string, unknown>) => ({
+  districtId: '1',
+  districtName: '1',
+  region: '1',
+  paidClubs: 100,
+  totalPayments: 5000,
+  distinguishedClubs: 50,
+  aggregateScore: 300,
+  overallRank: 1,
+  paidClubBase: 90,
+  paymentBase: 4500,
+  clubGrowthPercent: 10,
+  paymentGrowthPercent: 10,
+  activeClubs: 100,
+  selectDistinguished: 20,
+  presidentsDistinguished: 10,
+  distinguishedPercent: 50,
+  clubsRank: 1,
+  paymentsRank: 1,
+  distinguishedRank: 1,
+  ...overrides,
+})
+
+const renderRegion = (region: string) => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/region/${region}`]}>
+        <Routes>
+          <Route path="/region/:n" element={<RegionPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('RegionPage rank-within-region column (#515 #513)', () => {
+  it('renders a "Region Rank" column header on the district table', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({ districtId: '1', region: '1', aggregateScore: 300 }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('1')
+    expect(
+      await screen.findByRole('columnheader', { name: /region rank/i })
+    ).toBeInTheDocument()
+  })
+
+  it('ranks districts within the region by aggregateScore descending', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({
+          districtId: '60',
+          region: '2',
+          aggregateScore: 100,
+          overallRank: 50,
+        }),
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          aggregateScore: 300,
+          overallRank: 10,
+        }),
+        mkRanking({
+          districtId: '31',
+          region: '2',
+          aggregateScore: 200,
+          overallRank: 30,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('2')
+
+    const rows = await screen.findAllByRole('row')
+    // skip header row at index 0
+    const rank1 = within(rows[1]!).getByTestId('region-rank-cell')
+    const rank2 = within(rows[2]!).getByTestId('region-rank-cell')
+    const rank3 = within(rows[3]!).getByTestId('region-rank-cell')
+    expect(rank1.textContent).toContain('#1')
+    expect(rank2.textContent).toContain('#2')
+    expect(rank3.textContent).toContain('#3')
+    // D61 (score 300) ranks #1 within region 2.
+    expect(within(rows[1]!).getByText(/D61/)).toBeInTheDocument()
+  })
+
+  it('marks tied region ranks (same aggregateScore) as tied', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({
+          districtId: '7',
+          region: '3',
+          aggregateScore: 250,
+          overallRank: 20,
+        }),
+        mkRanking({
+          districtId: '8',
+          region: '3',
+          aggregateScore: 250,
+          overallRank: 21,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('3')
+
+    const rows = await screen.findAllByRole('row')
+    expect(
+      within(rows[1]!).getByTestId('region-rank-cell').textContent
+    ).toMatch(/#1.*tied/i)
+    expect(
+      within(rows[2]!).getByTestId('region-rank-cell').textContent
+    ).toMatch(/#1.*tied/i)
+  })
+})


### PR DESCRIPTION
## Summary

Sprint A of Region rollup epic #513 — three quick wins:

- **#518** — Region chip in TargetProgressCard now links to \`/region/:n\`. Digit extraction via regex so it works whether prod sends \`"1"\` or \`"Region 1"\`. Non-numeric regions fall back to a plain span (no dead-end routes).
- **#515** — RegionPage district table gains a leading "Region Rank" column, computed via \`computeTiedRanks\` on \`aggregateScore\` descending. Ties share rank with a "(tied)" marker.
- **#514** — RegionPage KPI strip replaced with a base → current → Δ → ±% rhythm for Paid Clubs and Payments. Distinguished Clubs treated as year-cumulative (base = 0, Δ = current). Negative deltas render in maroon.

## Commits

1. \`test(district): RED — linkify region chip to /region/:n (#518 #513)\`
2. \`feat(district): GREEN — linkify Region chip to /region/:n (#518 #513)\`
3. \`test(region): RED — rank-within-region column on RegionPage (#515 #513)\`
4. \`feat(region): GREEN — rank-within-region column on RegionPage (#515 #513)\`
5. \`test(region): RED — KPI strip with base / current / Δ / ±% (#514 #513)\`
6. \`feat(region): GREEN — KPI strip with base / current / Δ / ±% (#514 #513)\`
7. \`refactor(region): /simplify pass — extract RegionRankChip, drop changelog refs, named interfaces\`

## /simplify pass

Three reviewer agents found:
- Extract \`<RegionRankChip>\` from inline IIFE in TargetProgressCard.
- Drop \`#NNN —\` issue refs from inline comments; keep WHY-content.
- Drop defensive optional chaining on guaranteed-in-bounds index.
- Extract \`KpiCardProps\` interface (codebase convention).

**Skipped**: reviewer suggested migrating \`KpiCard\` to existing \`StatCard\`. StatCard uses different brand classes + Card shell — migration would diverge RegionPage from the rest of the \`districts-kpi-strip\` visual treatment. Filing as a follow-up consolidation candidate (cross-page KPI primitive).

## Fresh-context critical review

One **Medium** finding documented for triage:

- \`paidClubBase\` / \`paymentBase\` are typed as required \`number\` but the rollup uses \`?? 0\`. Either the type lies (older CDN snapshots may serve undefined) or the guard is dead code. The new \`?? 0\`s I added match the **pre-existing pattern in the same reduce** (paidClubs, totalPayments, distinguishedClubs all used \`?? 0\` before this PR). Reviewer's concern is real but pre-existing — not introduced by this change. **Action:** if undefined-base is a real concern, file a follow-up to either tighten the type or drop all guards.

## Test plan

- [x] 9 RED tests across 3 issues → all GREEN
- [x] 2279/2279 frontend tests pass; TypeScript clean
- [x] /simplify pass applied
- [x] Fresh-context reviewer ran independently
- [x] Award chips / world rank / existing region chip semantics preserved
- [ ] Visual: 375 / 768 / 1280 + dark mode after deploy

## Follow-ups not in this PR

- **#516, #517** (Distinguished countdown columns + tier column) — need per-district officer-awards JSON; deserve a focused sprint after investigation.
- Consolidate cross-page KPI primitive (KpiCard vs StatCard vs districts-kpi-card).
- Tighten or drop the \`?? 0\` guards on number-typed base fields (per critical review Medium).

Closes #514, #515, #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)