### PR TITLE
refactor: dedupe calculateDistinguishedPercent — shared helper in analytics-core (#547)

### DIFF
--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -217,4 +217,5 @@ export {
   OfficerAwardsCalculator,
   type OfficerAwardResult,
   type OfficerAwardStandings,
+  calculateDistinguishedPercent,
 } from './rankings/index.js'

--- a/packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts
+++ b/packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts
@@ -18,6 +18,7 @@ import type {
 } from '@toastmasters/shared-contracts'
 
 import { getConfirmedDistinguishedLevel } from '../analytics/ClubEligibilityUtils.js'
+import { calculateDistinguishedPercent } from './distinguishedPercent.js'
 
 /**
  * Logger interface for ranking calculator.
@@ -644,8 +645,10 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
           paymentGrowthPercent: this.parsePercentage(
             districtPerformance['% Payment Growth']
           ),
-          distinguishedPercent:
-            this.calculateDistinguishedPercent(districtPerformance),
+          distinguishedPercent: calculateDistinguishedPercent(
+            this.parseNumber(districtPerformance['Total Distinguished Clubs']),
+            this.parseNumber(districtPerformance['Paid Club Base'])
+          ),
           paidClubs: this.parseNumber(districtPerformance['Paid Clubs']),
           paidClubBase: this.parseNumber(districtPerformance['Paid Club Base']),
           totalPayments: this.parseNumber(
@@ -814,33 +817,6 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
       if (chartered && chartered >= programYearStart) count++
     }
     return count
-  }
-
-  /**
-   * Calculate distinguished club percentage from raw data
-   */
-  private calculateDistinguishedPercent(data: AllDistrictsCSVRecord): number {
-    // Per the Distinguished District Program (Item 1490), % Distinguished
-    // is computed against Paid Club Base (PY-start club count), NOT
-    // current Active Clubs. Using activeClubs as the denominator
-    // under-reports the percentage whenever a district has gained clubs
-    // since PY start — which is exactly when recognition matters most.
-    //
-    // When paidClubBase is 0 or missing, return 0 rather than falling
-    // back to activeClubs. A missing base is either a brand-new district
-    // (no clubs at PY start → 0% Distinguished is correct) or a pipeline
-    // schema regression (which we want LOUD, not silently masked by the
-    // old buggy denominator).
-    const distinguishedClubs = this.parseNumber(
-      data['Total Distinguished Clubs']
-    )
-    const paidClubBase = this.parseNumber(data['Paid Club Base'])
-
-    if (paidClubBase === 0) {
-      return 0
-    }
-
-    return (distinguishedClubs / paidClubBase) * 100
   }
 
   /**

--- a/packages/analytics-core/src/rankings/distinguishedPercent.test.ts
+++ b/packages/analytics-core/src/rankings/distinguishedPercent.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { calculateDistinguishedPercent } from './distinguishedPercent.js'
+
+describe('calculateDistinguishedPercent', () => {
+  it('returns 0 when paidClubBase is 0 (new-district / missing-base case)', () => {
+    expect(calculateDistinguishedPercent(0, 0)).toBe(0)
+    expect(calculateDistinguishedPercent(5, 0)).toBe(0)
+  })
+
+  it('D110-shape: typical mid-PY district (e.g. 12 distinguished / 40 base = 30%)', () => {
+    expect(calculateDistinguishedPercent(12, 40)).toBe(30)
+  })
+
+  it('D93-shape: gained clubs since PY start — % rises above naive activeClubs denom', () => {
+    expect(calculateDistinguishedPercent(18, 45)).toBe(40)
+  })
+
+  it('returns 100 when every PY-base club is distinguished', () => {
+    expect(calculateDistinguishedPercent(40, 40)).toBe(100)
+  })
+
+  it('returns 0 when no clubs distinguished yet (pre-April typical)', () => {
+    expect(calculateDistinguishedPercent(0, 40)).toBe(0)
+  })
+
+  it('uses paidClubBase (not activeClubs) as denominator', () => {
+    // The whole point of #545/#547: if a district has 50 active clubs but
+    // PY-start base was 40, recognition is computed against 40.
+    expect(calculateDistinguishedPercent(20, 40)).toBe(50)
+  })
+})

--- a/packages/analytics-core/src/rankings/distinguishedPercent.ts
+++ b/packages/analytics-core/src/rankings/distinguishedPercent.ts
@@ -1,0 +1,23 @@
+/**
+ * Toastmasters International Distinguished District Program (Item 1490)
+ * — % Distinguished is computed against Paid Club Base (PY-start club
+ * count), NOT current Active Clubs. Using activeClubs as the
+ * denominator under-reports the percentage whenever a district has
+ * gained clubs since PY start.
+ *
+ * When paidClubBase is 0, return 0 rather than falling back to
+ * activeClubs. A missing base is either a brand-new district (0% is
+ * correct) or a pipeline schema regression (we want it LOUD, not
+ * silently masked by the old buggy denominator).
+ *
+ * Single source of truth for this formula across the codebase. See
+ * lessons 60 + 61 for the two-copies failure mode that motivated
+ * dedupe (#547).
+ */
+export function calculateDistinguishedPercent(
+  distinguishedClubs: number,
+  paidClubBase: number
+): number {
+  if (paidClubBase === 0) return 0
+  return (distinguishedClubs / paidClubBase) * 100
+}

--- a/packages/analytics-core/src/rankings/index.ts
+++ b/packages/analytics-core/src/rankings/index.ts
@@ -56,3 +56,5 @@ export {
   type OfficerAwardResult,
   type OfficerAwardStandings,
 } from './OfficerAwardsCalculator.js'
+
+export { calculateDistinguishedPercent } from './distinguishedPercent.js'

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -26,6 +26,7 @@ import {
   ClubStrengthAwardCalculator,
   LeadershipExcellenceCalculator,
   OfficerAwardsCalculator,
+  calculateDistinguishedPercent,
   type Logger,
   type RawCSVData,
 } from '@toastmasters/analytics-core'
@@ -659,7 +660,10 @@ export class TransformService {
           paymentGrowthPercent: this.parsePercentage(
             record['% Payment Growth']
           ),
-          distinguishedPercent: this.calculateDistinguishedPercent(record),
+          distinguishedPercent: calculateDistinguishedPercent(
+            this.parseNumber(record['Total Distinguished Clubs']),
+            this.parseNumber(record['Paid Club Base'])
+          ),
           paidClubs: this.parseNumber(record['Paid Clubs']),
           paidClubBase: this.parseNumber(record['Paid Club Base']),
           totalPayments: this.parseNumber(record['Total YTD Payments']),
@@ -777,37 +781,6 @@ export class TransformService {
     }
 
     return 'Unknown validation error'
-  }
-
-  /**
-   * Calculate distinguished club percentage from raw data
-   */
-  private calculateDistinguishedPercent(record: AllDistrictsCSVRecord): number {
-    // Per the Distinguished District Program (Item 1490), % Distinguished
-    // is computed against Paid Club Base (PY-start club count), NOT
-    // current Active Clubs. Using activeClubs as the denominator
-    // under-reports the percentage whenever a district has gained clubs
-    // since PY start — which is exactly when recognition matters most.
-    //
-    // When paidClubBase is 0 or missing, return 0 rather than falling
-    // back to activeClubs. A missing base is either a brand-new district
-    // (no clubs at PY start → 0% Distinguished is correct) or a pipeline
-    // schema regression (which we want LOUD, not silently masked by the
-    // old buggy denominator).
-    //
-    // Mirrors BordaCountRankingCalculator.calculateDistinguishedPercent
-    // in analytics-core (PR #538). Both copies must stay in lockstep
-    // until #547 dedupes them.
-    const distinguishedClubs = this.parseNumber(
-      record['Total Distinguished Clubs']
-    )
-    const paidClubBase = this.parseNumber(record['Paid Club Base'])
-
-    if (paidClubBase === 0) {
-      return 0
-    }
-
-    return (distinguishedClubs / paidClubBase) * 100
   }
 
   /**

--- a/tasks/lessons/076-shared-formula-helper-eliminates-the-two-copies-trap.md
+++ b/tasks/lessons/076-shared-formula-helper-eliminates-the-two-copies-trap.md
@@ -1,0 +1,110 @@
+---
+name: A shared pure-function helper is the right shape for cross-package formulas
+description: When the same formula lives in two packages (analytics-core
+  + collector-cli) and a "fix" only lands in one, prod ships the bug
+  for days despite green CI (lessons 60+61). The structural fix is to
+  extract a pure function in the lower-level package and have both
+  call sites inline-invoke it at the field assignment — not behind a
+  private wrapper method. Wrappers re-introduce the drift surface.
+type: feedback
+---
+
+# Lesson 76 — Shared formula helper eliminates the two-copies trap
+
+**Date:** 2026-05-22
+**Issue:** #547 (Sprint 8 — dedupe `calculateDistinguishedPercent` between
+TransformService + BordaCountRankingCalculator)
+
+## What happened
+
+Lesson 61 captured the failure mode: PR #538 fixed the % Distinguished
+formula in analytics-core's `BordaCountRankingCalculator`, but the same
+formula was independently re-implemented in collector-cli's
+`TransformService`. The CI pipeline runs both, so the second copy
+silently kept producing the buggy value. Prod data carried the bug for
+~5 days despite a green main.
+
+The follow-up issue (#547) proposed two options:
+
+1. Have `TransformService.calculateDistinguishedPercent` **delegate** to
+   the analytics-core implementation
+2. Extract a **shared helper** in analytics-core that both files call
+
+Option 2 won because it puts the formula in the analytics layer where
+it belongs and makes the dependency direction obvious. But the choice
+_inside_ Option 2 still matters: keep each call site's private wrapper
+method (now thin), or inline the helper at the field-assignment site.
+
+**The right move is inline.** A thin wrapper around the shared helper
+re-creates exactly the kind of surface where drift can hide. Today
+it's `return shared(this.parse(a), this.parse(b))`. Tomorrow someone
+"fixes" something locally inside the wrapper before remembering it
+delegates. The wrapper has a name (`calculateDistinguishedPercent`)
+that suggests "this is where the formula lives" — and the next person
+to look believes it. Two copies in one repo are two copies. Inline at
+the call site removes the trap.
+
+## How to apply
+
+**Rule:** when deduping a cross-package formula, do all three:
+
+1. **Extract** as a pure function in the lower-level package, exported
+   from its public barrel.
+2. **Inline** at the call site — `field: sharedHelper(parse(x),
+parse(y))`. Do **not** keep a private wrapper method that calls the
+   shared helper.
+3. **Delete** the mirror-warning comments. They were a workaround for
+   the duplication. With the duplication gone, the comments are a
+   maintenance liability — future readers will edit them, future
+   greps will return them, future PRs will treat them as load-bearing.
+
+**Why:** the wrapper method is shaped like the old duplicated method
+(same name, same signature, same parameter type). It invites the same
+mistakes. Inline calls are syntactically obvious — the dependency on
+the shared helper is visible on the assignment line, so any drift
+attempt is also visible.
+
+**How to apply:** at the end of the refactor, `grep` for the OLD
+private method name (`calculateDistinguishedPercent`) across the
+deduplicated packages. The only hits should be in the new helper's
+file. If there are private methods still wearing that name, they're
+still drift surfaces — inline them.
+
+## What the integration tests already cover (don't add redundant ones)
+
+Two adjacent test files already exercise the call-site path with the
+right denominator:
+
+- `BordaCountRankingCalculator.test.ts:606` — "computes
+  distinguishedPercent against Paid Club Base, not Active Clubs"
+- The transform tests that build a ranking output from a CSV record
+
+A transposed-args regression (`calc(paidClubBase,
+distinguishedClubs)`) would be caught there immediately. So the new
+`distinguishedPercent.test.ts` only needs to assert the formula
+itself, not the call-site wiring. Adding a "test that the call site
+calls the helper" is double-entry bookkeeping; the integration tests
+ARE that test.
+
+## Telltale signs
+
+- The same field name (e.g. `distinguishedPercent`) is assigned in two
+  files in two packages, each computing the same thing from raw CSV
+  fields. `grep -rn "fieldName:" packages/` is the audit.
+- A bug fix lands in one package, CI is green, and a production smoke
+  test surfaces the bug a few days later. The pipeline has a second
+  copy of the rule the fix missed.
+- A private method on a service has a comment that ends with "must
+  stay in lockstep with [other class]." The lockstep comment is the
+  smell — the lockstep itself is the bug.
+
+## Related
+
+- Lesson 60 — % Distinguished must use `Paid Club Base`, not
+  `Active Clubs` (the formula spec)
+- Lesson 61 — "fix the formula everywhere, not just the one in the bug
+  report" (the two-copies failure mode that motivated #547)
+- `packages/analytics-core/src/rankings/distinguishedPercent.ts` — the
+  shared helper, exported from `@toastmasters/analytics-core`
+- `packages/analytics-core/src/rankings/distinguishedPercent.test.ts`
+  — formula unit tests (6 cases covering D93 + D110 shapes)


### PR DESCRIPTION
## Summary
- Extracts `calculateDistinguishedPercent(distinguishedClubs, paidClubBase)` as a pure helper in `@toastmasters/analytics-core` (the issue's preferred Option 2).
- Both prior call sites (`BordaCountRankingCalculator` + `TransformService`) now invoke the shared helper directly. The two private wrapper methods and their "must stay in lockstep" mirror-warning comments are gone.
- Adds 6 focused unit tests covering the D93/D110 shapes (gained-clubs district, typical mid-PY, all-distinguished, pre-April 0-numerator, paidClubBase=0 fallback).

Closes #547.

## Acceptance criteria (from issue)
- [x] One implementation of the formula in tracked source — `packages/analytics-core/src/rankings/distinguishedPercent.ts`
- [x] Both call sites use that single helper
- [x] Test in analytics-core covers D93 + D110 fixture shapes — `distinguishedPercent.test.ts`
- [x] Inline mirror-warning comments removed from both call sites

## Why this matters
Lesson 61 documented the failure mode: PR #538 fixed only the analytics-core copy, so prod data carried the buggy value for ~5 days despite green CI. The two-copies trap is now structurally impossible.

Existing integration coverage remains intact — `BordaCountRankingCalculator.test.ts:606` ("computes distinguishedPercent against Paid Club Base, not Active Clubs") would catch any transposed-args regression at the call site.

## Test plan
- [x] `npm run test` — 230 test files / 3961 tests pass
- [x] `npm run typecheck` — green across all 4 workspaces
- [x] No regressions in `BordaCountRankingCalculator` / `TransformService` ranking tests
- [ ] Verify on https://ts.taverns.red after deploy — D93 and D110 distinguishedPercent values unchanged (this is a pure refactor; identical formula)

🤖 Generated with [Claude Code](https://claude.com/claude-code)