### PR TITLE
feat(app-shell): move ThemeToggle from footer to header (#565)

### DIFF
--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -173,16 +173,16 @@ describe('AppShell (#354)', () => {
       expect(text).toMatch(/MIT License\s*·\s*(?:v\d|dev)/i)
     })
 
-    it('preserves the theme toggle for manual dark-mode access', () => {
+    it('does not render the theme toggle in the footer (#565 moved it to the header)', () => {
       renderShell()
       const footer = screen.getByRole('contentinfo')
-      // ThemeToggle's aria-label flips with state ("Switch to dark mode" /
-      // "Switch to light mode") — match either.
+      // ThemeToggle moved to AppShellTopBar in #565. The header-placement
+      // contract is covered by AppShell.layout.test.tsx.
       expect(
-        within(footer).getByRole('button', {
+        within(footer).queryByRole('button', {
           name: /switch to (light|dark) mode/i,
         })
-      ).toBeInTheDocument()
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/AppShell/AppShell.tsx
+++ b/frontend/src/components/AppShell/AppShell.tsx
@@ -6,8 +6,8 @@ import CommandPalette from './CommandPalette'
 import { useGoogleAnalytics } from '../../hooks/useGoogleAnalytics'
 
 /* Per Epic #352: no notifications/help/avatar (no auth today),
-   no Regions/Awards "soon" stubs. ThemeToggle stays in the footer
-   so manual dark-mode access survives the chrome swap.
+   no Regions/Awards "soon" stubs. ThemeToggle now lives in the top
+   bar (#565) — chrome-level controls all sit in the header.
 
    #422 Universal search: Cmd-K / Ctrl-K opens the CommandPalette modal
    from anywhere. The palette shares the React-Query cache with

--- a/frontend/src/components/AppShell/AppShellFooter.tsx
+++ b/frontend/src/components/AppShell/AppShellFooter.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
-import ThemeToggle from '../ThemeToggle'
 
 declare const __APP_VERSION__: string
 
-/* The handoff design has no theme toggle (it relies on prefers-color-scheme),
-   but Epic #352 keeps the manual [data-theme='dark'] toggle, so the toggle
-   lives here in the footer to preserve a11y access. */
+/* Footer carries the meta strip (license, version, data source) only.
+   The ThemeToggle moved to AppShellTopBar in #565 — chrome-level
+   controls all live in the header now. */
 
 const AppShellFooter: React.FC = () => {
   const version =
@@ -38,7 +37,6 @@ const AppShellFooter: React.FC = () => {
             {' · '}
             {version}
           </span>
-          <ThemeToggle />
         </div>
       </div>
     </footer>

--- a/frontend/src/components/AppShell/AppShellTopBar.tsx
+++ b/frontend/src/components/AppShell/AppShellTopBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { NavLink, Link } from 'react-router-dom'
+import ThemeToggle from '../ThemeToggle'
 
 const NAV_ITEMS = [
   { to: '/', label: 'Districts', end: true },
@@ -60,6 +61,7 @@ const AppShellTopBar: React.FC = () => {
             <circle cx="8" cy="12" r=".4" fill="currentColor" />
           </svg>
         </Link>
+        <ThemeToggle />
         <span
           className="app-shell-avatar"
           aria-label="Account (placeholder)"

--- a/frontend/src/components/AppShell/__tests__/AppShell.layout.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/AppShell.layout.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * AppShell layout tests — assert chrome-level placement of controls
+ * that have moved between header and footer over time (#565).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import AppShell from '../AppShell'
+import { DarkModeProvider } from '../../../contexts/DarkModeContext'
+import { ProgramYearProvider } from '../../../contexts/ProgramYearContext'
+
+afterEach(() => cleanup())
+
+const renderShell = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <ProgramYearProvider>
+        <DarkModeProvider>
+          <MemoryRouter>
+            <AppShell />
+          </MemoryRouter>
+        </DarkModeProvider>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('AppShell layout (#565)', () => {
+  it('renders the theme toggle inside the header banner, not the footer', () => {
+    renderShell()
+    const banner = screen.getByRole('banner')
+    const toggle = screen.getByRole('button', {
+      name: /switch to (dark|light) mode/i,
+    })
+    expect(banner.contains(toggle)).toBe(true)
+
+    const footer = screen.getByRole('contentinfo')
+    expect(footer.contains(toggle)).toBe(false)
+  })
+
+  it('places the theme toggle between the help icon and the avatar in the header tools cluster', () => {
+    renderShell()
+    const banner = screen.getByRole('banner')
+    const helpIcon = within(banner).getByRole('link', { name: /how it works/i })
+    const toggle = within(banner).getByRole('button', {
+      name: /switch to (dark|light) mode/i,
+    })
+    const avatar = within(banner).getByRole('img', {
+      name: /account.*placeholder/i,
+    })
+
+    // DOM order: help → toggle → avatar
+    const helpPos = Array.from(banner.querySelectorAll('*')).indexOf(helpIcon)
+    const togglePos = Array.from(banner.querySelectorAll('*')).indexOf(toggle)
+    const avatarPos = Array.from(banner.querySelectorAll('*')).indexOf(avatar)
+    expect(helpPos).toBeLessThan(togglePos)
+    expect(togglePos).toBeLessThan(avatarPos)
+  })
+})

--- a/frontend/src/components/AppShell/__tests__/AppShell.layout.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/AppShell.layout.test.tsx
@@ -47,7 +47,11 @@ describe('AppShell layout (#565)', () => {
   it('places the theme toggle between the help icon and the avatar in the header tools cluster', () => {
     renderShell()
     const banner = screen.getByRole('banner')
-    const helpIcon = within(banner).getByRole('link', { name: /how it works/i })
+    // The "How it works" text appears twice in the banner (nav link +
+    // tools-cluster icon button). The help icon in the tools cluster is
+    // the one with the explicit aria-label, identified by its title
+    // attribute as well.
+    const helpIcon = within(banner).getByTitle('How it works')
     const toggle = within(banner).getByRole('button', {
       name: /switch to (dark|light) mode/i,
     })
@@ -56,10 +60,8 @@ describe('AppShell layout (#565)', () => {
     })
 
     // DOM order: help → toggle → avatar
-    const helpPos = Array.from(banner.querySelectorAll('*')).indexOf(helpIcon)
-    const togglePos = Array.from(banner.querySelectorAll('*')).indexOf(toggle)
-    const avatarPos = Array.from(banner.querySelectorAll('*')).indexOf(avatar)
-    expect(helpPos).toBeLessThan(togglePos)
-    expect(togglePos).toBeLessThan(avatarPos)
+    const allEls = Array.from(banner.querySelectorAll('*'))
+    expect(allEls.indexOf(helpIcon)).toBeLessThan(allEls.indexOf(toggle))
+    expect(allEls.indexOf(toggle)).toBeLessThan(allEls.indexOf(avatar))
   })
 })


### PR DESCRIPTION
Closes #565.

## Summary

Moves `<ThemeToggle />` from `AppShellFooter` to `AppShellTopBar`'s `app-shell-tools` cluster, between the help icon and the avatar placeholder.

Chrome-level controls now all live in the header. The footer carries the meta strip (license, version, data source) only.

## Why now

Theme switching was below-the-fold on most viewports — users had to scroll to the footer of every page. With the contrast audit (#564) about to start, one-click theme switching is necessary for efficient visual verification.

## Changes

- `AppShellTopBar.tsx`: import `ThemeToggle`, render between help icon and avatar.
- `AppShellFooter.tsx`: drop `ThemeToggle` import and JSX, update stale header comment.
- `AppShell.tsx`: update stale "ThemeToggle stays in the footer" comment.
- `AppShell.layout.test.tsx`: **new** file — asserts the structural contract (toggle in `<header role="banner">`, not in `<footer>`; DOM order help → toggle → avatar).
- `AppShell.test.tsx`: old "preserves the theme toggle … in the footer" assertion inverted — it now asserts the toggle is NOT in the footer.

## Tests

- 2/2 new `AppShell.layout` tests pass
- 16/16 in the `AppShell` test files combined
- Full frontend suite green (1 known flake from #525 hits on rerun; clean on retry)

## Test plan

- [ ] CI green
- [ ] Header on every page shows toggle to the left of the avatar
- [ ] Toggle still flips between light/dark and persists in localStorage
- [ ] Footer no longer renders a button
- [ ] Mobile widths (< 480px): toggle visible, top bar doesn't squeeze it out
- [ ] No regression to other top-bar interactions (search palette, nav links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)