### PR TITLE
refactor: extract <DistrictChipAndName> (#522)

### DIFF
--- a/frontend/src/components/AppShell/CommandPalette.tsx
+++ b/frontend/src/components/AppShell/CommandPalette.tsx
@@ -13,6 +13,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { fetchCdnRankings } from '../../services/cdn'
 import type { DistrictRanking } from '../../types/districts'
+import { DistrictChipAndName } from '../DistrictChipAndName'
 
 const MAX_RESULTS = 8
 
@@ -180,12 +181,12 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
                   onClick={onClose}
                   className="command-palette__result-link"
                 >
-                  <span className="command-palette__result-num">
-                    D{m.districtId}
-                  </span>
-                  <span className="command-palette__result-name">
-                    {m.districtName}
-                  </span>
+                  <DistrictChipAndName
+                    districtId={m.districtId}
+                    name={m.districtName}
+                    chipClassName="command-palette__result-num"
+                    nameClassName="command-palette__result-name"
+                  />
                   <span className="command-palette__result-region">
                     Region {m.region}
                   </span>

--- a/frontend/src/components/AppShell/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/CommandPalette.test.tsx
@@ -115,4 +115,41 @@ describe('CommandPalette (#422)', () => {
     expect(links[0]?.getAttribute('href')).toBe('/district/57')
     expect(links[1]?.getAttribute('href')).toBe('/district/61')
   })
+
+  it('does not duplicate the district number when districtName is bare (#522)', async () => {
+    const { fetchCdnRankings } = await import('../../../services/cdn')
+    vi.mocked(fetchCdnRankings).mockResolvedValueOnce({
+      rankings: [
+        {
+          districtId: '86',
+          districtName: '86',
+          region: '6',
+          paidClubs: 100,
+          paidClubBase: 90,
+          clubGrowthPercent: 11.1,
+          totalPayments: 5000,
+          paymentBase: 4500,
+          paymentGrowthPercent: 11.1,
+          activeClubs: 100,
+          distinguishedClubs: 50,
+          selectDistinguished: 20,
+          presidentsDistinguished: 10,
+          distinguishedPercent: 50,
+          clubsRank: 1,
+          paymentsRank: 1,
+          distinguishedRank: 1,
+          aggregateScore: 300,
+          overallRank: 1,
+        },
+      ],
+      date: '2025-11-22',
+    })
+    renderPalette(true)
+
+    const listbox = await screen.findByRole('listbox', {
+      name: /search results/i,
+    })
+    expect(within(listbox).getByText('D86')).toBeInTheDocument()
+    expect(within(listbox).queryByText(/^86$/)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/DistrictChipAndName.tsx
+++ b/frontend/src/components/DistrictChipAndName.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { hasDescriptiveName } from '../utils/districtName'
+
+interface DistrictChipAndNameProps {
+  districtId: string
+  name?: string
+  chipClassName?: string
+  nameClassName?: string
+  ariaHidden?: boolean
+  testId?: string
+}
+
+const DEFAULT_CHIP_CLASS = 'districts-rankings-table__district-chip'
+const DEFAULT_NAME_CLASS = 'ml-3 text-sm font-medium text-gray-900'
+
+export const DistrictChipAndName: React.FC<DistrictChipAndNameProps> = ({
+  districtId,
+  name,
+  chipClassName,
+  nameClassName,
+  ariaHidden,
+  testId,
+}) => (
+  <>
+    <span
+      data-testid={testId ?? `district-number-chip-D${districtId}`}
+      className={chipClassName ?? DEFAULT_CHIP_CLASS}
+      aria-hidden={ariaHidden ? 'true' : undefined}
+    >
+      D{districtId}
+    </span>
+    {hasDescriptiveName(name) && (
+      <span className={nameClassName ?? DEFAULT_NAME_CLASS}>{name}</span>
+    )}
+  </>
+)

--- a/frontend/src/components/__tests__/DistrictChipAndName.test.tsx
+++ b/frontend/src/components/__tests__/DistrictChipAndName.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DistrictChipAndName } from '../DistrictChipAndName'
+
+describe('DistrictChipAndName', () => {
+  it('renders the D{id} chip', () => {
+    render(<DistrictChipAndName districtId="86" />)
+    expect(screen.getByText('D86')).toBeInTheDocument()
+  })
+
+  it('does NOT render the name when name is the bare district number', () => {
+    render(<DistrictChipAndName districtId="86" name="86" />)
+    expect(screen.getByText('D86')).toBeInTheDocument()
+    expect(screen.queryByText('86')).not.toBeInTheDocument()
+  })
+
+  it('renders the name when descriptive', () => {
+    render(<DistrictChipAndName districtId="57" name="District 57 Carolinas" />)
+    expect(screen.getByText('D57')).toBeInTheDocument()
+    expect(screen.getByText('District 57 Carolinas')).toBeInTheDocument()
+  })
+
+  it('omits the name span when name is undefined', () => {
+    const { container } = render(<DistrictChipAndName districtId="110" />)
+    expect(screen.getByText('D110')).toBeInTheDocument()
+    expect(container.querySelectorAll('span')).toHaveLength(1)
+  })
+
+  it('omits the name span when name is whitespace-wrapped bare number', () => {
+    render(<DistrictChipAndName districtId="57" name="  57  " />)
+    expect(screen.queryByText(/57\s*$/)).not.toBeInTheDocument()
+    expect(screen.getByText('D57')).toBeInTheDocument()
+  })
+
+  it('uses provided chipClassName and nameClassName', () => {
+    const { container } = render(
+      <DistrictChipAndName
+        districtId="86"
+        name="District 86 Ontario"
+        chipClassName="custom-chip"
+        nameClassName="custom-name"
+      />
+    )
+    expect(container.querySelector('.custom-chip')).toHaveTextContent('D86')
+    expect(container.querySelector('.custom-name')).toHaveTextContent(
+      'District 86 Ontario'
+    )
+  })
+
+  it('sets aria-hidden on the chip when requested', () => {
+    render(<DistrictChipAndName districtId="86" ariaHidden />)
+    expect(screen.getByText('D86')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('exposes a default data-testid', () => {
+    render(<DistrictChipAndName districtId="86" />)
+    expect(screen.getByTestId('district-number-chip-D86')).toHaveTextContent(
+      'D86'
+    )
+  })
+})

--- a/frontend/src/components/__tests__/DistrictChipAndName.test.tsx
+++ b/frontend/src/components/__tests__/DistrictChipAndName.test.tsx
@@ -27,9 +27,11 @@ describe('DistrictChipAndName', () => {
   })
 
   it('omits the name span when name is whitespace-wrapped bare number', () => {
-    render(<DistrictChipAndName districtId="57" name="  57  " />)
-    expect(screen.queryByText(/57\s*$/)).not.toBeInTheDocument()
+    const { container } = render(
+      <DistrictChipAndName districtId="57" name="  57  " />
+    )
     expect(screen.getByText('D57')).toBeInTheDocument()
+    expect(container.querySelectorAll('span')).toHaveLength(1)
   })
 
   it('uses provided chipClassName and nameClassName', () => {

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -14,6 +14,7 @@ import { DataControlsBar } from '../components/DataControlsBar'
 import { useRankHistory } from '../hooks/useRankHistory'
 import InfoTooltip from '../components/InfoTooltip'
 import DistrictTierChip from '../components/DistrictTierChip'
+import { DistrictChipAndName } from '../components/DistrictChipAndName'
 import { useMyDistrict } from '../hooks/useMyDistrict'
 import { usePersistedState } from '../hooks/usePersistedState'
 import { useLastVisit } from '../hooks/useLastVisit'
@@ -25,12 +26,6 @@ import {
 } from '../utils/programYear'
 import { DistrictRanking } from '../types/districts'
 import { arrayToCSV, downloadCSV } from '../utils/csvExport'
-
-/** A descriptive name is anything beyond the bare district number — e.g.
- *  "District 57 Carolinas" but not "57". The D## chip already conveys
- *  the number, so showing it again is duplication. */
-const hasDescriptiveName = (name: string | undefined): boolean =>
-  !!name && !/^\d+$/.test(name.trim())
 
 const DistrictsPage: React.FC = () => {
   const navigate = useNavigate()
@@ -903,12 +898,12 @@ const DistrictsPage: React.FC = () => {
                     aria-selected={false}
                     className="districts-toolbar__search-suggestion"
                   >
-                    <span className="districts-toolbar__search-suggestion-num">
-                      D{s.districtId}
-                    </span>
-                    <span className="districts-toolbar__search-suggestion-name">
-                      {s.districtName}
-                    </span>
+                    <DistrictChipAndName
+                      districtId={s.districtId}
+                      name={s.districtName}
+                      chipClassName="districts-toolbar__search-suggestion-num"
+                      nameClassName="districts-toolbar__search-suggestion-name"
+                    />
                     <span className="districts-toolbar__search-suggestion-rank">
                       #{s.displayRank}
                     </span>
@@ -1063,23 +1058,12 @@ const DistrictsPage: React.FC = () => {
                               />
                             </svg>
                           </button>
-                          <span
-                            data-testid={`district-number-chip-D${district.districtId}`}
-                            className="districts-rankings-table__district-chip"
-                            aria-hidden="true"
-                          >
-                            D{district.districtId}
-                          </span>
-                          {/* TI's CSV districtName is just the number ("86"
-                              for D86), which the chip already shows. Only
-                              render the name span when it carries
-                              additional information (e.g. "District 57
-                              Carolinas"). */}
-                          {hasDescriptiveName(district.districtName) && (
-                            <span className="text-sm font-medium text-gray-900">
-                              {district.districtName}
-                            </span>
-                          )}
+                          <DistrictChipAndName
+                            districtId={district.districtId}
+                            name={district.districtName}
+                            nameClassName="text-sm font-medium text-gray-900"
+                            ariaHidden
+                          />
                           {/* Competitive award winner badges (#331) */}
                           {competitiveAwards?.byDistrict?.[district.districtId]
                             ?.extensionIsWinner && (

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -17,6 +17,7 @@ import {
   getDistinguishedCountdown,
   type CountdownCell,
 } from '../utils/distinguishedCountdown'
+import { DistrictChipAndName } from '../components/DistrictChipAndName'
 
 interface KpiCardProps {
   label: string
@@ -387,16 +388,11 @@ const RegionPage: React.FC = () => {
                       )}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <span
-                        data-testid={`district-number-chip-D${d.districtId}`}
-                        className="districts-rankings-table__district-chip"
-                        aria-hidden="true"
-                      >
-                        D{d.districtId}
-                      </span>
-                      <span className="ml-3 text-sm font-medium text-gray-900">
-                        {d.districtName}
-                      </span>
+                      <DistrictChipAndName
+                        districtId={d.districtId}
+                        name={d.districtName}
+                        ariaHidden
+                      />
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                       #{d.overallRank}

--- a/frontend/src/pages/__tests__/DistrictsPage.search.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.search.test.tsx
@@ -296,4 +296,32 @@ describe('DistrictsPage - District Search (#91)', () => {
     )
     expect(rankOneInSticky).toBeUndefined()
   })
+
+  it('search suggestions do not duplicate bare-numeric districtName (#522)', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        {
+          ...MOCK_RANKINGS[0]!,
+          districtId: '86',
+          districtName: '86',
+          region: '6',
+        },
+      ],
+      date: '2025-11-22',
+      generatedAt: '2025-01-01T00:00:00Z',
+    })
+    renderWithProviders(<DistrictsPage />)
+
+    await screen.findByTestId('district-number-chip-D86')
+    const searchInput = screen.getByPlaceholderText(/search/i)
+    fireEvent.focus(searchInput)
+    fireEvent.change(searchInput, { target: { value: '86' } })
+
+    const suggestions = await screen.findByRole('listbox', {
+      name: /district search suggestions/i,
+    })
+    expect(within(suggestions).getByText('D86')).toBeInTheDocument()
+    // Bare "86" should NOT render as a sibling — the chip already conveys it.
+    expect(within(suggestions).queryByText(/^86$/)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -597,4 +597,28 @@ describe('RegionPage rank-within-region column (#515 #513)', () => {
       within(rows[2]!).getByTestId('region-rank-cell').textContent
     ).toMatch(/#1.*tied/i)
   })
+
+  it('does not duplicate the district number when districtName is bare (#522)', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({
+          districtId: '86',
+          districtName: '86',
+          region: '6',
+          overallRank: 5,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('6')
+
+    const rows = await screen.findAllByRole('row')
+    const districtCell = within(rows[1]!).getByTestId(
+      'district-number-chip-D86'
+    )
+    expect(districtCell).toHaveTextContent('D86')
+    // The bare "86" name should NOT render as a sibling span — the chip
+    // already conveys the number.
+    expect(within(rows[1]!).queryByText(/^86$/)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/utils/__tests__/districtName.test.ts
+++ b/frontend/src/utils/__tests__/districtName.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { hasDescriptiveName } from '../districtName'
+
+describe('hasDescriptiveName', () => {
+  it('returns false for undefined', () => {
+    expect(hasDescriptiveName(undefined)).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(hasDescriptiveName('')).toBe(false)
+  })
+
+  it('returns false for a bare district number (TI CSV default)', () => {
+    expect(hasDescriptiveName('86')).toBe(false)
+    expect(hasDescriptiveName('110')).toBe(false)
+  })
+
+  it('returns false for whitespace-wrapped bare number', () => {
+    expect(hasDescriptiveName('  57  ')).toBe(false)
+  })
+
+  it('returns true for a descriptive district name', () => {
+    expect(hasDescriptiveName('District 57 Carolinas')).toBe(true)
+    expect(hasDescriptiveName('Greater Toronto')).toBe(true)
+  })
+
+  it('returns true for any non-numeric content', () => {
+    expect(hasDescriptiveName('D86')).toBe(true)
+  })
+})

--- a/frontend/src/utils/districtName.ts
+++ b/frontend/src/utils/districtName.ts
@@ -1,0 +1,8 @@
+/**
+ * A descriptive district name is anything beyond the bare district number
+ * (e.g. "District 57 Carolinas" but not "57"). The Toastmasters CSV exports
+ * frequently set `districtName` to the bare ID, which the `D{id}` chip
+ * already conveys — so we suppress the name in that case.
+ */
+export const hasDescriptiveName = (name: string | undefined): boolean =>
+  !!name && !/^\d+$/.test(name.trim())

--- a/tasks/lessons/077-presentational-extraction-override-classes-not-variants.md
+++ b/tasks/lessons/077-presentational-extraction-override-classes-not-variants.md
@@ -1,0 +1,127 @@
+---
+name: When extracting a shared presentational component used in visually-divergent surfaces, override className via props — don't introduce a variant taxonomy
+description: Three call sites rendering `D{id}` + optional district name
+  each had their own CSS class for the chip (rankings-table chip pill,
+  toolbar suggestion text, command-palette result text). The temptation
+  during extraction is to invent a `variant='pill'|'inline'` prop and
+  pick the visual treatment in the component. Don't — that bakes a
+  design vocabulary into a refactor PR. Accept `chipClassName` /
+  `nameClassName` overrides with sensible defaults; each call site
+  passes its existing class string. The logic ("show chip; show name
+  only when descriptive") unifies, the visuals stay byte-identical,
+  and the PR diff stays a refactor instead of becoming a design change.
+type: feedback
+---
+
+# Lesson 77 — Presentational extraction: override classes, don't invent variants
+
+**Date:** 2026-05-22
+**Issue:** #522 (extract `<DistrictChipAndName>` reusable component)
+
+## What happened
+
+#520 fixed a bug where `DistrictsPage` rendered `D86` followed by a
+bare `86` (TI CSVs set `districtName === districtId` for many
+districts; the chip already conveys the number). #522 was the
+follow-up to remove the same latent bug from two more places:
+
+- `RegionPage` district table
+- `DistrictsPage` search-suggestion dropdown
+- `CommandPalette` results
+
+All three render `D{id}` + name, but each surface styles its chip
+differently:
+
+| Site                       | Chip CSS class                              | Visual                             |
+| -------------------------- | ------------------------------------------- | ---------------------------------- |
+| Rankings table row         | `.districts-rankings-table__district-chip`  | Full pill with border + background |
+| Search suggestion dropdown | `.districts-toolbar__search-suggestion-num` | Bold colored text only             |
+| Command palette result     | `.command-palette__result-num`              | Bold colored text only             |
+
+The temptation was to introduce a `variant: 'pill' | 'inline'` prop
+and let the component pick the right CSS internally. **That's a
+design decision dressed up as a refactor.** A `variant` taxonomy
+freezes a vocabulary you don't yet know is right — "pill" vs
+"inline" might not survive the next surface (e.g. an upcoming
+sidebar widget might want neither). It also _hides_ the per-site
+CSS, so future readers can't tell what styles each surface uses
+without diving into the component.
+
+The simpler shape: `chipClassName?: string` and
+`nameClassName?: string` props, with sensible defaults for the
+canonical (rankings-table) usage. Each call site passes its existing
+class string. Visuals stay byte-identical, and the visible diff at
+each call site is a 1:1 replacement.
+
+## How to apply
+
+**Rule:** when a presentational component lives in N visually-distinct
+surfaces, accept className overrides as props, not a variant enum:
+
+```tsx
+<DistrictChipAndName
+  districtId={s.districtId}
+  name={s.districtName}
+  chipClassName="districts-toolbar__search-suggestion-num" // ← site's own class
+  nameClassName="districts-toolbar__search-suggestion-name"
+/>
+```
+
+Reach for `variant` only when:
+
+1. There are ≥3 surfaces, AND
+2. The visual treatments fall into a small fixed taxonomy already
+   named elsewhere in the codebase (e.g. button variants), AND
+3. The taxonomy is unlikely to grow.
+
+Until then, the className-prop shape keeps the refactor's blast
+radius small. The next refactor PR can introduce a `variant` enum
+once the right groupings are obvious from repeated patterns — not
+guessed in advance.
+
+## Why
+
+- **Refactor PRs should not change visuals.** A variant enum forces
+  a design decision (which sites are "pill"? which are "inline"?
+  what about hybrids?). className overrides preserve the existing
+  visual exactly.
+- **Visibility.** With class overrides, every call site shows its
+  own class in the JSX. With a variant prop, you have to jump into
+  the component to learn what `variant="inline"` means.
+- **Reversibility.** Adding a `variant` later is easy when the
+  surfaces are already known. Removing it after callers depend on
+  it is harder.
+
+## Telltale signs the variant taxonomy is the wrong shape
+
+- The variant names ("pill" / "inline" / "compact") describe visuals,
+  not roles. Role-shaped names ("primary" / "secondary" / "destructive")
+  are usually fine; visual-shaped names usually fight reality.
+- You're adding a variant in the same PR that introduces the
+  component. Wait for the second consumer to ask for the variant
+  before defining it.
+- The component file grows a `switch (variant)` for class selection.
+  That's the smell — the component now owns design decisions.
+
+## What "default class" means here
+
+`DistrictChipAndName` defaults to:
+
+- `chipClassName ?? 'districts-rankings-table__district-chip'`
+- `nameClassName ?? 'ml-3 text-sm font-medium text-gray-900'`
+
+These defaults are the **canonical** use (the rankings table — the
+most common, most chrome-heavy site). New consumers that fit the
+canonical shape can omit both props. Consumers with their own
+treatment pass both. There is no "no chip class" fallback because
+every consumer wants _some_ class on the chip.
+
+## Related
+
+- `frontend/src/components/DistrictChipAndName.tsx` — the component.
+- `frontend/src/utils/districtName.ts` — the `hasDescriptiveName`
+  helper, extracted at the same time so the suppression rule has
+  a single home.
+- #520 — the original bug fix (DistrictsPage main table only).
+- Lesson 71 — "right-sized audit scope" sibling pattern. Same
+  discipline applied to a contrast audit.


### PR DESCRIPTION
## Summary

- Extracts `<DistrictChipAndName>` so the `D{id}` chip + optional descriptive-name rendering lives in one place. Closes #522.
- Replaces 4 call sites that previously inlined the chip+name pattern: `RegionPage` district table, `DistrictsPage` search suggestions, `DistrictsPage` main rankings table, and `AppShell/CommandPalette`.
- Moves `hasDescriptiveName` from `DistrictsPage.tsx` to `frontend/src/utils/districtName.ts` so the suppression rule (TI CSVs set `districtName === districtId` for many districts; the chip already conveys the number) has one home.

The new component accepts `chipClassName` / `nameClassName` props with sensible defaults so each call site preserves its existing visual treatment (rankings-table pill, toolbar suggestion, command-palette text). Lesson 077 captures why a class-override shape is preferable to a `variant` enum on a refactor PR.

## What this fixes

Before this PR, `RegionPage`, the search-suggestion dropdown, and `CommandPalette` would render `D86 86` for districts whose `districtName` is the bare district number — the same latent bug #520 fixed for the rankings table.

## Test plan

- [x] `npm run test:frontend` — 2351/2351 passing locally
- [x] New regression tests for each call site assert no bare-numeric `86` renders next to the `D86` chip
- [x] `npm run pre-commit` — clean (typecheck + lint, warnings only)
- [ ] CI green
- [ ] Manual smoke on PR preview: search dropdown on `/districts`, command palette (⌘K), district list on `/region/6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)