### PR TITLE
fix(collector-cli): %Distinguished uses Paid Club Base (#545)

### DIFF
--- a/packages/collector-cli/src/__tests__/TransformService.rankings.test.ts
+++ b/packages/collector-cli/src/__tests__/TransformService.rankings.test.ts
@@ -282,6 +282,115 @@ U,Undistricted,50,45,11.11%,500,450,11.11%,50,5,2,1`
     })
   })
 
+  describe('Distinguished Percent uses Paid Club Base, not Active Clubs (#545)', () => {
+    // Per TI Distinguished District Program (Item 1490, Rev. 04/2025),
+    // % Distinguished is computed against the program-year-start club
+    // count (Paid Club Base), NOT the current Active Clubs count.
+    //
+    // PR #538 fixed this in analytics-core's BordaCountRankingCalculator
+    // but missed the parallel implementation in collector-cli's
+    // TransformService.calculateDistinguishedPercent — which is the
+    // method that actually writes distinguishedPercent into
+    // all-districts-rankings.json (the snapshot the frontend reads).
+    //
+    // Live D93 + D110 evidence on 2026-05-18 confirms the snapshot
+    // still has activeClubs-based percentages despite PR #538.
+
+    it('should compute D93-shape distinguishedPercent against Paid Club Base', async () => {
+      const date = '2024-01-15'
+      const rawCsvDir = path.join(tempDir, 'raw-csv', date)
+      await fs.mkdir(rawCsvDir, { recursive: true })
+
+      // D93 shape from 2026-05-18 snapshot: paidClubBase=69, activeClubs=75,
+      // distinguishedClubs=39. Correct percent = 39/69 ≈ 56.52%.
+      // Buggy (activeClubs-based) = 39/75 = 52.0%.
+      const csvContent = `DISTRICT,REGION,Paid Clubs,Paid Club Base,% Club Growth,Total YTD Payments,Payment Base,% Payment Growth,Active Clubs,Total Distinguished Clubs,Select Distinguished Clubs,Presidents Distinguished Clubs
+93,Region 8,75,69,8.70%,2839,2566,10.63%,75,39,20,12`
+
+      await fs.writeFile(path.join(rawCsvDir, 'all-districts.csv'), csvContent)
+      await createDistrictDir(rawCsvDir, '93')
+
+      await transformService.transform({ date, force: true })
+
+      const rankingsPath = path.join(
+        tempDir,
+        'snapshots',
+        date,
+        'all-districts-rankings.json'
+      )
+      const rankings = JSON.parse(await fs.readFile(rankingsPath, 'utf-8'))
+      const d93 = rankings.rankings.find(
+        (r: { districtId: string }) => r.districtId === '93'
+      )
+
+      // 39 / 69 = 56.5217... — meets President's Distinguished 55% threshold.
+      // Buggy value 39/75 = 52.0% would fail the 55% threshold by 3.0%,
+      // which is the gap the founder reported on /district/93.
+      expect(d93.distinguishedPercent).toBeCloseTo(56.5217, 3)
+    })
+
+    it('should compute D110-shape distinguishedPercent against Paid Club Base', async () => {
+      const date = '2024-01-15'
+      const rawCsvDir = path.join(tempDir, 'raw-csv', date)
+      await fs.mkdir(rawCsvDir, { recursive: true })
+
+      // D110 shape from 2026-05-18 snapshot: paidClubBase=72, activeClubs=77,
+      // distinguishedClubs=33. Correct = 33/72 ≈ 45.83% (meets Distinguished
+      // 45% threshold). Buggy = 33/77 ≈ 42.86% (fails by 2.14%, which is
+      // exactly the gap the live page shows).
+      const csvContent = `DISTRICT,REGION,Paid Clubs,Paid Club Base,% Club Growth,Total YTD Payments,Payment Base,% Payment Growth,Active Clubs,Total Distinguished Clubs,Select Distinguished Clubs,Presidents Distinguished Clubs
+110,Region 11,75,72,4.17%,3181,3106,2.41%,77,33,15,8`
+
+      await fs.writeFile(path.join(rawCsvDir, 'all-districts.csv'), csvContent)
+      await createDistrictDir(rawCsvDir, '110')
+
+      await transformService.transform({ date, force: true })
+
+      const rankingsPath = path.join(
+        tempDir,
+        'snapshots',
+        date,
+        'all-districts-rankings.json'
+      )
+      const rankings = JSON.parse(await fs.readFile(rankingsPath, 'utf-8'))
+      const d110 = rankings.rankings.find(
+        (r: { districtId: string }) => r.districtId === '110'
+      )
+
+      expect(d110.distinguishedPercent).toBeCloseTo(45.8333, 3)
+    })
+
+    it('should fall back to 0 when Paid Club Base is missing or 0', async () => {
+      // Brand-new district edge case — paidClubBase=0 → 0% (not NaN, not
+      // a silent fall-through to activeClubs). Mirrors analytics-core
+      // hardening from PR #538.
+      const date = '2024-01-15'
+      const rawCsvDir = path.join(tempDir, 'raw-csv', date)
+      await fs.mkdir(rawCsvDir, { recursive: true })
+
+      const csvContent = `DISTRICT,REGION,Paid Clubs,Paid Club Base,% Club Growth,Total YTD Payments,Payment Base,% Payment Growth,Active Clubs,Total Distinguished Clubs,Select Distinguished Clubs,Presidents Distinguished Clubs
+99,Region 1,30,0,0%,500,0,0%,30,5,2,1`
+
+      await fs.writeFile(path.join(rawCsvDir, 'all-districts.csv'), csvContent)
+      await createDistrictDir(rawCsvDir, '99')
+
+      await transformService.transform({ date, force: true })
+
+      const rankingsPath = path.join(
+        tempDir,
+        'snapshots',
+        date,
+        'all-districts-rankings.json'
+      )
+      const rankings = JSON.parse(await fs.readFile(rankingsPath, 'utf-8'))
+      const d99 = rankings.rankings.find(
+        (r: { districtId: string }) => r.districtId === '99'
+      )
+
+      expect(d99.distinguishedPercent).toBe(0)
+    })
+  })
+
   describe('Rankings File Output', () => {
     it('should write rankings file with correct metadata', async () => {
       const date = '2024-01-15'

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -780,19 +780,31 @@ export class TransformService {
   }
 
   /**
-   * Calculate distinguished club percentage from raw data
+   * Calculate distinguished club percentage from raw data.
+   *
+   * Per TI Distinguished District Program (Item 1490, Rev. 04/2025), the
+   * qualifying % is computed against Paid Club Base (PY-start club count),
+   * NOT current Active Clubs. Using activeClubs under-reports the percentage
+   * whenever a district has gained clubs during the PY — exactly the
+   * districts that most deserve to qualify at higher tiers. See lesson 60
+   * and PR #538 which fixed the analytics-core copy of this formula.
+   *
+   * When paidClubBase is 0 (genuinely brand-new district or schema
+   * regression), return 0 rather than silently falling through to
+   * activeClubs. The 0% is semantically correct for the new-district case
+   * and loud-fails the regression case.
    */
   private calculateDistinguishedPercent(record: AllDistrictsCSVRecord): number {
     const distinguishedClubs = this.parseNumber(
       record['Total Distinguished Clubs']
     )
-    const activeClubs = this.parseNumber(record['Active Clubs'])
+    const paidClubBase = this.parseNumber(record['Paid Club Base'])
 
-    if (activeClubs === 0) {
+    if (paidClubBase === 0) {
       return 0
     }
 
-    return (distinguishedClubs / activeClubs) * 100
+    return (distinguishedClubs / paidClubBase) * 100
   }
 
   /**

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -780,21 +780,24 @@ export class TransformService {
   }
 
   /**
-   * Calculate distinguished club percentage from raw data.
-   *
-   * Per TI Distinguished District Program (Item 1490, Rev. 04/2025), the
-   * qualifying % is computed against Paid Club Base (PY-start club count),
-   * NOT current Active Clubs. Using activeClubs under-reports the percentage
-   * whenever a district has gained clubs during the PY — exactly the
-   * districts that most deserve to qualify at higher tiers. See lesson 60
-   * and PR #538 which fixed the analytics-core copy of this formula.
-   *
-   * When paidClubBase is 0 (genuinely brand-new district or schema
-   * regression), return 0 rather than silently falling through to
-   * activeClubs. The 0% is semantically correct for the new-district case
-   * and loud-fails the regression case.
+   * Calculate distinguished club percentage from raw data
    */
   private calculateDistinguishedPercent(record: AllDistrictsCSVRecord): number {
+    // Per the Distinguished District Program (Item 1490), % Distinguished
+    // is computed against Paid Club Base (PY-start club count), NOT
+    // current Active Clubs. Using activeClubs as the denominator
+    // under-reports the percentage whenever a district has gained clubs
+    // since PY start — which is exactly when recognition matters most.
+    //
+    // When paidClubBase is 0 or missing, return 0 rather than falling
+    // back to activeClubs. A missing base is either a brand-new district
+    // (no clubs at PY start → 0% Distinguished is correct) or a pipeline
+    // schema regression (which we want LOUD, not silently masked by the
+    // old buggy denominator).
+    //
+    // Mirrors BordaCountRankingCalculator.calculateDistinguishedPercent
+    // in analytics-core (PR #538). Both copies must stay in lockstep
+    // until they are deduped (see lesson 61).
     const distinguishedClubs = this.parseNumber(
       record['Total Distinguished Clubs']
     )

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -797,7 +797,7 @@ export class TransformService {
     //
     // Mirrors BordaCountRankingCalculator.calculateDistinguishedPercent
     // in analytics-core (PR #538). Both copies must stay in lockstep
-    // until they are deduped (see lesson 61).
+    // until #547 dedupes them.
     const distinguishedClubs = this.parseNumber(
       record['Total Distinguished Clubs']
     )

--- a/tasks/lessons/061-fix-the-formula-everywhere-not-just-the-one-in-the-bug-report.md
+++ b/tasks/lessons/061-fix-the-formula-everywhere-not-just-the-one-in-the-bug-report.md
@@ -64,11 +64,10 @@ Telltale signs you have this kind of bug:
 
 ## Follow-up
 
-Consider an issue to dedupe: `TransformService.calculateDistinguishedPercent`
-should delegate to `BordaCountRankingCalculator.calculateDistinguishedPercent`
-(or both should call a shared helper in `analytics-core`). Until then, R8
-(audit write AND read paths) applies in reverse to fixes too — audit every
-implementation, not just the one you found first.
+Tracked: **#547** — dedupe `calculateDistinguishedPercent` so both
+sites call a single helper in `analytics-core`. Until that lands, R8
+(audit write AND read paths) applies in reverse to fixes too — audit
+every implementation, not just the one you found first.
 
 ## Related
 

--- a/tasks/lessons/061-fix-the-formula-everywhere-not-just-the-one-in-the-bug-report.md
+++ b/tasks/lessons/061-fix-the-formula-everywhere-not-just-the-one-in-the-bug-report.md
@@ -1,0 +1,78 @@
+---
+name: When fixing a formula, audit every implementation of it
+description: A bug report that names one file may hide parallel implementations
+  of the same formula in other packages. Grep the codebase before declaring
+  a fix complete.
+type: feedback
+---
+
+# Lesson 61 — Fix the formula everywhere, not just the one in the bug report
+
+**Date:** 2026-05-20
+**PR:** Issue #545 (founder-reported D93 + D110 tier mis-display)
+
+## What happened
+
+PR #538 (lesson 60) "fixed" `% Distinguished` to divide by Paid Club
+Base instead of Active Clubs, per TI DDP rule (Item 1490). The fix was
+applied to `analytics-core/src/rankings/BordaCountRankingCalculator.ts`
+— the file named in the bug report and the file where `meetsThreshold`
+consumes the value.
+
+Five days later the founder reported the same symptom on D93 and D110:
+tier chip showing "Select" / "Not Yet Distinguished" when the prereqs +
+counts pointed to higher tiers. The live snapshot still had the buggy
+percentage (D93: 39/75=52% instead of 39/69=56.52%).
+
+Root cause: **`collector-cli/src/services/TransformService.ts:785`
+had a parallel implementation of the exact same formula** — using
+`activeClubs` as the denominator — and that's the method that actually
+writes `distinguishedPercent` into `all-districts-rankings.json`, the
+snapshot the CDN serves. The analytics-core fix never reached the
+data the frontend reads.
+
+The collector-cli copy and the analytics-core copy diverged at the
+exact line that mattered. Two implementations of the same TI rule;
+only one was named in the bug, only one was fixed.
+
+## How to apply
+
+**When fixing a formula, grep the entire codebase for the input field
+names before declaring the fix complete:**
+
+```
+rg -n "distinguishedClubs.*activeClubs|distinguishedClubs.*paidClubBase"
+rg -n "calculateDistinguishedPercent"
+```
+
+Treat a hit in a different package as a co-equal fix site, not as
+"someone else's problem." Specifically for this codebase:
+
+- `collector-cli` writes snapshot JSON. **It is the source of truth
+  for what the frontend reads.**
+- `analytics-core` is a library used by collector-cli AND used at
+  read-time in places. Fixing the library does not retroactively fix
+  data already written by collector-cli.
+
+Telltale signs you have this kind of bug:
+
+- Production data still shows the old behaviour after a fix landed.
+- Pipeline ran successfully post-fix but produced the wrong values.
+- The reported file diverges in implementation from another file with
+  the same method name. (`calculateDistinguishedPercent` lives in
+  both `BordaCountRankingCalculator` and `TransformService`.)
+
+## Follow-up
+
+Consider an issue to dedupe: `TransformService.calculateDistinguishedPercent`
+should delegate to `BordaCountRankingCalculator.calculateDistinguishedPercent`
+(or both should call a shared helper in `analytics-core`). Until then, R8
+(audit write AND read paths) applies in reverse to fixes too — audit every
+implementation, not just the one you found first.
+
+## Related
+
+- Lesson 60 — the formula spec (paidClubBase, not activeClubs)
+- `packages/collector-cli/src/services/TransformService.ts:782-808` (the fix)
+- `packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts:822-843` (PR #538's site)
+- Rule R6 — "Trace the actual call graph before refactoring" applies symmetrically to fixes


### PR DESCRIPTION
## Summary

- `TransformService.calculateDistinguishedPercent` now divides distinguished clubs by **Paid Club Base** (PY-start count) instead of **Active Clubs** (current count), per TI Distinguished District Program rule (Item 1490).
- Mirrors the analytics-core fix from PR #538, which missed this parallel implementation in collector-cli — the method that actually populates `all-districts-rankings.json` (the snapshot the frontend reads).
- Three new tests reproduce D93 + D110 live-snapshot shapes and the `paidClubBase=0` edge case.
- New lesson 61 documents the "fix the formula everywhere" discipline.
- Follow-up #547 filed to dedupe the two parallel implementations.

## Closes

Closes #545.

## Real-world impact (verified against live 2026-05-18 snapshot)

| District | Before | After | Tier flip |
|---|---|---|---|
| **D93** | 39/75 = 52.0% | 39/69 = 56.52% | Select → President's Distinguished |
| **D110** | 33/77 = 42.86% | 33/72 = 45.83% | Not Yet Distinguished → Distinguished |

Both surfaces (Overview cards + DDP Trophy Case) will now agree — the visible contradiction founder reported is gone.

## Why PR #538's fix was incomplete

The same formula lives in two places:

- `analytics-core/src/rankings/BordaCountRankingCalculator.ts:822` — fixed in #538
- `collector-cli/src/services/TransformService.ts:785` — **this PR**

The collector-cli copy writes the snapshot. The pipeline ran 5 consecutive days post-#538 and produced wrong data despite green CI. Lesson 61 captures the failure mode; #547 tracks the dedupe.

## Verification

- 18/18 TransformService.rankings.test.ts pass (3 new + 15 existing)
- 731/731 collector-cli pass
- 763/763 analytics-core pass
- No new lint errors; type-check clean
- Fresh-context review verdict: APPROVE-WITH-NITS (no High findings)

## Deployment note

The fix only affects future snapshots. Existing CDN snapshot JSON will be corrected on the next daily Data Pipeline run after merge. No manual replay needed.

## Test plan

- [ ] CI green
- [ ] After merge + next Data Pipeline run, verify https://ts.taverns.red/district/93?date=<latest> shows "President's Distinguished" tier chip
- [ ] Verify https://ts.taverns.red/district/110?date=<latest> shows "Distinguished" tier chip
- [ ] Spot-check other districts to confirm no false flips downward (no district should move from Distinguished → NotYet, since the new denominator is smaller, producing higher %)

🤖 Generated with [Claude Code](https://claude.com/claude-code)