### PR TITLE
chore(automation): sprint-runner — session self-verifies + closes sub-issue (#591)

### DIFF
--- a/scripts/sprint-bootstrap.prompt
+++ b/scripts/sprint-bootstrap.prompt
@@ -17,7 +17,17 @@ Do these steps in order, and stop if any check fails:
 
 4. **Run the sprint skill** for the target: invoke `/sprint` with issue `#{{TARGET_ISSUE}}` as the input. Follow the sprint skill's full workflow (Red / Green / Refactor / Verify per CLAUDE.md), including filing the PR and watching CI.
 
-5. **Stop short of closing the sub-issue.** The runner gates on sub-issue closure as the live-verification signal. Closing the sub-issue is the operator's call after they verify the change on ts.taverns.red. Leave a comment on the sub-issue summarising what shipped and what to verify, then stop.
+5. **Run live verification on `ts.taverns.red`, then close the sub-issue on pass.** Once the PR is merged and the deploy job is green, drive the actual change in production — not just a curl. Pattern proven on #444:
+
+   - Write a temporary Playwright smoke at `frontend/e2e/<feature>-verify.smoke.ts`, run with `BASE_URL=https://ts.taverns.red npx playwright test --config playwright.config.ts e2e/<feature>-verify.smoke.ts --workers=1`, then delete the file (no PR churn).
+   - Corroborate with a data-path check (fetch the prod CDN snapshot under `https://cdn.taverns.red/snapshots/<date>/`, decompress if gzipped, assert the new field/value lands).
+   - Capture full-page screenshots into `/tmp/` and surface them via `SendUserFile` so the operator sees the evidence.
+
+   **If every acceptance criterion verifies:** close the sub-issue with a comment containing the evidence table (selectors, counts, screenshot paths), then edit the epic body to tick the Sprint N checkbox. The runner's existing `PREV_STATE == CLOSED` gate will pick up the next sprint on the next tick.
+
+   **If any criterion fails:** leave the sub-issue open, post the failure evidence as a comment, and stop. Do not retry — the operator decides whether to re-launch, revert, or hand-fix.
+
+   Stop after either of those branches.
 
 Operating constraints:
 - This session has full local tool access (`gh`, `gcloud`, `supabase`, project skills). Don't try to delegate to a cloud agent — it would lack these.

--- a/scripts/sprint-runner.sh
+++ b/scripts/sprint-runner.sh
@@ -2,9 +2,15 @@
 # scripts/sprint-runner.sh — cron-driven sprint runner for epic #574 (#575).
 #
 # Reads the checklist in GitHub issue #574, finds the first unchecked
-# Sprint N, and — if Sprint N-1's sub-issue is CLOSED (the manifesto's
-# live-verification gate) — launches a fresh `claude --remote-control`
-# session inside a detached `screen` to execute /sprint for that sprint.
+# Sprint N, and — if Sprint N-1's sub-issue is CLOSED — launches a
+# fresh `claude --remote-control` session inside a detached `screen`
+# to execute /sprint for that sprint.
+#
+# The PREV_STATE == CLOSED gate is the handshake between sessions: it
+# now means "the previous session self-verified on ts.taverns.red and
+# closed its sub-issue" (per sprint-bootstrap.prompt step 5), NOT
+# "operator manually verified." Operator still reopens if a close was
+# premature.
 #
 # Usage:
 #   scripts/sprint-runner.sh             # normal run


### PR DESCRIPTION
## Summary

- Step 5 of `scripts/sprint-bootstrap.prompt` now requires the session to drive the actual change in production (Playwright smoke against `ts.taverns.red` + CDN snapshot corroboration + screenshots) and close the sub-issue on pass — replacing the previous "stop short, operator closes" model.
- `scripts/sprint-runner.sh` header comment refreshed to document the new semantic of the `PREV_STATE == CLOSED` gate ("previous session self-verified," not "operator manually verified"). Script logic unchanged.
- Closes #591.

## Why

Sprint 16 (#444) demonstrated that a session can do live verification more rigorously than a quick operator smoke: headless Chromium hitting real prod, snapshot-data corroboration, full-page screenshots, computed expected values vs. observed counts. Operator-gated closes were adding ~12h of latency between sprint completion and the next launch without adding rigor. The runner's gate semantics stay identical (the operator still reopens if a close was premature).

## Test plan

- [x] `bash -n scripts/sprint-runner.sh` — syntax ok
- [x] `./scripts/sprint-runner.sh --dry-run` — still parses epic body, still respects the existing session lock (this very session)
- [ ] Operator reads the new step 5 and confirms the verification protocol matches what they want sessions to do
- [ ] Next sprint launch (post-merge) follows the new protocol end-to-end and closes its own sub-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)