### PR TITLE
fix(analytics): % Distinguished uses Paid Club Base per TI DDP rule (#537)

### DIFF
--- a/packages/analytics-core/src/rankings/BordaCountRankingCalculator.test.ts
+++ b/packages/analytics-core/src/rankings/BordaCountRankingCalculator.test.ts
@@ -560,4 +560,63 @@ describe('BordaCountRankingCalculator', () => {
       expect(ranked.ranking!.distinguishedClubs).toBe(2)
     })
   })
+
+  describe('% Distinguished denominator — TI DDP rule (#537)', () => {
+    /* The Distinguished District Program (Item 1490) computes
+       "% Distinguished" as distinguishedClubs / paidClubBase × 100,
+       where paidClubBase is the PY-start club count. The historical
+       implementation used activeClubs (current count) which produced
+       a lower number whenever districts gained clubs during the PY —
+       see /district/93 where 38/74 = 51.35% disagreed with the count
+       targets that correctly used base (38/69 = 55.07%). */
+    function mkD93LikeDistrict(): RankingDistrictStatistics {
+      // D93's actual numbers as of the reported snapshot.
+      return {
+        districtId: '93',
+        asOfDate: '2026-05-14',
+        membership: { total: 1198, change: 0, changePercent: 0, byClub: [] },
+        clubs: {
+          total: 74,
+          active: 74,
+          suspended: 0,
+          ineligible: 0,
+          low: 0,
+          distinguished: 38,
+        },
+        education: { totalAwards: 0, byType: [], topClubs: [] },
+        districtPerformance: [
+          {
+            DISTRICT: '93',
+            REGION: '14',
+            'Paid Clubs': '74',
+            'Paid Club Base': '69',
+            '% Club Growth': '7.25%',
+            'Total YTD Payments': '2818',
+            'Payment Base': '2500',
+            '% Payment Growth': '12.72%',
+            'Active Clubs': '74',
+            'Total Distinguished Clubs': '38',
+            'Select Distinguished Clubs': '6',
+            'Presidents Distinguished Clubs': '4',
+          },
+        ],
+      }
+    }
+
+    it('computes distinguishedPercent against Paid Club Base, not Active Clubs', async () => {
+      const district = mkD93LikeDistrict()
+      const result = await calculator.calculateRankings([district])
+      const ranking = result[0]!.ranking!
+      // 38 / 69 = 55.0724...% — the TI-correct figure.
+      // Old buggy formula 38 / 74 = 51.35% would fail this assertion.
+      expect(ranking.distinguishedPercent).toBeCloseTo(55.07, 1)
+    })
+
+    it('returns 0 when Paid Club Base is missing or zero', async () => {
+      const district = mkD93LikeDistrict()
+      district.districtPerformance![0]!['Paid Club Base'] = '0'
+      const result = await calculator.calculateRankings([district])
+      expect(result[0]!.ranking!.distinguishedPercent).toBe(0)
+    })
+  })
 })

--- a/packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts
+++ b/packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts
@@ -820,16 +820,21 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
    * Calculate distinguished club percentage from raw data
    */
   private calculateDistinguishedPercent(data: AllDistrictsCSVRecord): number {
+    // Per the Distinguished District Program (Item 1490), % Distinguished
+    // is computed against Paid Club Base (PY-start club count), NOT
+    // current Active Clubs. Using activeClubs as the denominator
+    // under-reports the percentage whenever a district has gained clubs
+    // since PY start — which is exactly when recognition matters most.
     const distinguishedClubs = this.parseNumber(
       data['Total Distinguished Clubs']
     )
-    const activeClubs = this.parseNumber(data['Active Clubs'])
+    const paidClubBase = this.parseNumber(data['Paid Club Base'])
 
-    if (activeClubs === 0) {
+    if (paidClubBase === 0) {
       return 0
     }
 
-    return (distinguishedClubs / activeClubs) * 100
+    return (distinguishedClubs / paidClubBase) * 100
   }
 
   /**

--- a/packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts
+++ b/packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts
@@ -825,6 +825,12 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
     // current Active Clubs. Using activeClubs as the denominator
     // under-reports the percentage whenever a district has gained clubs
     // since PY start — which is exactly when recognition matters most.
+    //
+    // When paidClubBase is 0 or missing, return 0 rather than falling
+    // back to activeClubs. A missing base is either a brand-new district
+    // (no clubs at PY start → 0% Distinguished is correct) or a pipeline
+    // schema regression (which we want LOUD, not silently masked by the
+    // old buggy denominator).
     const distinguishedClubs = this.parseNumber(
       data['Total Distinguished Clubs']
     )


### PR DESCRIPTION
## Summary

Fixes the D93 contradiction in the Distinguished District Status section: trophy case said "Select" while every count threshold (Paid Clubs, Membership Payments, Distinguished Clubs) correctly showed ✓ for President's.

Root cause: \`BordaCountRankingCalculator.calculateDistinguishedPercent\` divided distinguishedClubs by **activeClubs** (current count) instead of **paidClubBase** (PY-start count). Per the Distinguished District Program (Item 1490), the qualifying percentage uses Paid Club Base.

### D93 math

- distinguishedClubs = 38
- activeClubs = 74 (current paid)
- paidClubBase = 69 (PY start, June 30)

| Calculation | Result | vs 55% President's threshold |
|---|---|---|
| Before: 38 / 74 (active) | 51.35% | ❌ Fails by 3.65% (matches the "+3.6%" gap shown in the screenshot) |
| After: 38 / 69 (base) | 55.07% | ✓ Meets President's |

The KPI count targets (e.g. President's 38) were already computed against \`paidClubBase\` via \`calculatePercentageTargets\`, which is why the two surfaces disagreed.

## Blast radius

\`distinguishedPercent\` flows into 8+ consumers (trophy case, Borda count, comparison panel, region rollups). All of them now consume the TI-correct value. Display labels read slightly higher across the site — matches official terminology.

## Commits

1. \`test(analytics): RED — % Distinguished should use Paid Club Base, not Active Clubs\` — 2 failing tests
2. \`fix(analytics): GREEN — % Distinguished uses Paid Club Base per TI DDP rule\`
3. \`refactor(analytics): /simplify pass — document paidClubBase=0 fallback choice\`

## /simplify + critical review

Fresh-context reviewer found:
- ✅ Fix is correct, scope-minimal, aligned with TI Item 1490.
- One **Medium** (M1): document the deliberate \`paidClubBase=0\` fallback choice (returning 0 rather than the old activeClubs denominator). Applied in commit 3.
- Reviewer audited 8 frontend consumers — none assume the old "% of active" semantic; all read the field as the official DDP %.
- Reviewer audited test fixtures — all existing fixtures already supply \`Paid Club Base\`, no silent breakage.

## Test plan

- [x] 2 RED → 2 GREEN tests for the new behaviour (D93-like fixture asserting 55.07%, defensive zero case)
- [x] 763/763 analytics-core tests pass
- [x] 7 frontend "timed out in 5000ms" failures in parallel run all pass in isolation (known parallel-contention flake family, issue #525)
- [ ] Live verification on \`/district/93\` after deploy — trophy case should flip from "Select Distinguished" to "President's Distinguished"

## Note on data freshness

The fix is in the compute layer. The next scheduled pipeline snapshot will regenerate \`distinguishedPercent\` with the corrected formula. Historical archived \`all-districts-rankings.json\` files stay stale until overwritten by daily runs — acceptable for the rare archive consumer.

Closes #537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)