### PR TITLE
feat(region): Club Growth % column + CGD officer-award rename (#534)

### DIFF
--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -351,8 +351,12 @@ const RegionPage: React.FC = () => {
                 </th>
                 {/* CGD = Club Growth Director — TI officer award. Renamed
                     from "Club Growth" to disambiguate from the % Club
-                    Growth prerequisite immediately to its left. */}
-                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Growth prerequisite immediately to its left. Title
+                    attribute spells out the acronym for non-TM viewers. */}
+                <th
+                  className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  title="Club Growth Director — officer award"
+                >
                   CGD
                 </th>
                 {/* Current Distinguished tier when achieved; em-dash

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -165,6 +165,10 @@ const DistinguishedCells: React.FC<{
         cell={c?.distinguishedPercent ?? null}
       />
       <CountdownTd
+        metric="clubGrowthPercent"
+        cell={c?.clubGrowthPercent ?? null}
+      />
+      <CountdownTd
         metric="educationTraining"
         cell={c?.educationTraining ?? null}
       />
@@ -340,10 +344,16 @@ const RegionPage: React.FC = () => {
                   Distinguished %
                 </th>
                 <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Education / Training
+                  Club Growth %
                 </th>
                 <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Club Growth
+                  Education / Training
+                </th>
+                {/* CGD = Club Growth Director — TI officer award. Renamed
+                    from "Club Growth" to disambiguate from the % Club
+                    Growth prerequisite immediately to its left. */}
+                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  CGD
                 </th>
                 {/* Current Distinguished tier when achieved; em-dash
                     for districts still below. */}

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -239,12 +239,58 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
     expect(
       screen.getByRole('columnheader', { name: /distinguished %/i })
     ).toBeInTheDocument()
+    // #534 — % Club Growth prerequisite, distinct from the CGD officer
+    // award below. Renamed the officer-award column to "CGD" to avoid
+    // ambiguity.
+    expect(
+      screen.getByRole('columnheader', { name: /club growth %/i })
+    ).toBeInTheDocument()
     expect(
       screen.getByRole('columnheader', { name: /education ?\/ ?training/i })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('columnheader', { name: /^club growth$/i })
+      screen.getByRole('columnheader', { name: /^cgd$/i })
     ).toBeInTheDocument()
+  })
+
+  it('renders the Club Growth % gap value (#534)', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValue(
+      awardsFixture({
+        distinguishedDistrict: {
+          '61': {
+            districtId: '61',
+            currentTier: 'NotDistinguished',
+            allPrerequisitesMet: false,
+            prerequisites: {
+              dspSubmitted: false,
+              trainingMet: false,
+              marketAnalysisSubmitted: false,
+              communicationPlanSubmitted: false,
+              regionAdvisorVisitMet: false,
+            },
+            nextTierGap: {
+              tier: 'Distinguished',
+              netClubGrowthGap: 0,
+              paymentGrowthGap: 0,
+              distinguishedPercentGap: 0,
+              clubGrowthGap: 4,
+            },
+          },
+        },
+      })
+    )
+    renderRegion('2')
+
+    const row = (await screen.findByTestId('district-number-chip-D61')).closest(
+      'tr'
+    )!
+    expect(
+      within(row).getByTestId('countdown-clubGrowthPercent')
+    ).toHaveTextContent(/\+4/)
   })
 
   it('renders gap values as +N for numeric countdowns', async () => {

--- a/frontend/src/utils/__tests__/distinguishedCountdown.test.ts
+++ b/frontend/src/utils/__tests__/distinguishedCountdown.test.ts
@@ -69,16 +69,34 @@ const ddStatus = (
   ...overrides,
 })
 
-describe('getDistinguishedCountdown (#516)', () => {
-  it('returns the three numeric gaps + two officer-award booleans', () => {
+describe('getDistinguishedCountdown (#516 #534)', () => {
+  it('returns the four numeric gaps + two officer-award booleans', () => {
     const awards = mkAwards(ddStatus(), false, true)
     const c = getDistinguishedCountdown('61', awards)
     expect(c).not.toBeNull()
     expect(c!.netClubGrowth).toEqual({ kind: 'gap', value: 3 })
     expect(c!.paymentGrowth).toEqual({ kind: 'gap', value: 12 })
     expect(c!.distinguishedPercent).toEqual({ kind: 'gap', value: 8 })
+    // #534 — the fourth numeric DD prerequisite, distinct from the
+    // officer-award clubGrowth boolean below.
+    expect(c!.clubGrowthPercent).toEqual({ kind: 'met' })
     expect(c!.educationTraining).toEqual({ kind: 'boolean', met: false })
     expect(c!.clubGrowth).toEqual({ kind: 'boolean', met: true })
+  })
+
+  it('surfaces clubGrowthGap as a gap when the % Club Growth prerequisite is unmet', () => {
+    const status = ddStatus({
+      nextTierGap: {
+        tier: 'Distinguished',
+        netClubGrowthGap: 0,
+        paymentGrowthGap: 0,
+        distinguishedPercentGap: 0,
+        clubGrowthGap: 4,
+      },
+    })
+    const awards = mkAwards(status, true, true)
+    const c = getDistinguishedCountdown('61', awards)
+    expect(c!.clubGrowthPercent).toEqual({ kind: 'gap', value: 4 })
   })
 
   it('flips a numeric gap to "met" when the value is 0 or negative', () => {

--- a/frontend/src/utils/distinguishedCountdown.ts
+++ b/frontend/src/utils/distinguishedCountdown.ts
@@ -14,6 +14,9 @@ export interface DistinguishedCountdown {
   netClubGrowth: CountdownCell
   paymentGrowth: CountdownCell
   distinguishedPercent: CountdownCell
+  /** % Club Growth threshold (DD prerequisite #4 — distinct from the
+   *  CGD officer-award boolean `clubGrowth` below). */
+  clubGrowthPercent: CountdownCell
   educationTraining: CountdownCell
   clubGrowth: CountdownCell
 }
@@ -34,17 +37,22 @@ export function getDistinguishedCountdown(
   const gap = status.nextTierGap
   const numeric: Pick<
     DistinguishedCountdown,
-    'netClubGrowth' | 'paymentGrowth' | 'distinguishedPercent'
+    | 'netClubGrowth'
+    | 'paymentGrowth'
+    | 'distinguishedPercent'
+    | 'clubGrowthPercent'
   > = gap
     ? {
         netClubGrowth: gapCell(gap.netClubGrowthGap),
         paymentGrowth: gapCell(gap.paymentGrowthGap),
         distinguishedPercent: gapCell(gap.distinguishedPercentGap),
+        clubGrowthPercent: gapCell(gap.clubGrowthGap),
       }
     : {
         netClubGrowth: { kind: 'met' },
         paymentGrowth: { kind: 'met' },
         distinguishedPercent: { kind: 'met' },
+        clubGrowthPercent: { kind: 'met' },
       }
 
   const educationTraining: CountdownCell = {


### PR DESCRIPTION
## Summary

Adds the 6th countdown column to the \`/region/:n\` district table — closes the Medium reviewer found on PR #535 (Sprint D/E of the region rollup epic).

Distinguished District has **four** numeric prerequisites. The countdown previously surfaced three:

| | Column header | Source |
|---|---|---|
| ✅ | Net Club Growth | \`nextTierGap.netClubGrowthGap\` |
| ✅ | Payment Growth | \`nextTierGap.paymentGrowthGap\` |
| ✅ | Distinguished % | \`nextTierGap.distinguishedPercentGap\` |
| ❌ | **Club Growth %** *(new)* | \`nextTierGap.clubGrowthGap\` |

Without this column, a district could appear to qualify on every visible metric while still failing the % Club Growth prerequisite.

## Naming collision fix

The trailing officer-award column was previously labeled "Club Growth" — visually adjacent to the new "Club Growth %" prerequisite. Renamed to **CGD** (Club Growth Director — TI's formal officer-award name) with a \`title\` tooltip spelling out the acronym for non-Toastmasters viewers.

## Commits

1. \`test(region): RED — surface clubGrowthGap as Club Growth % column\`
2. \`feat(region): GREEN — Club Growth % column + CGD rename\`
3. \`refactor(region): /simplify pass — add title tooltip to CGD header\`

## /simplify + critical review

Reviewer caught one Medium: CGD is jargon. Resolved with a \`title\` tooltip in commit 3. Other findings:
- Testid collision check: \`countdown-clubGrowth\` vs \`countdown-clubGrowthPercent\` — distinct under exact-match \`getByTestId\`. Safe.
- Naming \`clubGrowthPercent\` mirrors the \`distinguishedPercent\` precedent. Keep.
- Comments are load-bearing WHY (disambiguation rationale), not changelog.

## Test plan

- [x] 4 new RED → all GREEN (helper field + RegionPage column header + cell + CGD rename)
- [x] 2295/2295 frontend tests pass
- [x] /simplify + critical review applied
- [ ] Visual: verify CGD tooltip on hover after deploy

Closes #534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)