### PR TITLE
fix(overview): bullet-bar zoom scale + region rank inline restyle (#557, #558)

### DIFF
--- a/frontend/src/components/KpiBulletCard.tsx
+++ b/frontend/src/components/KpiBulletCard.tsx
@@ -70,13 +70,16 @@ const BulletBar: React.FC<BulletBarProps> = ({
   // labels collided and the bar was unreadable (#558). The scale below
   // auto-expands to include `current` whenever it lies outside the tier
   // band, so no clamping is needed and no "below-scale" affordance is
-  // required — the marker is always on the bar.
+  // required — the marker is always on the bar. When the district has
+  // hit Smedley, maxScale collapses to `current` so the marker pins to
+  // 100% (a "you've made it" signal); the 5% headroom only applies when
+  // there's still tier to chase.
+  const allAchieved = current >= targets.smedley
   const minScale = Math.max(0, Math.min(current, 0.9 * targets.distinguished))
-  const maxScale = Math.max(current, 1.05 * targets.smedley)
+  const maxScale = allAchieved ? current : 1.05 * targets.smedley
   const range = maxScale - minScale
   const positionAt = (v: number): number => ((v - minScale) / range) * 100
   const markerPct = positionAt(current)
-  const allAchieved = current >= targets.smedley
 
   const tiers: TierTick[] = TIERS.map(t => ({ ...t, value: targets[t.key] }))
 

--- a/frontend/src/components/KpiBulletCard.tsx
+++ b/frontend/src/components/KpiBulletCard.tsx
@@ -61,12 +61,22 @@ const BulletBar: React.FC<BulletBarProps> = ({
   title,
   ariaLabel,
 }) => {
-  const max = targets.smedley
   // Real data always has Smedley > Distinguished > 0. Guard for synthetic
   // zero-target rows so tick positions never become NaN%.
-  if (max <= 0) return null
-  const markerPct = Math.min(100, (current / max) * 100)
-  const allAchieved = current >= max
+  if (targets.smedley <= 0) return null
+
+  // Zoom scale into the tier band so the four ticks have room to spread.
+  // A [0, Smedley] scale crushed D/S/P/Sm into 93%–100% on real data —
+  // labels collided and the bar was unreadable (#558). The scale below
+  // auto-expands to include `current` whenever it lies outside the tier
+  // band, so no clamping is needed and no "below-scale" affordance is
+  // required — the marker is always on the bar.
+  const minScale = Math.max(0, Math.min(current, 0.9 * targets.distinguished))
+  const maxScale = Math.max(current, 1.05 * targets.smedley)
+  const range = maxScale - minScale
+  const positionAt = (v: number): number => ((v - minScale) / range) * 100
+  const markerPct = positionAt(current)
+  const allAchieved = current >= targets.smedley
 
   const tiers: TierTick[] = TIERS.map(t => ({ ...t, value: targets[t.key] }))
 
@@ -76,10 +86,10 @@ const BulletBar: React.FC<BulletBarProps> = ({
       role="progressbar"
       aria-valuenow={current}
       aria-valuemin={0}
-      aria-valuemax={max}
+      aria-valuemax={targets.smedley}
       aria-label={
         ariaLabel ??
-        `${title} — current ${current.toLocaleString()} of ${max.toLocaleString()} (Smedley tier)`
+        `${title} — current ${current.toLocaleString()} of ${targets.smedley.toLocaleString()} (Smedley tier)`
       }
     >
       <div
@@ -107,7 +117,7 @@ const BulletBar: React.FC<BulletBarProps> = ({
       </div>
 
       {tiers.map(t => {
-        const pos = (t.value / max) * 100
+        const pos = positionAt(t.value)
         const achieved = current >= t.value
         return (
           <Tooltip

--- a/frontend/src/components/RegionRankChip.tsx
+++ b/frontend/src/components/RegionRankChip.tsx
@@ -8,10 +8,12 @@ interface RegionRankChipProps {
 }
 
 /**
- * Compact chip rendering a district's region rank ("05: #3"). Links
- * to `/region/<digits>` when the region label contains digits; falls
- * back to a plain span when it doesn't (no route exists for "Unknown"
- * or other non-numeric regions).
+ * Inline region rank ("05: #3"). Links to `/region/<digits>` when the
+ * region label contains digits; falls back to a plain span when it
+ * doesn't (no route exists for "Unknown" / other non-numeric regions).
+ * Renders as inline text — no chip background — so it sits alongside
+ * the other rank-line elements (world rank, percentile) at equal
+ * visual weight.
  */
 export const RegionRankChip: React.FC<RegionRankChipProps> = ({
   region,
@@ -27,22 +29,19 @@ export const RegionRankChip: React.FC<RegionRankChipProps> = ({
       {region}: {regionRank !== null ? `#${regionRank}` : '—'}
     </>
   )
-  const sharedClasses = 'px-2 py-1 rounded-sm bg-gray-100 text-gray-700'
   return (
     <Tooltip content={tooltipContent}>
       {digits ? (
         <Link
           to={`/region/${digits}`}
-          className={`${sharedClasses} hover:bg-gray-200`}
+          className="text-tm-loyal-blue hover:underline"
           data-testid="region-rank"
           aria-label={`View Region ${digits} overview`}
         >
           {label}
         </Link>
       ) : (
-        <span className={sharedClasses} data-testid="region-rank">
-          {label}
-        </span>
+        <span data-testid="region-rank">{label}</span>
       )}
     </Tooltip>
   )

--- a/frontend/src/components/__tests__/KpiBulletCard.test.tsx
+++ b/frontend/src/components/__tests__/KpiBulletCard.test.tsx
@@ -199,7 +199,7 @@ describe('KpiBulletCard', () => {
       //   D=158 → (158-142.2)/35.25*100 ≈ 44.82%
       //   S=161 → ≈ 53.33%
       //   P=164 → ≈ 61.84%
-      //   Sm=169 → ≈ 75.74%
+      //   Sm=169 → (169-142.2)/35.25*100 ≈ 76.03%
       renderWithRouter(
         <KpiBulletCard
           title="Paid Clubs"
@@ -219,7 +219,7 @@ describe('KpiBulletCard', () => {
         left: '61.84%',
       })
       expect(within(bar).getByTestId('tier-tick-smedley')).toHaveStyle({
-        left: '75.74%',
+        left: '76.03%',
       })
     })
 

--- a/frontend/src/components/__tests__/KpiBulletCard.test.tsx
+++ b/frontend/src/components/__tests__/KpiBulletCard.test.tsx
@@ -245,6 +245,24 @@ describe('KpiBulletCard', () => {
       expect(marker).toHaveStyle({ left: '0%' })
     })
 
+    it('pins marker at 100% when current is exactly at Smedley (you-made-it signal)', () => {
+      // For current=169 (= Smedley):
+      //   allAchieved = true → maxScale = current = 169
+      //   minScale = min(169, 142.2) = 142.2
+      //   position(169) = (169-142.2)/(169-142.2) * 100 = 100%
+      renderWithRouter(
+        <KpiBulletCard
+          title="Paid Clubs"
+          current={169}
+          targets={standardTargets}
+          rankings={standardRankings}
+        />
+      )
+      const marker = screen.getByTestId('current-marker')
+      expect(marker).toHaveStyle({ left: '100%' })
+      expect(marker).toHaveAttribute('data-all-achieved', 'true')
+    })
+
     it('expands maxScale to include current when current exceeds Smedley', () => {
       // For current=200, targets D=158/Sm=169:
       //   minScale = min(200, 142.2) = 142.2

--- a/frontend/src/components/__tests__/KpiBulletCard.test.tsx
+++ b/frontend/src/components/__tests__/KpiBulletCard.test.tsx
@@ -176,7 +176,12 @@ describe('KpiBulletCard', () => {
       )
     })
 
-    it('positions the current-value marker proportionally between 0 and Smedley', () => {
+    it('positions the marker on a zoom-scale focused on the tier band', () => {
+      // Scale = [max(0, min(current, 0.9 × Distinguished)), max(current, 1.05 × Smedley)]
+      // For current=149, targets D=158/Sm=169:
+      //   minScale = min(149, 142.2) = 142.2
+      //   maxScale = max(149, 177.45) = 177.45
+      //   position(149) = (149 - 142.2) / 35.25 * 100 ≈ 19.29%
       renderWithRouter(
         <KpiBulletCard
           title="Paid Clubs"
@@ -186,11 +191,65 @@ describe('KpiBulletCard', () => {
         />
       )
       const marker = screen.getByTestId('current-marker')
-      // 149 / 169 = 88.16%
-      expect(marker).toHaveStyle({ left: '88.17%' })
+      expect(marker).toHaveStyle({ left: '19.29%' })
     })
 
-    it('caps marker position at 100% when current exceeds Smedley', () => {
+    it('spreads tier ticks across the bar so labels do not collide', () => {
+      // Same scale calc; tier ticks land at:
+      //   D=158 → (158-142.2)/35.25*100 ≈ 44.82%
+      //   S=161 → ≈ 53.33%
+      //   P=164 → ≈ 61.84%
+      //   Sm=169 → ≈ 75.74%
+      renderWithRouter(
+        <KpiBulletCard
+          title="Paid Clubs"
+          current={149}
+          targets={standardTargets}
+          rankings={standardRankings}
+        />
+      )
+      const bar = screen.getByRole('progressbar')
+      expect(within(bar).getByTestId('tier-tick-distinguished')).toHaveStyle({
+        left: '44.82%',
+      })
+      expect(within(bar).getByTestId('tier-tick-select')).toHaveStyle({
+        left: '53.33%',
+      })
+      expect(within(bar).getByTestId('tier-tick-presidents')).toHaveStyle({
+        left: '61.84%',
+      })
+      expect(within(bar).getByTestId('tier-tick-smedley')).toHaveStyle({
+        left: '75.74%',
+      })
+    })
+
+    it('pins marker at 0% when current is far below the tier band', () => {
+      // For Distinguished Clubs on D61 (D=71, Sm=94, current=49):
+      //   minScale = min(49, 63.9) = 49 (current < 0.9 × D)
+      //   maxScale = max(49, 98.7) = 98.7
+      //   position(49) = 0%
+      renderWithRouter(
+        <KpiBulletCard
+          title="Distinguished Clubs"
+          current={49}
+          targets={{
+            distinguished: 71,
+            select: 78,
+            presidents: 86,
+            smedley: 94,
+          }}
+          rankings={standardRankings}
+        />
+      )
+      const marker = screen.getByTestId('current-marker')
+      expect(marker).toHaveStyle({ left: '0%' })
+    })
+
+    it('expands maxScale to include current when current exceeds Smedley', () => {
+      // For current=200, targets D=158/Sm=169:
+      //   minScale = min(200, 142.2) = 142.2
+      //   maxScale = max(200, 177.45) = 200
+      //   position(200) = (200-142.2)/57.8*100 ≈ 100%
       renderWithRouter(
         <KpiBulletCard
           title="Paid Clubs"

--- a/tasks/lessons/065-when-tier-thresholds-cluster-zoom-the-scale-into-the-band.md
+++ b/tasks/lessons/065-when-tier-thresholds-cluster-zoom-the-scale-into-the-band.md
@@ -1,0 +1,87 @@
+---
+name: When tier thresholds cluster, zoom the scale into the band
+description: A linear [0, max] bar crushes tightly-clustered tier
+  thresholds into a single illegible cluster at the right edge. Zoom the
+  scale around the tier band so each threshold has room to breathe.
+type: feedback
+---
+
+# Lesson 65 — When tier thresholds cluster, zoom the scale into the band
+
+**Date:** 2026-05-21
+**Issue:** #558 (KpiBulletCard tier ticks collide on D61 data)
+
+## What happened
+
+The bullet bar in #550 used a `[0, Smedley]` linear scale to show
+"how close are you to each Distinguished tier?" For Paid Clubs on
+District 61 the four thresholds are D=158, S=161, P=164, Sm=169 —
+a ~7% spread at the top of the bar. The four tier ticks collapsed
+into positions 93%, 95%, 97%, 100% with their labels (D, S, P, Sm)
+and threshold values (158, 161, 164, 169) **visually overlapping each
+other**. The bar was illegible.
+
+The redesign assumed "0 is a meaningful anchor" (you can see how far
+from the start you are). In practice, districts always have a
+meaningful baseline well above 0 — paid clubs grow from a paid-club
+base, payments grow from a payment base, etc. The 0 anchor was
+informational nothing.
+
+## How to apply
+
+**When tier thresholds for a metric are clustered in the top decile
+of the metric range, drop the 0 anchor and zoom the scale around the
+tier band.**
+
+A self-expanding zoom scale is simpler than fixed paddings:
+
+```ts
+const minScale = Math.max(0, Math.min(current, 0.9 * lowestTier))
+const maxScale = allTopTierAchieved ? current : 1.05 * topTier
+const positionAt = (v: number) => ((v - minScale) / (maxScale - minScale)) * 100
+```
+
+The auto-expansion handles three edge cases without explicit clamping:
+
+- **current far below the band** → `minScale = current` → marker pins
+  to the left edge; tiers spread across the rest of the bar.
+- **current at/above the top tier** → `maxScale = current` → marker
+  pins to the right edge; the "5% headroom" disappears so the bar
+  reads as full ("you've made it").
+- **current well above** → `maxScale = current` → marker at 100%;
+  tier ticks slide left as the bar zooms out.
+
+Telltale signs you have this problem brewing:
+
+- Three or more tier ticks fall within 10% of the bar's right edge.
+- Labels need staggering (alternate above/below the bar) to be
+  readable — that's the visual asking for a scale change.
+- The first time you see real data, you think "wait, the bar is
+  broken" — but the math is right; the scale is wrong.
+
+**Why:** the user's question is "where am I within the tier range?"
+not "where am I within the full metric range starting at 0?" Bars
+should answer the actual question.
+
+**How to apply:** measure the tier span (`topTier - lowestTier`). If
+it's < 10% of `topTier`, your scale must zoom; if it's > 30%, a
+`[0, topTier]` linear scale is probably fine.
+
+## Trade-offs
+
+- Lose the 0 anchor. A user can no longer eyeball "I'm at 88% of
+  Smedley" from the marker position. But that information wasn't
+  legible on the cluttered bar either.
+- At-Smedley behavior is non-continuous (marker jumps from ~76% to
+  100% as current crosses Smedley). Defensible: hitting Smedley IS a
+  discrete milestone; the visual saying "you did it" with a full bar
+  is the right semantic.
+
+## Related
+
+- `frontend/src/components/KpiBulletCard.tsx` — the zoom-scale algorithm
+- Issue #558 — the bug report with screenshots
+- Lesson 63 (#550) — the parent decision to use a bullet bar for the
+  progress question in the first place. Picking the right chart type
+  is necessary but not sufficient; the scale choice is the rest of
+  "answer the question well."


### PR DESCRIPTION
Closes #557 and #558.

## Summary

- **#558 (P0 production bug)**: The bullet bar's `[0, Smedley]` scale was crushing the four tier ticks into the rightmost 7% of the bar on real D61 data. Labels and threshold values overlapped each other into illegible blobs. Replaced with a self-expanding zoom scale focused on the tier band.
- **#557**: `RegionRankChip` rendered as a gray chip with padding/background while its rank-line siblings (world rank, percentile) were plain inline text. Stripped the chip styling so all three elements have equal visual weight.

## Algorithm (#558)

```ts
const allAchieved = current >= targets.smedley
const minScale = Math.max(0, Math.min(current, 0.9 × targets.distinguished))
const maxScale = allAchieved ? current : 1.05 × targets.smedley
const positionAt = (v) => ((v - minScale) / (maxScale - minScale)) × 100
```

The scale auto-expands to include `current` when it falls outside the tier band, so no clamping is required. When `current >= Smedley`, `maxScale` collapses to `current` and the bar reads as full ("you've made it").

For Paid Clubs on D61 (D=158, S=161, P=164, Sm=169, current=149):

| | Before | After |
|---|---|---|
| Marker | 88.17% | **19.29%** |
| Distinguished tick | 93.49% | **44.82%** |
| Select tick | 95.27% | **53.33%** |
| President's tick | 97.04% | **61.84%** |
| Smedley tick | 100% | **76.03%** |

## Commits

1. `ed5f2350` — Red: zoom-scale contract tests
2. `12bd0fed` — Green: implement zoom scale (#558)
3. `57dadeec` — Lightweight: RegionRankChip → inline text (#557)
4. `749a22ff` — /simplify+/review pass: pin marker to 100% at Smedley; add lesson #65

## Tests

- 18/18 KpiBulletCard tests (4 new: spread, below-band pin, at-Smedley pin, above-Smedley expansion)
- 2311/2311 full frontend suite passing
- Existing tests adjusted honestly to reflect new scale (no assertion pinning — the spec changed, the assertions reflect the spec)

## Test plan

- [ ] District 61 — Paid Clubs bullet bar: marker at ~19%, ticks visibly spaced
- [ ] District 61 — Distinguished Clubs bullet bar: current (49) far below tier band, marker pinned to left
- [ ] A district that's hit Smedley — marker pinned to 100%, all tier ticks shown as achieved
- [ ] Region rank in rank line reads as inline text matching siblings, with hover-underline on the link
- [ ] Dark mode rendering verified

## Acceptance from issues

### #558
- [x] Scale auto-expands when current is outside the tier band
- [x] Four tier ticks distinct and readable at all three KPI cards
- [x] Marker pins to 0% when current < 0.9×Distinguished
- [x] Marker pins to 100% when current >= Smedley (with `data-all-achieved="true"`)
- [x] `aria-valuemin=0` / `aria-valuemax=Smedley` remain as logical bounds (separated from visual scale)
- [x] Tests updated for the new scale

### #557
- [x] No chip background / padding on RegionRankChip
- [x] Numeric regions still render as `<Link>` to `/region/{digits}`
- [x] Non-numeric regions still render as plain `<span>`
- [x] Tooltip behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)