### PR TITLE
feat(district): IA Phase 1 — stack Overview/Trends/Analytics into scrollable narrative (#569)

### DIFF
--- a/frontend/src/__tests__/integration/journeys/01-NavigationFlow.test.tsx
+++ b/frontend/src/__tests__/integration/journeys/01-NavigationFlow.test.tsx
@@ -70,21 +70,17 @@ describe('Journey 01: The Navigation Flow', () => {
     )
     expect(districtHeading).toBeInTheDocument()
 
-    // Make sure we are on the District detail page viewing some summary content
-    // We use findAllByText with a longer timeout because the data might be loading via React Query
-    const trendsTabs = await screen.findAllByText(
-      /Trends/i,
-      {},
-      { timeout: 3000 }
-    )
-    expect(trendsTabs.length).toBeGreaterThan(0)
-
-    // Step 6: Go to the Analytics tab to view clubs
-    // Step 6: Go to the Clubs tab to view clubs
-    // Step 6: Go to the Clubs tab to view clubs
+    // Make sure we are on the District detail page viewing some summary
+    // content. #569 dropped the Trends/Overview/Analytics tabs in favor
+    // of a single scrollable narrative — assert against the Clubs tab
+    // instead, which still exists and is the destination of the next
+    // step anyway.
+    // Step 6: Go to the Clubs tab to view clubs.
+    // After #569 the tab carries a count badge ("Clubs 305"), so the
+    // accessible name starts with "Clubs" but isn't a strict equal.
     const clubsTab = await screen.findByRole(
       'tab',
-      { name: /^Clubs$/i },
+      { name: /^Clubs/i },
       { timeout: 5000 }
     )
     await user.click(clubsTab)

--- a/frontend/src/components/DistrictDetailTabs.tsx
+++ b/frontend/src/components/DistrictDetailTabs.tsx
@@ -15,6 +15,17 @@ import React, { useRef } from 'react'
      `tabIdFor` / `panelIdFor` exports.
    Reference: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/ */
 
+/**
+ * District tab IDs.
+ *
+ * #569 (IA Phase 1) collapsed 'overview' / 'trends' / 'analytics' into
+ * a single scrollable narrative — none of them appear in the tab strip
+ * anymore, but the IDs survive in this union so existing `?tab=...`
+ * URLs still parse cleanly and the merged-panel id (`panelIdFor`) is
+ * stable for a11y labelling. The remaining strip is Clubs / Divisions /
+ * Global Rankings; Phases 2 + 3 will route them and the strip goes
+ * away entirely.
+ */
 export type DistrictTabId =
   | 'overview'
   | 'clubs'
@@ -22,6 +33,9 @@ export type DistrictTabId =
   | 'trends'
   | 'analytics'
   | 'globalRankings'
+
+/** Subset of DistrictTabId that actually appears in the tab strip after #569. */
+export type DistrictStripTabId = 'clubs' | 'divisions' | 'globalRankings'
 
 export const tabIdFor = (id: DistrictTabId) => `district-tab-${id}`
 export const panelIdFor = (id: DistrictTabId) => `district-tabpanel-${id}`
@@ -41,12 +55,14 @@ interface TabSpec {
   countKey?: 'clubsCount' | 'divisionsCount'
 }
 
+/**
+ * Visible tab strip. #569 dropped Overview / Trends / Analytics —
+ * their content scroll-stacks above the strip as one narrative now.
+ * Phases 2 + 3 will route the three remaining destinations.
+ */
 const TABS: ReadonlyArray<TabSpec> = [
-  { id: 'overview', label: 'Overview' },
   { id: 'clubs', label: 'Clubs', countKey: 'clubsCount' },
   { id: 'divisions', label: 'Divisions & Areas', countKey: 'divisionsCount' },
-  { id: 'trends', label: 'Trends' },
-  { id: 'analytics', label: 'Analytics' },
   { id: 'globalRankings', label: 'Global Rankings' },
 ]
 

--- a/frontend/src/components/__tests__/DistrictDetailTabs.test.tsx
+++ b/frontend/src/components/__tests__/DistrictDetailTabs.test.tsx
@@ -24,34 +24,29 @@ const renderTabs = (
 
 describe('DistrictDetailTabs (#359)', () => {
   describe('structure', () => {
-    it('renders all 6 tabs in order', () => {
+    it('renders the 3 remaining tabs in order (#569 dropped narrative tabs)', () => {
       renderTabs()
       const tablist = screen.getByRole('tablist', {
         name: /district analysis tabs/i,
       })
       const tabs = within(tablist).getAllByRole('tab')
-      // Tabs render label + (optional) count badge as siblings; textContent
-      // concatenates them without whitespace.
+      // After #569, the strip is just Clubs / Divisions / Global Rankings.
+      // Overview / Trends / Analytics scroll-stack above the strip.
       expect(tabs.map(t => t.textContent?.trim())).toEqual([
-        'Overview',
         'Clubs305',
         'Divisions & Areas7',
-        'Trends',
-        'Analytics',
         'Global Rankings',
       ])
     })
 
     it('marks the active tab with aria-selected="true" and others false', () => {
-      renderTabs({ activeTab: 'trends' })
+      renderTabs({ activeTab: 'clubs' })
       const tablist = screen.getByRole('tablist')
-      const trends = within(tablist).getByRole('tab', { name: /trends/i })
-      expect(trends).toHaveAttribute('aria-selected', 'true')
+      const clubs = within(tablist).getByRole('tab', { name: /^clubs/i })
+      expect(clubs).toHaveAttribute('aria-selected', 'true')
 
-      const overview = within(tablist).getByRole('tab', {
-        name: /overview/i,
-      })
-      expect(overview).toHaveAttribute('aria-selected', 'false')
+      const divs = within(tablist).getByRole('tab', { name: /divisions/i })
+      expect(divs).toHaveAttribute('aria-selected', 'false')
     })
   })
 
@@ -92,9 +87,9 @@ describe('DistrictDetailTabs (#359)', () => {
 
     it('does not fire onTabChange when the already-active tab is clicked', () => {
       const onTabChange = vi.fn()
-      renderTabs({ activeTab: 'overview', onTabChange })
+      renderTabs({ activeTab: 'clubs', onTabChange })
       const tablist = screen.getByRole('tablist')
-      fireEvent.click(within(tablist).getByRole('tab', { name: /overview/i }))
+      fireEvent.click(within(tablist).getByRole('tab', { name: /^clubs/i }))
       expect(onTabChange).not.toHaveBeenCalled()
     })
   })
@@ -114,39 +109,42 @@ describe('DistrictDetailTabs (#359)', () => {
     })
 
     it('ArrowRight moves focus to the next tab (with wrap)', () => {
-      renderTabs({ activeTab: 'overview' })
+      renderTabs({ activeTab: 'clubs' })
       const tablist = screen.getByRole('tablist')
       const tabs = within(tablist).getAllByRole('tab')
       tabs[0].focus()
       fireEvent.keyDown(tabs[0], { key: 'ArrowRight' })
       expect(tabs[1]).toHaveFocus()
-      // wrap at end
-      tabs[5].focus()
-      fireEvent.keyDown(tabs[5], { key: 'ArrowRight' })
+      // wrap at end (3 tabs after #569)
+      const last = tabs.length - 1
+      tabs[last].focus()
+      fireEvent.keyDown(tabs[last], { key: 'ArrowRight' })
       expect(tabs[0]).toHaveFocus()
     })
 
     it('ArrowLeft moves focus to the previous tab (with wrap)', () => {
-      renderTabs({ activeTab: 'overview' })
+      renderTabs({ activeTab: 'clubs' })
       const tablist = screen.getByRole('tablist')
       const tabs = within(tablist).getAllByRole('tab')
       tabs[2].focus()
       fireEvent.keyDown(tabs[2], { key: 'ArrowLeft' })
       expect(tabs[1]).toHaveFocus()
       // wrap at start
+      const last = tabs.length - 1
       tabs[0].focus()
       fireEvent.keyDown(tabs[0], { key: 'ArrowLeft' })
-      expect(tabs[5]).toHaveFocus()
+      expect(tabs[last]).toHaveFocus()
     })
 
     it('Home jumps focus to the first tab; End jumps to the last', () => {
-      renderTabs({ activeTab: 'overview' })
+      renderTabs({ activeTab: 'clubs' })
       const tablist = screen.getByRole('tablist')
       const tabs = within(tablist).getAllByRole('tab')
-      tabs[3].focus()
-      fireEvent.keyDown(tabs[3], { key: 'End' })
-      expect(tabs[5]).toHaveFocus()
-      fireEvent.keyDown(tabs[5], { key: 'Home' })
+      const last = tabs.length - 1
+      tabs[1].focus()
+      fireEvent.keyDown(tabs[1], { key: 'End' })
+      expect(tabs[last]).toHaveFocus()
+      fireEvent.keyDown(tabs[last], { key: 'Home' })
       expect(tabs[0]).toHaveFocus()
     })
 

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -73,6 +73,9 @@ const DistrictDetailPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
 
   // Read active tab from URL params (defaults to 'overview') (#230)
+  // #569 — 'overview' / 'trends' / 'analytics' are still recognized as
+  // valid `?tab=` values but they all resolve to the same merged
+  // narrative view. They no longer have separate tabpanels.
   const VALID_TABS: TabType[] = [
     'overview',
     'clubs',
@@ -81,9 +84,17 @@ const DistrictDetailPage: React.FC = () => {
     'analytics',
     'globalRankings',
   ]
+  const NARRATIVE_TABS: TabType[] = ['overview', 'trends', 'analytics']
   const tabParam = searchParams.get('tab') as TabType | null
-  const activeTab: TabType =
+  const rawActiveTab: TabType =
     tabParam && VALID_TABS.includes(tabParam) ? tabParam : 'overview'
+  // Collapse the three narrative IDs into 'overview' for rendering /
+  // tab-strip purposes. The URL is left alone so deep links to old
+  // trends/analytics URLs keep working.
+  const activeTab: TabType = NARRATIVE_TABS.includes(rawActiveTab)
+    ? 'overview'
+    : rawActiveTab
+  const isNarrativeView = activeTab === 'overview'
 
   const setActiveTab = useCallback(
     (tab: TabType) => {
@@ -558,7 +569,7 @@ const DistrictDetailPage: React.FC = () => {
           />
 
           {/* Global Error State */}
-          {overviewError && activeTab === 'overview' && (
+          {overviewError && isNarrativeView && (
             <ErrorDisplay
               error={overviewError}
               title="Failed to Load District Data"
@@ -596,9 +607,9 @@ const DistrictDetailPage: React.FC = () => {
               role="tabpanel"
               id={panelIdFor('overview')}
               aria-labelledby={tabIdFor('overview')}
-              hidden={activeTab !== 'overview'}
+              hidden={!isNarrativeView}
             >
-              {activeTab === 'overview' && districtId && hasOverviewData && (
+              {isNarrativeView && districtId && hasOverviewData && (
                 <>
                   {/* District Overview - Now uses global date selector */}
                   {hasValidDates && effectiveProgramYear && (
@@ -718,9 +729,9 @@ const DistrictDetailPage: React.FC = () => {
               role="tabpanel"
               id={panelIdFor('trends')}
               aria-labelledby={tabIdFor('trends')}
-              hidden={activeTab !== 'trends'}
+              hidden={!isNarrativeView}
             >
-              {activeTab === 'trends' && (
+              {isNarrativeView && (
                 <>
                   {/* Membership Trend Chart */}
                   {aggregatedAnalytics ? (
@@ -880,9 +891,9 @@ const DistrictDetailPage: React.FC = () => {
               role="tabpanel"
               id={panelIdFor('analytics')}
               aria-labelledby={tabIdFor('analytics')}
-              hidden={activeTab !== 'analytics'}
+              hidden={!isNarrativeView}
             >
-              {activeTab === 'analytics' && (
+              {isNarrativeView && (
                 <>
                   {/* Top Growth Clubs */}
                   {analytics ? (

--- a/frontend/src/pages/__tests__/DistrictDetailPage.AnalyticsTab.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.AnalyticsTab.test.tsx
@@ -8,13 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import {
-  screen,
-  render,
-  fireEvent,
-  waitFor,
-  cleanup,
-} from '@testing-library/react'
+import { screen, render, waitFor, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -159,7 +153,7 @@ const renderWithProviders = (initialRoute = '/district/57') => {
   )
 }
 
-describe('DistrictDetailPage - Analytics Tab (#78)', () => {
+describe('DistrictDetailPage — Analytics section (post-#569 narrative merge)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -168,63 +162,38 @@ describe('DistrictDetailPage - Analytics Tab (#78)', () => {
     cleanup()
   })
 
-  // Helper: get the Analytics tab button from the navigation
-  const getAnalyticsTab = () => {
-    const tabNav = screen.getByRole('tablist')
-    const tabButtons = tabNav.querySelectorAll('button')
-    const analyticsTab = Array.from(tabButtons).find(
-      btn => btn.textContent?.trim() === 'Analytics'
-    )
-    return analyticsTab as HTMLButtonElement
-  }
-
-  describe('Tab Navigation', () => {
-    it('should display Analytics tab in the tab navigation', () => {
+  describe('Tab strip', () => {
+    it('does not render an Analytics tab — content scroll-stacks above the strip (#569)', () => {
       renderWithProviders()
-
-      const analyticsTab = getAnalyticsTab()
-      expect(analyticsTab).toBeDefined()
-      expect(analyticsTab).toBeInTheDocument()
-    })
-
-    it('should include Analytics tab between Trends and Global Rankings', () => {
-      renderWithProviders()
-
       const tabNav = screen.getByRole('tablist')
       const tabButtons = tabNav.querySelectorAll('button')
+      const labels = Array.from(tabButtons).map(b => b.textContent?.trim())
+      expect(labels).not.toContain('Analytics')
+      expect(labels).not.toContain('Trends')
+      expect(labels).not.toContain('Overview')
+    })
 
-      // Should now have 6 tabs: Overview, Clubs, Divisions, Trends, Analytics, Global Rankings
-      expect(tabButtons).toHaveLength(6)
-      expect(tabButtons[3]).toHaveTextContent(/trends/i)
-      expect(tabButtons[4]).toHaveTextContent(/analytics/i)
-      expect(tabButtons[5]).toHaveTextContent(/global rankings/i)
+    it('shows the 3 remaining tabs: Clubs / Divisions & Areas / Global Rankings', () => {
+      renderWithProviders()
+      const tabNav = screen.getByRole('tablist')
+      const tabButtons = tabNav.querySelectorAll('button')
+      expect(tabButtons).toHaveLength(3)
+      expect(tabButtons[0]).toHaveTextContent(/^clubs/i)
+      expect(tabButtons[1]).toHaveTextContent(/divisions/i)
+      expect(tabButtons[2]).toHaveTextContent(/global rankings/i)
     })
   })
 
-  describe('Tab Content', () => {
-    it('should render analytics content when tab is clicked', async () => {
+  describe('Narrative rendering', () => {
+    it('does not crash with all analytics data null — narrative renders gracefully', async () => {
+      // All hook mocks at the top of this file return null/empty; the page
+      // should still mount without throwing. Pre-#569 this test clicked an
+      // Analytics tab; post-#569 there is no tab to click — the content
+      // either renders (with empty states) or is skipped, but the page
+      // must not crash.
       renderWithProviders()
-
-      const analyticsTab = getAnalyticsTab()
-      fireEvent.click(analyticsTab)
-
-      // After removing LeadershipInsights (#183), the first visible content
-      // on the analytics tab is TopGrowthClubs (which shows empty state)
       await waitFor(() => {
-        expect(analyticsTab).toHaveAttribute('aria-selected', 'true')
-      })
-    })
-
-    it('should not crash when all analytics data is null', async () => {
-      // All analytics mocks return null — component should render gracefully
-      renderWithProviders()
-
-      const analyticsTab = getAnalyticsTab()
-      fireEvent.click(analyticsTab)
-
-      // Should render without crashing — Analytics tab should become active
-      await waitFor(() => {
-        expect(analyticsTab).toHaveAttribute('aria-selected', 'true')
+        expect(screen.getByRole('tablist')).toBeInTheDocument()
       })
     })
   })

--- a/frontend/src/pages/__tests__/DistrictDetailPage.GlobalRankings.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.GlobalRankings.test.tsx
@@ -213,19 +213,16 @@ describe('DistrictDetailPage - Global Rankings Tab Navigation Integration', () =
       expect(globalRankingsTab).toBeInTheDocument()
     })
 
-    it('should display Global Rankings tab alongside existing tabs', () => {
+    it('should display Global Rankings tab alongside the remaining tabs (#569)', () => {
       renderWithProviders()
 
       // Get the tab navigation container
       const tabNav = screen.getByRole('tablist')
 
-      // Verify all tabs are present within the navigation
-      // Note: Analytics tab is now re-enabled (#78)
-      expect(tabNav).toHaveTextContent(/overview/i)
+      // After #569 only Clubs / Divisions / Global Rankings remain in
+      // the strip. Overview / Trends / Analytics scroll-stack above.
       expect(tabNav).toHaveTextContent(/clubs/i)
       expect(tabNav).toHaveTextContent(/divisions & areas/i)
-      expect(tabNav).toHaveTextContent(/trends/i)
-      expect(tabNav).toHaveTextContent(/analytics/i)
       expect(tabNav).toHaveTextContent(/global rankings/i)
     })
 
@@ -236,14 +233,11 @@ describe('DistrictDetailPage - Global Rankings Tab Navigation Integration', () =
       const tabNav = screen.getByRole('tablist')
       const tabButtons = tabNav.querySelectorAll('button')
 
-      // Verify the order (Analytics tab is now re-enabled #78)
-      expect(tabButtons).toHaveLength(6)
-      expect(tabButtons[0]).toHaveTextContent(/overview/i)
-      expect(tabButtons[1]).toHaveTextContent(/clubs/i)
-      expect(tabButtons[2]).toHaveTextContent(/divisions & areas/i)
-      expect(tabButtons[3]).toHaveTextContent(/trends/i)
-      expect(tabButtons[4]).toHaveTextContent(/analytics/i)
-      expect(tabButtons[5]).toHaveTextContent(/global rankings/i)
+      // 3-tab strip after #569.
+      expect(tabButtons).toHaveLength(3)
+      expect(tabButtons[0]).toHaveTextContent(/^clubs/i)
+      expect(tabButtons[1]).toHaveTextContent(/divisions & areas/i)
+      expect(tabButtons[2]).toHaveTextContent(/global rankings/i)
     })
   })
 
@@ -334,7 +328,7 @@ describe('DistrictDetailPage - Global Rankings Tab Navigation Integration', () =
       })
     })
 
-    it('should switch back to other tabs from Global Rankings', async () => {
+    it('should switch back to other tabs from Global Rankings (#569: switches to Clubs since Overview is no longer a tab)', async () => {
       renderWithProviders()
 
       // Click on Global Rankings tab
@@ -350,9 +344,9 @@ describe('DistrictDetailPage - Global Rankings Tab Navigation Integration', () =
         ).toBeInTheDocument()
       })
 
-      // Click on Overview tab
-      const overviewTab = screen.getByRole('tab', { name: /overview/i })
-      fireEvent.click(overviewTab)
+      // Click on Clubs tab (was previously Overview, but #569 dropped that)
+      const clubsTab = screen.getByRole('tab', { name: /^clubs/i })
+      fireEvent.click(clubsTab)
 
       // Verify Global Rankings content is hidden
       await waitFor(() => {
@@ -371,16 +365,18 @@ describe('DistrictDetailPage - Global Rankings Tab Navigation Integration', () =
         name: /global rankings/i,
       })
 
-      // Get the tab navigation and find the Trends tab within it (Analytics is now re-enabled)
-      const tabNav = screen.getByRole('tablist')
-      const tabButtons = tabNav.querySelectorAll('button')
-      const trendsTab = Array.from(tabButtons).find(btn =>
-        btn.textContent?.toLowerCase().includes('trends')
-      )
+      // Compare against another non-active tab in the 3-tab strip. Clubs
+      // is the default mount state per VALID_TABS resolution, so it
+      // should be active and divisions inactive.
+      const divisionsTab = screen.getByRole('tab', {
+        name: /divisions & areas/i,
+      })
 
-      // Both should be inactive on initial render (Overview is the default)
+      // Both should be inactive on initial mount — the narrative
+      // (collapsed Overview) is the default landing view, no tab is
+      // active in the 3-tab strip until the user clicks one.
       expect(globalRankingsTab).toHaveAttribute('aria-selected', 'false')
-      expect(trendsTab).toHaveAttribute('aria-selected', 'false')
+      expect(divisionsTab).toHaveAttribute('aria-selected', 'false')
     })
 
     it('should expose the active state via aria-selected when selected', async () => {

--- a/frontend/src/pages/__tests__/DistrictDetailPage.TrendsTab.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.TrendsTab.test.tsx
@@ -21,7 +21,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen, render, waitFor, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import React from 'react'
@@ -457,12 +456,10 @@ describe('DistrictDetailPage - Trends Tab Data Source Wiring', () => {
         usedFallback: false,
       })
 
-      const user = userEvent.setup()
       renderDistrictDetailPage()
 
-      // Navigate to Trends tab
-      const trendsTab = screen.getByRole('tab', { name: /Trends/i })
-      await user.click(trendsTab)
+      // #569 — Trends content now scroll-stacks on the default district
+      // page. No tab click required; the charts render on mount.
 
       // Wait for LazyChart IntersectionObserver to fire
       await waitFor(() => {
@@ -503,12 +500,10 @@ describe('DistrictDetailPage - Trends Tab Data Source Wiring', () => {
         usedFallback: false,
       })
 
-      const user = userEvent.setup()
       renderDistrictDetailPage()
 
-      // Navigate to Trends tab
-      const trendsTab = screen.getByRole('tab', { name: /Trends/i })
-      await user.click(trendsTab)
+      // #569 — Trends content now scroll-stacks on the default district
+      // page. No tab click required; the charts render on mount.
 
       // Wait for YearOverYearComparison to render
       await waitFor(() => {
@@ -564,12 +559,9 @@ describe('DistrictDetailPage - Trends Tab Data Source Wiring', () => {
         usedFallback: false,
       })
 
-      const user = userEvent.setup()
       renderDistrictDetailPage()
 
-      const trendsTab = screen.getByRole('tab', { name: /Trends/i })
-      await user.click(trendsTab)
-
+      // #569 — Trends content scroll-stacks on the default page.
       await waitFor(() => {
         expect(screen.getByTestId('membership-trend-chart')).toBeInTheDocument()
         expect(
@@ -600,16 +592,12 @@ describe('DistrictDetailPage - Trends Tab Data Source Wiring', () => {
         usedFallback: false,
       })
 
-      const user = userEvent.setup()
       renderDistrictDetailPage()
 
-      const trendsTab = screen.getByRole('tab', { name: /Trends/i })
-      await user.click(trendsTab)
-
-      // Verify the Trends tab is active
+      // #569 — Trends content scroll-stacks on the default page; no tab
+      // click needed. Wait a microtask to let the page mount.
       await waitFor(() => {
-        const trendsButton = screen.getByRole('tab', { name: /Trends/i })
-        expect(trendsButton).toHaveAttribute('aria-selected', 'true')
+        expect(screen.getByRole('tablist')).toBeInTheDocument()
       })
 
       // Neither component should be rendered
@@ -643,16 +631,12 @@ describe('DistrictDetailPage - Trends Tab Data Source Wiring', () => {
       // single-snapshot analytics IS available (via the default mock above)
       // This verifies the guard is on aggregatedAnalytics, not analytics
 
-      const user = userEvent.setup()
       renderDistrictDetailPage()
 
-      const trendsTab = screen.getByRole('tab', { name: /Trends/i })
-      await user.click(trendsTab)
-
-      // Verify the Trends tab is active
+      // #569 — Trends content scroll-stacks on the default page; no tab
+      // click needed. Wait a microtask to let the page mount.
       await waitFor(() => {
-        const trendsButton = screen.getByRole('tab', { name: /Trends/i })
-        expect(trendsButton).toHaveAttribute('aria-selected', 'true')
+        expect(screen.getByRole('tablist')).toBeInTheDocument()
       })
 
       // Neither component should be rendered despite analytics being available

--- a/tasks/lessons/068-tab-merge-cascades-into-the-test-surface-budget-for-it.md
+++ b/tasks/lessons/068-tab-merge-cascades-into-the-test-surface-budget-for-it.md
@@ -1,0 +1,104 @@
+---
+name: Tab merge cascades into the test surface — budget for it
+description: Removing a tab from a tabbed UI doesn't just delete one
+  panel — it invalidates every test that asserted "click tab → see
+  content." Plan the test-rewrite cost up front; it's 5–10× the
+  component edit.
+type: feedback
+---
+
+# Lesson 68 — Tab merge cascades into the test surface — budget for it
+
+**Date:** 2026-05-22
+**Issue:** #569 (District IA Phase 1 — stack narrative)
+
+## What happened
+
+#569 collapsed three tabs (Overview / Trends / Analytics) into a
+single scrollable narrative on `/district/:id`. The component-level
+change was small:
+
+- 3 entries removed from a `TABS` array
+- 3 conditional guards updated (`activeTab !== 'trends'` → `!isNarrativeView`)
+- A new `isNarrativeView` derivation
+
+Maybe 15 lines net.
+
+The test surface broke open immediately:
+
+| File                                         | Old assertion shape                                              | Tests broken |
+| -------------------------------------------- | ---------------------------------------------------------------- | ------------ |
+| `DistrictDetailPage.AnalyticsTab.test.tsx`   | "click Analytics tab → see content"                              | 4            |
+| `DistrictDetailPage.TrendsTab.test.tsx`      | "click Trends tab → see chart"                                   | 5            |
+| `DistrictDetailPage.GlobalRankings.test.tsx` | "Global Rankings appears alongside 5 other tabs"                 | 4            |
+| `01-NavigationFlow.test.tsx` (integration)   | "tab named `/^Clubs$/i`" — strict-equal, breaks with count badge | 1            |
+| `DistrictDetailTabs.test.tsx` (unit)         | "renders 6 tabs in order"                                        | 6            |
+
+20 tests across 5 files. ~1,400 lines of test code transitively
+affected. The component change was bounded; the test cascade was not.
+
+## How to apply
+
+**When you propose collapsing a tabbed UI into a scrolled narrative,
+estimate the work as `component_diff_size × 5–10` for the test
+rewrite cost, not the diff itself.** A 15-line component change here
+turned into ~150 lines of mechanical-but-careful test-assertion
+updates.
+
+The rewrites fall into predictable patterns. Sharing them so the next
+similar refactor goes faster:
+
+1. **"Click tab → assert content"** becomes **"render page → assert
+   content"** because the content is now rendered by default. Drop
+   the `user.click(tab)` line; the `await waitFor(...)` for content
+   stays.
+2. **"6 tabs in this exact order"** becomes **"N tabs in this exact
+   order"** where N depends on which were removed. Update both the
+   `toHaveLength` and the indexed `toHaveTextContent` assertions.
+3. **"Strict-equal tab name with regex `/^Foo$/i`"** becomes
+   **"prefix match `/^Foo/i`"** because the surviving tabs now carry
+   count badges (the accessible name is "Foo 305", not "Foo").
+4. **"Switch from Foo tab to Overview tab"** becomes **"switch to
+   Clubs tab"** (or whichever tab still exists). The "default" tab
+   concept is gone — the narrative is the default landing view.
+
+**Test descriptions and `describe(...)` blocks lie now.** Update them
+or the test file's stated purpose ages out of sync. Search for the
+tab names being removed in `describe(...)` and `it(...)` strings,
+not just `getByRole(...)`.
+
+## Telltale signs
+
+- A planning estimate that says "drop 3 tabs, ~2 days" — multiply by
+  3–5 for the test rewrite cascade.
+- A failing-test count that scales with the number of tabs touched.
+- "Click tab → assert content" patterns in `*.tsx` test files. Each
+  is one upcoming rewrite.
+
+## Why
+
+Tabs and tests are tightly coupled in this codebase: tests use
+`getByRole('tab', ...)` + `user.click()` to navigate, then assert
+content. That's a valid pattern, but it bakes the tab structure into
+the test surface. When the structure changes, the tests do too. The
+alternative pattern — testing components in isolation, with the page
+just composing them — is lower coupling but doesn't exist for
+DistrictDetailPage's sub-views today.
+
+A future refactor could lower the coupling by extracting each
+narrative section as its own component with its own test file
+(`DistrictNarrativeOverview.test.tsx`, etc.). The page-level test
+would then just assert "page renders the section components" and the
+content tests would mount each section directly. Lots of churn —
+worth doing when the next IA shift is on the horizon, not as a
+standalone refactor.
+
+## Related
+
+- Issue #569 — Phase 1 of EPIC #568 (District IA migration)
+- IA doc at `tasks/design/district-ia/project/Toast Stats - District IA.html` § 06 phases
+- Lesson 51 — `testTimeout` cap and component-in-isolation testing trade-offs (related family of test-coupling lessons)
+- Lesson 66 — JSDOM doesn't catch visual bugs; this lesson is the
+  complementary insight: JSDOM tests CAN catch structural changes,
+  but they catch them as a flood of breakage that needs budgeted
+  cleanup


### PR DESCRIPTION
Closes #569. EPIC #568 Phase 1.

## Summary

The District page drops three tabs (Overview / Trends / Analytics) and renders their content as **one scroll-stacked narrative**. The 3 remaining tabs — Clubs / Divisions & Areas / Global Rankings — survive in the strip; Phases 2 + 3 will route them and the strip will disappear entirely.

## Changes

- **`DistrictDetailTabs.tsx`**: `TABS` array drops the three narrative IDs. `DistrictTabId` union retains them so existing `?tab=` URLs continue to parse cleanly. New `DistrictStripTabId` subtype names the three that actually appear.
- **`DistrictDetailPage.tsx`**: a new `isNarrativeView` derivation collapses `'overview' | 'trends' | 'analytics'` into the merged-panel rendering. Three `hidden={activeTab !== X}` guards become `hidden={!isNarrativeView}`.
- **5 test files updated** for the new shape (see lesson #68 for the cascade pattern).

## Backward compatibility

- `?tab=clubs|divisions|globalRankings` → render their tab panels (unchanged)
- `?tab=overview|trends|analytics` → resolve to the merged narrative (no redirect, no 404 — hard break per founder decision in EPIC #568, but the URL still loads the right page)
- All `panelIdFor()` ids stable for a11y labelling

## Out of scope (deferred to subsequent phases per EPIC #568)

- New components for inline Division summary + Vs-world callout + Leaderboards CTA buttons (Phase 1.5 follow-up)
- URL routing for Clubs (Phase 2), Divisions / Rankings / Leaderboards (Phase 3)
- Sticky KPI strip + anchor TOC (Phase 4)

## Tests

- 2315/2315 passing
- 20 tests across 5 files updated to reflect the new structure (no `.skip`, no assertion pinning — the spec changed, the tests follow)
- Lesson #68 captures the rewrite patterns for future similar refactors

## Test plan

- [ ] CI green
- [ ] Preview channel URL renders the District page with all three sections (Overview cards, Trends charts, Analytics top-N) scrolling as one
- [ ] Tab strip shows only Clubs / Divisions / Global Rankings
- [ ] `?tab=overview`, `?tab=trends`, `?tab=analytics` all render the merged page
- [ ] `?tab=clubs`, `?tab=divisions`, `?tab=globalRankings` still work
- [ ] Mobile (375px): no horizontal scroll, narrative stacks vertically
- [ ] Light + dark mode both correct
- [ ] Back button: tab-strip click → back → returns to narrative, not to a previous tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)