### PR TITLE
fix(theme): #564 Phase 2 — opacity-variant dark-mode sweep + inert bg-amber-50/N fix

### DIFF
--- a/frontend/src/__tests__/css-migration/opacity-variants-dark.test.ts
+++ b/frontend/src/__tests__/css-migration/opacity-variants-dark.test.ts
@@ -67,11 +67,11 @@ describe('Opacity-variant dark-mode overrides (#564 Phase 2)', () => {
     'tm-* opacity variant `%s`',
     cls => {
       it("has an explicit [data-theme='dark'] override in dark-mode.css", () => {
-        // Escape `.` is not needed inside a character class; the class name
-        // contains only `[a-z0-9-]` so a plain substring + boundary check
-        // via a regex is sufficient.
+        // `[^,{]*` (not `[^{]*`) prevents the regex from bridging a comma
+        // — `[data-theme='dark'] .foo, .bg-tm-X-N { ... }` only scopes
+        // .foo to dark mode, so we must NOT match the trailing item.
         const pattern = new RegExp(
-          `\\[data-theme=['"]dark['"]\\]\\s+(?:[^{]*\\s)?\\.${cls}(?![\\w-])`,
+          `\\[data-theme=['"]dark['"]\\]\\s+(?:[^,{]*\\s)?\\.${cls}(?![\\w-])`,
           'm'
         )
         expect(DARK_MODE_CSS).toMatch(pattern)
@@ -83,11 +83,14 @@ describe('Opacity-variant dark-mode overrides (#564 Phase 2)', () => {
     // `bg-amber-50/50` is used UNCONDITIONALLY in DCPProjectionsTable.tsx
     // (line ~422). Tailwind compiles this to a baked `rgba(254, 243, 199,
     // 0.5)` value that renders washed-out beige on the dark surface. The
-    // project covers this with a wildcard class-attribute selector since
-    // the slash is escaped in the compiled selector.
-    it('bg-amber-50 wildcard override exists', () => {
+    // override must target the COMPILED selector form (`.bg-amber-50\/50`
+    // — backslash-escaped slash in CSS source, plain `bg-amber-50/50`
+    // class on the DOM element). A prior attempt used an attribute-
+    // substring selector `[class*="bg-amber-50\\/"]` which looks for a
+    // LITERAL backslash in the class attribute and never matched.
+    it('bg-amber-50/50 literal-selector override exists', () => {
       expect(DARK_MODE_CSS).toMatch(
-        /\[data-theme=['"]dark['"]\]\s+\[class\*="bg-amber-50\\\\\/"\]/
+        /\[data-theme=['"]dark['"]\]\s+\.bg-amber-50\\\/50\b/
       )
     })
 

--- a/frontend/src/__tests__/css-migration/opacity-variants-dark.test.ts
+++ b/frontend/src/__tests__/css-migration/opacity-variants-dark.test.ts
@@ -1,0 +1,110 @@
+// Opacity-variant dark-mode override coverage (#564 Phase 2)
+//
+// Project rule R10 (`tasks/rules.md`):
+//   "Tailwind opacity variants (`text-tm-*-80`) don't inherit CSS variable
+//   overrides. Audit on every new brand token."
+//
+// Every brand opacity-variant utility (`bg-tm-*-N`, `text-tm-*-N`,
+// `border-tm-*-N`) and every Tailwind v3 `bg-X/N` utility that is actually
+// USED in the component tree must have an explicit `[data-theme='dark']`
+// override in `frontend/src/styles/dark-mode.css`. Otherwise the class
+// renders with its baked-in light-mode rgba in dark mode and produces the
+// contrast bugs catalogued in the parent issue.
+//
+// The Red->Green driver for Phase 2 of the contrast audit (#564). When a
+// future component introduces a new opacity-variant utility, this test
+// will fail until a dark-mode override is added.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const FRONTEND_SRC = resolve(__dirname, '../..')
+const DARK_MODE_CSS = readFileSync(
+  resolve(FRONTEND_SRC, 'styles/dark-mode.css'),
+  'utf-8'
+)
+
+// Set of opacity-variant utility classes that are currently used in the
+// frontend component tree (audited 2026-05-22 for #564 Phase 2). Each must
+// have a corresponding `[data-theme='dark'] .<class>` rule in
+// `dark-mode.css`. When adding a new opacity-variant utility to any
+// component, append it here AND add the override.
+const TM_OPACITY_VARIANTS_IN_USE = [
+  // bg — loyal-blue
+  'bg-tm-loyal-blue-10',
+  'bg-tm-loyal-blue-20',
+  'bg-tm-loyal-blue-30',
+  'bg-tm-loyal-blue-80',
+  'bg-tm-loyal-blue-90',
+  // bg — cool-gray
+  'bg-tm-cool-gray-10',
+  'bg-tm-cool-gray-20',
+  'bg-tm-cool-gray-30',
+  'bg-tm-cool-gray-80',
+  // bg — happy-yellow
+  'bg-tm-happy-yellow-20',
+  'bg-tm-happy-yellow-30',
+  'bg-tm-happy-yellow-80',
+  // bg — true-maroon
+  'bg-tm-true-maroon-10',
+  'bg-tm-true-maroon-20',
+  'bg-tm-true-maroon-80',
+  // text
+  'text-tm-loyal-blue-70',
+  'text-tm-loyal-blue-80',
+  'text-tm-happy-yellow-80',
+  // border
+  'border-tm-cool-gray-20',
+  'border-tm-cool-gray-30',
+  'border-tm-loyal-blue-20',
+  'border-tm-loyal-blue-30',
+  'border-tm-true-maroon-30',
+] as const
+
+describe('Opacity-variant dark-mode overrides (#564 Phase 2)', () => {
+  describe.each(TM_OPACITY_VARIANTS_IN_USE)(
+    'tm-* opacity variant `%s`',
+    cls => {
+      it("has an explicit [data-theme='dark'] override in dark-mode.css", () => {
+        // Escape `.` is not needed inside a character class; the class name
+        // contains only `[a-z0-9-]` so a plain substring + boundary check
+        // via a regex is sufficient.
+        const pattern = new RegExp(
+          `\\[data-theme=['"]dark['"]\\]\\s+(?:[^{]*\\s)?\\.${cls}(?![\\w-])`,
+          'm'
+        )
+        expect(DARK_MODE_CSS).toMatch(pattern)
+      })
+    }
+  )
+
+  describe('Tailwind v3 `bg-X/N` opacity utilities used in components', () => {
+    // `bg-amber-50/50` is used UNCONDITIONALLY in DCPProjectionsTable.tsx
+    // (line ~422). Tailwind compiles this to a baked `rgba(254, 243, 199,
+    // 0.5)` value that renders washed-out beige on the dark surface. The
+    // project covers this with a wildcard class-attribute selector since
+    // the slash is escaped in the compiled selector.
+    it('bg-amber-50 wildcard override exists', () => {
+      expect(DARK_MODE_CSS).toMatch(
+        /\[data-theme=['"]dark['"]\]\s+\[class\*="bg-amber-50\\\\\/"\]/
+      )
+    })
+
+    // `dark:bg-yellow-900/40`, `dark:bg-blue-900/40`,
+    // `dark:hover:bg-gray-800/50` all live behind Tailwind's `dark:`
+    // variant. The project's manual `[data-theme='dark']` toggle does NOT
+    // currently activate the Tailwind `dark:` variant (no
+    // `@custom-variant dark` directive). These utilities therefore render
+    // only when the OS preference is dark — under the manual toggle they
+    // are inert (no opacity-bake bug to override). Tracked separately as a
+    // tooling concern for #564 Phase 4 (regression coverage).
+    //
+    // This test pins the current behaviour so a future Tailwind dark-
+    // variant rewire is a deliberate, reviewed change.
+    it('manual dark toggle is NOT wired to Tailwind `dark:` variant', () => {
+      const indexCss = readFileSync(resolve(FRONTEND_SRC, 'index.css'), 'utf-8')
+      expect(indexCss).not.toMatch(/@custom-variant\s+dark/)
+    })
+  })
+})

--- a/frontend/src/styles/dark-mode.css
+++ b/frontend/src/styles/dark-mode.css
@@ -721,6 +721,100 @@
     border-color: rgba(20, 184, 166, 0.30) !important;
 }
 
+/* ═══════════════════════════════════════════
+   Opacity-Variant Sweep — #564 Phase 2
+   ═══════════════════════════════════════════
+
+   R10 in tasks/rules.md: Tailwind opacity-variant utilities
+   (`bg-tm-*-N`, `text-tm-*-N`, `border-tm-*-N`) bake their rgba at
+   compile time from the light-mode token. They do NOT inherit the
+   dark-mode CSS-variable overrides defined under [data-theme='dark']
+   in the :root block — those variables are computed at light time and
+   never re-evaluated when Tailwind expands the utility.
+
+   Every `tm-*-N` utility actually used in the component tree
+   (audited 2026-05-22, asserted in
+   `__tests__/css-migration/opacity-variants-dark.test.ts`) therefore
+   needs an explicit override here. The dark-mode rgba uses the same
+   hue as the existing dark base color (loyal-blue #5DADE2, true-maroon
+   #E8879A, cool-gray #C0C8C7, happy-yellow #F7D164) and is tuned for
+   readability on the #0a0f15 / #111922 surface family — not a
+   mechanical mapping of the light-mode rgba (rgba(R,G,B,N/100) on a
+   dark surface looks muddier than on white).
+
+   Loyal-blue 10/20/30, text-tm-loyal-blue-70/80, border-tm-loyal-
+   blue-20, border-tm-cool-gray-20/30, and bg-amber-50/* live higher
+   in this file (legacy positions kept for stable diffs); the rules
+   below close the remaining 15 gaps. */
+
+/* ─── loyal-blue (high opacity — emphasis fills) ─── */
+
+[data-theme='dark'] .bg-tm-loyal-blue-80 {
+    background-color: rgba(93, 173, 226, 0.55) !important;
+}
+
+[data-theme='dark'] .bg-tm-loyal-blue-90 {
+    background-color: rgba(93, 173, 226, 0.7) !important;
+}
+
+[data-theme='dark'] .border-tm-loyal-blue-30 {
+    border-color: rgba(93, 173, 226, 0.35) !important;
+}
+
+/* ─── cool-gray (subtle surface tints + dividers) ─── */
+
+[data-theme='dark'] .bg-tm-cool-gray-10 {
+    background-color: rgba(192, 200, 199, 0.06) !important;
+}
+
+[data-theme='dark'] .bg-tm-cool-gray-20 {
+    background-color: rgba(192, 200, 199, 0.12) !important;
+}
+
+[data-theme='dark'] .bg-tm-cool-gray-30 {
+    background-color: rgba(192, 200, 199, 0.2) !important;
+}
+
+[data-theme='dark'] .bg-tm-cool-gray-80 {
+    background-color: rgba(192, 200, 199, 0.4) !important;
+}
+
+/* ─── happy-yellow (callouts, accents) ─── */
+
+[data-theme='dark'] .bg-tm-happy-yellow-20 {
+    background-color: rgba(247, 209, 100, 0.15) !important;
+}
+
+[data-theme='dark'] .bg-tm-happy-yellow-30 {
+    background-color: rgba(247, 209, 100, 0.22) !important;
+}
+
+[data-theme='dark'] .bg-tm-happy-yellow-80 {
+    background-color: rgba(247, 209, 100, 0.55) !important;
+}
+
+[data-theme='dark'] .text-tm-happy-yellow-80 {
+    color: rgba(247, 209, 100, 0.9) !important;
+}
+
+/* ─── true-maroon (status pills, emphasis chips) ─── */
+
+[data-theme='dark'] .bg-tm-true-maroon-10 {
+    background-color: rgba(232, 135, 154, 0.1) !important;
+}
+
+[data-theme='dark'] .bg-tm-true-maroon-20 {
+    background-color: rgba(232, 135, 154, 0.16) !important;
+}
+
+[data-theme='dark'] .bg-tm-true-maroon-80 {
+    background-color: rgba(232, 135, 154, 0.55) !important;
+}
+
+[data-theme='dark'] .border-tm-true-maroon-30 {
+    border-color: rgba(232, 135, 154, 0.35) !important;
+}
+
 /* ─── Transition for Theme Switch ─── */
 
 html[data-theme] body {

--- a/frontend/src/styles/dark-mode.css
+++ b/frontend/src/styles/dark-mode.css
@@ -596,8 +596,14 @@
     color: #FDE68A !important;
 }
 
-/* bg-amber-50/50 is generated as a Tailwind arbitrary modifier */
-[data-theme='dark'] [class*="bg-amber-50\\/"] {
+/* bg-amber-50/N is Tailwind's opacity-modifier syntax. The compiled
+   selector escapes the slash (`.bg-amber-50\/50`) but the DOM class
+   attribute carries the plain string `bg-amber-50/50` — no backslash.
+   The prior wildcard `[class*="bg-amber-50\\/"]` looked for a literal
+   backslash + slash and never matched. The literal escaped selector
+   below targets the exact compiled form Tailwind emits and so reaches
+   any element actually wearing the class. */
+[data-theme='dark'] .bg-amber-50\/50 {
     background-color: rgba(161, 98, 7, 0.12) !important;
 }
 

--- a/tasks/lessons/073-opacity-variant-utilities-need-explicit-dark-mode-overrides.md
+++ b/tasks/lessons/073-opacity-variant-utilities-need-explicit-dark-mode-overrides.md
@@ -1,0 +1,99 @@
+---
+name: Tailwind opacity-variant utilities need explicit dark-mode overrides
+description: bg-tm-*-N / text-tm-*-N / border-tm-*-N classes bake their rgba
+  at compile time from the LIGHT-mode CSS variable. They never re-resolve
+  under [data-theme='dark']. Every used opacity variant therefore needs an
+  explicit selector override in dark-mode.css — there is no inheritance to
+  fall back on, and overriding the underlying CSS var only fixes the base
+  utility, not the opacity variants.
+type: feedback
+---
+
+# Lesson 73 — Opacity-variant utilities need explicit dark-mode overrides
+
+**Date:** 2026-05-22
+**Issue:** #564 (contrast audit — Phase 2: opacity-variant sweep)
+
+## What happened
+
+Phase 1 of the contrast audit (shipped in earlier #564 commits) put
+named, semantic overrides under `[data-theme='dark']` for the tier-
+badge backgrounds and Additional Awards chips. That cleared the
+visible bugs the user reported on the live site.
+
+Phase 2 inventory found 23 additional opacity-variant utility classes
+in use across the component tree (`bg-tm-loyal-blue-{10..90}`,
+`bg-tm-cool-gray-{10..80}`, `bg-tm-happy-yellow-{20..80}`,
+`bg-tm-true-maroon-{10..80}`, plus matching text and border variants).
+10 of these already had overrides — accidentally; from earlier point
+fixes — and 13 did not. The pre-existing overrides matched no obvious
+ordering or rule.
+
+The reason there is no inheritance to fall back on: Tailwind compiles
+`bg-tm-loyal-blue-80` to a literal `background-color: rgba(93, 173,
+226, 0.8)` at build time, sourced from the `--tm-loyal-blue` CSS var
+**as it was defined when the utility was emitted** — i.e., the
+light-mode value. The dark-mode override on `--tm-loyal-blue` (defined
+elsewhere in `styles/dark-mode.css`) does NOT propagate to that
+utility because the utility's `rgba()` call is gone; only the literal
+remains.
+
+So overriding the CSS variable fixes `.tm-bg-loyal-blue`, but does
+**nothing** for `.bg-tm-loyal-blue-80`. The latter needs its own
+selector.
+
+## How to apply
+
+**Rule (extends R10):** every `bg-tm-*-N` / `text-tm-*-N` /
+`border-tm-*-N` utility used in a component must have a corresponding
+`[data-theme='dark'] .<class>` rule in `frontend/src/styles/dark-
+mode.css`. Override the variable in the `:root` block AND the
+variant selector — both are necessary.
+
+**Tooling:** the audit is automated by
+`frontend/src/__tests__/css-migration/opacity-variants-dark.test.ts`.
+When introducing a new opacity-variant utility, add the class name to
+`TM_OPACITY_VARIANTS_IN_USE` AND add the override; the test will go
+red otherwise.
+
+**Why:** **Why:** CSS variables are computed where they appear in source. Tailwind's `rgba(var(--tm-X), N/100)` is computed once at build (or at the utility-emission site) and inlined as a literal `rgba(...)`. There is no live binding back to the variable. Re-binding only happens when the SELECTOR has the variable resolution INSIDE it — which is true for `.tm-bg-loyal-blue` (uses `var(--tm-loyal-blue)` directly) but FALSE for `.bg-tm-loyal-blue-80` (inlined `rgba()`).
+
+**How to apply:** Before merging any PR that adds a `bg-tm-X-N` /
+`text-tm-X-N` / `border-tm-X-N` class, grep the diff for that pattern
+and confirm `opacity-variants-dark.test.ts` accepts the new class.
+
+## Tailwind v3 `bg-X/N` opacity classes are a sibling problem
+
+Same root cause, two flavours of expression:
+
+- **Unconditional** usage (`bg-amber-50/50`) bakes a light rgba at
+  build time. Needs a dark override; covered today by a wildcard
+  attribute selector `[class*="bg-amber-50\\/"]` in `dark-mode.css`.
+- **Variant-gated** usage (`dark:bg-yellow-900/40`) only emits CSS
+  inside `@media (prefers-color-scheme: dark)` — by Tailwind 4's
+  default `dark:` strategy. The project's manual `[data-theme='dark']`
+  toggle does NOT activate this media query, so these utilities are
+  inert under the manual toggle. They're not a contrast bug, they're a
+  dead selector. **Tracked separately**; Phase 4 of #564 will decide
+  whether to add `@custom-variant dark (&:where([data-theme='dark']
+*))` and merge the two surfaces or audit and replace each call site.
+
+## Telltale signs
+
+- Component looks great in light mode, contrast bug in dark mode, and
+  `grep` shows the offender is `bg-tm-X-N` or `bg-COLOR-N/M`.
+- The brand color tokens (e.g. `--tm-loyal-blue`) ARE overridden in
+  the `[data-theme='dark']` block — but the bug persists.
+- DOM inspector shows `background-color: rgba(93, 173, 226, 0.2)` as
+  a literal, not a computed value referencing a variable.
+
+## Related
+
+- Lesson R10 in `tasks/rules.md` — original "opacity variants don't
+  inherit" rule. This lesson generalises it across all three sub-
+  prefixes (bg / text / border) and adds the v3 `/N` slash sibling.
+- `frontend/src/__tests__/css-migration/opacity-variants-dark.test.ts`
+  — automated guard.
+- `frontend/src/styles/dark-mode.css` — the override surface.
+- #564 Phase 3 (light-mode small-text tightening) and Phase 4 (axe-
+  core regression coverage) are separate sprints.


### PR DESCRIPTION
Sprint 5 of epic #574 — Phase 2 of contrast audit #564.

## Summary

- **15 new `[data-theme='dark']` overrides** for `bg-tm-*-N`,
  `text-tm-*-N`, `border-tm-*-N` utilities that were rendering with
  their baked light-mode rgba on dark surfaces (R10 tripwire).
- **Critical-review pass surfaced + fixed a pre-existing inert
  selector**: the prior `[class*=\"bg-amber-50\\\\/\"]` wildcard at
  line 600 was searching for a literal backslash that never appears
  in the DOM class attribute. Replaced with the compiled
  literal-selector form `.bg-amber-50\\/50`.
- New structure test
  (`__tests__/css-migration/opacity-variants-dark.test.ts`, 25 cases)
  asserts every audited utility has its override and pins the
  Tailwind `dark:` variant as not-wired (deferred to Phase 4).
- Lesson 73 captures the \"opacity variants don't inherit\" rule.

## Why this PR is bounded to Phase 2

Phase 1 of #564 (tier-badge + chip overrides) shipped in earlier
commits. Phase 3 (light-mode small-text tightening) and Phase 4
(axe-core regression coverage) are separate sprints per epic #574.

## Test plan

- [x] `opacity-variants-dark.test.ts` — 25/25 green (was 10/25 at Red commit)
- [x] `css-migration/` + `accessibility/` suites — 139/139 green
- [x] Typecheck, lint, yaml-lint all green via pre-commit
- [ ] **Operator visual QA on ts.taverns.red (dark mode)** —
      especially the components reviewers flagged as needing
      eyeballs (see PR review notes below)

## Review notes for operator verification

Critical review surfaced visual concerns that JSDOM tests can't
validate. Worth a manual pass at 375 / 768 / 1280px before closing
the sub-issue:

1. **`DistinguishedCompositionBar` (Composition bar segments)** —
   `bg-tm-loyal-blue-80` now at 0.55 alpha in dark; check
   Select segment is still visually distinct from neighbours.
2. **`ClubDCPGoalsCard` Training pill** — `bg-tm-true-maroon-80` at
   0.55 alpha + `text-white`; verify legible (WCAG AA risk).
3. **`AreaPerformanceTable` thead** — `bg-tm-cool-gray-10` at 0.06
   alpha is intentionally near-invisible (surface tint); confirm
   row hierarchy still reads.
4. **`ClubsTable` Smedley chip** — `bg-tm-happy-yellow-20` chip with
   `text-tm-true-maroon` text; check chip-affordance survives.
5. **`DCPGoalAnalysis` progress bars** — `bg-tm-happy-yellow-80` on
   `bg-gray-200` track (untreated for dark mode in this PR); flag
   any cross-screen luminance drift.

If any of (1)–(5) regress, the fix is an additional
component-specific dark rule in dark-mode.css, not a revert of this
sweep.

## Deferred to future sprints

- **Tailwind `dark:` variant wiring** — `dark:bg-yellow-900/40`
  etc. in `ClubAnniversaryBadge` and `RegionsLeaderboard` are
  currently inert under the manual `[data-theme='dark']` toggle
  (no `@custom-variant dark` directive). Pinned in the test;
  Phase 4 of #564 to decide.
- **Snapshot-vs-live test gap** — `TM_OPACITY_VARIANTS_IN_USE` is a
  2026-05-22 snapshot, not a dynamic grep of the component tree.
  Sprint 7 (#564 Phase 4) is the natural home for the live audit.
- Pre-existing duplicate `.bg-green-50` / `.bg-blue-50` rules
  (lines 329/343 vs 673/699) — out of Phase 2 scope.

Closes the Phase 2 checkbox in #564 but does not close the parent
issue (Phases 3 + 4 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)