### PR TITLE
fix(theme): #564 Phase 4 — axe-core regression coverage + unmitigated-utilities guard

### DIFF
--- a/frontend/src/__tests__/accessibility/DistrictDetailPage.axe.test.tsx
+++ b/frontend/src/__tests__/accessibility/DistrictDetailPage.axe.test.tsx
@@ -1,0 +1,177 @@
+// Full-page axe scan of DistrictDetailPage (#564 Phase 4).
+//
+// Phase 4 of the contrast audit closes the loop with two guards:
+//   1. `unmitigated-color-utilities.test.ts` — static scan for color
+//      utilities used in components without a dark-mode override.
+//   2. THIS FILE — axe-core scan of the rendered DOM in both light and
+//      dark themes. Catches the structural a11y regressions that the
+//      static scan can't (ARIA, semantic structure, labels, focus order).
+//
+// Known JSDOM limitation: axe-core's `color-contrast` rule is auto-
+// disabled in JSDOM (no canvas → no computed color). Contrast coverage
+// therefore lives in `contrastRequirements.test.ts` (property tests on
+// the calculator) and `unmitigated-color-utilities.test.ts` (static
+// presence-of-override check). This file's job is the rest of WCAG
+// 2.1 AA — and to surface theme-toggle regressions where a dark-mode
+// override drops an ARIA-affecting class.
+//
+// The dark-mode sweep matters because some dark-mode overrides change
+// or hide elements (e.g. swapping an SVG illustration). Axe runs the
+// full WCAG rule set on the dark DOM tree, not just the light one.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import DistrictDetailPage from '../../pages/DistrictDetailPage'
+
+// @ts-expect-error - jest-axe matcher types vs vitest expect
+expect.extend(toHaveNoViolations)
+
+// Mount cost is the full DistrictDetailPage with lazy children. Honest
+// ceiling — same category as DistrictsPage.a11y.test.tsx (line 13).
+vi.setConfig({ testTimeout: 15000 })
+
+// IntersectionObserver mock (lazy children need to flush). Mirrors the
+// shape from DistrictDetailPage.AnalyticsTab.test.tsx — note Lesson 72:
+// callbacks consuming `entry.target` must guard with `?.`.
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | null = null
+  readonly rootMargin: string = ''
+  readonly thresholds: ReadonlyArray<number> = []
+  constructor(
+    callback: (
+      entries: IntersectionObserverEntry[],
+      observer: IntersectionObserver
+    ) => void
+  ) {
+    setTimeout(() => {
+      callback([{ isIntersecting: true } as IntersectionObserverEntry], this)
+    }, 0)
+  }
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+}
+Object.defineProperty(global, 'IntersectionObserver', {
+  value: MockIntersectionObserver,
+  writable: true,
+})
+
+// Hook mocks — same surface as DistrictDetailPage.AnalyticsTab.test.tsx
+// so we test the page chrome + scaffolding, not the data layer.
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: vi.fn(() => ({
+    data: { districts: [{ id: '57', name: 'District 57' }] },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+vi.mock('../../hooks/useDistrictAnalytics', () => ({
+  useDistrictAnalytics: vi.fn(() => ({
+    data: {
+      allClubs: [],
+      interventionRequiredClubs: [],
+      vulnerableClubs: [],
+      distinguishedClubs: { total: 10 },
+      distinguishedProjection: null,
+      thrivingClubs: [],
+      divisionRankings: [],
+      topPerformingAreas: [],
+      membershipTrend: [],
+      topGrowthClubs: [],
+      totalMembership: 1000,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+vi.mock('../../hooks/usePerformanceTargets', () => ({
+  usePerformanceTargets: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+vi.mock('../../hooks/usePaymentsTrend', () => ({
+  usePaymentsTrend: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    data: { dates: ['2024-01-15', '2024-01-01'] },
+    isLoading: false,
+  })),
+}))
+
+vi.mock('../../contexts/ProgramYearContext', () => ({
+  useProgramYear: vi.fn(() => ({
+    selectedProgramYear: {
+      year: 2024,
+      startDate: '2024-07-01',
+      endDate: '2025-06-30',
+      label: '2024-2025',
+    },
+    setSelectedProgramYear: vi.fn(),
+    selectedDate: null,
+    setSelectedDate: vi.fn(),
+  })),
+}))
+
+// Heavy lazy children get stubbed so axe scans the page chrome, not
+// duplicated coverage of the child components (each has its own axe
+// test in src/__tests__/accessibility/).
+vi.mock('../../components/GlobalRankingsTab', () => ({
+  default: vi.fn(() => <div data-testid="global-rankings-tab-stub" />),
+}))
+
+const renderPage = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const router = createMemoryRouter(
+    [{ path: '/district/:districtId', element: <DistrictDetailPage /> }],
+    { initialEntries: ['/district/57'] }
+  )
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  )
+}
+
+describe('DistrictDetailPage — axe-core scan in light and dark mode (#564 Phase 4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Ensure clean theme state per test. Source of truth is the
+    // document-root attribute; the app's DarkModeContext writes to it.
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('has no axe violations in light mode (default theme)', async () => {
+    const { container } = renderPage()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no axe violations in dark mode ([data-theme=dark] on root)', async () => {
+    document.documentElement.setAttribute('data-theme', 'dark')
+    const { container } = renderPage()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/__tests__/css-migration/unmitigated-color-utilities.test.ts
+++ b/frontend/src/__tests__/css-migration/unmitigated-color-utilities.test.ts
@@ -1,0 +1,170 @@
+// Unmitigated color-utility guard (#564 Phase 4)
+//
+// Parent issue #564 catalogued 53 Tailwind color utilities that are used in
+// the component tree but lack a corresponding `[data-theme='dark']` override
+// in `frontend/src/styles/dark-mode.css`. Phases 1–3 fixed the highest-
+// impact dark-mode bugs (tier badges, opacity variants) and the light-mode
+// small-text contrast issues. Phase 4 closes the loop with this guard so
+// future PRs cannot grow the gap.
+//
+// Watchlist composition:
+//   - All `text-{red,green,yellow,blue,purple,teal}-{700,800,900}` — mid /
+//     dark saturated foregrounds that go illegible on the dark surface.
+//   - All `border-{red,green,yellow,blue,purple,teal}-{200,300}` — light
+//     pastel borders that vanish on the dark surface.
+//   - `text-gray-200` — already very light; needs adjustment on dark.
+//   - `border-gray-700` — identical tone to the dark surface, invisible.
+//   - High-saturation backgrounds (`bg-red-500`, `bg-green-500`,
+//     `bg-yellow-500`, `bg-blue-500`) that need text-on-fill contrast checks.
+//
+// For each watchlist class actually USED in a `.tsx`/`.jsx` file under
+// `frontend/src/`, the test asserts a `[data-theme='dark']` rule exists in
+// `dark-mode.css`. Classes that are known-missing today (the residue of
+// the original 53 after Phases 1–3) live in `EXPECTED_FAILURES` and may
+// only SHRINK in future PRs — never grow. New classes appearing in the
+// codebase without an override fail the build.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { resolve, join } from 'path'
+
+const FRONTEND_SRC = resolve(__dirname, '../..')
+const DARK_MODE_CSS = readFileSync(
+  resolve(FRONTEND_SRC, 'styles/dark-mode.css'),
+  'utf-8'
+)
+
+// Watchlist of Tailwind color utilities considered high-risk for dark-mode
+// contrast bugs (per #564 audit). Any of these used in a component without
+// a corresponding dark override is a regression candidate.
+const WATCHLIST_COLORS = ['red', 'green', 'yellow', 'blue', 'purple', 'teal']
+const WATCHLIST_DARK_SHADES = ['700', '800', '900']
+const WATCHLIST_LIGHT_SHADES = ['200', '300']
+const WATCHLIST_FILL_SHADES = ['500']
+
+const WATCHLIST: string[] = [
+  ...WATCHLIST_COLORS.flatMap(c =>
+    WATCHLIST_DARK_SHADES.map(s => `text-${c}-${s}`)
+  ),
+  ...WATCHLIST_COLORS.flatMap(c =>
+    WATCHLIST_LIGHT_SHADES.map(s => `border-${c}-${s}`)
+  ),
+  ...WATCHLIST_COLORS.flatMap(c =>
+    WATCHLIST_FILL_SHADES.map(s => `bg-${c}-${s}`)
+  ),
+  'text-gray-200',
+  'border-gray-700',
+]
+
+// Classes known to be in use without an override at the time of #564 Phase 4
+// (2026-05-22). Each entry is technical debt scheduled for fix in Track D
+// sprints 12–15 (per epic #574). PRs MAY shrink this list (by adding an
+// override). PRs MAY NOT add to it — that would mean a new component
+// introduced an unmitigated utility, which is the regression class this
+// guard exists to prevent. To shrink: add the override in dark-mode.css,
+// run this test, delete the entry from EXPECTED_FAILURES.
+const EXPECTED_FAILURES = new Set<string>([
+  // Tracked debt from #564 audit, scoped to Track D sprints (epic #574):
+  //   - Sprint 12 (Awards), Sprint 13 (Region pages), Sprint 14 (ClubDetail),
+  //     Sprint 15 (Methodology / History / Districts landing) each remove
+  //     entries from this list as their page-by-page dark-mode sweeps land.
+  // Saturated foreground tones — illegible on the dark surface, need a
+  // lighter shade override in dark mode.
+  'text-red-900',
+  'text-green-900',
+  'text-yellow-900',
+  'text-blue-900',
+  // High-saturation fill colors — text-on-fill contrast may degrade on the
+  // dark surface; needs a per-callsite check before override.
+  'bg-red-500',
+  'bg-green-500',
+  'bg-yellow-500',
+  // Already-light foreground; bleeds into the dark surface.
+  'text-gray-200',
+  // Matches the dark surface tone — invisible border.
+  'border-gray-700',
+])
+
+// Recursive .tsx/.jsx file walker, excluding test files (so test fixtures
+// using a watchlist class for assertions don't trip the guard).
+function collectComponentFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const stat = statSync(full)
+    if (stat.isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue
+      out.push(...collectComponentFiles(full))
+    } else if (/\.(tsx|jsx)$/.test(entry) && !/\.test\.|\.spec\./.test(entry)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function classIsUsed(cls: string, files: string[]): boolean {
+  // Match the class as a standalone token inside a className attribute.
+  // Bound by non-word chars on both sides to avoid e.g. `text-red-700` matching
+  // a hypothetical `border-text-red-700`.
+  const pattern = new RegExp(`(?<![\\w-])${cls}(?![\\w-])`)
+  return files.some(f => pattern.test(readFileSync(f, 'utf-8')))
+}
+
+function darkOverrideExists(cls: string): boolean {
+  // Mirror the regex shape proven in opacity-variants-dark.test.ts: anchor
+  // to `[data-theme='dark']` followed by the class, allowing intermediate
+  // descendant tokens but not crossing a comma (which would scope a
+  // sibling, not this class).
+  const pattern = new RegExp(
+    `\\[data-theme=['"]dark['"]\\]\\s+(?:[^,{]*\\s)?\\.${cls.replace(/[-/]/g, '\\$&')}(?![\\w-])`,
+    'm'
+  )
+  return pattern.test(DARK_MODE_CSS)
+}
+
+describe('Unmitigated color utility guard (#564 Phase 4)', () => {
+  const files = collectComponentFiles(FRONTEND_SRC)
+  const usedClasses = WATCHLIST.filter(cls => classIsUsed(cls, files))
+  const missingOverrides = usedClasses.filter(cls => !darkOverrideExists(cls))
+  const unexpected = missingOverrides.filter(cls => !EXPECTED_FAILURES.has(cls))
+  const stale = [...EXPECTED_FAILURES].filter(
+    cls => !missingOverrides.includes(cls)
+  )
+
+  it('no new watchlist class appears without a dark-mode override', () => {
+    if (unexpected.length > 0) {
+      const msg = [
+        'Watchlist color utilities found in components without a',
+        "`[data-theme='dark']` override in styles/dark-mode.css.",
+        '',
+        'Either add the override (preferred) or, if this is intentional',
+        'tracked debt, add the class to EXPECTED_FAILURES in this file',
+        'with a comment linking the follow-up issue.',
+        '',
+        'Missing overrides:',
+        ...unexpected.map(c => `  - ${c}`),
+      ].join('\n')
+      throw new Error(msg)
+    }
+    expect(unexpected).toEqual([])
+  })
+
+  it('EXPECTED_FAILURES entries reflect real gaps (no stale entries)', () => {
+    if (stale.length > 0) {
+      const msg = [
+        'EXPECTED_FAILURES entries are stale — these classes are either',
+        'no longer used or now have a dark-mode override. Remove from',
+        'EXPECTED_FAILURES to keep the allowlist accurate.',
+        '',
+        'Stale entries:',
+        ...stale.map(c => `  - ${c}`),
+      ].join('\n')
+      throw new Error(msg)
+    }
+    expect(stale).toEqual([])
+  })
+
+  it('watchlist is non-empty (regression on the test itself)', () => {
+    expect(WATCHLIST.length).toBeGreaterThan(20)
+  })
+})

--- a/frontend/src/components/DistrictAnchorToc.tsx
+++ b/frontend/src/components/DistrictAnchorToc.tsx
@@ -63,11 +63,7 @@ export const DistrictAnchorToc: React.FC<DistrictAnchorTocProps> = ({
   if (sections.length === 0) return null
 
   return (
-    <aside
-      className="district-anchor-toc"
-      role="navigation"
-      aria-label="On this page"
-    >
+    <nav className="district-anchor-toc" aria-label="On this page">
       <div className="district-anchor-toc__heading">On this page</div>
       <ul className="district-anchor-toc__list">
         {sections.map(s => {
@@ -85,6 +81,6 @@ export const DistrictAnchorToc: React.FC<DistrictAnchorTocProps> = ({
           )
         })}
       </ul>
-    </aside>
+    </nav>
   )
 }

--- a/frontend/src/components/DistrictKpiStrip.tsx
+++ b/frontend/src/components/DistrictKpiStrip.tsx
@@ -71,11 +71,14 @@ export const DistrictKpiStrip: React.FC<DistrictKpiStripProps> = ({ kpis }) => {
 
   return (
     <section
-      aria-label="District KPI strip"
+      aria-labelledby="district-kpi-strip-heading"
       className={`district-kpi-strip${
         collapsed ? ' district-kpi-strip--collapsed' : ''
       }`}
     >
+      <h2 id="district-kpi-strip-heading" className="sr-only">
+        Key district metrics
+      </h2>
       <button
         type="button"
         onClick={toggle}

--- a/frontend/src/components/__tests__/DistrictKpiStrip.test.tsx
+++ b/frontend/src/components/__tests__/DistrictKpiStrip.test.tsx
@@ -49,7 +49,7 @@ afterEach(() => cleanup())
 describe('DistrictKpiStrip (#572)', () => {
   it('renders the three KPI cards inside a labelled landmark', () => {
     renderStrip(<DistrictKpiStrip kpis={sampleKpis} />)
-    const strip = screen.getByRole('region', { name: /district kpi strip/i })
+    const strip = screen.getByRole('region', { name: /key district metrics/i })
     expect(within(strip).getByText('Paid Clubs')).toBeInTheDocument()
     expect(within(strip).getByText('Membership Payments')).toBeInTheDocument()
     expect(within(strip).getByText('Distinguished Clubs')).toBeInTheDocument()

--- a/tasks/lessons/075-axe-core-jsdom-and-the-allowlist-pattern.md
+++ b/tasks/lessons/075-axe-core-jsdom-and-the-allowlist-pattern.md
@@ -1,0 +1,160 @@
+---
+name: axe-core in JSDOM doesn't catch contrast — pair it with a static allowlist
+description: jest-axe's color-contrast rule is auto-disabled in JSDOM
+  (no canvas → no computed color), so a Phase 4-style "axe scan on a
+  rendered page" catches structural a11y (ARIA, headings, labels) but
+  NOT contrast. Pair it with a static greppy guard that asserts
+  presence of a dark-mode override for every watchlist color utility,
+  and ship the static guard with an allowlist (`EXPECTED_FAILURES`)
+  that future PRs can only SHRINK.
+type: feedback
+---
+
+# Lesson 75 — axe-core in JSDOM + the allowlist-as-tracked-debt pattern
+
+**Date:** 2026-05-22
+**Issue:** #583 (#564 Phase 4 — axe-core regression coverage + lint
+guard for unmitigated utilities)
+
+## What happened
+
+Phase 4 of the contrast audit (parent #564) closes the loop with
+automated regression coverage so future PRs cannot re-introduce the
+classes of contrast bug Phases 1–3 hunted by hand. The temptation
+was to write "one big axe-core test on every page" and call it done.
+Two things made that wrong:
+
+**1. JSDOM can't compute color contrast.** axe-core's
+`color-contrast` rule needs a real layout engine to compute background
+
+- foreground RGB. JSDOM has no canvas, so axe **auto-disables** the
+  rule. A passing `expect(results).toHaveNoViolations()` in vitest is
+  NOT evidence that the page passes WCAG AA contrast — it's evidence
+  that the page passes WCAG AA _except_ contrast. Easy to miss because
+  axe's output doesn't say "skipping color-contrast"; it just omits it
+  from the violations array.
+
+**2. The 53 unmitigated utilities catalogued in #564 are heterogeneous
+debt.** Some are scoped to pages the contrast audit hasn't reached yet
+(Awards, Region pages, ClubDetail, Methodology — Track D of epic #574).
+Phase 4 was explicitly **guard-rail work, not fix work**. Adding
+overrides for all 53 would have ballooned the diff into Tracks D
+12–15, defeating the "one focused sprint per session" rule.
+
+The answer to both: pair an axe scan (catches structural a11y) with a
+static greppy scan (catches the contrast gaps axe can't), and let the
+static scan ship with an `EXPECTED_FAILURES` allowlist that encodes
+current tracked debt. Future PRs may shrink the allowlist as they add
+overrides. PRs may not add to it without explicit acknowledgement —
+the test errors with the list of class names so the author has to
+choose: add the override (preferred) or document why the gap is
+intentional debt.
+
+## How to apply
+
+**Rule:** When testing accessibility under jsdom-based vitest, treat
+axe + static-grep as complementary, not alternatives:
+
+- **axe-core** (jest-axe) — owns the structural rules: ARIA role
+  permissions (`<aside role="navigation">` is a violation),
+  heading-order, labels, landmark uniqueness, focusable controls.
+- **Static greppy test** — owns the rules JSDOM can't compute:
+  presence of a `[data-theme='dark']` override for every color
+  utility that needs one, presence of any opacity-variant override
+  (cf. opacity-variants-dark.test.ts), etc.
+
+Pattern for the static test (`unmitigated-color-utilities.test.ts`):
+
+```ts
+const WATCHLIST = [
+  /* color utilities known to need dark overrides */
+]
+const EXPECTED_FAILURES = new Set<string>([
+  // Each entry is tracked debt with a clear owner sprint.
+  // PRs may shrink. PRs may not grow without removing the test guard.
+])
+
+// Walk .tsx/.jsx, collect usedClasses, find missingOverrides,
+// fail if (missing - allowlist) is non-empty,
+// also fail if allowlist contains entries that are no longer missing
+// (= stale, should be removed).
+```
+
+The two failure modes — "new gap appeared" and "allowlist is stale"
+— together keep the allowlist accurate without manual audits.
+
+**Watch out for:** the static test's regex needs to bound the class
+name on both sides with `(?<![\\w-])` / `(?![\\w-])` to avoid matching
+`text-red-700` inside a hypothetical `border-text-red-700`. Mirror
+the regex shape that opacity-variants-dark.test.ts uses; it's been
+debugged twice already.
+
+## What axe DID catch in JSDOM that the static test couldn't
+
+The new DistrictDetailPage axe scan caught two real structural bugs
+on first run:
+
+- `<aside class="district-anchor-toc" role="navigation">` — `aside`'s
+  implicit role is `complementary`; you can't override to
+  `navigation`. Fix: switch to `<nav>` (which is what the element
+  was _intended_ to be).
+- `<h3>` KPI card titles rendered directly under the page `<h1>` with
+  no intervening `<h2>`. Fix: visually-hidden `<h2>` inside the KPI
+  strip section, plus `aria-labelledby` pointing at it.
+
+Both bugs predate Phase 4 — they were quietly broken since #572
+shipped (sticky KPI bar). The lesson: **axe catches structural drift
+that goes undetected when per-component tests stay focused on
+unit-level rendering.** Page-level axe is worth running even when
+per-component axe coverage is already in place.
+
+## Theme toggle in tests
+
+To run axe in dark mode under vitest, set
+`document.documentElement.setAttribute('data-theme', 'dark')` BEFORE
+the render call, then remove it in `afterEach`. The
+DarkModeContext-driven attribute is the single source of truth for
+the app's dark-mode CSS scope; setting it directly bypasses the
+context plumbing without changing the render output.
+
+```ts
+beforeEach(() => document.documentElement.removeAttribute('data-theme'))
+afterEach(() => document.documentElement.removeAttribute('data-theme'))
+
+it('dark mode', async () => {
+  document.documentElement.setAttribute('data-theme', 'dark')
+  const { container } = renderPage()
+  expect(await axe(container)).toHaveNoViolations()
+})
+```
+
+Per-test attribute hygiene matters: forget the `afterEach` cleanup
+and the next test in the file inherits dark mode silently.
+
+## Telltale signs
+
+- A page renders crisp green axe results under vitest, then ships with
+  visible contrast bugs in production. axe didn't lie — JSDOM just
+  doesn't have what axe needs to compute the contrast check.
+- A PR adds a new `text-red-700` (or any saturated foreground) and CI
+  is silent. Means the static guard's watchlist doesn't cover that
+  utility yet, OR the class already had a dark override and you
+  missed the regression elsewhere.
+- A test claims "tests WCAG 2.1 AA compliance" but contains only
+  jest-axe calls. Without an explicit color-contrast pairing, the
+  claim overstates by ~30% (axe runs ~90 rules; ~30 of them are
+  contrast-related and disabled in JSDOM).
+
+## Related
+
+- Lesson 73 — opacity-variant utilities need explicit dark overrides
+  (sibling pattern; this lesson generalises it to ALL color
+  utilities, not just opacity variants).
+- `frontend/src/__tests__/css-migration/unmitigated-color-utilities.test.ts`
+  — the static greppy guard with allowlist.
+- `frontend/src/__tests__/accessibility/DistrictDetailPage.axe.test.tsx`
+  — page-level axe scan in both themes.
+- `frontend/src/__tests__/css-migration/opacity-variants-dark.test.ts`
+  — the regex pattern this guard mirrors.
+- jest-axe README's "Considerations" section — documents the JSDOM
+  color-contrast limitation officially.


### PR DESCRIPTION
## Summary

Sprint 7 of epic #574 — closes the #564 contrast audit loop with automated regression coverage so future PRs cannot re-introduce the bugs Phases 1–3 hunted by hand.

Closes #583.

### What ships

- **Static guard** (`frontend/src/__tests__/css-migration/unmitigated-color-utilities.test.ts`) — scans `.tsx`/`.jsx` for a watchlist of color utilities `#564` flagged as dark-mode contrast risks (saturated `text-*-{700..900}`, light pastel `border-*-{200,300}`, high-saturation `bg-*-500`, `text-gray-200`, `border-gray-700`). For each class actually in use, asserts a `[data-theme='dark']` override exists in `dark-mode.css`. Ships with `EXPECTED_FAILURES = 9` (residue after Phases 1–3) — PRs may shrink the allowlist, may not grow it.
- **Page-level axe scan** (`frontend/src/__tests__/accessibility/DistrictDetailPage.axe.test.tsx`) — mounts the full `DistrictDetailPage` with hooks mocked to a quiet empty state, runs axe-core in **both** light and dark mode (toggles `[data-theme='dark']` on `documentElement`). Catches structural a11y the static guard can't (ARIA, headings, labels).
- **Two real a11y fixes** the new axe scan caught on first run:
  - `DistrictAnchorToc`: `<aside role="navigation">` → `<nav>` (axe `aria-allowed-role` violation; `<aside>`'s implicit role is `complementary` and can't be overridden).
  - `DistrictKpiStrip`: added a visually-hidden `<h2>` between the page `<h1>` and the `<h3>` KPI card titles (axe `heading-order` violation). Both bugs predate this PR; surfaced because per-component axe coverage missed the page-level composition.
- **Lesson 075** documenting the JSDOM color-contrast limitation + the allowlist-as-tracked-debt pattern.

### Why this design

axe-core's color-contrast rule is **auto-disabled in JSDOM** (no canvas → no computed color). A passing axe test in vitest is NOT evidence of contrast compliance — see lesson 075. The static greppy guard covers the contrast gap by asserting presence-of-override; the axe scan covers everything else. Together they replace the manual audit work `#564` Phases 1–3 did by hand.

`EXPECTED_FAILURES` (9 classes) is tracked debt for Track D sprints 12–15 (Awards, Region pages, ClubDetail, Methodology — each shrinks the list as its page-by-page dark-mode sweep lands).

### What we're NOT doing

- **No fix-the-residual-53.** Per the issue (`#583`), Phase 4 is *guard-rail* work, not *fix* work. Replacing the 9 unmitigated classes belongs in Track D sprints 12–15.
- **No CSS variable refactor.** The opacity-variant + `dark:` Tailwind question raised in lesson 73 / opacity-variants-dark.test.ts line 100 stays deferred; the guard catches the symptom either way.
- **No ESLint rule.** Vitest test stays consistent with how Phases 2 + 3 shipped (`opacity-variants-dark.test.ts`, `small-text-light-mode.test.ts`).

## Test plan

- [x] `npx vitest --run src/__tests__/css-migration/unmitigated-color-utilities.test.ts` — guard passes with current `EXPECTED_FAILURES`.
- [x] `npx vitest --run src/__tests__/accessibility/DistrictDetailPage.axe.test.tsx` — axe scan passes in both themes.
- [x] `npx vitest --run` (full frontend suite) — 2334 passed, zero regressions.
- [ ] After merge: deploy succeeds and `ts.taverns.red` still renders DistrictDetailPage normally (header + KPI strip + anchor TOC). The DOM changes are semantic-only; no visual diff expected.

## Followups (out of scope)

- Track D Sprints 12–15: shrink `EXPECTED_FAILURES` page by page.
- Phase 4½ idea: add the same axe scan to `ClubDetailPage`, `RegionPage`, `AwardsPage` — gated on those pages first getting the Track D sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)