### PR TITLE
feat(district-status): concrete units + reorder + drop net in gap tiles (#555, #556)

### DIFF
--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -91,12 +91,27 @@ const PREREQUISITE_KEYS = Object.keys(PREREQUISITE_LABELS) as Array<
 
 interface GapTileSpec {
   label: string
+  /** Headline gap value, in percent. */
   gap: number
-  suffix: string
+  /**
+   * Concrete unit count derived from `gap × base`. `null` skips the
+   * secondary line (older snapshots without base values).
+   */
+  concreteCount: number | null
+  /** Unit noun used singular when concreteCount === 1. */
+  unitSingular: string
+  unitPlural: string
 }
 
-const GapTile: React.FC<GapTileSpec> = ({ label, gap, suffix }) => {
+const GapTile: React.FC<GapTileSpec> = ({
+  label,
+  gap,
+  concreteCount,
+  unitSingular,
+  unitPlural,
+}) => {
   const closed = gap === 0
+  const showConcrete = !closed && concreteCount != null && concreteCount > 0
   return (
     <div className="rounded-md border border-gray-200 dark:border-gray-700 px-3 py-2">
       <div
@@ -111,10 +126,31 @@ const GapTile: React.FC<GapTileSpec> = ({ label, gap, suffix }) => {
           closed ? 'text-tm-loyal-blue' : 'text-gray-900 dark:text-gray-100'
         }`}
       >
-        {closed ? '✓' : `+${gap.toFixed(1)}${suffix}`}
+        {closed ? '✓' : `+${gap.toFixed(1)}%`}
       </div>
+      {showConcrete && (
+        <div
+          data-testid="gap-tile-units"
+          className="mt-0.5 text-[11px] text-gray-500 dark:text-gray-400 font-tm-body tabular-nums"
+        >
+          ~{concreteCount} {concreteCount === 1 ? unitSingular : unitPlural}
+        </div>
+      )}
     </div>
   )
+}
+
+/**
+ * Convert a growth-percentage gap to a concrete unit count using the
+ * program-year baseline. Returns `null` when base is unavailable so
+ * the tile can omit the secondary line gracefully.
+ */
+function concreteUnitsFromGap(
+  gapPercent: number,
+  base: number | undefined
+): number | null {
+  if (gapPercent <= 0 || base == null || base <= 0) return null
+  return Math.max(1, Math.round((base * gapPercent) / 100))
 }
 
 export const DistinguishedDistrictTrophyCase: React.FC<
@@ -241,27 +277,40 @@ export const DistinguishedDistrictTrophyCase: React.FC<
           )}
           <div
             data-testid="distinguished-gap-tiles"
-            className="grid grid-cols-2 md:grid-cols-4 gap-2"
+            className="grid grid-cols-1 md:grid-cols-3 gap-2"
           >
-            <GapTile
-              label="Payment growth"
-              gap={nextTierGap.paymentGrowthGap}
-              suffix="%"
-            />
+            {/* Order: Club growth → Payment growth → % Distinguished (#556).
+                Net Club Growth tile dropped — Club Growth % conveys the same
+                fact as the absolute count for any positive growth. */}
             <GapTile
               label="Club growth"
               gap={nextTierGap.clubGrowthGap}
-              suffix="%"
+              concreteCount={concreteUnitsFromGap(
+                nextTierGap.clubGrowthGap,
+                nextTierGap.paidClubBase
+              )}
+              unitSingular="club"
+              unitPlural="clubs"
+            />
+            <GapTile
+              label="Payment growth"
+              gap={nextTierGap.paymentGrowthGap}
+              concreteCount={concreteUnitsFromGap(
+                nextTierGap.paymentGrowthGap,
+                nextTierGap.paymentBase
+              )}
+              unitSingular="payment"
+              unitPlural="payments"
             />
             <GapTile
               label="% Distinguished"
               gap={nextTierGap.distinguishedPercentGap}
-              suffix="%"
-            />
-            <GapTile
-              label="Net club growth"
-              gap={nextTierGap.netClubGrowthGap}
-              suffix=" clubs"
+              concreteCount={concreteUnitsFromGap(
+                nextTierGap.distinguishedPercentGap,
+                nextTierGap.paidClubBase
+              )}
+              unitSingular="club"
+              unitPlural="clubs"
             />
           </div>
         </div>

--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -21,6 +21,14 @@ export interface DistinguishedDistrictGap {
   clubGrowthGap: number
   distinguishedPercentGap: number
   netClubGrowthGap: number
+  /**
+   * Program-year baseline values used to derive concrete unit counts
+   * from the gap percentages (#555). Optional during the rollout —
+   * downstream callers that don't populate them simply omit the
+   * secondary "~N units" line.
+   */
+  paidClubBase?: number
+  paymentBase?: number
 }
 
 export interface DistinguishedDistrictStatus {

--- a/frontend/src/components/__tests__/DistinguishedDistrictTrophyCase.test.tsx
+++ b/frontend/src/components/__tests__/DistinguishedDistrictTrophyCase.test.tsx
@@ -26,6 +26,9 @@ const baseStatus: DistinguishedDistrictStatus = {
     clubGrowthGap: 5.5,
     distinguishedPercentGap: 13.6,
     netClubGrowthGap: 7,
+    // #555 — base values used to derive concrete-unit secondary lines.
+    paidClubBase: 161,
+    paymentBase: 5605,
   },
 }
 
@@ -101,25 +104,61 @@ describe('DistinguishedDistrictTrophyCase', () => {
     })
   })
 
-  describe('gap to next tier — inline tile row', () => {
-    it('renders four labeled tiles for the four delta metrics', () => {
+  describe('gap to next tier — inline tile row (#555, #556)', () => {
+    it('renders three tiles in Club Growth → Payment Growth → % Distinguished order', () => {
       render(<DistinguishedDistrictTrophyCase status={baseStatus} />)
       const tiles = screen.getByTestId('distinguished-gap-tiles')
       const labels = within(tiles).getAllByTestId('gap-tile-label')
-      const values = within(tiles).getAllByTestId('gap-tile-value')
       expect(labels.map(l => l.textContent)).toEqual([
-        'Payment growth',
         'Club growth',
+        'Payment growth',
         '% Distinguished',
-        'Net club growth',
       ])
-      expect(values[0]).toHaveTextContent('+2.0%')
-      expect(values[1]).toHaveTextContent('+5.5%')
-      expect(values[2]).toHaveTextContent('+13.6%')
-      expect(values[3]).toHaveTextContent('+7.0 clubs')
+      // Net Club Growth tile is gone (#556)
+      expect(screen.queryByText(/Net club growth/i)).not.toBeInTheDocument()
     })
 
-    it('renders a ✓ when a gap is zero', () => {
+    it('renders both the percentage and the concrete unit count per tile (#555)', () => {
+      render(<DistinguishedDistrictTrophyCase status={baseStatus} />)
+      const tiles = screen.getByTestId('distinguished-gap-tiles')
+      const values = within(tiles).getAllByTestId('gap-tile-value')
+      const units = within(tiles).getAllByTestId('gap-tile-units')
+
+      // Order: Club growth, Payment growth, % Distinguished
+      expect(values[0]).toHaveTextContent('+5.5%')
+      // 161 × 5.5% = 8.855 → ~9 clubs
+      expect(units[0]).toHaveTextContent('~9 clubs')
+
+      expect(values[1]).toHaveTextContent('+2.0%')
+      // 5605 × 2% = 112.1 → ~112 payments
+      expect(units[1]).toHaveTextContent('~112 payments')
+
+      expect(values[2]).toHaveTextContent('+13.6%')
+      // 161 × 13.6 / 100 = 21.896 → ~22 clubs (Distinguished clubs)
+      expect(units[2]).toHaveTextContent('~22 clubs')
+    })
+
+    it('singularises units when count is exactly 1', () => {
+      const tinyGap: DistinguishedDistrictStatus = {
+        ...baseStatus,
+        nextTierGap: {
+          tier: 'Distinguished',
+          paymentGrowthGap: 0.018, // 5605 × 0.00018 = 1.01 → 1 payment
+          clubGrowthGap: 0.62, // 161 × 0.0062 = 1.0 → 1 club
+          distinguishedPercentGap: 0.62, // 161 × 0.62/100 = 1.0 → 1 club
+          netClubGrowthGap: 1,
+          paidClubBase: 161,
+          paymentBase: 5605,
+        },
+      }
+      render(<DistinguishedDistrictTrophyCase status={tinyGap} />)
+      const units = screen.getAllByTestId('gap-tile-units')
+      expect(units[0]).toHaveTextContent('~1 club')
+      expect(units[1]).toHaveTextContent('~1 payment')
+      expect(units[2]).toHaveTextContent('~1 club')
+    })
+
+    it('renders a ✓ with no concrete-unit line when a gap is zero', () => {
       const closed: DistinguishedDistrictStatus = {
         ...baseStatus,
         nextTierGap: {
@@ -128,11 +167,15 @@ describe('DistinguishedDistrictTrophyCase', () => {
           clubGrowthGap: 0,
           distinguishedPercentGap: 0,
           netClubGrowthGap: 0,
+          paidClubBase: 161,
+          paymentBase: 5605,
         },
       }
       render(<DistinguishedDistrictTrophyCase status={closed} />)
       const values = screen.getAllByTestId('gap-tile-value')
       values.forEach(v => expect(v).toHaveTextContent('✓'))
+      // No "gap-tile-units" rendered when the gap is closed
+      expect(screen.queryByTestId('gap-tile-units')).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/services/cdn.ts
+++ b/frontend/src/services/cdn.ts
@@ -202,6 +202,13 @@ export interface DistinguishedDistrictGap {
   clubGrowthGap: number
   distinguishedPercentGap: number
   netClubGrowthGap: number
+  /**
+   * Program-year baselines, propagated by analytics-core (#555) so the
+   * UI can derive concrete unit counts from gap percentages. Optional
+   * to tolerate older CDN snapshots that predate the field.
+   */
+  paidClubBase?: number
+  paymentBase?: number
 }
 
 export interface DistinguishedDistrictStatus {

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
@@ -57,6 +57,17 @@ export interface DistinguishedDistrictGap {
   distinguishedPercentGap: number
   /** Additional net club growth needed (0 if already met) */
   netClubGrowthGap: number
+  /**
+   * Program-year baseline values, propagated from the source ranking so
+   * downstream UIs can derive concrete-unit gaps from the percentages
+   * (#555). The TI DDP rule (Item 1490) measures growth as
+   * `(current - base) / base × 100`, so the base is the multiplier the
+   * UI needs to translate "+1.9%" into "+108 payments". Optional during
+   * rollout — older snapshots may omit these and consumers gracefully
+   * degrade to displaying only the percentage.
+   */
+  paidClubBase?: number
+  paymentBase?: number
 }
 
 /**
@@ -242,6 +253,8 @@ export class DistinguishedDistrictCalculator {
         threshold.distinguishedPercentMin - ranking.distinguishedPercent
       ),
       netClubGrowthGap: Math.max(0, requiredNetChange - netChange),
+      paidClubBase: ranking.paidClubBase,
+      paymentBase: ranking.paymentBase,
     }
   }
 


### PR DESCRIPTION
Closes #555 and #556.

## Summary

- **#555**: Gap tiles render both the percentage AND a concrete unit count derived from the program-year baseline. \`+5.5%\` → \`~9 clubs\`, \`+2.0%\` → \`~112 payments\`, \`+13.6 pp\` → \`~22 clubs\`. Singularises units when count is exactly 1.
- **#556**: Reorders tiles to **Club Growth → Payment Growth → % Distinguished** (matches user mental model: foundational lever → consequence → outcome). Drops the **Net Club Growth** tile — Club Growth % conveys the same signal proportionally.

## Type changes (three parallel definitions kept in sync)

\`DistinguishedDistrictGap\` is defined in **three** places. Per lesson 61, all three were updated:

1. \`packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts\` — adds optional \`paidClubBase\` / \`paymentBase\`; \`computeNextTierGap\` now propagates them from the source \`DistrictRanking\`
2. \`frontend/src/services/cdn.ts\` — CDN fetch shape, adds same optional fields (caught by /review pass — would have been the next lesson-61 incident if missed)
3. \`frontend/src/components/DistinguishedDistrictTrophyCase.tsx\` — component-local shape, adds same optional fields

Fields are **optional** during rollout so older CDN snapshots gracefully degrade to "percentage only" with no errors.

## Formulas (per docs/toastmasters-rules-reference.md §13.2)

| Metric | Concrete number |
|---|---|
| Club Growth | \`Math.max(1, Math.round(paidClubBase × gap% / 100))\` → ~N clubs |
| Payment Growth | \`Math.max(1, Math.round(paymentBase × gap% / 100))\` → ~N payments |
| % Distinguished | \`Math.max(1, Math.round(paidClubBase × gapPP / 100))\` → ~N clubs |

The \`Math.max(1, ...)\` floor prevents a small open gap rounding to "~0 units".

## Commits

1. \`1a4d67a2\` — Red: type changes + 4 new contract tests
2. \`8c0da393\` — Green + /simplify+/review: GapTile implementation + cdn.ts type sync + comment cleanup

## Tests

- 10/10 TrophyCase contract tests
- 763/763 analytics-core (no regressions)
- 2310/2310 frontend full suite

## Test plan

- [ ] District 61 — gap tiles render in Club → Payment → % order
- [ ] Each tile shows both the % and the ~N units secondary line
- [ ] District that's at Distinguished tier with a small gap to Select → singular ("~1 club") renders
- [ ] District that's already at next tier (gap=0) — ✓ shows, no secondary line
- [ ] Older snapshot without paidClubBase/paymentBase → tile shows % only, no errors

## Acceptance from issues

### #555
- [x] Each tile renders percentage AND concrete-units secondary line
- [x] Singularised units
- [x] \`Math.round\` (discrete units), floored at 1 for tiny gaps
- [x] Closed gaps show ✓ with no secondary line
- [x] Component test asserts both lines

### #556
- [x] Tile order: Club Growth → Payment Growth → % Distinguished
- [x] Net Club Growth tile removed from JSX
- [x] \`netClubGrowthGap\` field retained on type (CGD officer-award uses it)
- [x] Grid: \`md:grid-cols-3\` at desktop, \`grid-cols-1\` at mobile
- [x] Test asserts three labels in new order; assertion confirms Net tile is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)