### PR TITLE
feat(district): IA Phase 2 — /district/:id/clubs route with URL-param filter state (#570)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,9 @@ const DistrictDetailPage = React.lazy(
 // Code-split: ClubDetailPage — full club subpage (#208)
 const ClubDetailPage = React.lazy(() => import('./pages/ClubDetailPage'))
 
+// Code-split: DistrictClubsPage — district clubs subroute (#570, epic #568 Phase 2)
+const DistrictClubsPage = React.lazy(() => import('./pages/DistrictClubsPage'))
+
 // Code-split: ClubRedirectPage — district-free club URL (#320)
 const ClubRedirectPage = React.lazy(() => import('./pages/ClubRedirectPage'))
 
@@ -69,6 +72,14 @@ const router = createBrowserRouter(
           element: (
             <Suspense fallback={<PageLoadingFallback />}>
               <DistrictDetailPage />
+            </Suspense>
+          ),
+        },
+        {
+          path: 'district/:districtId/clubs',
+          element: (
+            <Suspense fallback={<PageLoadingFallback />}>
+              <DistrictClubsPage />
             </Suspense>
           ),
         },

--- a/frontend/src/__tests__/integration/journeys/01-NavigationFlow.test.tsx
+++ b/frontend/src/__tests__/integration/journeys/01-NavigationFlow.test.tsx
@@ -85,6 +85,17 @@ describe('Journey 01: The Navigation Flow', () => {
     )
     await user.click(clubsTab)
 
+    // #570 (Phase 2): the Clubs tab is now a route, not an in-tab
+    // switch. Wait for the new page (DistrictClubsPage) to mount
+    // before searching for a club row — otherwise findByText can
+    // match the lingering TopGrowthClubs row on the narrative view
+    // that just unmounted.
+    await screen.findByRole(
+      'heading',
+      { name: /^All Clubs$/i },
+      { timeout: 5000 }
+    )
+
     // Step 7: Find Ottawa Club in the data table and click it
     const ottawaClubRow = await screen.findByText(
       /Ottawa Club/i,
@@ -93,11 +104,11 @@ describe('Journey 01: The Navigation Flow', () => {
     )
     await user.click(ottawaClubRow)
 
-    // Step 8: Verify Successful Navigation to Club Detail Page
+    // Step 8: Verify Successful Navigation to Club Detail Page.
     const clubHeading = await screen.findByRole(
       'heading',
       { name: /Ottawa Club/i },
-      { timeout: 3000 }
+      { timeout: 5000 }
     )
     expect(clubHeading).toBeInTheDocument()
   }, 15000)

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const DistrictClubsPage: React.FC = () => {
+  return null
+}
+
+export default DistrictClubsPage

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -1,7 +1,350 @@
-import React from 'react'
+import React, { useCallback, useMemo } from 'react'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { useDistricts } from '../hooks/useDistricts'
+import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
+import { useDistrictCachedDates } from '../hooks/useDistrictData'
+import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
+import {
+  getAvailableProgramYears,
+  filterDatesByProgramYear,
+  getMostRecentDateInProgramYear,
+  isDateInProgramYear,
+} from '../utils/programYear'
+import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
+import {
+  DistrictDetailTabs,
+  type DistrictTabId,
+} from '../components/DistrictDetailTabs'
+import { ClubsTable } from '../components/ClubsTable'
+import ErrorBoundary from '../components/ErrorBoundary'
+import { LoadingSkeleton } from '../components/LoadingSkeleton'
+import type {
+  FilterState,
+  SortDirection,
+  SortField,
+} from '../components/filters/types'
+
+/* District Clubs Page (#570, epic #568 Phase 2).
+   Dedicated route for the clubs subview. URL params (clean spec):
+     ?status=<thriving|vulnerable|intervention>
+     ?search=<q>
+     ?sort=<field>&dir=<asc|desc>
+     ?page=<n>
+   Other column filters (Distinguished, Members range, etc.) stay
+   in-session — they're discoverable through the table UI but no
+   longer survive a reload. The router-level redirect from the legacy
+   `?tab=clubs` URL lives in App.tsx and translates `f_status`/`f_name`
+   into the new names. */
+
+const statusUrlToInternal = (raw: string | null): string | null => {
+  switch (raw) {
+    case 'thriving':
+    case 'vulnerable':
+      return raw
+    case 'intervention':
+      return 'intervention-required'
+    default:
+      return null
+  }
+}
+
+const statusInternalToUrl = (raw: string): string | null => {
+  if (raw === 'thriving' || raw === 'vulnerable') return raw
+  if (raw === 'intervention-required') return 'intervention'
+  return null
+}
+
+const buildFilterStateFromUrl = (params: URLSearchParams): FilterState => {
+  const state: FilterState = {}
+  const status = statusUrlToInternal(params.get('status'))
+  if (status) {
+    state['status'] = {
+      field: 'status',
+      type: 'categorical',
+      value: [status],
+      operator: 'in',
+    }
+  }
+  const search = params.get('search')
+  if (search) {
+    state['name'] = {
+      field: 'name',
+      type: 'text',
+      value: search,
+      operator: 'contains',
+    }
+  }
+  return state
+}
+
+const filterStateToUrlPatch = (
+  state: FilterState
+): { status: string | null; search: string | null } => {
+  const statusFilter = state['status']
+  let status: string | null = null
+  if (statusFilter && Array.isArray(statusFilter.value)) {
+    const values = statusFilter.value as string[]
+    if (values.length === 1 && values[0]) {
+      status = statusInternalToUrl(values[0])
+    }
+  }
+  const nameFilter = state['name']
+  const search =
+    nameFilter && typeof nameFilter.value === 'string' && nameFilter.value
+      ? (nameFilter.value as string)
+      : null
+  return { status, search }
+}
 
 const DistrictClubsPage: React.FC = () => {
-  return null
+  const { districtId } = useParams<{ districtId: string }>()
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // Sort / page URL state -- mirrors DistrictDetailPage's conventions so
+  // sort field names line up with ClubsTable's existing SortField union.
+  const initialSortField = (searchParams.get('sort') ?? undefined) as
+    | SortField
+    | undefined
+  const initialSortDir =
+    (searchParams.get('dir') as SortDirection | null) || undefined
+  const initialPageRaw = searchParams.get('page')
+  const initialPage = initialPageRaw ? parseInt(initialPageRaw, 10) : undefined
+
+  const initialFilterState = useMemo(
+    () => buildFilterStateFromUrl(searchParams),
+    // Intentionally only computed once on mount — URL is the source of
+    // truth for INITIAL state; later updates flow through callbacks
+    // instead of re-reading.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  const handleSortChange = useCallback(
+    (field: string, direction: string) => {
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          if (field === 'name' && direction === 'asc') {
+            next.delete('sort')
+            next.delete('dir')
+          } else {
+            next.set('sort', field)
+            next.set('dir', direction)
+          }
+          return next
+        },
+        { replace: true }
+      )
+    },
+    [setSearchParams]
+  )
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      // Bail when there's nothing to write: ClubsTable's auto-reset to
+      // page 1 on filter change fires onPageChange in the same React
+      // batch as the filter update. Both setSearchParams(prev => …)
+      // calls see the SAME stale `prev` snapshot, so the second call
+      // would clobber the first (status=vulnerable would disappear).
+      // Skipping the no-op write keeps the filter URL intact.
+      if (page === 1 && !searchParams.has('page')) return
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          if (page === 1) {
+            next.delete('page')
+          } else {
+            next.set('page', page.toString())
+          }
+          return next
+        },
+        { replace: true }
+      )
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const handleFilterChange = useCallback(
+    (state: FilterState) => {
+      const patch = filterStateToUrlPatch(state)
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          if (patch.status) {
+            next.set('status', patch.status)
+          } else {
+            next.delete('status')
+          }
+          if (patch.search) {
+            next.set('search', patch.search)
+          } else {
+            next.delete('search')
+          }
+          // Reset pagination when filters change.
+          next.delete('page')
+          return next
+        },
+        { replace: true }
+      )
+    },
+    [setSearchParams]
+  )
+
+  // Program-year + date wiring (matches DistrictDetailPage so the header
+  // controls behave the same way across the two routes).
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+  } = useUrlProgramYear()
+
+  const { data: districtsData } = useDistricts()
+  const selectedDistrict = districtsData?.districts?.find(
+    d => d.id === districtId
+  )
+
+  const { data: cachedDatesData } = useDistrictCachedDates(districtId || '')
+  const allCachedDates = useMemo(
+    () => cachedDatesData?.dates || [],
+    [cachedDatesData?.dates]
+  )
+  const availableProgramYears = useMemo(
+    () => getAvailableProgramYears(allCachedDates),
+    [allCachedDates]
+  )
+
+  React.useEffect(() => {
+    if (availableProgramYears.length > 0) {
+      const has = availableProgramYears.some(
+        py => py.year === selectedProgramYear.year
+      )
+      if (!has) {
+        const mostRecent = availableProgramYears[0]
+        if (mostRecent) setSelectedProgramYear(mostRecent)
+      }
+    }
+  }, [availableProgramYears, selectedProgramYear.year, setSelectedProgramYear])
+
+  const cachedDatesInProgramYear = useMemo(
+    () => filterDatesByProgramYear(allCachedDates, selectedProgramYear),
+    [allCachedDates, selectedProgramYear]
+  )
+
+  const effectiveProgramYear = useMemo(() => {
+    if (availableProgramYears.length === 0) return null
+    const has = availableProgramYears.some(
+      py => py.year === selectedProgramYear.year
+    )
+    if (has) return selectedProgramYear
+    return availableProgramYears[0] ?? null
+  }, [availableProgramYears, selectedProgramYear])
+
+  const effectiveEndDate = useMemo(() => {
+    if (!effectiveProgramYear) return null
+    if (
+      selectedDate &&
+      isDateInProgramYear(selectedDate, effectiveProgramYear)
+    ) {
+      return selectedDate
+    }
+    const mostRecent = getMostRecentDateInProgramYear(
+      allCachedDates,
+      effectiveProgramYear
+    )
+    return mostRecent || effectiveProgramYear.endDate
+  }, [selectedDate, effectiveProgramYear, allCachedDates])
+
+  const hasValidDates =
+    effectiveProgramYear !== null && effectiveEndDate !== null
+
+  const { data: analytics, isLoading } = useDistrictAnalytics(
+    hasValidDates ? districtId || null : null,
+    effectiveProgramYear?.startDate,
+    effectiveEndDate ?? undefined
+  )
+
+  const allClubs = analytics?.allClubs || []
+  const clubsCount = allClubs.length
+
+  const rawName = selectedDistrict?.name || districtId || ''
+  const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
+
+  const availableDates = cachedDatesInProgramYear.sort((a, b) =>
+    b.localeCompare(a)
+  )
+
+  const handleClubClick = useCallback(
+    (club: ClubTrend) => {
+      navigate(`/district/${districtId}/club/${club.clubId}`)
+    },
+    [navigate, districtId]
+  )
+
+  // Tab strip on this route: clicking a non-Clubs tab navigates back to
+  // the narrative page with the matching ?tab=... value. Clicking Clubs
+  // is a no-op (we're already here).
+  const handleTabChange = useCallback(
+    (tab: DistrictTabId) => {
+      if (tab === 'clubs') return
+      const qs = tab === 'overview' ? '' : `?tab=${encodeURIComponent(tab)}`
+      navigate(`/district/${districtId}${qs}`)
+    },
+    [navigate, districtId]
+  )
+
+  if (!districtId) {
+    return null
+  }
+
+  return (
+    <ErrorBoundary>
+      <div className="district-detail-page-root">
+        <div className="district-detail-page">
+          <DistrictDetailHeader
+            districtId={districtId}
+            districtName={districtName}
+            selectedProgramYear={selectedProgramYear}
+            setSelectedProgramYear={setSelectedProgramYear}
+            availableProgramYears={availableProgramYears}
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+            availableDates={availableDates}
+            latestSnapshotDate={
+              cachedDatesData?.dateRange?.endDate ?? availableDates[0]
+            }
+          />
+
+          <DistrictDetailTabs
+            activeTab="clubs"
+            onTabChange={handleTabChange}
+            clubsCount={clubsCount}
+          />
+
+          <div className="space-y-4 sm:space-y-6">
+            {isLoading && allClubs.length === 0 ? (
+              <LoadingSkeleton variant="table" count={6} />
+            ) : (
+              <ClubsTable
+                clubs={allClubs}
+                districtId={districtId}
+                isLoading={isLoading}
+                onClubClick={handleClubClick}
+                initialSortField={initialSortField}
+                initialSortDirection={initialSortDir}
+                onSortChange={handleSortChange}
+                initialPage={initialPage}
+                onPageChange={handlePageChange}
+                initialFilterState={initialFilterState}
+                onFilterChange={handleFilterChange}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </ErrorBoundary>
+  )
 }
 
 export default DistrictClubsPage

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useMemo } from 'react'
-import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
+import {
+  Navigate,
+  useParams,
+  useNavigate,
+  useSearchParams,
+} from 'react-router-dom'
+import { redirectLegacyClubsTab } from '../utils/legacyClubsRedirect'
 import { useDistricts } from '../hooks/useDistricts'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
 import {
@@ -67,7 +73,7 @@ type TabType =
   | 'analytics'
   | 'globalRankings'
 
-const DistrictDetailPage: React.FC = () => {
+const DistrictDetailPageInner: React.FC = () => {
   const { districtId } = useParams<{ districtId: string }>()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -98,6 +104,12 @@ const DistrictDetailPage: React.FC = () => {
 
   const setActiveTab = useCallback(
     (tab: TabType) => {
+      if (tab === 'clubs') {
+        // Phase 2 (#570): Clubs has its own route. Clicking the chip in
+        // the tab strip navigates instead of updating ?tab=.
+        navigate(`/district/${districtId}/clubs`)
+        return
+      }
       setSearchParams(
         prev => {
           const next = new URLSearchParams(prev)
@@ -111,7 +123,7 @@ const DistrictDetailPage: React.FC = () => {
         { replace: true }
       )
     },
-    [setSearchParams]
+    [setSearchParams, navigate, districtId]
   )
 
   // Read sort state from URL params (#230)
@@ -967,6 +979,32 @@ const DistrictDetailPage: React.FC = () => {
       </div>
     </ErrorBoundary>
   )
+}
+
+/**
+ * Default export: thin wrapper that intercepts the legacy `?tab=clubs`
+ * URL and redirects to `/district/:id/clubs` BEFORE the heavy
+ * DistrictDetailPageInner hooks run. Without this guard, inner effects
+ * (date selection, etc.) would race against `<Navigate>` and clobber
+ * the new URL's search params after the route transition.
+ */
+const DistrictDetailPage: React.FC = () => {
+  const { districtId } = useParams<{ districtId: string }>()
+  const [searchParams] = useSearchParams()
+  const legacyClubsTarget = redirectLegacyClubsTab(
+    `http://localhost/district/${districtId ?? ''}?${searchParams.toString()}`,
+    districtId
+  )
+  if (legacyClubsTarget) {
+    const [pathname, search = ''] = legacyClubsTarget.split('?') as [
+      string,
+      string?,
+    ]
+    return (
+      <Navigate to={{ pathname, search: search ? `?${search}` : '' }} replace />
+    )
+  }
+  return <DistrictDetailPageInner />
 }
 
 export default DistrictDetailPage

--- a/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
@@ -14,7 +14,13 @@
 
 import React, { Suspense } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   createMemoryRouter,
@@ -233,13 +239,17 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
 
     await screen.findByText(/alpha toastmasters/i)
 
-    const vulnerableChip = screen.getByRole('button', {
+    const statusStrip = screen.getByRole('tablist', {
+      name: /filter clubs by health status/i,
+    })
+    const vulnerableChip = within(statusStrip).getByRole('tab', {
       name: /^vulnerable/i,
     })
     await user.click(vulnerableChip)
 
     await waitFor(() => {
-      expect(router.state.location.search).toBe('?status=vulnerable')
+      const params = new URLSearchParams(router.state.location.search)
+      expect(params.get('status')).toBe('vulnerable')
     })
   })
 
@@ -249,11 +259,15 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
 
     await screen.findByText(/beta speakers/i)
 
-    const allChip = screen.getByRole('button', { name: /^all\b/i })
+    const statusStrip = screen.getByRole('tablist', {
+      name: /filter clubs by health status/i,
+    })
+    const allChip = within(statusStrip).getByRole('tab', { name: /^all\b/i })
     await user.click(allChip)
 
     await waitFor(() => {
-      expect(router.state.location.search).toBe('')
+      const params = new URLSearchParams(router.state.location.search)
+      expect(params.get('status')).toBeNull()
     })
   })
 

--- a/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * District Clubs Page — Phase 2 of the District IA migration (#570).
+ *
+ * Verifies the new route `/district/:districtId/clubs` plus its URL-param
+ * contract:
+ *   - `?status=<thriving|vulnerable|intervention>` for the segmented chip
+ *   - `?search=<q>` for the club-name text filter
+ *   - `?sort=<field>&dir=<asc|desc>` for sort
+ *   - `?page=<n>` for pagination
+ * And the legacy redirect: `/district/:id?tab=clubs[&extra]` 301-equivalents
+ * to `/district/:id/clubs[?extra]`, translating `f_status`/`f_name` into
+ * the new clean parameter names.
+ */
+
+import React, { Suspense } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  createMemoryRouter,
+  RouterProvider,
+  type RouteObject,
+} from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '@testing-library/jest-dom'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import { DarkModeProvider } from '../../contexts/DarkModeContext'
+import DistrictDetailPage from '../DistrictDetailPage'
+
+const TEST_CLUBS: ClubTrend[] = [
+  {
+    clubId: '1001',
+    clubName: 'Alpha Toastmasters',
+    divisionId: 'A',
+    divisionName: 'Division A',
+    areaId: '11',
+    areaName: 'Area 11',
+    currentStatus: 'thriving',
+    distinguishedLevel: 'Distinguished',
+    riskFactors: [],
+    membershipTrend: [{ date: '2025-07-01', count: 28 }],
+    dcpGoalsTrend: [{ date: '2025-07-01', goalsAchieved: 7 }],
+  },
+  {
+    clubId: '1002',
+    clubName: 'Beta Speakers',
+    divisionId: 'A',
+    divisionName: 'Division A',
+    areaId: '12',
+    areaName: 'Area 12',
+    currentStatus: 'vulnerable',
+    distinguishedLevel: 'Select',
+    riskFactors: ['DCP checkpoint not met'],
+    membershipTrend: [{ date: '2025-07-01', count: 14 }],
+    dcpGoalsTrend: [{ date: '2025-07-01', goalsAchieved: 4 }],
+  },
+  {
+    clubId: '1003',
+    clubName: 'Gamma Communicators',
+    divisionId: 'B',
+    divisionName: 'Division B',
+    areaId: '21',
+    areaName: 'Area 21',
+    currentStatus: 'intervention-required',
+    distinguishedLevel: 'NotDistinguished',
+    riskFactors: ['Membership below 12'],
+    membershipTrend: [{ date: '2025-07-01', count: 9 }],
+    dcpGoalsTrend: [{ date: '2025-07-01', goalsAchieved: 1 }],
+  },
+  {
+    clubId: '1004',
+    clubName: 'Delta Orators',
+    divisionId: 'B',
+    divisionName: 'Division B',
+    areaId: '22',
+    areaName: 'Area 22',
+    currentStatus: 'thriving',
+    distinguishedLevel: 'Smedley',
+    riskFactors: [],
+    membershipTrend: [{ date: '2025-07-01', count: 31 }],
+    dcpGoalsTrend: [{ date: '2025-07-01', goalsAchieved: 9 }],
+  },
+]
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: vi.fn(() => ({
+    data: {
+      districts: [{ id: '61', name: 'District 61' }],
+    },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+vi.mock('../../hooks/useDistrictAnalytics', () => ({
+  useDistrictAnalytics: vi.fn(() => ({
+    data: {
+      allClubs: TEST_CLUBS,
+      interventionRequiredClubs: [],
+      vulnerableClubs: [],
+      distinguishedClubs: { total: 1 },
+      distinguishedProjection: null,
+      thrivingClubs: [],
+      divisionRankings: [],
+      topPerformingAreas: [],
+      membershipTrend: [],
+      topGrowthClubs: [],
+      totalMembership: 100,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('../../hooks/useAggregatedAnalytics', () => ({
+  useAggregatedAnalytics: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+vi.mock('../../hooks/usePerformanceTargets', () => ({
+  usePerformanceTargets: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+vi.mock('../../hooks/usePaymentsTrend', () => ({
+  usePaymentsTrend: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+vi.mock('../../hooks/useTimeSeries', () => ({
+  useTimeSeries: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    data: {
+      dates: ['2025-07-15', '2025-07-01'],
+      dateRange: { startDate: '2025-07-01', endDate: '2025-07-15' },
+    },
+    isLoading: false,
+  })),
+}))
+
+vi.mock('../../hooks/useCompetitiveAwards', () => ({
+  useCompetitiveAwards: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+vi.mock('../../components/LazyCharts', () => ({
+  LazyMembershipTrendChart: () => null,
+  LazyMembershipPaymentsChart: () => null,
+  LazyYearOverYearComparison: () => null,
+}))
+
+vi.mock('../../components/GlobalRankingsTab', () => ({
+  default: () => null,
+}))
+
+const DistrictClubsPage = React.lazy(() => import('../DistrictClubsPage'))
+
+const renderAt = (initialUrl: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+
+  const routes: RouteObject[] = [
+    { path: '/district/:districtId', element: <DistrictDetailPage /> },
+    {
+      path: '/district/:districtId/clubs',
+      element: (
+        <Suspense fallback={<div>Loading…</div>}>
+          <DistrictClubsPage />
+        </Suspense>
+      ),
+    },
+  ]
+
+  const router = createMemoryRouter(routes, { initialEntries: [initialUrl] })
+
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <DarkModeProvider>
+          <RouterProvider router={router} />
+        </DarkModeProvider>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+  return { ...utils, router }
+}
+
+describe('DistrictClubsPage (#570 — Phase 2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the ClubsTable at /district/:districtId/clubs', async () => {
+    renderAt('/district/61/clubs')
+
+    expect(await screen.findByText(/alpha toastmasters/i)).toBeInTheDocument()
+    expect(screen.getByText(/beta speakers/i)).toBeInTheDocument()
+  })
+
+  it('applies ?status=vulnerable to filter clubs on load', async () => {
+    renderAt('/district/61/clubs?status=vulnerable')
+
+    await screen.findByText(/beta speakers/i)
+    expect(screen.queryByText(/alpha toastmasters/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/gamma communicators/i)).not.toBeInTheDocument()
+  })
+
+  it('maps the "intervention" URL param to the intervention-required filter value', async () => {
+    renderAt('/district/61/clubs?status=intervention')
+
+    await screen.findByText(/gamma communicators/i)
+    expect(screen.queryByText(/alpha toastmasters/i)).not.toBeInTheDocument()
+  })
+
+  it('writes ?status= to the URL when a status chip is activated', async () => {
+    const user = userEvent.setup()
+    const { router } = renderAt('/district/61/clubs')
+
+    await screen.findByText(/alpha toastmasters/i)
+
+    const vulnerableChip = screen.getByRole('button', {
+      name: /^vulnerable/i,
+    })
+    await user.click(vulnerableChip)
+
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?status=vulnerable')
+    })
+  })
+
+  it('clears ?status= from the URL when chip is deactivated', async () => {
+    const user = userEvent.setup()
+    const { router } = renderAt('/district/61/clubs?status=vulnerable')
+
+    await screen.findByText(/beta speakers/i)
+
+    const allChip = screen.getByRole('button', { name: /^all\b/i })
+    await user.click(allChip)
+
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('')
+    })
+  })
+
+  it('honors ?sort=membership&dir=desc on load', async () => {
+    renderAt('/district/61/clubs?sort=membership&dir=desc')
+
+    const rows = await screen.findAllByRole('row')
+    // First data row should be Delta (31), then Alpha (28).
+    const dataRows = rows.filter(
+      r =>
+        r.textContent?.includes('Toastmasters') ||
+        r.textContent?.includes('Speakers') ||
+        r.textContent?.includes('Communicators') ||
+        r.textContent?.includes('Orators')
+    )
+    expect(dataRows[0]?.textContent).toMatch(/delta orators/i)
+  })
+
+  it('honors ?page=2 on load', async () => {
+    renderAt('/district/61/clubs?page=2')
+    // With 4 clubs and 25/page, page 2 is empty but the pagination
+    // control must still reflect the URL state. Page is single-page
+    // here; the test exercises that no crash occurs and clubs render.
+    await screen.findByText(/alpha toastmasters/i)
+  })
+
+  it('redirects /district/:id?tab=clubs to /district/:id/clubs', async () => {
+    const { router } = renderAt('/district/61?tab=clubs')
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/district/61/clubs')
+    })
+  })
+
+  it('translates legacy ?tab=clubs&f_status=vulnerable to ?status=vulnerable', async () => {
+    const { router } = renderAt('/district/61?tab=clubs&f_status=vulnerable')
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/district/61/clubs')
+      // Order of query params is not contractual; assert presence.
+      const params = new URLSearchParams(router.state.location.search)
+      expect(params.get('status')).toBe('vulnerable')
+    })
+  })
+
+  it('translates legacy ?tab=clubs&f_name=alpha to ?search=alpha', async () => {
+    const { router } = renderAt('/district/61?tab=clubs&f_name=alpha')
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/district/61/clubs')
+      const params = new URLSearchParams(router.state.location.search)
+      expect(params.get('search')).toBe('alpha')
+    })
+  })
+
+  it('preserves sort/dir/page during legacy redirect', async () => {
+    const { router } = renderAt(
+      '/district/61?tab=clubs&sort=membership&dir=desc&page=2'
+    )
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/district/61/clubs')
+      const params = new URLSearchParams(router.state.location.search)
+      expect(params.get('sort')).toBe('membership')
+      expect(params.get('dir')).toBe('desc')
+      expect(params.get('page')).toBe('2')
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/DistrictDetailPage.GlobalRankings.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.GlobalRankings.test.tsx
@@ -450,6 +450,10 @@ describe('DistrictDetailPage - Global Rankings Tab Navigation Integration', () =
 
   describe('Tab State Management', () => {
     it('should maintain tab state when switching between tabs', async () => {
+      // #570 (Phase 2): Clubs now routes to /district/:id/clubs instead
+      // of switching in-tab, so this test now toggles between Global
+      // Rankings and Divisions — the two tabs that still own panels on
+      // this page.
       renderWithProviders()
 
       // Click on Global Rankings tab
@@ -463,13 +467,15 @@ describe('DistrictDetailPage - Global Rankings Tab Navigation Integration', () =
         expect(globalRankingsTab).toHaveAttribute('aria-selected', 'true')
       })
 
-      // Click on Clubs tab
-      const clubsTab = screen.getByRole('tab', { name: /clubs/i })
-      fireEvent.click(clubsTab)
+      // Click on Divisions tab
+      const divisionsTab = screen.getByRole('tab', {
+        name: /divisions & areas/i,
+      })
+      fireEvent.click(divisionsTab)
 
-      // Verify Clubs is now active and Global Rankings is inactive
+      // Verify Divisions is now active and Global Rankings is inactive
       await waitFor(() => {
-        expect(clubsTab).toHaveAttribute('aria-selected', 'true')
+        expect(divisionsTab).toHaveAttribute('aria-selected', 'true')
         expect(globalRankingsTab).toHaveAttribute('aria-selected', 'false')
       })
 
@@ -479,7 +485,7 @@ describe('DistrictDetailPage - Global Rankings Tab Navigation Integration', () =
       // Verify Global Rankings is active again
       await waitFor(() => {
         expect(globalRankingsTab).toHaveAttribute('aria-selected', 'true')
-        expect(clubsTab).toHaveAttribute('aria-selected', 'false')
+        expect(divisionsTab).toHaveAttribute('aria-selected', 'false')
       })
     })
 

--- a/frontend/src/utils/legacyClubsRedirect.ts
+++ b/frontend/src/utils/legacyClubsRedirect.ts
@@ -1,0 +1,45 @@
+/* Legacy `?tab=clubs` redirect translator (#570, epic #568 Phase 2).
+   Returns the new `/district/:id/clubs` URL when the incoming request
+   carries `tab=clubs`, translating the old `f_status` / `f_name` filter
+   codec values into the new clean URL contract (status / search) and
+   preserving sort / dir / page. Returns null for any other URL so the
+   router falls through to DistrictDetailPage. */
+
+const STATUS_INTERNAL_TO_URL: Record<string, string> = {
+  thriving: 'thriving',
+  vulnerable: 'vulnerable',
+  'intervention-required': 'intervention',
+}
+
+export function redirectLegacyClubsTab(
+  url: string,
+  districtId: string | undefined
+): string | null {
+  if (!districtId) return null
+  const parsed = new URL(url)
+  if (parsed.searchParams.get('tab') !== 'clubs') return null
+
+  const next = new URLSearchParams()
+
+  const oldStatus = parsed.searchParams.get('f_status')
+  if (oldStatus) {
+    // f_status uses comma-separated categorical values. The new contract
+    // is single-value: take the first recognized status.
+    const first = oldStatus.split(',')[0]
+    if (first) {
+      const mapped = STATUS_INTERNAL_TO_URL[first] ?? null
+      if (mapped) next.set('status', mapped)
+    }
+  }
+
+  const oldName = parsed.searchParams.get('f_name')
+  if (oldName) next.set('search', oldName)
+
+  for (const key of ['sort', 'dir', 'page'] as const) {
+    const v = parsed.searchParams.get(key)
+    if (v) next.set(key, v)
+  }
+
+  const qs = next.toString()
+  return `/district/${districtId}/clubs${qs ? `?${qs}` : ''}`
+}

--- a/tasks/lessons/070-setSearchParams-prev-races-in-batched-updates.md
+++ b/tasks/lessons/070-setSearchParams-prev-races-in-batched-updates.md
@@ -1,0 +1,144 @@
+---
+name: setSearchParams prev callback races against same-batch updaters
+description: Two setSearchParams(prev => …) calls dispatched in the same
+  React batch see the SAME stale `prev` snapshot — the second clobbers
+  the first. Bail out on no-op writes (e.g. delete a key that isn't
+  present) so the simultaneous filter write survives.
+type: feedback
+---
+
+# Lesson 70 — `setSearchParams(prev => …)` races against same-batch updaters
+
+**Date:** 2026-05-22
+**Issue:** #570 (District IA Phase 2 — route Clubs to `/district/:id/clubs`)
+
+## What happened
+
+Wiring URL state for the new `/district/:id/clubs` route looked
+identical to the pattern already used in `DistrictDetailPage`:
+
+```ts
+const handleFilterChange = useCallback(
+  state => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev)
+        if (patch.status) next.set('status', patch.status)
+        else next.delete('status')
+        next.delete('page') // reset pagination
+        return next
+      },
+      { replace: true }
+    )
+  },
+  [setSearchParams]
+)
+
+const handlePageChange = useCallback(
+  page => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev)
+        if (page === 1) next.delete('page')
+        else next.set('page', String(page))
+        return next
+      },
+      { replace: true }
+    )
+  },
+  [setSearchParams]
+)
+```
+
+A unit test that clicked the **Vulnerable** status chip and asserted
+`?status=vulnerable` ended up on the URL with an **empty** search. The
+filter change _did_ fire (`handleFilterChange` ran, set the URL to
+`?status=vulnerable`) — and then `ClubsTable`'s own pagination-reset
+effect fired in the same batch:
+
+```ts
+useEffect(() => {
+  if (isInitialLoad.current && filteredClubs.length > 0) {
+    isInitialLoad.current = false
+    return
+  }
+  if (!isInitialLoad.current) {
+    pagination.goToPage(1)
+    onPageChange?.(1) // <- fires inside the same batch
+  }
+}, [filteredClubs.length, pagination.goToPage])
+```
+
+Both `handleFilterChange` and `handlePageChange` therefore called
+`setSearchParams(prev => …)` inside the same React update cycle.
+React Router calls each updater with the **same `prev`** — the
+pre-batch snapshot — because, like `setState(prev => …)` queued
+updates, there is no chained "result of the previous updater" for
+`useSearchParams`. The first updater computed
+`status=vulnerable`, the second computed `''` (no-op delete on an
+empty prev), and the second one won. Status was clobbered.
+
+The same race exists in `DistrictDetailPage` but stays latent in
+existing tests because they don't exercise filter-then-pagination in
+the same tick.
+
+## How to apply
+
+**Bail out of `setSearchParams` when the write would be a no-op.**
+Particularly when the call originates from a "reset-on-change" effect
+that fires after another `setSearchParams` in the same batch:
+
+```ts
+const handlePageChange = useCallback(
+  (page: number) => {
+    if (page === 1 && !searchParams.has('page')) return // bail
+    setSearchParams(
+      prev => {
+        /* … */
+      },
+      { replace: true }
+    )
+  },
+  [searchParams, setSearchParams]
+)
+```
+
+The bail makes the function depend on the freshly-rendered
+`searchParams` getter (which reflects the current location), not on a
+stale `prev` snapshot. The dependency change also means the callback
+identity refreshes each render — fine, because consumers re-attach to
+the latest one through normal prop flow.
+
+## Telltale signs
+
+- A `setSearchParams` call demonstrably fires (you can log it) but
+  the URL ends up empty / missing the key it just wrote.
+- A second `setSearchParams` (or a sibling URL-writing hook like
+  `useUrlProgramYear.setSelectedDate`) runs in the same render cycle.
+- The "lost" key is one that the second call's `prev`-derived `next`
+  would have stripped (e.g. `delete('page')` on an empty prev).
+- Tests pass for a single status read (`?status=vulnerable` mounts
+  cleanly) but fail when the value has to be written from a user
+  action.
+
+## Why this matters here vs. the existing `DistrictDetailPage`
+
+`DistrictDetailPage` has the same wiring shape but the
+filter-then-pagination race wasn't covered by tests there — clicking a
+filter chip was always followed by an explicit assertion on filter
+state, not URL search. #570 is the first sprint where the URL contract
+is asserted directly under userEvent, so the race finally surfaced.
+Phase 3 (#571) will move Divisions / Global Rankings to their own
+routes too — apply the same bail-on-no-op pattern when extracting
+those filter callbacks.
+
+## Related
+
+- `frontend/src/pages/DistrictClubsPage.tsx` — `handlePageChange` bail
+- `frontend/src/components/ClubsTable.tsx` — the auto-reset effect
+  that triggers the same-batch `onPageChange` call
+- React Router 7 [`useSearchParams` docs](https://reactrouter.com/api/hooks/useSearchParams)
+  — `prev` callback semantics
+- Lesson 68 — IA refactors cascade tests; this one was the tests
+  cascading **into** the production code (lesson here is the new
+  feedback the assertions surfaced)


### PR DESCRIPTION
## Summary

- New `/district/:districtId/clubs` route hosts `DistrictClubsPage` with a clean URL contract: `?status=<thriving|vulnerable|intervention>`, `?search=`, `?sort=&dir=`, `?page=`.
- Legacy `/district/:id?tab=clubs` URLs redirect to the new route, translating `f_status` → `status` and `f_name` → `search` while preserving `sort`/`dir`/`page`.
- DistrictDetailPage's Clubs tab now navigates to the new route instead of switching in-tab. Divisions / Global Rankings remain in-tab pending Phase 3 (#571).

Resolves Friction 2 from epic #568 (filter state colliding with tab state).

## Test plan

- [x] 11 new tests cover the new page (route mount, URL → filter state for each contract param, chip → URL writeback, all four legacy redirect translations)
- [x] Updated `DistrictDetailPage.GlobalRankings` tab-state test (Clubs no longer in-tab; uses Divisions toggle now)
- [x] Updated journey 01 — wait for the new page's "All Clubs" heading after the tab click
- [x] Full frontend suite green locally (2326 / 2326)
- [ ] CI green
- [ ] Live verification on ts.taverns.red after deploy: load `/district/61/clubs?status=vulnerable`, confirm filter applied; load `/district/61?tab=clubs&f_status=vulnerable` and confirm 30x-equivalent redirect to the new URL; back/forward preserves state

## Notes

Lesson #70 captured a `setSearchParams(prev => …)` same-batch race that surfaced wiring this contract under userEvent (the existing `DistrictDetailPage` carries the same shape but tests there never asserted URL writeback). The bail-on-no-op pattern in `handlePageChange` is the durable fix; Phase 3 callbacks should adopt the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)