### PR TITLE
fix(theme): #564 Phase 3 — light-mode small-text tightening

### DIFF
--- a/frontend/src/__tests__/css-migration/small-text-light-mode.test.ts
+++ b/frontend/src/__tests__/css-migration/small-text-light-mode.test.ts
@@ -1,0 +1,139 @@
+// Light-mode small-text contrast tightening (#564 Phase 3)
+//
+// WCAG 2.1 AA requires 4.5:1 contrast for normal text. Tailwind's
+// default `text-gray-400` (#9ca3af) on white yields only 2.85:1 — a
+// clear AA failure anywhere it lands on a light surface, and especially
+// at small sizes (`text-xs` = 12px) where it's already at a legibility
+// disadvantage. `text-gray-500` (#6b7280) on white is 4.83:1 — it
+// passes AA but only barely, and at `text-[11px]` (smaller than the
+// `text-xs` default) the audit calls for tightening to `text-gray-600`
+// (7.59:1, full AAA).
+//
+// This test scans the component tree and fails on any of:
+//
+//   1. `text-gray-400` paired with `text-xs` (AA failure on white)
+//   2. `text-gray-500` paired with `text-[11px]` (Phase 3 tightening)
+//
+// The check is greppy on purpose. It catches both forward-order
+// (`text-xs text-gray-400`) and reverse-order (`text-gray-400 text-xs`)
+// combinations within a single class attribute, which is the actual
+// way these utilities ship together in JSX.
+//
+// Exclusions: `dark:text-gray-400` is fine — that selector only
+// applies under the `[data-theme='dark']` toggle and is not the
+// light-mode foreground.
+//
+// When a future component needs `text-gray-400` at `text-xs`, either
+// (a) raise the foreground to `text-gray-600`+, or (b) raise the size
+// out of small-text territory (>=18.66px bold / 24px normal) where AA
+// drops to 3:1. Do not allowlist new offenders here.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { resolve, relative, join } from 'path'
+
+const FRONTEND_SRC = resolve(__dirname, '../..')
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === '__tests__' || entry === 'node_modules') continue
+    const full = join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) {
+      walk(full, out)
+    } else if (
+      (entry.endsWith('.tsx') || entry.endsWith('.jsx')) &&
+      !entry.includes('.test.')
+    ) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+const SOURCE_FILES = walk(FRONTEND_SRC)
+
+// Match a JSX className/class attribute value (either string-literal or
+// the inside of a template literal). The capture is the attribute body.
+const CLASS_ATTR_PATTERN =
+  /class(?:Name)?\s*=\s*(?:"([^"]*)"|'([^']*)'|\{`([^`]*)`\})/g
+
+interface Offender {
+  file: string
+  line: number
+  classAttr: string
+  rule: string
+}
+
+function findOffenders(rule: {
+  name: string
+  hasForeground: RegExp
+  hasSize: RegExp
+}): Offender[] {
+  const hits: Offender[] = []
+  for (const file of SOURCE_FILES) {
+    const src = readFileSync(file, 'utf-8')
+    const lines = src.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      CLASS_ATTR_PATTERN.lastIndex = 0
+      let m: RegExpExecArray | null
+      while ((m = CLASS_ATTR_PATTERN.exec(line))) {
+        const attr = m[1] ?? m[2] ?? m[3] ?? ''
+        if (rule.hasForeground.test(attr) && rule.hasSize.test(attr)) {
+          hits.push({
+            file: relative(FRONTEND_SRC, file),
+            line: i + 1,
+            classAttr: attr.trim(),
+            rule: rule.name,
+          })
+        }
+      }
+    }
+  }
+  return hits
+}
+
+// Negative lookbehind for `dark:` — we only care about the light-mode
+// foreground. `(?<![\w-])` ensures we don't match `text-gray-4000` or
+// similar.
+const LIGHT_GRAY_400 = /(?<![\w-])(?<!dark:)text-gray-400(?![\w-])/
+const LIGHT_GRAY_500 = /(?<![\w-])(?<!dark:)text-gray-500(?![\w-])/
+const TEXT_XS = /(?<![\w-])text-xs(?![\w-])/
+const TEXT_11PX = /(?<![\w-])text-\[11px\](?![\w-])/
+
+describe('Small-text light-mode contrast (#564 Phase 3)', () => {
+  it('no `text-gray-400` paired with `text-xs` (WCAG AA fail, 2.85:1 on white)', () => {
+    const offenders = findOffenders({
+      name: 'text-gray-400 + text-xs',
+      hasForeground: LIGHT_GRAY_400,
+      hasSize: TEXT_XS,
+    })
+    expect(
+      offenders,
+      offenders.length
+        ? `Found ${offenders.length} light-mode AA failures. Bump foreground to text-gray-600 (7.59:1):\n` +
+            offenders
+              .map(o => `  ${o.file}:${o.line}  ${o.classAttr}`)
+              .join('\n')
+        : ''
+    ).toEqual([])
+  })
+
+  it('no `text-gray-500` paired with `text-[11px]` (Phase 3 tightening to gray-600)', () => {
+    const offenders = findOffenders({
+      name: 'text-gray-500 + text-[11px]',
+      hasForeground: LIGHT_GRAY_500,
+      hasSize: TEXT_11PX,
+    })
+    expect(
+      offenders,
+      offenders.length
+        ? `Found ${offenders.length} sites needing Phase 3 tightening. Bump foreground to text-gray-600:\n` +
+            offenders
+              .map(o => `  ${o.file}:${o.line}  ${o.classAttr}`)
+              .join('\n')
+        : ''
+    ).toEqual([])
+  })
+})

