### PR TITLE
fix(overview): tier-tick positioning — hotfix #559 visual regression

### DIFF
--- a/frontend/src/components/KpiBulletCard.tsx
+++ b/frontend/src/components/KpiBulletCard.tsx
@@ -122,28 +122,34 @@ const BulletBar: React.FC<BulletBarProps> = ({
       {tiers.map(t => {
         const pos = positionAt(t.value)
         const achieved = current >= t.value
+        // Position the outer wrapper, NOT the Tooltip's child. Tooltip
+        // wraps its child in `relative inline-block`, which would
+        // otherwise become the absolute-positioning context and
+        // collapse all four ticks to ~left:0 of zero-width boxes.
         return (
-          <Tooltip
+          <div
             key={t.key}
-            content={`${t.fullLabel} — ${t.value.toLocaleString()} (${title.toLowerCase()})`}
+            data-testid={`tier-tick-${t.key}`}
+            className="absolute top-3"
+            style={{ left: formatPct(pos), transform: 'translateX(-50%)' }}
           >
-            <div
-              data-testid={`tier-tick-${t.key}`}
-              className="absolute top-3 flex flex-col items-center text-xs"
-              style={{ left: formatPct(pos), transform: 'translateX(-50%)' }}
+            <Tooltip
+              content={`${t.fullLabel} — ${t.value.toLocaleString()} (${title.toLowerCase()})`}
             >
-              <div
-                aria-hidden="true"
-                className={`h-2 w-px ${
-                  achieved ? 'bg-tm-loyal-blue' : 'bg-gray-400'
-                }`}
-              />
-              <div className="mt-1 font-medium text-gray-700">
-                {t.shortLabel}
+              <div className="flex flex-col items-center text-xs">
+                <div
+                  aria-hidden="true"
+                  className={`h-2 w-px ${
+                    achieved ? 'bg-tm-loyal-blue' : 'bg-gray-400'
+                  }`}
+                />
+                <div className="mt-1 font-medium text-gray-700">
+                  {t.shortLabel}
+                </div>
+                <div className="text-gray-500">{t.value.toLocaleString()}</div>
               </div>
-              <div className="text-gray-500">{t.value.toLocaleString()}</div>
-            </div>
-          </Tooltip>
+            </Tooltip>
+          </div>
         )
       })}
     </div>

--- a/frontend/src/components/__tests__/KpiBulletCard.test.tsx
+++ b/frontend/src/components/__tests__/KpiBulletCard.test.tsx
@@ -130,6 +130,31 @@ describe('KpiBulletCard', () => {
       expect(bar).toHaveAttribute('aria-valuemax', '169') // Smedley
     })
 
+    it('places each tier-tick as a direct child of the progressbar (no positioned Tooltip wrapper between)', () => {
+      // Regression — the Tooltip component wraps children in
+      // `<div className="relative inline-block">`. If the tier tick is
+      // INSIDE the Tooltip wrapper instead of OUTSIDE it, its
+      // `position: absolute` resolves against the zero-width Tooltip
+      // wrapper rather than the progressbar — all four ticks collapse
+      // to ~left:0 visually even though the inline `style.left` is
+      // correct. (Shipped briefly with PR #559; caught by audit of
+      // the live site, hotfixed.)
+      renderWithRouter(
+        <KpiBulletCard
+          title="Paid Clubs"
+          current={149}
+          targets={standardTargets}
+          rankings={standardRankings}
+        />
+      )
+      const bar = screen.getByRole('progressbar')
+      const distinguishedTick = screen.getByTestId('tier-tick-distinguished')
+      // The positioned element (the one carrying style.left) must be a
+      // direct child of the bar so its % offset resolves in the bar's
+      // coordinate space.
+      expect(distinguishedTick.parentElement).toBe(bar)
+    })
+
     it('renders four tier ticks with short labels D, S, P, Sm', () => {
       renderWithRouter(
         <KpiBulletCard

--- a/tasks/lessons/066-jsdom-style-assertions-do-not-catch-positioning-bugs.md
+++ b/tasks/lessons/066-jsdom-style-assertions-do-not-catch-positioning-bugs.md
@@ -1,0 +1,106 @@
+---
+name: JSDOM style assertions don't catch positioning bugs
+description: Asserting `toHaveStyle({ left: "X%" })` on an absolutely-positioned
+  element confirms the inline style is set — not that the element ends up at
+  X% of where you expect. If a positioned ancestor wraps the element, the %
+  resolves against the wrapper's zero-width box and the visual position is wrong.
+type: feedback
+---
+
+# Lesson 66 — JSDOM style assertions don't catch positioning bugs
+
+**Date:** 2026-05-22
+**Issue:** hotfix for #559 (caught by audit of live site)
+
+## What happened
+
+#559 zoomed the bullet bar scale into the tier band so the four
+tier ticks would have room to spread. The Green commit's tests
+asserted:
+
+```ts
+expect(within(bar).getByTestId('tier-tick-distinguished')).toHaveStyle({
+  left: '44.82%',
+})
+```
+
+All 18 tests passed. The math was right. The PR shipped to
+production.
+
+When the user audited the live site, every tier-tick label was
+collapsed onto the same x-position — visually unfixed.
+
+Root cause: the tier ticks were rendered INSIDE a `<Tooltip>` wrapper
+that itself renders `<div className="relative inline-block">`. The
+DOM looked like:
+
+```html
+<div role="progressbar" class="relative ...">
+  <div class="relative inline-block">
+    <!-- Tooltip wrapper -->
+    <div class="absolute" style="left: 44.82%">D / 158</div>
+  </div>
+  <div class="relative inline-block">
+    <div class="absolute" style="left: 53.33%">S / 161</div>
+  </div>
+  ...
+</div>
+```
+
+`position: absolute` resolves against the nearest positioned ancestor.
+The Tooltip's `relative inline-block` _is_ a positioned ancestor —
+and it's a zero-width inline-block. All four ticks collapsed to ~0% of
+their respective wrappers, producing the visual pile-up.
+
+`toHaveStyle({ left: '44.82%' })` looks at the inline `style`
+attribute, not at computed layout. It can't see the difference between
+"44.82% of the progressbar" and "44.82% of a zero-width box". JSDOM
+doesn't run a real layout engine, so even `getComputedStyle` wouldn't
+help here.
+
+## How to apply
+
+**For absolutely-positioned elements, also assert the structural
+context.** A style attribute is necessary but not sufficient — the
+positioning context (nearest positioned ancestor) is part of the
+semantic.
+
+Add at least one regression test per layout that says:
+
+```ts
+// The positioned tick must be a direct child of the bar so its %
+// offset resolves in the bar's coordinate space.
+expect(distinguishedTick.parentElement).toBe(bar)
+```
+
+`parentElement === expectedAncestor` catches the "something wrapped my
+element in a positioned div" class of bugs without requiring a real
+browser. If the element needs to be exactly N levels deep (e.g. inside
+a portal), assert the closest positioned ancestor with
+`.closest('[class*="relative"]')` against the same expected ref.
+
+**Telltale signs you have this kind of bug:**
+
+- Tests pass; production looks broken.
+- The element you styled has the right inline style attribute.
+- Multiple sibling elements you positioned at different percentages
+  visually overlap.
+- A wrapper component (Tooltip, Popover, FocusTrap, etc.) was added
+  recently — those often inject a positioned div.
+
+**How to apply when adding tooltips/popovers to positioned
+children:** position the OUTER wrapper of the
+tooltip/popover, then put the visual content inside. Don't wrap a
+positioned element in another positioned element; if you must, the
+inner positioning should be relative to the outer, and that should
+be deliberate.
+
+## Related
+
+- `frontend/src/components/KpiBulletCard.tsx` — the bullet bar
+- `frontend/src/components/Tooltip.tsx` — the wrapper component that
+  caused the issue (`<div className="relative inline-block">` is the
+  fixed wrapper class; consumers can't opt out)
+- Lesson 65 (#558) — the zoom-scale algorithm this hotfix preserves
+- Lesson 49/50/51 (per earlier history) — components in isolation
+  vs. under real chrome; this is the same lesson applied to positioning


### PR DESCRIPTION
Hotfix for the bullet-bar tier-tick positioning bug that shipped with PR #559.

## The bug

PR #559 zoomed the bullet bar scale into the tier band and tests asserted \`toHaveStyle({ left: '44.82%' })\` on each tick. All 18 tests passed; the math was right. The PR merged. On the live site, **every tier tick label still collapsed onto the same x-position** — visually unfixed.

## Root cause

The tier ticks render INSIDE a \`<Tooltip>\` component. Tooltip wraps its child in \`<div className="relative inline-block">\`. The live DOM was:

\`\`\`html
<div role="progressbar" class="relative ...">
  <div class="relative inline-block">           <!-- Tooltip wrapper -->
    <div class="absolute" style="left:44.82%">D / 158</div>
  </div>
  <div class="relative inline-block">
    <div class="absolute" style="left:53.33%">S / 161</div>
  </div>
  ...
</div>
\`\`\`

\`position: absolute\` resolves against the nearest positioned ancestor. The Tooltip's \`relative inline-block\` IS a positioned ancestor — and it's a zero-width inline-block. All four ticks collapsed to ~0% of their respective wrappers.

\`toHaveStyle({ left: '44.82%' })\` looks at the inline \`style\` attribute, not at computed layout. JSDOM doesn't run a real layout engine, so even \`getComputedStyle\` wouldn't have caught this.

## The fix

Lift the absolute positioning to the **outer wrapper** (a direct child of the progressbar root). The Tooltip lives inside it:

\`\`\`tsx
<div data-testid={\`tier-tick-\${t.key}\`} className="absolute top-3" style={{ left: ..., transform: 'translateX(-50%)' }}>
  <Tooltip content={...}>
    <div className="flex flex-col items-center text-xs">
      {/* tick line + label + value */}
    </div>
  </Tooltip>
</div>
\`\`\`

The Tooltip's \`relative inline-block\` now lives inside an already-positioned div and can't interfere with the layout.

## Regression test

\`KpiBulletCard.test.tsx\` now also asserts \`distinguishedTick.parentElement === bar\`. This catches "something wrapped my positioned element in a positioned div" without needing a real browser.

## Commits

1. \`da717623\` — Red: regression test (1 fail, 18 pass)
2. \`85509447\` — Green + lesson #66: lift positioning to outer wrapper; document the JSDOM-style-assertion limitation

## Tests

- 19/19 KpiBulletCard tests
- 2312/2312 full frontend suite

## Test plan

- [ ] CI green
- [ ] Merge → Deploy → ts.taverns.red shows tier ticks spaced out (D/S/P/Sm visible as separate labels, no collisions)
- [ ] Hover/focus a tick → tooltip shows full tier name

## Notes

- Lesson #66 captures the general principle: \`toHaveStyle\` confirms the style attribute, not visual layout. For absolutely-positioned elements, also assert the structural context.
- This is a small, focused fix off main — does not touch PR #560 or #561 in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)