### PR TITLE
feat(districts): DDP tier chip + row density on rankings page (#546)

### DIFF
--- a/frontend/src/components/DistrictTierChip.tsx
+++ b/frontend/src/components/DistrictTierChip.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import type { DistinguishedDistrictTier } from '../services/cdn'
+
+type AchievedTier = Exclude<DistinguishedDistrictTier, 'NotDistinguished'>
+
+const TIER_CONFIG: Record<AchievedTier, { label: string; className: string }> =
+  {
+    Distinguished: {
+      label: 'Distinguished',
+      className: 'bg-tm-true-maroon text-white',
+    },
+    Select: {
+      label: 'Select',
+      className: 'bg-tm-cool-gray text-gray-900',
+    },
+    Presidents: {
+      label: "President's",
+      className: 'bg-tm-happy-yellow text-gray-900',
+    },
+    Smedley: {
+      // Smedley is genuinely rare (<10 districts/year globally). The
+      // gold ring is the rare-tier visual treatment required by #546.
+      label: 'Smedley',
+      className:
+        'bg-purple-200 text-purple-900 ring-2 ring-tm-happy-yellow ring-offset-1',
+    },
+  }
+
+interface Props {
+  districtId: string
+  tier: DistinguishedDistrictTier | null | undefined
+}
+
+export const DistrictTierChip: React.FC<Props> = ({ districtId, tier }) => {
+  // Absence = signal: pre-Distinguished districts render nothing.
+  // This keeps the row visually quiet while letting achieved districts
+  // pop.
+  if (!tier || tier === 'NotDistinguished') return null
+  const cfg = TIER_CONFIG[tier]
+  return (
+    <span
+      data-testid={`tier-chip-${districtId}`}
+      data-tier={tier}
+      aria-label={`${cfg.label} Distinguished District`}
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ${cfg.className}`}
+    >
+      {cfg.label}
+    </span>
+  )
+}
+
+export default DistrictTierChip

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -985,10 +985,16 @@ const DistrictsPage: React.FC = () => {
                   const pinDisabled =
                     !isPinned && pinnedDistrictIds.size >= MAX_PINNED
                   const isMine = isMyDistrict(district.districtId)
-                  const ddpTier =
+                  const rawTier =
                     competitiveAwards?.distinguishedDistrict?.[
                       district.districtId
                     ]?.currentTier ?? null
+                  // The row-level data-tier hook is only meaningful for
+                  // ACHIEVED tiers; CSS rules like [data-tier="Smedley"]
+                  // never want to match NotDistinguished. So absence is
+                  // the signal there too — same convention as the chip.
+                  const ddpTier =
+                    rawTier && rawTier !== 'NotDistinguished' ? rawTier : null
                   return (
                     <tr
                       key={district.districtId}
@@ -1006,8 +1012,18 @@ const DistrictsPage: React.FC = () => {
                       {/* District cell first (#436) — primary entity. The
                           number is rendered as a standalone chip so the
                           click affordance reads as obviously interactive.
-                          (#417) Star button toggles 'my district'. */}
-                      <td className="px-6 py-4 whitespace-nowrap sticky left-0 z-10 bg-white">
+                          (#417) Star button toggles 'my district'.
+                          Sticky cell background must honour the row's
+                          isMine/isPinned tint, not stay white (#546 review). */}
+                      <td
+                        className={`px-6 py-4 whitespace-nowrap sticky left-0 z-10 ${
+                          isMine
+                            ? 'bg-yellow-50'
+                            : isPinned
+                              ? 'bg-blue-50'
+                              : 'bg-white'
+                        }`}
+                      >
                         <div className="flex items-center gap-3 flex-wrap">
                           <button
                             type="button"
@@ -1110,8 +1126,17 @@ const DistrictsPage: React.FC = () => {
                       </td>
                       {/* Rank cell — now second column (#436). Pin button
                           stays adjacent to rank badge for symmetry with
-                          the existing comparison-pin UX. */}
-                      <td className="px-6 py-4 whitespace-nowrap sticky left-[200px] z-10 bg-white sticky-column-shadow">
+                          the existing comparison-pin UX. Sticky background
+                          must honour the row tint (#546 review). */}
+                      <td
+                        className={`px-6 py-4 whitespace-nowrap sticky left-[200px] z-10 sticky-column-shadow ${
+                          isMine
+                            ? 'bg-yellow-50'
+                            : isPinned
+                              ? 'bg-blue-50'
+                              : 'bg-white'
+                        }`}
+                      >
                         <div className="flex items-center gap-2">
                           <button
                             onClick={e => {
@@ -1160,9 +1185,13 @@ const DistrictsPage: React.FC = () => {
                             tier={ddpTier}
                           />
                         ) : (
+                          // Empty Tier cell: the column header "Tier"
+                          // already provides context; an aria-label here
+                          // would chatter on every NotDistinguished row
+                          // (which is the majority).
                           <span
                             className="text-gray-400 text-sm"
-                            aria-label="Not yet Distinguished"
+                            aria-hidden="true"
                           >
                             —
                           </span>

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -930,6 +930,20 @@ const DistrictsPage: React.FC = () => {
 
         {/* Rankings Table */}
         <div className="districts-rankings-table-wrap">
+          {/* Methodology affordance — single visible "i" beside a quiet
+              "About these metrics" label, replacing the four per-column
+              tooltips that used to wrap the header row (#546). Kept
+              outside the table so its focus ring is visible to keyboard
+              users (Lesson 58 / WCAG 2.4.7). */}
+          <div className="flex items-center justify-end mb-2 px-2">
+            <span
+              data-testid="rankings-table-methodology-affordance"
+              className="text-xs text-gray-500 inline-flex items-center"
+            >
+              About these metrics
+              <InfoTooltip text="Paid Clubs = clubs that have met renewal obligations for the program year. Total Payments = year-to-date membership payment count. Distinguished = clubs achieving Distinguished status or higher. Score = Borda-count composite of the three rankings. Higher is better on all four." />
+            </span>
+          </div>
           <div className="overflow-x-auto">
             <table
               className="districts-rankings-table"
@@ -938,12 +952,6 @@ const DistrictsPage: React.FC = () => {
               <caption className="sr-only">
                 District rankings by Paid Clubs, Total Payments, Distinguished
                 club count, and Borda-count Score.
-                <span
-                  data-testid="rankings-table-methodology-affordance"
-                  className="inline-block"
-                >
-                  <InfoTooltip text="Paid Clubs = clubs that have met renewal obligations for the program year. Total Payments = year-to-date membership payment count. Distinguished = clubs achieving Distinguished status or higher. Score = Borda-count composite of the three rankings. Higher is better on all four." />
-                </span>
               </caption>
               <thead>
                 <tr>

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -13,6 +13,7 @@ import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
 import { DataControlsBar } from '../components/DataControlsBar'
 import { useRankHistory } from '../hooks/useRankHistory'
 import InfoTooltip from '../components/InfoTooltip'
+import DistrictTierChip from '../components/DistrictTierChip'
 import { useMyDistrict } from '../hooks/useMyDistrict'
 import { usePersistedState } from '../hooks/usePersistedState'
 import { useLastVisit } from '../hooks/useLastVisit'
@@ -930,35 +931,42 @@ const DistrictsPage: React.FC = () => {
         {/* Rankings Table */}
         <div className="districts-rankings-table-wrap">
           <div className="overflow-x-auto">
-            <table className="districts-rankings-table">
+            <table
+              className="districts-rankings-table"
+              aria-label="District rankings"
+            >
+              <caption className="sr-only">
+                District rankings by Paid Clubs, Total Payments, Distinguished
+                club count, and Borda-count Score.
+                <span
+                  data-testid="rankings-table-methodology-affordance"
+                  className="inline-block"
+                >
+                  <InfoTooltip text="Paid Clubs = clubs that have met renewal obligations for the program year. Total Payments = year-to-date membership payment count. Distinguished = clubs achieving Distinguished status or higher. Score = Borda-count composite of the three rankings. Higher is better on all four." />
+                </span>
+              </caption>
               <thead>
                 <tr>
-                  {/* District first (#436) — primary entity reads left-to-right.
-                      Rank moves to second column. */}
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-0 z-10">
                     District
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-[200px] z-10 sticky-column-shadow">
                     Rank
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Region
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Tier
                   </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Paid Clubs
-                    <InfoTooltip text="Number of clubs with paid memberships. Rank and year-over-year growth shown below." />
                   </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Total Payments
-                    <InfoTooltip text="Year-to-date membership payment count. Higher payments indicate active member engagement." />
                   </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Distinguished
-                    <InfoTooltip text="Clubs achieving Distinguished status or higher. Reflects club-level goal completion." />
                   </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Score
-                    <InfoTooltip text="Borda-count composite of Paid Clubs, Payments, and Distinguished rankings. Higher is better." />
                   </th>
                 </tr>
               </thead>
@@ -969,9 +977,15 @@ const DistrictsPage: React.FC = () => {
                   const pinDisabled =
                     !isPinned && pinnedDistrictIds.size >= MAX_PINNED
                   const isMine = isMyDistrict(district.districtId)
+                  const ddpTier =
+                    competitiveAwards?.distinguishedDistrict?.[
+                      district.districtId
+                    ]?.currentTier ?? null
                   return (
                     <tr
                       key={district.districtId}
+                      data-testid={`district-row-${district.districtId}`}
+                      data-tier={ddpTier ?? undefined}
                       onClick={() => handleDistrictClick(district.districtId)}
                       className={`cursor-pointer ${
                         isMine
@@ -1073,9 +1087,17 @@ const DistrictsPage: React.FC = () => {
                               <span className="ml-1">Retention</span>
                             </span>
                           )}
-                        </div>
-                        <div className="text-sm text-gray-500">
-                          {district.activeClubs} active clubs
+                          {/* Region collapses into the District cell as
+                              a quiet "· R<n>" suffix (#546) — saves the
+                              standalone Region column's width. */}
+                          {district.region && (
+                            <span
+                              data-testid={`district-region-suffix-${district.districtId}`}
+                              className="text-xs text-gray-500"
+                            >
+                              · R{district.region}
+                            </span>
+                          )}
                         </div>
                       </td>
                       {/* Rank cell — now second column (#436). Pin button
@@ -1123,8 +1145,20 @@ const DistrictsPage: React.FC = () => {
                           </span>
                         </div>
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {district.region}
+                      <td className="px-4 py-4 whitespace-nowrap">
+                        {ddpTier ? (
+                          <DistrictTierChip
+                            districtId={district.districtId}
+                            tier={ddpTier}
+                          />
+                        ) : (
+                          <span
+                            className="text-gray-400 text-sm"
+                            aria-label="Not yet Distinguished"
+                          >
+                            —
+                          </span>
+                        )}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-right">
                         <div className="text-sm font-medium text-gray-900">
@@ -1132,7 +1166,7 @@ const DistrictsPage: React.FC = () => {
                         </div>
                         <div className="text-xs flex items-center justify-end gap-1">
                           <span className="text-tm-loyal-blue font-tm-body">
-                            Rank #{district.clubsRank}
+                            #{district.clubsRank}
                           </span>
                           <span className="text-gray-400">•</span>
                           <span
@@ -1150,7 +1184,7 @@ const DistrictsPage: React.FC = () => {
                         </div>
                         <div className="text-xs flex items-center justify-end gap-1">
                           <span className="text-tm-loyal-blue font-tm-body">
-                            Rank #{district.paymentsRank}
+                            #{district.paymentsRank}
                           </span>
                           <span className="text-gray-400">•</span>
                           <span
@@ -1172,7 +1206,7 @@ const DistrictsPage: React.FC = () => {
                         </div>
                         <div className="text-xs flex items-center justify-end gap-1">
                           <span className="text-tm-loyal-blue font-tm-body">
-                            Rank #{district.distinguishedRank}
+                            #{district.distinguishedRank}
                           </span>
                           <span className="text-gray-400">•</span>
                           <span

--- a/frontend/src/pages/__tests__/DistrictsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.test.tsx
@@ -276,9 +276,11 @@ describe('DistrictsPage - Table Cell Rendering', () => {
 
     renderWithProviders(<DistrictsPage />)
 
-    // Wait for data to load and check for rank numbers
-    const clubsRank = await screen.findByText('Rank #5')
-    const paymentsRank = await screen.findByText('Rank #3')
+    // Wait for data to load and check for rank numbers.
+    // Per #546 the "Rank " word prefix is dropped — the per-metric
+    // cells now show just "#N · +X.X%".
+    const clubsRank = await screen.findByText('#5')
+    const paymentsRank = await screen.findByText('#3')
     expect(clubsRank).toBeInTheDocument()
     expect(clubsRank).toHaveClass('text-tm-loyal-blue')
     expect(paymentsRank).toBeInTheDocument()
@@ -398,19 +400,19 @@ describe('DistrictsPage - Table Cell Rendering', () => {
     // these same numbers as global totals.
     const table = within(container.querySelector('table')!)
 
-    // Check paid clubs column
+    // Check paid clubs column. Per #546 the "Rank " word prefix is
+    // dropped — per-metric cells show just "#N · +X.X%".
     expect(table.getByText('100')).toBeInTheDocument()
-    expect(table.getByText('Rank #5')).toBeInTheDocument()
+    expect(table.getByText('#5')).toBeInTheDocument()
     expect(table.getByText('+12.5%')).toBeInTheDocument()
 
     // Check total payments column
     expect(table.getByText('5,000')).toBeInTheDocument()
-    expect(table.getByText('Rank #3')).toBeInTheDocument()
+    expect(table.getByText('#3')).toBeInTheDocument()
     expect(table.getByText('+11.1%')).toBeInTheDocument()
 
-    // Verify the rank and percentage are in the same container (text-xs class)
-    const rankElements = screen.getAllByText(/Rank #\d+/)
-    // Check that rank elements exist and are styled correctly
+    // Verify the rank elements exist and are styled correctly.
+    const rankElements = screen.getAllByText(/^#\d+$/)
     expect(rankElements.length).toBeGreaterThan(0)
     rankElements.forEach(rankElement => {
       expect(rankElement).toHaveClass('text-tm-loyal-blue')

--- a/frontend/src/pages/__tests__/DistrictsPage.tierChipDensity.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.tierChipDensity.test.tsx
@@ -1,0 +1,233 @@
+/* Districts page — DDP tier chip + row-density improvements (#546).
+   - Tier chip appears on each row when the district has qualified for
+     Distinguished or higher.
+   - No chip when currentTier is NotDistinguished or missing.
+   - Smedley districts receive an extra rare-tier visual treatment
+     (data-attribute hook for CSS).
+   - Per-metric cells no longer prefix "Rank " — just "#1 · +8.7%".
+   - Per-column InfoTooltips are consolidated to a single header-level
+     affordance (the four icons no longer wrap the header row).
+   - REGION as a standalone column is collapsed into the District cell. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import DistrictsPage from '../DistrictsPage'
+import { fetchCdnRankings, fetchCdnCompetitiveAwards } from '../../services/cdn'
+import { renderWithProviders } from '../../__tests__/test-utils'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: [],
+    count: 0,
+    generatedAt: '2025-01-01T00:00:00Z',
+  }),
+  fetchCdnSnapshotIndex: vi.fn().mockResolvedValue({}),
+  fetchCdnRankings: vi.fn(),
+  fetchCdnRankingsForDate: vi.fn(),
+  fetchCdnManifest: vi.fn().mockResolvedValue({
+    latestSnapshotDate: '2026-05-18',
+    generatedAt: '2026-05-18T00:00:00Z',
+  }),
+  fetchCdnCompetitiveAwards: vi.fn(),
+  cdnAnalyticsUrl: vi.fn().mockReturnValue('https://cdn.taverns.red/test'),
+  fetchFromCdn: vi.fn(),
+}))
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: () => ({
+    data: { districts: [] },
+    isLoading: false,
+    isError: false,
+  }),
+}))
+
+const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)
+const mockedFetchCdnCompetitiveAwards = vi.mocked(fetchCdnCompetitiveAwards)
+
+const setupRankingsWithFourTiers = () => {
+  mockedFetchCdnRankings.mockResolvedValue({
+    rankings: [
+      mkRanking('93', '8', 1),
+      mkRanking('110', '11', 2),
+      mkRanking('57', '7', 3),
+      mkRanking('1', '1', 4),
+      mkRanking('99', '1', 5),
+    ],
+    date: '2026-05-18',
+  })
+  mockedFetchCdnCompetitiveAwards.mockResolvedValue({
+    metadata: {
+      snapshotId: '2026-05-18',
+      calculatedAt: '2026-05-18T00:00:00Z',
+      totalDistricts: 5,
+    },
+    extensionAward: [],
+    twentyPlusAward: [],
+    retentionAward: [],
+    byDistrict: {},
+    distinguishedDistrict: {
+      '93': mkStatus('93', 'Presidents'),
+      '110': mkStatus('110', 'Distinguished'),
+      '57': mkStatus('57', 'Select'),
+      '1': mkStatus('1', 'Smedley'),
+      '99': mkStatus('99', 'NotDistinguished'),
+    },
+  })
+}
+
+const mkRanking = (id: string, region: string, rank: number) => ({
+  districtId: id,
+  districtName: id,
+  region,
+  paidClubs: 75,
+  paidClubBase: 70,
+  clubGrowthPercent: 7.14,
+  totalPayments: 2800,
+  paymentBase: 2600,
+  paymentGrowthPercent: 7.69,
+  activeClubs: 75,
+  distinguishedClubs: 35,
+  selectDistinguished: 15,
+  presidentsDistinguished: 8,
+  distinguishedPercent: 50,
+  clubsRank: rank,
+  paymentsRank: rank,
+  distinguishedRank: rank,
+  aggregateScore: 300 - rank * 10,
+})
+
+const mkStatus = (
+  id: string,
+  tier:
+    | 'NotDistinguished'
+    | 'Distinguished'
+    | 'Select'
+    | 'Presidents'
+    | 'Smedley'
+) => ({
+  districtId: id,
+  currentTier: tier,
+  allPrerequisitesMet: tier !== 'NotDistinguished',
+  prerequisites: {
+    dspSubmitted: true,
+    trainingMet: true,
+    marketAnalysisSubmitted: true,
+    communicationPlanSubmitted: true,
+    regionAdvisorVisitMet: true,
+  },
+  nextTierGap: null,
+})
+
+const findRow = (districtId: string) =>
+  screen.getByTestId(`district-row-${districtId}`)
+
+describe('DistrictsPage — DDP tier chip + density (#546)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  describe('tier chip', () => {
+    it("renders a President's chip for a President's-tier district", async () => {
+      setupRankingsWithFourTiers()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-93')
+      const chip = within(findRow('93')).getByTestId('tier-chip-93')
+      expect(chip).toHaveTextContent(/president/i)
+    })
+
+    it('renders a Distinguished chip for a Distinguished-tier district', async () => {
+      setupRankingsWithFourTiers()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-110')
+      expect(
+        within(findRow('110')).getByTestId('tier-chip-110')
+      ).toHaveTextContent(/distinguished/i)
+    })
+
+    it('renders a Select chip for a Select-tier district', async () => {
+      setupRankingsWithFourTiers()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-57')
+      expect(
+        within(findRow('57')).getByTestId('tier-chip-57')
+      ).toHaveTextContent(/select/i)
+    })
+
+    it('does NOT render a chip for NotDistinguished districts (absence = signal)', async () => {
+      setupRankingsWithFourTiers()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-99')
+      expect(
+        within(findRow('99')).queryByTestId('tier-chip-99')
+      ).not.toBeInTheDocument()
+    })
+
+    it('gives Smedley districts a rare-tier visual hook (data-tier="Smedley")', async () => {
+      setupRankingsWithFourTiers()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-1')
+      const chip = within(findRow('1')).getByTestId('tier-chip-1')
+      expect(chip).toHaveAttribute('data-tier', 'Smedley')
+      expect(chip).toHaveTextContent(/smedley/i)
+    })
+  })
+
+  describe('density — per-metric cells', () => {
+    it('drops the "Rank " word prefix from per-metric cells (just shows #N)', async () => {
+      setupRankingsWithFourTiers()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-93')
+      const row = findRow('93')
+      // None of the per-metric cells should contain the literal "Rank #"
+      // prefix anymore — they should show just "#1" or "#2" etc.
+      expect(within(row).queryByText(/Rank\s+#/)).not.toBeInTheDocument()
+      // The numeric rank itself is still present.
+      expect(within(row).getAllByText(/#1\b/).length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('density — header tooltips', () => {
+    it('consolidates per-column InfoTooltips into a single table-level affordance', async () => {
+      setupRankingsWithFourTiers()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-93')
+      // Single affordance lives near the table title with a stable testid.
+      expect(
+        screen.getByTestId('rankings-table-methodology-affordance')
+      ).toBeInTheDocument()
+      // The four per-column InfoTooltip icons inside the rankings table
+      // header are gone. InfoTooltip renders a <button aria-label="info">
+      // so we count those inside columnheader cells.
+      const table = screen.getByRole('table', { name: /district rankings/i })
+      const header = within(table).getAllByRole('columnheader')
+      const tooltipButtons = header.flatMap(h =>
+        within(h).queryAllByRole('button', { name: /^info$/i })
+      )
+      expect(tooltipButtons).toHaveLength(0)
+    })
+  })
+
+  describe('density — REGION column collapse', () => {
+    it('removes the standalone REGION column from the rankings table header', async () => {
+      setupRankingsWithFourTiers()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-93')
+      const table = screen.getByRole('table', { name: /district rankings/i })
+      const headers = within(table).getAllByRole('columnheader')
+      const headerTexts = headers.map(h => h.textContent?.trim() ?? '')
+      // The standalone "Region" column is gone — region info moves into
+      // the District cell as a subtle suffix.
+      expect(headerTexts).not.toContain('Region')
+      expect(headerTexts).not.toContain('REGION')
+    })
+
+    it('surfaces region as a subtle "· R<n>" suffix inside the District cell', async () => {
+      setupRankingsWithFourTiers()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-93')
+      const row = findRow('93')
+      // D93 is in region 8 per the fixture.
+      expect(
+        within(row).getByTestId('district-region-suffix-93')
+      ).toHaveTextContent(/R8/)
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/DistrictsPage.tierChipDensity.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.tierChipDensity.test.tsx
@@ -168,6 +168,37 @@ describe('DistrictsPage — DDP tier chip + density (#546)', () => {
       expect(chip).toHaveAttribute('data-tier', 'Smedley')
       expect(chip).toHaveTextContent(/smedley/i)
     })
+
+    it('exposes data-tier on the <tr> so CSS can style the whole row by tier', async () => {
+      setupRankingsWithFourTiers()
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-1')
+      // Row for the Smedley district carries the data-tier hook so
+      // future CSS (e.g. row gold border) is one selector away.
+      expect(findRow('1')).toHaveAttribute('data-tier', 'Smedley')
+      // NotDistinguished rows do not get a data-tier attribute.
+      expect(findRow('99')).not.toHaveAttribute('data-tier')
+    })
+
+    it('renders rows without chips when competitiveAwards fetch fails', async () => {
+      mockedFetchCdnRankings.mockResolvedValue({
+        rankings: [mkRanking('93', '8', 1), mkRanking('110', '11', 2)],
+        date: '2026-05-18',
+      })
+      // CDN fetch failure → hook returns null/undefined → page must
+      // still render rows with em-dash placeholders, not crash.
+      mockedFetchCdnCompetitiveAwards.mockRejectedValue(
+        new Error('CDN fetch failed')
+      )
+      renderWithProviders(<DistrictsPage />)
+      await screen.findByTestId('district-row-93')
+      expect(
+        within(findRow('93')).queryByTestId('tier-chip-93')
+      ).not.toBeInTheDocument()
+      expect(
+        within(findRow('110')).queryByTestId('tier-chip-110')
+      ).not.toBeInTheDocument()
+    })
   })
 
   describe('density — per-metric cells', () => {

--- a/tasks/lessons/062-give-distinct-badge-families-distinct-row-positions.md
+++ b/tasks/lessons/062-give-distinct-badge-families-distinct-row-positions.md
@@ -63,10 +63,16 @@ class lands in the segment that matches its meaning.
 ## Related
 
 - `frontend/src/components/DistrictTierChip.tsx` — the new component
-- `frontend/src/pages/DistrictsPage.tsx:944` — the new Tier column header
+- `frontend/src/pages/DistrictsPage.tsx` — Tier column header + cell
 - Lesson 58 — when an interactive element is invisible to keyboard
   users, you have a focus-visibility bug (caught mid-#546 when the
   methodology InfoTooltip ended up inside sr-only chrome)
+- Lessons 60 + 61 + #545 — note that tier chips depend on
+  `competitiveAwards.distinguishedDistrict[id].currentTier` which is
+  computed from snapshot percentages. Until #545 lands and the next
+  pipeline run completes, the chip will reflect the OLD denominator
+  for some districts (e.g. D93 shows Select instead of President's
+  on the first deploy of this PR). Both must ship as a pair.
 - Issue #546 — the design exploration in the PM/UX framing of the
   issue was right to flag "make the page feel like a sticker
   collection" as a failure mode

--- a/tasks/lessons/062-give-distinct-badge-families-distinct-row-positions.md
+++ b/tasks/lessons/062-give-distinct-badge-families-distinct-row-positions.md
@@ -1,0 +1,72 @@
+---
+name: Give distinct badge families distinct row positions
+description: When a row already has inline badges, a new badge class with
+  different semantics deserves its own column — not another inline pill.
+  Same shape ≠ same meaning, and the position telegraphs the distinction.
+type: feedback
+---
+
+# Lesson 62 — Give distinct badge families distinct row positions
+
+**Date:** 2026-05-20
+**Issue:** #546 (DDP tier chip + density on Districts ranking page)
+
+## What happened
+
+The Districts ranking row already carries three inline competitive-award
+badges in the District cell (Extension, 20-Plus, Retention trophies).
+They are pill-shaped, yellow-on-light-border, all share the 🏆 prefix.
+
+#546 added a fourth badge class — the DDP tier chip — for the year-end
+outcome (Distinguished / Select / President's / Smedley). At first
+glance, "small pill near the district number" was the obvious place
+to put it. Same shape, same neighbourhood, minimal layout impact.
+
+But the tier chip's _meaning_ is structurally different:
+
+- Trophies = won a single award (one row per award type)
+- Tier chip = overall year-end DDP outcome (one chip, weighted by tier)
+
+Mashing both into the District cell would have made the row read as
+"this district has 4 stickers" — visually flat, semantically incoherent.
+The user has no way to tell that the tier chip is the headline outcome
+and the trophies are subordinate.
+
+The fix: give the tier its own column between Rank and Paid Clubs. Same
+chip shape, but the column header ("Tier") plus the dedicated x-position
+do the disambiguation work that the chip shape alone couldn't.
+
+## How to apply
+
+**When you add a new badge to a row that already has badges, ask: do
+they belong to the same family?**
+
+- Same family (e.g. several award trophies of the same type) → cluster
+  inline; the visual repetition reinforces the family.
+- Different family (e.g. award trophy vs. tier outcome vs. health
+  status) → give each family its own structural position (column,
+  cell, region). The position is the disambiguator.
+
+Telltale signs you have this issue brewing:
+
+- A row description starts to need scare quotes: "this is the _tier_
+  chip, not a trophy."
+- Hover tooltips do the disambiguation work that layout should do.
+- Acceptance copy says "give it stronger visual weight" — you're
+  asking the chip's appearance to compensate for muddled placement.
+
+Specifically for this codebase: the rankings table is now structurally
+divided into "identity (District / Region)", "outcome (Rank / Tier)",
+"metrics (Paid / Payments / Distinguished)", and "score." Each badge
+class lands in the segment that matches its meaning.
+
+## Related
+
+- `frontend/src/components/DistrictTierChip.tsx` — the new component
+- `frontend/src/pages/DistrictsPage.tsx:944` — the new Tier column header
+- Lesson 58 — when an interactive element is invisible to keyboard
+  users, you have a focus-visibility bug (caught mid-#546 when the
+  methodology InfoTooltip ended up inside sr-only chrome)
+- Issue #546 — the design exploration in the PM/UX framing of the
+  issue was right to flag "make the page feel like a sticker
+  collection" as a failure mode


### PR DESCRIPTION
## Summary

- New `<DistrictTierChip>` component renders the district's current DDP tier (Distinguished / Select / President's / Smedley) in a dedicated Tier column between Rank and Paid Clubs.
- Smedley districts get a rare-tier gold-ring treatment + row-level `data-tier="Smedley"` hook for future CSS row styling.
- Pre-Distinguished districts get no chip (absence = signal per #546).
- Density: "Rank " word dropped from per-metric cells; four per-column InfoTooltips collapsed into a single "About these metrics ⓘ" affordance above the table; standalone Region column collapsed into the District cell as "· R<n>" suffix; "X active clubs" subtitle removed.
- Methodology affordance lives in a visible div, not inside `<caption class="sr-only">`, so its focus ring is visible to keyboard users (re-applying Lesson 58 / WCAG 2.4.7).

## Closes

Closes #546.

## ⚠️ Coordinate with #545 / PR #548

Tier chip values come from `competitiveAwards.distinguishedDistrict[id].currentTier`, which is computed from snapshot percentages — the same percentages fixed by **#545 / PR #548**. Until that PR merges AND the next daily Data Pipeline run completes, this PR will display **wrong tiers** for some districts (D93 will show "Select" instead of "President's", D110 will show no chip instead of "Distinguished").

**Recommended merge order**: #548 → wait for next pipeline run → confirm D93/D110 corrected on prod → merge this PR.

If shipped in the wrong order, the visible regression is short-lived (one pipeline cycle) but visible on the most-trafficked surface. Worth getting right.

## /review feedback addressed

Fresh-context review caught:

- Sticky District + Rank cells hardcoded `bg-white`, leaving a visible white strip on `isMine`/`isPinned` rows once the adjacent Tier column tinted the row. Both sticky cells now honour the row tint.
- CDN-failure path was untested. Added a test asserting page renders without crash when `competitiveAwards` fetch rejects.
- Em-dash placeholder had `aria-label="Not yet Distinguished"` which would chatter on every NotDistinguished row (the majority). Switched to `aria-hidden="true"` — the column header "Tier" already provides context.
- Row-level `data-tier` was rendering "NotDistinguished" too. Now only emits for achieved tiers, mirroring the chip-absence convention.

## Verification

- 147/147 frontend test files / 2306/2306 tests pass
- New test file `DistrictsPage.tierChipDensity.test.tsx` (11 tests) covers all #546 acceptance criteria
- Type-check clean; lint clean (existing warnings only)
- Started dev server locally; could not visually verify 375px / 768px / 1280px / dark-mode renders from this environment — sighted smoke test before merge is recommended

## Lessons added

- **Lesson 62** — "Give distinct badge families distinct row positions." Captures the design rationale for putting the tier chip in its own column rather than inline with the trophy badges.

## Test plan

- [ ] CI green
- [ ] Sighted smoke at 375 / 768 / 1280, dark + light mode
- [ ] After #548 merges + next pipeline run, verify on prod:
  - D93 row shows "President's" tier chip
  - D110 row shows "Distinguished" tier chip
  - A Smedley district (if any) renders with the gold-ring treatment
- [ ] Sort/filter/search still work with the new Tier column present
- [ ] Pinned and "my district" rows still tint correctly through the sticky cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)