--- a/frontend/src/components/ClubCard.tsx
+++ b/frontend/src/components/ClubCard.tsx
@@ -88,7 +88,7 @@ const ClubCard: React.FC<ClubCardProps> = ({ club, onClick }) => {
         <div>
           <div className="text-lg font-bold text-gray-900">
             {club.latestDcpGoals}
-            <span className="text-xs text-gray-400 font-normal">/10</span>
+            <span className="text-xs text-gray-600 font-normal">/10</span>
           </div>
           <div className="text-xs text-gray-500">DCP Goals</div>
         </div>

--- a/frontend/src/components/ClubPerformanceTable.tsx
+++ b/frontend/src/components/ClubPerformanceTable.tsx
@@ -413,7 +413,7 @@ const ClubPerformanceTable: React.FC<ClubPerformanceTableProps> = ({
                                 )}
                             </div>
                           ) : (
-                            <div className="text-xs text-gray-400">
+                            <div className="text-xs text-gray-600">
                               Loading...
                             </div>
                           )}

--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -116,7 +116,7 @@ const GapTile: React.FC<GapTileSpec> = ({
     <div className="rounded-md border border-gray-200 dark:border-gray-700 px-3 py-2">
       <div
         data-testid="gap-tile-label"
-        className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400 font-tm-body"
+        className="text-[11px] uppercase tracking-wide text-gray-600 dark:text-gray-400 font-tm-body"
       >
         {label}
       </div>
@@ -131,7 +131,7 @@ const GapTile: React.FC<GapTileSpec> = ({
       {showConcrete && (
         <div
           data-testid="gap-tile-units"
-          className="mt-0.5 text-[11px] text-gray-500 dark:text-gray-400 font-tm-body tabular-nums"
+          className="mt-0.5 text-[11px] text-gray-600 dark:text-gray-400 font-tm-body tabular-nums"
         >
           ~{concreteCount} {concreteCount === 1 ? unitSingular : unitPlural}
         </div>

--- a/frontend/src/components/MilestonesCallout.tsx
+++ b/frontend/src/components/MilestonesCallout.tsx
@@ -222,7 +222,7 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
         <h3 id="milestones-heading" className="redesign-panel__header !mb-0">
           Milestones · PY {pyLabel}
         </h3>
-        <span className="text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400 font-tm-body">
+        <span className="text-[11px] uppercase tracking-wider text-gray-600 dark:text-gray-400 font-tm-body">
           {totalCount} club{totalCount === 1 ? '' : 's'}
         </span>
       </div>
@@ -249,7 +249,7 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
                   >
                     {entry.club.clubName}
                   </Link>
-                  <span className="text-[11px] text-gray-500 dark:text-gray-400 tabular-nums">
+                  <span className="text-[11px] text-gray-600 dark:text-gray-400 tabular-nums">
                     {formatShortDate(entry.anniversaryDate)}
                   </span>
                   {i < group.entries.length - 1 && (

--- a/frontend/src/components/TopGrowthClubs.tsx
+++ b/frontend/src/components/TopGrowthClubs.tsx
@@ -179,7 +179,7 @@ export const TopGrowthClubs: React.FC<TopGrowthClubsProps> = ({
                           {club.clubName}
                         </h4>
                         {isTied && (
-                          <span className="text-xs text-gray-400 font-tm-body">
+                          <span className="text-xs text-gray-600 font-tm-body">
                             (tied)
                           </span>
                         )}
@@ -257,7 +257,7 @@ export const TopGrowthClubs: React.FC<TopGrowthClubsProps> = ({
                         </h4>
                         {getDistinguishedBadge(club.distinguishedLevel)}
                         {isTied && (
-                          <span className="text-xs text-gray-400 font-tm-body">
+                          <span className="text-xs text-gray-600 font-tm-body">
                             (tied)
                           </span>
                         )}

--- a/frontend/src/components/UpcomingAnniversariesPanel.tsx
+++ b/frontend/src/components/UpcomingAnniversariesPanel.tsx
@@ -135,7 +135,7 @@ export const UpcomingAnniversariesPanel: React.FC<
         >
           Upcoming anniversaries
         </h3>
-        <span className="text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400 font-tm-body">
+        <span className="text-[11px] uppercase tracking-wider text-gray-600 dark:text-gray-400 font-tm-body">
           Next {UPCOMING_WINDOW_DAYS}d · {upcoming.length}
         </span>
       </div>

--- a/frontend/src/components/filters/NumericFilter.tsx
+++ b/frontend/src/components/filters/NumericFilter.tsx
@@ -170,7 +170,7 @@ export const NumericFilter: React.FC<NumericFilterProps> = ({
 
         {/* Bounds Info */}
         {(min !== undefined || max !== undefined) && (
-          <div className="text-xs text-gray-400 pt-2 border-t border-gray-100">
+          <div className="text-xs text-gray-600 pt-2 border-t border-gray-100">
             {min !== undefined && max !== undefined
               ? `Valid range: ${min} - ${max}`
               : min !== undefined

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -381,7 +381,7 @@ const RegionPage: React.FC = () => {
                     >
                       #{rank.rank}
                       {rank.isTied && (
-                        <span className="ml-1 text-xs text-gray-400 font-normal">
+                        <span className="ml-1 text-xs text-gray-600 font-normal">
                           (tied)
                         </span>
                       )}

--- a/tasks/lessons/074-light-mode-small-text-tightening-thresholds.md
+++ b/tasks/lessons/074-light-mode-small-text-tightening-thresholds.md
@@ -1,0 +1,119 @@
+---
+name: Light-mode small-text contrast — where to tighten, where to stop
+description: WCAG AA for normal text is 4.5:1. Tailwind's text-gray-400
+  (#9ca3af) at any small size on white is 2.85:1 — flat AA failure.
+  text-gray-500 (#6b7280) is 4.83:1 — passes AA but marginal, and at
+  text-[11px] the audit's call is to tighten to gray-600 (7.59:1). The
+  pair (text-xs, text-gray-500) is intentionally left alone — it passes
+  AA at 12px and re-coloring it would balloon the diff into design
+  territory.
+type: feedback
+---
+
+# Lesson 74 — Light-mode small-text contrast: where to tighten, where to stop
+
+**Date:** 2026-05-22
+**Issue:** #564 (Phase 3 — light-mode small-text tightening)
+
+## What happened
+
+Phase 3 of the contrast audit had a deliberately narrow scope: bump
+small-text foregrounds in light mode where they were either failing
+or marginal under WCAG AA. The temptation in any contrast sweep is
+to "darken everything one notch" — but that's a design change, not
+a bug fix, and balloons the diff into territory that needs UX
+re-review.
+
+Two clear, mechanical rules sufficed:
+
+| Rule                                   | Before     | After      | Contrast on white |
+| -------------------------------------- | ---------- | ---------- | ----------------- |
+| `text-gray-400` + `text-xs` (12px)     | `gray-400` | `gray-600` | 2.85:1 → 7.59:1   |
+| `text-gray-500` + `text-[11px]` (11px) | `gray-500` | `gray-600` | 4.83:1 → 7.59:1   |
+
+11 call sites across 8 files. The fix was a token swap.
+
+Deliberately **out of scope**:
+
+- **`text-gray-500` + `text-xs` (12px).** 4.83:1 passes AA. Sprint 6's
+  audit didn't flag it. Touching it would have required a sweep of
+  ~50+ sites and a UX call on whether to lift the entire small-grey
+  band one step. Phase 4 (axe-core) is the place to mechanise that
+  decision later.
+- **Dark-mode foregrounds.** `dark:text-gray-400` is the companion at
+  every fix site; under `[data-theme='dark']` the surface is dark
+  enough that gray-400 over it lands above AA. Phase 2 (Lesson 73)
+  handled the dark-mode opacity-variant bug separately.
+- **Anything bigger than `text-xs`.** AA drops to 3:1 for large text
+  (≥18.66px bold / ≥24px). `text-sm` (14px) is still "normal" by
+  WCAG; gray-500 there is also 4.83:1 and untouched on purpose.
+
+## How to apply
+
+**When auditing contrast, fix the AA failures first; tighten the
+marginals only where the audit calls for it.** The rule is:
+
+1. If the combo fails AA on a representative bg (white for light
+   mode, brand-darkest for dark), it's a bug → fix.
+2. If the combo passes AA but the audit body specifically calls for
+   tightening it (e.g. "11px is small enough that 4.83:1 is too
+   tight"), it's in scope → fix.
+3. Otherwise — even if it "looks low" — out of scope for the bug-fix
+   PR. Tightening universally is a design change, not a fix.
+
+The corollary: when a PR's scope is "tighten light-mode small text,"
+do not also touch:
+
+- the same fg at non-small sizes (`text-sm`, `text-base`)
+- the same size at the next-darker fg (`text-gray-500` at `text-xs`
+  passes AA — not yours to lift)
+- dark-mode companions (different surface, different audit)
+
+**Tooling:** Phase 3 added a greppy regression-guard test:
+
+```
+frontend/src/__tests__/css-migration/small-text-light-mode.test.ts
+```
+
+It scans every `.tsx`/`.jsx` under `src/` for forbidden combinations
+within a single `className` attribute. When a new component
+introduces a `text-gray-400 + text-xs` pair, this test fails at PR
+time. No allowlist — only fix or refactor away from the pair.
+
+## Telltale signs you are scoping too widely
+
+- Contrast sweep PR diff is touching `text-sm` and `text-base` sites
+  alongside `text-xs` / `text-[11px]`.
+- You're "darkening text by one step" across the codebase without an
+  audit row pointing at specifically that combo.
+- Tests are failing because component snapshots changed, not because
+  contrast assertions changed.
+
+If any of these are true, narrow the scope back to "what specifically
+fails or what specifically the audit named."
+
+## The 7.59:1 destination
+
+`text-gray-600` (#4b5563) on white is 7.59:1 — full WCAG AAA. That's
+the right destination for `text-xs` and `text-[11px]` because:
+
+- The smaller the text, the more legibility headroom you want over
+  the bare AA floor.
+- Going one further to `text-gray-700` would visually flatten small
+  text against the dominant `text-gray-900` headings — distinction
+  matters for hierarchy.
+
+`gray-600` is the "safe small grey" in this codebase. New small-text
+work should default there, not to `gray-500`.
+
+## Related
+
+- Lesson 73 — Phase 2 opacity-variant dark-mode sweep (the prior
+  phase of this audit)
+- Lesson 71 — when an audit's structural scope is right-sized, the
+  diff should match. Same discipline.
+- `frontend/src/__tests__/css-migration/small-text-light-mode.test.ts`
+  — the regression guard
+- `frontend/src/utils/contrastCalculator.ts` —
+  ratio computation utility (already exists, used in the
+  `accessibility/contrastRequirements.test.ts` property tests)


### PR DESCRIPTION
## Summary

- Bump `text-gray-400` to `text-gray-600` at every site combined with `text-xs` (was 2.85:1 on white — WCAG AA fail for normal text; now 7.59:1, AAA).
- Bump `text-gray-500` to `text-gray-600` at every site combined with `text-[11px]` (was 4.83:1, marginal AA; tightened to 7.59:1 per Phase 3 audit).
- Light-mode only — `dark:text-gray-400` companions untouched.
- 11 call sites across 8 components/pages. New regression-guard test scans the component tree on every CI run.

## Why

Phase 3 of #564 contrast audit. Lesson 73 documented Phase 2 (opacity-variant dark-mode sweep, PR #581). This phase covers the light-mode small-text bucket the audit deferred: `text-gray-500 at text-[11px]` per epic #574 Sprint 6 wording, plus the closely-related `text-gray-400 at text-xs` failures the same audit surfaced.

## What's NOT in scope

- **Phase 4 (axe-core regression coverage)** is Sprint 7's job — separate issue + PR.
- `text-gray-500 + text-xs` is intentionally untouched. It passes AA (4.83:1) at 12px and the audit didn't flag it. Adding it here would balloon the diff and force a wave of design re-review.

## Test plan

- [x] Local: full frontend suite (2329 tests, 155 files) — passes
- [x] Local: full analytics-core + shared-contracts suites — pass
- [x] Local: `quality:check` (typecheck + lint + lint:yaml + format:check + workspace tests) — passes
- [x] New RED test (`frontend/src/__tests__/css-migration/small-text-light-mode.test.ts`) caught all 11 offenders before the fix and is GREEN after
- [ ] CI green
- [ ] PR preview channel — visually inspect Top Growth Clubs (tied label), Club Card (/10), Region Page (tied rank), Anniversaries panel (date header), Distinguished Trophy Case gap tiles, Milestones panel header, NumericFilter bounds line
- [ ] Production verification after merge (operator-driven; #564 stays open until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)