### PR TITLE
feat(region): Distinguished countdown + Tier columns — closes Epic #513 (#516 #517)

### DIFF
--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -98,6 +98,53 @@ const CountdownTd: React.FC<{
   )
 }
 
+/* Per-tier display label + chip style. Pre-Distinguished districts get
+   an em-dash; achieved tiers get a colored chip matching the tier. */
+const TIER_DISPLAY: Record<string, { label: string; className: string }> = {
+  Distinguished: {
+    label: 'Distinguished',
+    className: 'bg-tm-true-maroon text-white',
+  },
+  Select: {
+    label: 'Select',
+    className: 'bg-tm-cool-gray text-gray-900',
+  },
+  Presidents: {
+    label: "President's",
+    className: 'bg-tm-happy-yellow text-gray-900',
+  },
+  Smedley: {
+    label: 'Smedley',
+    className: 'bg-purple-200 text-purple-900',
+  },
+}
+
+const TierTd: React.FC<{ tier: string | null }> = ({ tier }) => {
+  if (!tier || tier === 'NotDistinguished') {
+    return (
+      <td
+        data-testid="tier-cell"
+        className="px-3 py-4 whitespace-nowrap text-right text-sm text-gray-400"
+      >
+        —
+      </td>
+    )
+  }
+  const config = TIER_DISPLAY[tier]
+  return (
+    <td
+      data-testid="tier-cell"
+      className="px-3 py-4 whitespace-nowrap text-right"
+    >
+      <span
+        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ${config?.className ?? 'bg-gray-200 text-gray-700'}`}
+      >
+        {config?.label ?? tier}
+      </span>
+    </td>
+  )
+}
+
 const RegionPage: React.FC = () => {
   const { n } = useParams<{ n: string }>()
   const navigate = useNavigate()
@@ -267,6 +314,11 @@ const RegionPage: React.FC = () => {
                 <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Club Growth
                 </th>
+                {/* Tier column (#517). Shows current Distinguished tier
+                    when achieved; em-dash for districts still below. */}
+                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Tier
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -318,6 +370,9 @@ const RegionPage: React.FC = () => {
                         d.districtId,
                         awards ?? null
                       )
+                      const tier =
+                        awards?.distinguishedDistrict?.[d.districtId]
+                          ?.currentTier ?? null
                       return (
                         <>
                           <CountdownTd
@@ -340,6 +395,7 @@ const RegionPage: React.FC = () => {
                             metric="clubGrowth"
                             cell={c?.clubGrowth ?? null}
                           />
+                          <TierTd tier={tier} />
                         </>
                       )
                     })()}

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '../components/ErrorDisplay'
 import type { DistrictRanking } from '../types/districts'
 import { computeTiedRanks } from '../utils/tieRankingUtils'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
+import type { DistinguishedDistrictTier } from '../services/cdn'
 import {
   getDistinguishedCountdown,
   type CountdownCell,
@@ -61,65 +62,66 @@ const KpiCard: React.FC<KpiCardProps> = ({ label, base, current }) => {
   )
 }
 
-/* Cell renderer for the 5 Distinguished countdown columns (#516).
-   Numeric gaps render as +N; metric-met as ✓; boolean (officer awards)
-   as ✓ or em-dash. Em-dash everywhere when the cell prop is null
+/* Cell renderer for the Distinguished countdown columns. Numeric gaps
+   render as +N (maroon); metric-met as ✓ (green); boolean (officer
+   awards) as ✓ or em-dash. Em-dash when the cell prop is null
    (district missing from awards or legacy snapshot). */
-const CountdownTd: React.FC<{
-  metric: keyof import('../utils/distinguishedCountdown').DistinguishedCountdown
-  cell: CountdownCell | null
-}> = ({ metric, cell }) => {
-  const inner = (() => {
-    if (!cell) return <span className="text-gray-400">—</span>
-    if (cell.kind === 'met') {
-      return <span className="text-green-700 font-semibold">✓</span>
-    }
-    if (cell.kind === 'boolean') {
-      return cell.met ? (
-        <span className="text-green-700 font-semibold">✓</span>
-      ) : (
-        <span className="text-gray-400">—</span>
-      )
-    }
-    // kind === 'gap'
-    return (
-      <span className="text-tm-true-maroon font-semibold tabular-nums">
-        +{cell.value}
-      </span>
+const renderCountdownInner = (cell: CountdownCell | null): React.ReactNode => {
+  if (!cell) return <span className="text-gray-400">—</span>
+  if (cell.kind === 'met')
+    return <span className="text-green-700 font-semibold">✓</span>
+  if (cell.kind === 'boolean')
+    return cell.met ? (
+      <span className="text-green-700 font-semibold">✓</span>
+    ) : (
+      <span className="text-gray-400">—</span>
     )
-  })()
   return (
-    <td
-      data-testid={`countdown-${metric}`}
-      className="px-3 py-4 whitespace-nowrap text-sm text-right"
-    >
-      {inner}
-    </td>
+    <span className="text-tm-true-maroon font-semibold tabular-nums">
+      +{cell.value}
+    </span>
   )
 }
 
+const CountdownTd: React.FC<{
+  metric: keyof import('../utils/distinguishedCountdown').DistinguishedCountdown
+  cell: CountdownCell | null
+}> = ({ metric, cell }) => (
+  <td
+    data-testid={`countdown-${metric}`}
+    className="px-3 py-4 whitespace-nowrap text-sm text-right"
+  >
+    {renderCountdownInner(cell)}
+  </td>
+)
+
 /* Per-tier display label + chip style. Pre-Distinguished districts get
    an em-dash; achieved tiers get a colored chip matching the tier. */
-const TIER_DISPLAY: Record<string, { label: string; className: string }> = {
-  Distinguished: {
-    label: 'Distinguished',
-    className: 'bg-tm-true-maroon text-white',
-  },
-  Select: {
-    label: 'Select',
-    className: 'bg-tm-cool-gray text-gray-900',
-  },
-  Presidents: {
-    label: "President's",
-    className: 'bg-tm-happy-yellow text-gray-900',
-  },
-  Smedley: {
-    label: 'Smedley',
-    className: 'bg-purple-200 text-purple-900',
-  },
-}
+type AchievedTier = Exclude<DistinguishedDistrictTier, 'NotDistinguished'>
 
-const TierTd: React.FC<{ tier: string | null }> = ({ tier }) => {
+const TIER_DISPLAY: Record<AchievedTier, { label: string; className: string }> =
+  {
+    Distinguished: {
+      label: 'Distinguished',
+      className: 'bg-tm-true-maroon text-white',
+    },
+    Select: {
+      label: 'Select',
+      className: 'bg-tm-cool-gray text-gray-900',
+    },
+    Presidents: {
+      label: "President's",
+      className: 'bg-tm-happy-yellow text-gray-900',
+    },
+    Smedley: {
+      label: 'Smedley',
+      className: 'bg-purple-200 text-purple-900',
+    },
+  }
+
+const TierTd: React.FC<{ tier: DistinguishedDistrictTier | null }> = ({
+  tier,
+}) => {
   if (!tier || tier === 'NotDistinguished') {
     return (
       <td
@@ -137,11 +139,38 @@ const TierTd: React.FC<{ tier: string | null }> = ({ tier }) => {
       className="px-3 py-4 whitespace-nowrap text-right"
     >
       <span
-        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ${config?.className ?? 'bg-gray-200 text-gray-700'}`}
+        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ${config.className}`}
       >
-        {config?.label ?? tier}
+        {config.label}
       </span>
     </td>
+  )
+}
+
+/* Trailing six cells (5 countdown + 1 tier) for one district row.
+   Folds the awards lookup so the row map stays a clean list of
+   sub-components. */
+const DistinguishedCells: React.FC<{
+  districtId: string
+  awards: import('../services/cdn').CompetitiveAwardStandings | null
+}> = ({ districtId, awards }) => {
+  const c = getDistinguishedCountdown(districtId, awards)
+  const tier = awards?.distinguishedDistrict?.[districtId]?.currentTier ?? null
+  return (
+    <>
+      <CountdownTd metric="netClubGrowth" cell={c?.netClubGrowth ?? null} />
+      <CountdownTd metric="paymentGrowth" cell={c?.paymentGrowth ?? null} />
+      <CountdownTd
+        metric="distinguishedPercent"
+        cell={c?.distinguishedPercent ?? null}
+      />
+      <CountdownTd
+        metric="educationTraining"
+        cell={c?.educationTraining ?? null}
+      />
+      <CountdownTd metric="clubGrowth" cell={c?.clubGrowth ?? null} />
+      <TierTd tier={tier} />
+    </>
   )
 }
 
@@ -295,10 +324,10 @@ const RegionPage: React.FC = () => {
                 <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Score
                 </th>
-                {/* Distinguished countdown columns (#516). Show the gap
-                    to the next tier per district: numeric for the three
-                    DD prerequisites that the pipeline calculates a delta
-                    for, ✓ / em-dash for the two officer-award booleans. */}
+                {/* Show the gap to the next Distinguished tier per
+                    district: numeric for the three DD prerequisites that
+                    the pipeline calculates a delta for, ✓ / em-dash for
+                    the two officer-award booleans. */}
                 <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Net Club Growth
                 </th>
@@ -314,8 +343,8 @@ const RegionPage: React.FC = () => {
                 <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Club Growth
                 </th>
-                {/* Tier column (#517). Shows current Distinguished tier
-                    when achieved; em-dash for districts still below. */}
+                {/* Current Distinguished tier when achieved; em-dash
+                    for districts still below. */}
                 <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Tier
                 </th>
@@ -365,40 +394,10 @@ const RegionPage: React.FC = () => {
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
                       {d.aggregateScore}
                     </td>
-                    {(() => {
-                      const c = getDistinguishedCountdown(
-                        d.districtId,
-                        awards ?? null
-                      )
-                      const tier =
-                        awards?.distinguishedDistrict?.[d.districtId]
-                          ?.currentTier ?? null
-                      return (
-                        <>
-                          <CountdownTd
-                            metric="netClubGrowth"
-                            cell={c?.netClubGrowth ?? null}
-                          />
-                          <CountdownTd
-                            metric="paymentGrowth"
-                            cell={c?.paymentGrowth ?? null}
-                          />
-                          <CountdownTd
-                            metric="distinguishedPercent"
-                            cell={c?.distinguishedPercent ?? null}
-                          />
-                          <CountdownTd
-                            metric="educationTraining"
-                            cell={c?.educationTraining ?? null}
-                          />
-                          <CountdownTd
-                            metric="clubGrowth"
-                            cell={c?.clubGrowth ?? null}
-                          />
-                          <TierTd tier={tier} />
-                        </>
-                      )
-                    })()}
+                    <DistinguishedCells
+                      districtId={d.districtId}
+                      awards={awards ?? null}
+                    />
                   </tr>
                 )
               })}

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -188,9 +188,11 @@ const RegionPage: React.FC = () => {
     staleTime: 15 * 60 * 1000,
   })
 
-  // Distinguished District prerequisite gaps for each district in the
-  // region. Always latest snapshot — RegionPage has no date control.
-  const { data: awards } = useCompetitiveAwards(undefined)
+  // Distinguished District prerequisite gaps. Pin to the rankings
+  // snapshot date so the countdown/tier columns can never drift to a
+  // newer snapshot than the row they describe — two independent "latest"
+  // calls would race during a publish.
+  const { data: awards } = useCompetitiveAwards(data?.date)
 
   // No useMemo — list is small (≤ ~10 districts) and the page is
   // route-level. The React Compiler manages memoization automatically.

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -11,6 +11,11 @@ import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 import type { DistrictRanking } from '../types/districts'
 import { computeTiedRanks } from '../utils/tieRankingUtils'
+import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
+import {
+  getDistinguishedCountdown,
+  type CountdownCell,
+} from '../utils/distinguishedCountdown'
 
 interface KpiCardProps {
   label: string
@@ -56,6 +61,43 @@ const KpiCard: React.FC<KpiCardProps> = ({ label, base, current }) => {
   )
 }
 
+/* Cell renderer for the 5 Distinguished countdown columns (#516).
+   Numeric gaps render as +N; metric-met as ✓; boolean (officer awards)
+   as ✓ or em-dash. Em-dash everywhere when the cell prop is null
+   (district missing from awards or legacy snapshot). */
+const CountdownTd: React.FC<{
+  metric: keyof import('../utils/distinguishedCountdown').DistinguishedCountdown
+  cell: CountdownCell | null
+}> = ({ metric, cell }) => {
+  const inner = (() => {
+    if (!cell) return <span className="text-gray-400">—</span>
+    if (cell.kind === 'met') {
+      return <span className="text-green-700 font-semibold">✓</span>
+    }
+    if (cell.kind === 'boolean') {
+      return cell.met ? (
+        <span className="text-green-700 font-semibold">✓</span>
+      ) : (
+        <span className="text-gray-400">—</span>
+      )
+    }
+    // kind === 'gap'
+    return (
+      <span className="text-tm-true-maroon font-semibold tabular-nums">
+        +{cell.value}
+      </span>
+    )
+  })()
+  return (
+    <td
+      data-testid={`countdown-${metric}`}
+      className="px-3 py-4 whitespace-nowrap text-sm text-right"
+    >
+      {inner}
+    </td>
+  )
+}
+
 const RegionPage: React.FC = () => {
   const { n } = useParams<{ n: string }>()
   const navigate = useNavigate()
@@ -69,6 +111,10 @@ const RegionPage: React.FC = () => {
     },
     staleTime: 15 * 60 * 1000,
   })
+
+  // Distinguished District prerequisite gaps for each district in the
+  // region. Always latest snapshot — RegionPage has no date control.
+  const { data: awards } = useCompetitiveAwards(undefined)
 
   // No useMemo — list is small (≤ ~10 districts) and the page is
   // route-level. The React Compiler manages memoization automatically.
@@ -202,6 +248,25 @@ const RegionPage: React.FC = () => {
                 <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Score
                 </th>
+                {/* Distinguished countdown columns (#516). Show the gap
+                    to the next tier per district: numeric for the three
+                    DD prerequisites that the pipeline calculates a delta
+                    for, ✓ / em-dash for the two officer-award booleans. */}
+                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Net Club Growth
+                </th>
+                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Payment Growth
+                </th>
+                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Distinguished %
+                </th>
+                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Education / Training
+                </th>
+                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Club Growth
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -226,6 +291,7 @@ const RegionPage: React.FC = () => {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span
+                        data-testid={`district-number-chip-D${d.districtId}`}
                         className="districts-rankings-table__district-chip"
                         aria-hidden="true"
                       >
@@ -247,6 +313,36 @@ const RegionPage: React.FC = () => {
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
                       {d.aggregateScore}
                     </td>
+                    {(() => {
+                      const c = getDistinguishedCountdown(
+                        d.districtId,
+                        awards ?? null
+                      )
+                      return (
+                        <>
+                          <CountdownTd
+                            metric="netClubGrowth"
+                            cell={c?.netClubGrowth ?? null}
+                          />
+                          <CountdownTd
+                            metric="paymentGrowth"
+                            cell={c?.paymentGrowth ?? null}
+                          />
+                          <CountdownTd
+                            metric="distinguishedPercent"
+                            cell={c?.distinguishedPercent ?? null}
+                          />
+                          <CountdownTd
+                            metric="educationTraining"
+                            cell={c?.educationTraining ?? null}
+                          />
+                          <CountdownTd
+                            metric="clubGrowth"
+                            cell={c?.clubGrowth ?? null}
+                          />
+                        </>
+                      )
+                    })()}
                   </tr>
                 )
               })}

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -6,7 +6,7 @@ import RegionPage from '../RegionPage'
 import {
   fetchCdnRankings,
   fetchCdnCompetitiveAwards,
-  fetchCdnManifest,
+  type CompetitiveAwardStandings,
 } from '../../services/cdn'
 
 vi.mock('../../services/cdn', () => ({
@@ -19,8 +19,6 @@ vi.mock('../../services/cdn', () => ({
 
 const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)
 const mockedFetchCdnAwards = vi.mocked(fetchCdnCompetitiveAwards)
-// fetchCdnManifest is mocked at module scope; we don't need a typed handle.
-void fetchCdnManifest
 
 const mkRanking = (overrides: Record<string, unknown>) => ({
   districtId: '1',
@@ -105,7 +103,7 @@ describe('RegionPage tier column (#517 #513)', () => {
         educationTraining: [],
         clubGrowth: [],
       },
-    }) as unknown as Awaited<ReturnType<typeof fetchCdnCompetitiveAwards>>
+    }) as CompetitiveAwardStandings
 
   it('renders an em-dash for districts that have not yet reached Distinguished', async () => {
     mockedFetchCdnRankings.mockResolvedValueOnce({
@@ -224,7 +222,7 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
         ],
       },
       ...overrides,
-    }) as unknown as Awaited<ReturnType<typeof fetchCdnCompetitiveAwards>>
+    }) as CompetitiveAwardStandings
 
   it('renders five countdown column headers', async () => {
     mockedFetchCdnRankings.mockResolvedValueOnce({

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -3,13 +3,24 @@ import { cleanup, render, screen, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import RegionPage from '../RegionPage'
-import { fetchCdnRankings } from '../../services/cdn'
+import {
+  fetchCdnRankings,
+  fetchCdnCompetitiveAwards,
+  fetchCdnManifest,
+} from '../../services/cdn'
 
 vi.mock('../../services/cdn', () => ({
   fetchCdnRankings: vi.fn(),
+  fetchCdnCompetitiveAwards: vi.fn().mockResolvedValue(null),
+  fetchCdnManifest: vi
+    .fn()
+    .mockResolvedValue({ latestSnapshotDate: '2026-05-12', generatedAt: 'x' }),
 }))
 
 const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)
+const mockedFetchCdnAwards = vi.mocked(fetchCdnCompetitiveAwards)
+// fetchCdnManifest is mocked at module scope; we don't need a typed handle.
+void fetchCdnManifest
 
 const mkRanking = (overrides: Record<string, unknown>) => ({
   districtId: '1',
@@ -52,6 +63,185 @@ const renderRegion = (region: string) => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+})
+
+describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
+  const awardsFixture = (overrides: Partial<Record<string, unknown>> = {}) =>
+    ({
+      metadata: {
+        snapshotId: 'x',
+        calculatedAt: 'x',
+        totalDistricts: 1,
+      },
+      extensionAward: [],
+      twentyPlusAward: [],
+      retentionAward: [],
+      byDistrict: {},
+      distinguishedDistrict: {
+        '61': {
+          districtId: '61',
+          currentTier: 'NotDistinguished',
+          allPrerequisitesMet: false,
+          prerequisites: {
+            dspSubmitted: false,
+            trainingMet: false,
+            marketAnalysisSubmitted: false,
+            communicationPlanSubmitted: false,
+            regionAdvisorVisitMet: false,
+          },
+          nextTierGap: {
+            tier: 'Distinguished',
+            netClubGrowthGap: 3,
+            paymentGrowthGap: 12,
+            distinguishedPercentGap: 8,
+            clubGrowthGap: 0,
+          },
+        },
+      },
+      officerAwards: {
+        educationTraining: [
+          {
+            districtId: '61',
+            districtName: 'District 61',
+            region: '2',
+            qualifies: false,
+          },
+        ],
+        clubGrowth: [
+          {
+            districtId: '61',
+            districtName: 'District 61',
+            region: '2',
+            qualifies: true,
+          },
+        ],
+      },
+      ...overrides,
+    }) as unknown as Awaited<ReturnType<typeof fetchCdnCompetitiveAwards>>
+
+  it('renders five countdown column headers', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValueOnce(awardsFixture())
+    renderRegion('2')
+
+    expect(
+      await screen.findByRole('columnheader', { name: /net club growth/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /payment growth/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /distinguished %/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /education ?\/ ?training/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /^club growth$/i })
+    ).toBeInTheDocument()
+  })
+
+  it('renders gap values as +N for numeric countdowns', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValueOnce(awardsFixture())
+    renderRegion('2')
+
+    const row = (await screen.findByTestId('district-number-chip-D61')).closest(
+      'tr'
+    )!
+    expect(
+      within(row).getByTestId('countdown-netClubGrowth')
+    ).toHaveTextContent(/\+3/)
+    expect(
+      within(row).getByTestId('countdown-paymentGrowth')
+    ).toHaveTextContent(/\+12/)
+    expect(
+      within(row).getByTestId('countdown-distinguishedPercent')
+    ).toHaveTextContent(/\+8/)
+  })
+
+  it('renders ✓ for officer-award booleans when met, em-dash when not', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValueOnce(awardsFixture())
+    renderRegion('2')
+
+    const row = (await screen.findByTestId('district-number-chip-D61')).closest(
+      'tr'
+    )!
+    expect(
+      within(row).getByTestId('countdown-educationTraining')
+    ).toHaveTextContent(/—/)
+    expect(within(row).getByTestId('countdown-clubGrowth')).toHaveTextContent(
+      /✓/
+    )
+  })
+
+  it('renders ✓ for numeric metrics that are already met', async () => {
+    const fixture = awardsFixture({
+      distinguishedDistrict: {
+        '61': {
+          districtId: '61',
+          currentTier: 'Distinguished',
+          allPrerequisitesMet: true,
+          prerequisites: {
+            dspSubmitted: true,
+            trainingMet: true,
+            marketAnalysisSubmitted: true,
+            communicationPlanSubmitted: true,
+            regionAdvisorVisitMet: true,
+          },
+          nextTierGap: {
+            tier: 'Select',
+            netClubGrowthGap: 0,
+            paymentGrowthGap: -2,
+            distinguishedPercentGap: 5,
+            clubGrowthGap: 0,
+          },
+        },
+      },
+    })
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValueOnce(fixture)
+    renderRegion('2')
+
+    const row = (await screen.findByTestId('district-number-chip-D61')).closest(
+      'tr'
+    )!
+    expect(
+      within(row).getByTestId('countdown-netClubGrowth')
+    ).toHaveTextContent(/✓/)
+    expect(
+      within(row).getByTestId('countdown-paymentGrowth')
+    ).toHaveTextContent(/✓/)
+  })
+
+  it('renders em-dashes when the awards JSON is null (legacy snapshot)', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValueOnce(null)
+    renderRegion('2')
+
+    const row = (await screen.findByTestId('district-number-chip-D61')).closest(
+      'tr'
+    )!
+    expect(
+      within(row).getByTestId('countdown-netClubGrowth')
+    ).toHaveTextContent(/—/)
+  })
 })
 
 describe('RegionPage KPI strip — base / current / Δ / ±% (#514 #513)', () => {

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -110,9 +110,7 @@ describe('RegionPage tier column (#517 #513)', () => {
       rankings: [mkRanking({ districtId: '61', region: '2' })],
       date: '2026-05-12',
     })
-    mockedFetchCdnAwards.mockResolvedValueOnce(
-      awardsWithTier('NotDistinguished')
-    )
+    mockedFetchCdnAwards.mockResolvedValue(awardsWithTier('NotDistinguished'))
     renderRegion('2')
 
     const row = (await screen.findByTestId('district-number-chip-D61')).closest(
@@ -133,7 +131,7 @@ describe('RegionPage tier column (#517 #513)', () => {
         rankings: [mkRanking({ districtId: '61', region: '2' })],
         date: '2026-05-12',
       })
-      mockedFetchCdnAwards.mockResolvedValueOnce(awardsWithTier(tier))
+      mockedFetchCdnAwards.mockResolvedValue(awardsWithTier(tier))
       renderRegion('2')
 
       const row = (
@@ -148,7 +146,7 @@ describe('RegionPage tier column (#517 #513)', () => {
       rankings: [mkRanking({ districtId: '61', region: '2' })],
       date: '2026-05-12',
     })
-    mockedFetchCdnAwards.mockResolvedValueOnce(null)
+    mockedFetchCdnAwards.mockResolvedValue(null)
     renderRegion('2')
 
     const row = (await screen.findByTestId('district-number-chip-D61')).closest(
@@ -162,7 +160,7 @@ describe('RegionPage tier column (#517 #513)', () => {
       rankings: [mkRanking({ districtId: '61', region: '2' })],
       date: '2026-05-12',
     })
-    mockedFetchCdnAwards.mockResolvedValueOnce(awardsWithTier('Distinguished'))
+    mockedFetchCdnAwards.mockResolvedValue(awardsWithTier('Distinguished'))
     renderRegion('2')
     expect(
       await screen.findByRole('columnheader', { name: /^tier$/i })
@@ -229,7 +227,7 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
       rankings: [mkRanking({ districtId: '61', region: '2' })],
       date: '2026-05-12',
     })
-    mockedFetchCdnAwards.mockResolvedValueOnce(awardsFixture())
+    mockedFetchCdnAwards.mockResolvedValue(awardsFixture())
     renderRegion('2')
 
     expect(
@@ -254,7 +252,7 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
       rankings: [mkRanking({ districtId: '61', region: '2' })],
       date: '2026-05-12',
     })
-    mockedFetchCdnAwards.mockResolvedValueOnce(awardsFixture())
+    mockedFetchCdnAwards.mockResolvedValue(awardsFixture())
     renderRegion('2')
 
     const row = (await screen.findByTestId('district-number-chip-D61')).closest(
@@ -276,7 +274,7 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
       rankings: [mkRanking({ districtId: '61', region: '2' })],
       date: '2026-05-12',
     })
-    mockedFetchCdnAwards.mockResolvedValueOnce(awardsFixture())
+    mockedFetchCdnAwards.mockResolvedValue(awardsFixture())
     renderRegion('2')
 
     const row = (await screen.findByTestId('district-number-chip-D61')).closest(
@@ -318,7 +316,7 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
       rankings: [mkRanking({ districtId: '61', region: '2' })],
       date: '2026-05-12',
     })
-    mockedFetchCdnAwards.mockResolvedValueOnce(fixture)
+    mockedFetchCdnAwards.mockResolvedValue(fixture)
     renderRegion('2')
 
     const row = (await screen.findByTestId('district-number-chip-D61')).closest(
@@ -337,7 +335,7 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
       rankings: [mkRanking({ districtId: '61', region: '2' })],
       date: '2026-05-12',
     })
-    mockedFetchCdnAwards.mockResolvedValueOnce(null)
+    mockedFetchCdnAwards.mockResolvedValue(null)
     renderRegion('2')
 
     const row = (await screen.findByTestId('district-number-chip-D61')).closest(

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -65,6 +65,113 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+describe('RegionPage tier column (#517 #513)', () => {
+  const awardsWithTier = (tier: string) =>
+    ({
+      metadata: {
+        snapshotId: 'x',
+        calculatedAt: 'x',
+        totalDistricts: 1,
+      },
+      extensionAward: [],
+      twentyPlusAward: [],
+      retentionAward: [],
+      byDistrict: {},
+      distinguishedDistrict: {
+        '61': {
+          districtId: '61',
+          currentTier: tier,
+          allPrerequisitesMet: tier !== 'NotDistinguished',
+          prerequisites: {
+            dspSubmitted: true,
+            trainingMet: true,
+            marketAnalysisSubmitted: true,
+            communicationPlanSubmitted: true,
+            regionAdvisorVisitMet: true,
+          },
+          nextTierGap:
+            tier === 'Smedley'
+              ? null
+              : {
+                  tier: 'Distinguished',
+                  netClubGrowthGap: 0,
+                  paymentGrowthGap: 0,
+                  distinguishedPercentGap: 0,
+                  clubGrowthGap: 0,
+                },
+        },
+      },
+      officerAwards: {
+        educationTraining: [],
+        clubGrowth: [],
+      },
+    }) as unknown as Awaited<ReturnType<typeof fetchCdnCompetitiveAwards>>
+
+  it('renders an em-dash for districts that have not yet reached Distinguished', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValueOnce(
+      awardsWithTier('NotDistinguished')
+    )
+    renderRegion('2')
+
+    const row = (await screen.findByTestId('district-number-chip-D61')).closest(
+      'tr'
+    )!
+    expect(within(row).getByTestId('tier-cell')).toHaveTextContent(/—/)
+  })
+
+  it('renders the tier name for Distinguished and above', async () => {
+    for (const [tier, label] of [
+      ['Distinguished', /distinguished/i],
+      ['Select', /select/i],
+      ['Presidents', /president/i],
+      ['Smedley', /smedley/i],
+    ] as const) {
+      cleanup()
+      mockedFetchCdnRankings.mockResolvedValueOnce({
+        rankings: [mkRanking({ districtId: '61', region: '2' })],
+        date: '2026-05-12',
+      })
+      mockedFetchCdnAwards.mockResolvedValueOnce(awardsWithTier(tier))
+      renderRegion('2')
+
+      const row = (
+        await screen.findByTestId('district-number-chip-D61')
+      ).closest('tr')!
+      expect(within(row).getByTestId('tier-cell')).toHaveTextContent(label)
+    }
+  })
+
+  it('renders an em-dash when the awards JSON is null (legacy snapshot)', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValueOnce(null)
+    renderRegion('2')
+
+    const row = (await screen.findByTestId('district-number-chip-D61')).closest(
+      'tr'
+    )!
+    expect(within(row).getByTestId('tier-cell')).toHaveTextContent(/—/)
+  })
+
+  it('renders a "Tier" column header', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValueOnce(awardsWithTier('Distinguished'))
+    renderRegion('2')
+    expect(
+      await screen.findByRole('columnheader', { name: /^tier$/i })
+    ).toBeInTheDocument()
+  })
+})
+
 describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
   const awardsFixture = (overrides: Partial<Record<string, unknown>> = {}) =>
     ({

--- a/frontend/src/utils/__tests__/distinguishedCountdown.test.ts
+++ b/frontend/src/utils/__tests__/distinguishedCountdown.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getDistinguishedCountdown,
+  type DistinguishedCountdown,
+} from '../distinguishedCountdown'
+import type {
+  CompetitiveAwardStandings,
+  DistinguishedDistrictStatus,
+} from '../../services/cdn'
+
+/* Unit tests for the per-district countdown helper used by the
+   Region page (#516). The helper folds three numeric gaps (net club
+   growth, payment growth, distinguished percent) and two officer-
+   award booleans (education-training, club-growth) into a uniform
+   shape the table cell renderer can consume. */
+
+const mkAwards = (
+  status: DistinguishedDistrictStatus | undefined,
+  educationQualifies: boolean,
+  clubGrowthQualifies: boolean
+): CompetitiveAwardStandings =>
+  ({
+    metadata: { snapshotId: 'x', calculatedAt: 'x', totalDistricts: 1 },
+    extensionAward: [],
+    twentyPlusAward: [],
+    retentionAward: [],
+    byDistrict: {},
+    distinguishedDistrict: status ? { [status.districtId]: status } : {},
+    officerAwards: {
+      educationTraining: [
+        {
+          districtId: '61',
+          districtName: 'District 61',
+          region: '2',
+          qualifies: educationQualifies,
+        },
+      ],
+      clubGrowth: [
+        {
+          districtId: '61',
+          districtName: 'District 61',
+          region: '2',
+          qualifies: clubGrowthQualifies,
+        },
+      ],
+    },
+  }) as CompetitiveAwardStandings
+
+const ddStatus = (
+  overrides: Partial<DistinguishedDistrictStatus> = {}
+): DistinguishedDistrictStatus => ({
+  districtId: '61',
+  currentTier: 'NotDistinguished',
+  allPrerequisitesMet: false,
+  prerequisites: {
+    dspSubmitted: false,
+    trainingMet: false,
+    marketAnalysisSubmitted: false,
+    communicationPlanSubmitted: false,
+    regionAdvisorVisitMet: false,
+  },
+  nextTierGap: {
+    tier: 'Distinguished',
+    netClubGrowthGap: 3,
+    paymentGrowthGap: 12,
+    distinguishedPercentGap: 8,
+    clubGrowthGap: 0,
+  },
+  ...overrides,
+})
+
+describe('getDistinguishedCountdown (#516)', () => {
+  it('returns the three numeric gaps + two officer-award booleans', () => {
+    const awards = mkAwards(ddStatus(), false, true)
+    const c = getDistinguishedCountdown('61', awards)
+    expect(c).not.toBeNull()
+    expect(c!.netClubGrowth).toEqual({ kind: 'gap', value: 3 })
+    expect(c!.paymentGrowth).toEqual({ kind: 'gap', value: 12 })
+    expect(c!.distinguishedPercent).toEqual({ kind: 'gap', value: 8 })
+    expect(c!.educationTraining).toEqual({ kind: 'boolean', met: false })
+    expect(c!.clubGrowth).toEqual({ kind: 'boolean', met: true })
+  })
+
+  it('flips a numeric gap to "met" when the value is 0 or negative', () => {
+    const status = ddStatus({
+      nextTierGap: {
+        tier: 'Distinguished',
+        netClubGrowthGap: 0,
+        paymentGrowthGap: -5,
+        distinguishedPercentGap: 4,
+        clubGrowthGap: 0,
+      },
+    })
+    const awards = mkAwards(status, false, false)
+    const c = getDistinguishedCountdown('61', awards)
+    expect(c!.netClubGrowth).toEqual({ kind: 'met' })
+    expect(c!.paymentGrowth).toEqual({ kind: 'met' })
+    expect(c!.distinguishedPercent).toEqual({ kind: 'gap', value: 4 })
+  })
+
+  it('returns "met" for all three numeric metrics when nextTierGap is null (district at Smedley)', () => {
+    const status = ddStatus({ currentTier: 'Smedley', nextTierGap: null })
+    const awards = mkAwards(status, true, true)
+    const c = getDistinguishedCountdown('61', awards)
+    expect(c!.netClubGrowth).toEqual({ kind: 'met' })
+    expect(c!.paymentGrowth).toEqual({ kind: 'met' })
+    expect(c!.distinguishedPercent).toEqual({ kind: 'met' })
+  })
+
+  it('returns null when the district has no Distinguished District status entry', () => {
+    const awards = mkAwards(undefined, false, false)
+    const c = getDistinguishedCountdown('61', awards)
+    expect(c).toBeNull()
+  })
+
+  it('returns null when awards is null (legacy snapshot)', () => {
+    const c: DistinguishedCountdown | null = getDistinguishedCountdown(
+      '61',
+      null
+    )
+    expect(c).toBeNull()
+  })
+
+  it('officer-award booleans default to {met: false} when the district is missing from the lists', () => {
+    // Awards present, but officerAwards arrays don't include district 61.
+    const awards: CompetitiveAwardStandings = {
+      ...mkAwards(ddStatus(), false, false),
+      officerAwards: { educationTraining: [], clubGrowth: [] },
+    }
+    const c = getDistinguishedCountdown('61', awards)
+    expect(c!.educationTraining).toEqual({ kind: 'boolean', met: false })
+    expect(c!.clubGrowth).toEqual({ kind: 'boolean', met: false })
+  })
+})

--- a/frontend/src/utils/distinguishedCountdown.ts
+++ b/frontend/src/utils/distinguishedCountdown.ts
@@ -1,6 +1,6 @@
 import type { CompetitiveAwardStandings } from '../services/cdn'
 
-/* Per-district countdown to the next Distinguished District tier (#516).
+/* Per-district countdown to the next Distinguished District tier.
    Folds three numeric gaps + two officer-award booleans from the
    competitive-awards JSON into a uniform shape the table cell renderer
    can consume. */
@@ -18,9 +18,48 @@ export interface DistinguishedCountdown {
   clubGrowth: CountdownCell
 }
 
+const gapCell = (value: number): CountdownCell =>
+  value <= 0 ? { kind: 'met' } : { kind: 'gap', value }
+
 export function getDistinguishedCountdown(
-  _districtId: string,
-  _awards: CompetitiveAwardStandings | null
+  districtId: string,
+  awards: CompetitiveAwardStandings | null
 ): DistinguishedCountdown | null {
-  return null
+  if (!awards) return null
+  const status = awards.distinguishedDistrict?.[districtId]
+  if (!status) return null
+
+  // nextTierGap is null when the district is already at Smedley — every
+  // numeric metric has been satisfied at the highest tier.
+  const gap = status.nextTierGap
+  const numeric: Pick<
+    DistinguishedCountdown,
+    'netClubGrowth' | 'paymentGrowth' | 'distinguishedPercent'
+  > = gap
+    ? {
+        netClubGrowth: gapCell(gap.netClubGrowthGap),
+        paymentGrowth: gapCell(gap.paymentGrowthGap),
+        distinguishedPercent: gapCell(gap.distinguishedPercentGap),
+      }
+    : {
+        netClubGrowth: { kind: 'met' },
+        paymentGrowth: { kind: 'met' },
+        distinguishedPercent: { kind: 'met' },
+      }
+
+  const educationTraining: CountdownCell = {
+    kind: 'boolean',
+    met:
+      awards.officerAwards?.educationTraining.find(
+        e => e.districtId === districtId
+      )?.qualifies ?? false,
+  }
+  const clubGrowth: CountdownCell = {
+    kind: 'boolean',
+    met:
+      awards.officerAwards?.clubGrowth.find(c => c.districtId === districtId)
+        ?.qualifies ?? false,
+  }
+
+  return { ...numeric, educationTraining, clubGrowth }
 }

--- a/frontend/src/utils/distinguishedCountdown.ts
+++ b/frontend/src/utils/distinguishedCountdown.ts
@@ -1,0 +1,26 @@
+import type { CompetitiveAwardStandings } from '../services/cdn'
+
+/* Per-district countdown to the next Distinguished District tier (#516).
+   Folds three numeric gaps + two officer-award booleans from the
+   competitive-awards JSON into a uniform shape the table cell renderer
+   can consume. */
+
+export type CountdownCell =
+  | { kind: 'gap'; value: number }
+  | { kind: 'met' }
+  | { kind: 'boolean'; met: boolean }
+
+export interface DistinguishedCountdown {
+  netClubGrowth: CountdownCell
+  paymentGrowth: CountdownCell
+  distinguishedPercent: CountdownCell
+  educationTraining: CountdownCell
+  clubGrowth: CountdownCell
+}
+
+export function getDistinguishedCountdown(
+  _districtId: string,
+  _awards: CompetitiveAwardStandings | null
+): DistinguishedCountdown | null {
+  return null
+}


### PR DESCRIPTION
## Summary

Final sprint of Epic #513 — Region page rollup + per-district Distinguished countdown. Adds six trailing columns to the \`/region/:n\` district table that recreate Ron's hand-maintained Excel sheet exactly.

### Distinguished countdown (#516) — 5 columns

| Column | Source | Display |
|---|---|---|
| **Net Club Growth** | \`nextTierGap.netClubGrowthGap\` | +N → ✓ when ≤ 0 |
| **Payment Growth** | \`nextTierGap.paymentGrowthGap\` | +N → ✓ when ≤ 0 |
| **Distinguished %** | \`nextTierGap.distinguishedPercentGap\` | +N → ✓ when ≤ 0 |
| **Education / Training** | \`officerAwards.educationTraining[].qualifies\` | ✓ / em-dash |
| **Club Growth** (officer award) | \`officerAwards.clubGrowth[].qualifies\` | ✓ / em-dash |

Em-dash everywhere when awards JSON is null (legacy snapshot).

### Tier column (#517)

Trailing chip showing the district's current Distinguished tier with brand colors:
- Distinguished → maroon
- Select → cool gray
- President's → happy yellow
- Smedley → purple
- NotDistinguished → em-dash

## Pure helper

\`frontend/src/utils/distinguishedCountdown.ts\` — folds the three numeric gaps + two officer-award booleans into a uniform \`CountdownCell\` shape. 6 unit tests cover the gap→met flip, null awards, missing district, Smedley (nextTierGap=null) case.

## Commits

1. \`test(util): RED — getDistinguishedCountdown helper\`
2. \`feat(util): GREEN — getDistinguishedCountdown helper\`
3. \`test(region): RED — 5-column Distinguished countdown\`
4. \`feat(region): GREEN — 5-column Distinguished countdown\`
5. \`test(region): RED — Tier column\`
6. \`feat(region): GREEN — Tier column\`
7. \`refactor(region): /simplify pass — type TIER_DISPLAY, extract <DistinguishedCells>, drop fixture casts\`
8. \`fix(region): pin awards fetch to rankings snapshot date\` (review-fix)

## /simplify pass

Three reviewer agents agreed:
- Replace \`Record<string, ...>\` with \`Record<AchievedTier, ...>\` using the exported \`DistinguishedDistrictTier\` type.
- Extract \`<DistinguishedCells>\` sub-component to replace an inline IIFE wrapping 6 cells.
- Extract \`renderCountdownInner()\` helper to replace another IIFE.
- Drop \`(#NNN)\` issue refs from inline comments (changelog rot per CLAUDE.md).
- Replace test fixture casts \`as unknown as Awaited<ReturnType<...>>\` with \`as CompetitiveAwardStandings\`.

## Critical fresh-context review

One **High** finding fixed in commit 8: \`useCompetitiveAwards(undefined)\` and \`fetchCdnRankings()\` both resolved their own "latest" — if a snapshot publishes between the two requests, the cells could drift across snapshots. Fix: pin awards to \`data?.date\` from the rankings query.

One **Medium** filed as follow-up **#534**: the gap interface has four numeric metrics; we surface three. \`clubGrowthGap\` (% threshold) is currently unused on this page. A district could appear to qualify on the visible columns while still failing the missing one.

Reviewer Lows documented:
- Apostrophe in \`Presidents\` → \`"President's"\`: consistent mapping centralized in \`TIER_DISPLAY\`.
- Row-drop edge case when district missing from awards: confirmed — \`getDistinguishedCountdown\` returns null → all cells render em-dashes; row still appears.
- Tier-chip styling diverges slightly from \`DistinguishedDistrictTrophyCase\` (compact-table variant). Filing as a future consolidation candidate.

## Test plan

- [x] 11 new RED tests across 2 issues → all GREEN
- [x] 2293/2293 frontend tests pass; TypeScript clean
- [x] /simplify + critical review applied
- [x] Awards pinned to rankings snapshot (no drift)
- [ ] Visual: 375 / 768 / 1280 + dark mode after deploy

Closes #513, #516, #517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)