### PR TITLE
feat(district): #449 longest-serving clubs leaderboard

### DIFF
--- a/frontend/src/components/LongestServingClubsLeaderboard.tsx
+++ b/frontend/src/components/LongestServingClubsLeaderboard.tsx
@@ -1,0 +1,147 @@
+import React, { useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import type { ClubTrend } from '../hooks/useDistrictAnalytics'
+import { getClubAnniversary } from '../utils/clubAnniversary'
+
+/* LongestServingClubsLeaderboard (#449) — district-scoped Top-N list of
+   the clubs with the most years since charter. Sibling to the existing
+   Notable Dates surfaces; same `ClubTrend.charterDate` data source.
+   Sort: years desc, ties broken alphabetically by clubName. */
+
+const DEFAULT_LIMIT = 10
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+
+export interface LongestServingClubsLeaderboardProps {
+  clubs: ClubTrend[]
+  districtId?: string
+  limit?: number
+  referenceDate?: Date
+}
+
+interface Row {
+  club: ClubTrend
+  years: number
+  charterLabel: string
+}
+
+const parseCharter = (input: string): Date | null => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(input)
+  if (!match) return null
+  const y = Number(match[1])
+  const m = Number(match[2]) - 1
+  const d = Number(match[3])
+  if (m < 0 || m > 11 || d < 1 || d > 31) return null
+  return new Date(Date.UTC(y, m, d))
+}
+
+const formatCharter = (charter: Date): string =>
+  `${MONTHS[charter.getUTCMonth()]} ${charter.getUTCFullYear()}`
+
+const buildRows = (clubs: ClubTrend[], referenceDate?: Date): Row[] => {
+  const rows: Row[] = []
+  for (const club of clubs) {
+    if (!club.charterDate) continue
+    const anniversary = getClubAnniversary(club.charterDate, referenceDate)
+    if (!anniversary) continue
+    const charter = parseCharter(club.charterDate)
+    if (!charter) continue
+    rows.push({
+      club,
+      years: anniversary.years,
+      charterLabel: formatCharter(charter),
+    })
+  }
+  rows.sort((a, b) => {
+    if (b.years !== a.years) return b.years - a.years
+    return a.club.clubName.localeCompare(b.club.clubName)
+  })
+  return rows
+}
+
+export const LongestServingClubsLeaderboard: React.FC<
+  LongestServingClubsLeaderboardProps
+> = ({ clubs, districtId, limit = DEFAULT_LIMIT, referenceDate }) => {
+  const rows = useMemo(
+    () => buildRows(clubs, referenceDate).slice(0, limit),
+    [clubs, referenceDate, limit]
+  )
+
+  if (rows.length === 0) {
+    return (
+      <section
+        aria-labelledby="longest-serving-heading"
+        className="redesign-panel"
+      >
+        <h3 id="longest-serving-heading" className="redesign-panel__header">
+          Longest-serving clubs
+        </h3>
+        <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+          No charter data yet for this district.
+        </p>
+      </section>
+    )
+  }
+
+  const clubHref = (clubId: string) =>
+    `/club/${clubId}${districtId ? `?district=${districtId}` : ''}`
+
+  return (
+    <section
+      aria-labelledby="longest-serving-heading"
+      className="redesign-panel"
+    >
+      <div className="flex items-baseline justify-between gap-2 mb-2">
+        <h3
+          id="longest-serving-heading"
+          className="redesign-panel__header !mb-0"
+        >
+          Longest-serving clubs
+        </h3>
+        <span className="text-[11px] uppercase tracking-wider text-gray-600 dark:text-gray-400 font-tm-body">
+          Top {rows.length}
+        </span>
+      </div>
+      <ol className="divide-y divide-gray-100 dark:divide-gray-800 -mx-1">
+        {rows.map((row, i) => (
+          <li
+            key={row.club.clubId}
+            data-testid="longest-serving-row"
+            className="flex items-baseline gap-3 px-2 py-1.5 text-sm font-tm-body"
+          >
+            <span className="w-6 shrink-0 tabular-nums text-xs font-bold text-tm-true-maroon">
+              #{i + 1}
+            </span>
+            <Link
+              to={clubHref(row.club.clubId)}
+              className="flex-1 min-w-0 truncate text-tm-loyal-blue hover:underline"
+            >
+              {row.club.clubName}
+            </Link>
+            <span className="shrink-0 tabular-nums text-xs font-semibold text-gray-700 dark:text-gray-200">
+              {row.years}y
+            </span>
+            <span className="shrink-0 tabular-nums text-[11px] text-gray-600 dark:text-gray-400">
+              {row.charterLabel}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}
+
+export default LongestServingClubsLeaderboard

--- a/frontend/src/components/__tests__/LongestServingClubsLeaderboard.test.tsx
+++ b/frontend/src/components/__tests__/LongestServingClubsLeaderboard.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import '@testing-library/jest-dom'
+import { LongestServingClubsLeaderboard } from '../LongestServingClubsLeaderboard'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+/* Red tests for #449. The leaderboard ranks clubs in a district by years
+   chartered (descending), defaults to top 10, and links each row to the
+   club detail page. Reference date is pinned for deterministic years. */
+
+afterEach(() => cleanup())
+
+const REF_DATE = new Date(Date.UTC(2026, 4, 22)) // 2026-05-22
+
+const mkClub = (overrides: Partial<ClubTrend>): ClubTrend => ({
+  clubId: '0',
+  clubName: 'Test Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '01',
+  areaName: 'Area 01',
+  membershipTrend: [],
+  dcpGoalsTrend: [],
+  currentStatus: 'thriving',
+  riskFactors: [],
+  distinguishedLevel: 'NotDistinguished',
+  ...overrides,
+})
+
+const renderBoard = (
+  clubs: ClubTrend[],
+  props: Partial<{
+    districtId: string
+    limit: number
+    referenceDate: Date
+  }> = {}
+) =>
+  render(
+    <MemoryRouter>
+      <LongestServingClubsLeaderboard
+        clubs={clubs}
+        districtId={props.districtId ?? '61'}
+        referenceDate={props.referenceDate ?? REF_DATE}
+        {...(props.limit !== undefined && { limit: props.limit })}
+      />
+    </MemoryRouter>
+  )
+
+describe('LongestServingClubsLeaderboard (#449)', () => {
+  it('renders an empty state when no clubs have a charter date', () => {
+    const clubs = [
+      mkClub({ clubId: '1', clubName: 'No Charter A' }),
+      mkClub({ clubId: '2', clubName: 'No Charter B', charterDate: '' }),
+    ]
+    renderBoard(clubs)
+    expect(screen.getByText(/no charter data yet/i)).toBeInTheDocument()
+    expect(screen.queryAllByTestId('longest-serving-row')).toHaveLength(0)
+  })
+
+  it('sorts rows by years chartered descending (oldest first)', () => {
+    const clubs = [
+      mkClub({
+        clubId: '1',
+        clubName: 'Young Club',
+        charterDate: '2020-03-15',
+      }),
+      mkClub({
+        clubId: '2',
+        clubName: 'Oldest Club',
+        charterDate: '1975-08-01',
+      }),
+      mkClub({ clubId: '3', clubName: 'Mid Club', charterDate: '2000-01-12' }),
+    ]
+    renderBoard(clubs)
+    const rows = screen.getAllByTestId('longest-serving-row')
+    expect(rows).toHaveLength(3)
+    expect(within(rows[0]).getByText(/Oldest Club/)).toBeInTheDocument()
+    expect(within(rows[1]).getByText(/Mid Club/)).toBeInTheDocument()
+    expect(within(rows[2]).getByText(/Young Club/)).toBeInTheDocument()
+  })
+
+  it('breaks year ties alphabetically by club name', () => {
+    const clubs = [
+      mkClub({ clubId: '1', clubName: 'Zulu Club', charterDate: '1990-06-01' }),
+      mkClub({
+        clubId: '2',
+        clubName: 'Alpha Club',
+        charterDate: '1990-06-01',
+      }),
+      mkClub({ clubId: '3', clubName: 'Mike Club', charterDate: '1990-06-01' }),
+    ]
+    renderBoard(clubs)
+    const rows = screen.getAllByTestId('longest-serving-row')
+    expect(within(rows[0]).getByText(/Alpha Club/)).toBeInTheDocument()
+    expect(within(rows[1]).getByText(/Mike Club/)).toBeInTheDocument()
+    expect(within(rows[2]).getByText(/Zulu Club/)).toBeInTheDocument()
+  })
+
+  it('defaults to the top 10 oldest clubs', () => {
+    const clubs = Array.from({ length: 14 }, (_, i) =>
+      mkClub({
+        clubId: String(i + 1),
+        clubName: `Club ${String(i + 1).padStart(2, '0')}`,
+        // Older clubId → earlier charter year → higher rank
+        charterDate: `${1960 + i}-01-01`,
+      })
+    )
+    renderBoard(clubs)
+    const rows = screen.getAllByTestId('longest-serving-row')
+    expect(rows).toHaveLength(10)
+    // Oldest charter (1960) ranks #1
+    expect(within(rows[0]).getByText(/Club 01/)).toBeInTheDocument()
+    // 10th oldest is the club chartered in 1969
+    expect(within(rows[9]).getByText(/Club 10/)).toBeInTheDocument()
+    // The 11th-oldest (Club 11, chartered 1970) must NOT appear
+    expect(screen.queryByText(/Club 11/)).not.toBeInTheDocument()
+  })
+
+  it('honors a custom limit prop', () => {
+    const clubs = Array.from({ length: 6 }, (_, i) =>
+      mkClub({
+        clubId: String(i + 1),
+        clubName: `Club ${i + 1}`,
+        charterDate: `${1990 + i}-01-01`,
+      })
+    )
+    renderBoard(clubs, { limit: 3 })
+    expect(screen.getAllByTestId('longest-serving-row')).toHaveLength(3)
+  })
+
+  it('skips clubs without a charter date entirely', () => {
+    const clubs = [
+      mkClub({
+        clubId: '1',
+        clubName: 'Has Charter',
+        charterDate: '1980-04-01',
+      }),
+      mkClub({ clubId: '2', clubName: 'No Charter Here' }),
+    ]
+    renderBoard(clubs)
+    const rows = screen.getAllByTestId('longest-serving-row')
+    expect(rows).toHaveLength(1)
+    expect(within(rows[0]).getByText(/Has Charter/)).toBeInTheDocument()
+    expect(screen.queryByText(/No Charter Here/)).not.toBeInTheDocument()
+  })
+
+  it('links each row to the club detail page scoped by district', () => {
+    const clubs = [
+      mkClub({
+        clubId: '042',
+        clubName: 'Linkable Club',
+        charterDate: '1985-02-14',
+      }),
+    ]
+    renderBoard(clubs, { districtId: '61' })
+    const link = screen.getByRole('link', { name: /Linkable Club/ })
+    expect(link).toHaveAttribute('href', '/club/042?district=61')
+  })
+
+  it('shows the years count and a formatted charter date for each row', () => {
+    const clubs = [
+      mkClub({
+        clubId: '1',
+        clubName: 'Vintage Club',
+        charterDate: '1990-06-15',
+      }),
+    ]
+    renderBoard(clubs)
+    const row = screen.getByTestId('longest-serving-row')
+    // 2026-05-22 vs 1990-06-15 → anniversary not yet reached → 35y
+    expect(within(row).getByText(/35y/i)).toBeInTheDocument()
+    expect(within(row).getByText(/Jun 1990/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -33,6 +33,7 @@ import type { MultiYearPaymentData } from '../hooks/usePaymentsTrend'
 import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
 import { DistrictOverview } from '../components/DistrictOverview'
 import { NotableDatesSection } from '../components/NotableDatesSection'
+import { LongestServingClubsLeaderboard } from '../components/LongestServingClubsLeaderboard'
 import { DistinguishedDistrictTrophyCase } from '../components/DistinguishedDistrictTrophyCase'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
 
@@ -571,6 +572,12 @@ const DistrictDetailPageInner: React.FC = () => {
                     {...(effectiveProgramYear?.year !== undefined && {
                       programYearStart: effectiveProgramYear.year,
                     })}
+                  />
+
+                  {/* Longest-serving clubs leaderboard (#449) */}
+                  <LongestServingClubsLeaderboard
+                    clubs={allClubs}
+                    {...(districtId !== undefined && { districtId })}
                   />
                 </section>
               )}

--- a/tasks/lessons/080-longest-serving-leaderboard-lives-with-its-data.md
+++ b/tasks/lessons/080-longest-serving-leaderboard-lives-with-its-data.md
@@ -1,0 +1,104 @@
+---
+name: A new district-scoped surface lives next to the data it consumes, not on the page its issue stub guessed
+description: #449's stub said "Top-N on /awards page"; the parent epic
+  guessed a non-existent "/district/:id/leaderboards" route. Both
+  guesses date from before the anniversary surfaces actually shipped
+  (#446 UpcomingAnniversariesPanel, #447 MilestonesCallout, #551
+  NotableDatesSection). The right landing for a Top-N list keyed on
+  ClubTrend.charterDate is the same DistrictDetailPage section that
+  already renders those siblings — same data hook, same audience, same
+  "recognition planner" purpose. When an issue stub names a location
+  that no longer matches reality, trust the data shape over the stub.
+type: feedback
+---
+
+# Lesson 80 — A new surface lives next to the data it reads
+
+**Date:** 2026-05-22
+**Issue:** #449 (Longest-serving clubs leaderboard, epic #443 stretch)
+
+## What happened
+
+#449 was filed during the original anniversary-epic planning (#443) as a
+stretch sub-issue, with the placement note "Top-N list on /awards page,
+scoped by district." The Sprint 17 plan in epic #574 contradicted that
+note with "lands at new /district/:id/leaderboards route from Sprint 3."
+
+Neither was accurate by the time the work landed:
+
+- **No `/district/:id/leaderboards` route exists.** Sprint 3 (#571)
+  created `/district/:id/divisions` and `/district/:id/rankings` and
+  retired the tab strip — it never created a "leaderboards" route.
+- **The /awards page is for competitive district-level standings**
+  (Extension / 20+ / Retention awards across the world's 117 districts).
+  Mixing a club-level longevity list into it would be a category error
+  on the page's audience (district directors looking at peer-district
+  comparisons) and on its data shape (district aggregates vs. clubs).
+
+The actual right landing was already obvious once you looked at the
+shipped UI: `DistrictDetailPage` has a "Notable Dates" cluster
+(`UpcomingAnniversariesPanel` + `MilestonesCallout`, orchestrated by
+`NotableDatesSection`) that reads `ClubTrend.charterDate` and is
+district-scoped. Top-N longest-serving is the third member of that
+cluster — same data, same audience, same recognition-planner intent.
+
+## How to apply
+
+**Rule:** When an issue's "where it goes" hint is stale, place the
+surface next to the data it consumes, not where the stub guessed.
+
+**Why:** Issue stubs in long-lived epics are written before the
+surrounding UI ships. Six months later, the page named in the stub
+may have been retired, renamed, or repurposed. The data is the
+durable anchor — the file the new component imports tells you which
+page already owns this data flow. Two grep queries (`grep -rn
+"<dataField>" frontend/src/pages/`) usually find the right landing in
+one shot.
+
+**How to apply:**
+
+1. Identify the new component's primary data source (here:
+   `ClubTrend.charterDate`).
+2. Grep for existing call sites of that field.
+3. The page that already renders sibling surfaces from that field is
+   the new component's home — unless the issue's audience is
+   demonstrably different.
+4. If you have to invent a new route or page, you're probably
+   over-scoping the issue.
+
+## Telltale signs the stub's landing is wrong
+
+- The stub names a page that doesn't exist in the current router.
+- The stub names a page whose audience differs from the new
+  component's user (here: cross-district vs. single-district).
+- The stub predates the shipping of sibling surfaces that already
+  read the same data field. Check the parent epic's commit history.
+- The "new" surface is structurally identical to an existing one (a
+  Top-N list reading a single ClubTrend field) — that existing one
+  has a home; copy it.
+
+## What we explicitly did NOT do
+
+- Did **not** create a `/district/:id/leaderboards` route. The epic
+  body in #574 mentioned one but Sprint 3 never built it. Inventing
+  a route just to honor a stub note from a sibling issue would have
+  introduced routing surface (legacy redirects, link audits, mobile
+  IA changes) for no gain — the DistrictDetailPage section that
+  already owns recognition-planner content is the obvious home.
+- Did **not** move it to /awards. Awards is competitive district
+  standings (Extension / 20+ / Retention) — a different category.
+- Did **not** add a "view all" link to a dedicated page. Top-10 is the
+  whole feature per the stub; a "view all" page would be future work.
+
+## Related
+
+- `frontend/src/components/LongestServingClubsLeaderboard.tsx` — the
+  new component.
+- `frontend/src/components/NotableDatesSection.tsx` — sibling
+  orchestrator for `UpcomingAnniversariesPanel` + `MilestonesCallout`.
+- `frontend/src/utils/clubAnniversary.ts` — shared `getClubAnniversary`
+  (`years` field) the leaderboard sorts by.
+- Lesson 77 — "presentational extraction: override classes, don't
+  invent variants." Same discipline applied at the placement level:
+  prefer the obvious landing in existing IA over inventing a new
+  route to honor a stale stub.


### PR DESCRIPTION
## Summary

Closes the last open Track-E sub-issue on Epic #443 (anniversaries + milestone recognition): a district-scoped Top-10 list of the clubs with the most years since charter.

### Production changes

- **New component** `LongestServingClubsLeaderboard` — reads `ClubTrend.charterDate`, sorts by `getClubAnniversary().years` desc, ties broken alphabetically, default limit 10.
- **Mounted on `DistrictDetailPage`** below the existing `NotableDatesSection` (UpcomingAnniversariesPanel + MilestonesCallout). Same `allClubs` data hook, same recognition-section guard.
- **Empty state** — "No charter data yet for this district." for districts whose snapshots haven't yet been enriched by the Find-A-Club merger.

### Placement decision

The original issue stub (filed during epic #443 planning) named `/awards` as the landing. Epic #574 later guessed `/district/:id/leaderboards`. Neither matches the shipped IA:

- `/awards` is the **competitive district-level** standings page (Extension / 20+ / Retention across the world's 117 districts). A club-level longevity list is a category mismatch on both audience and data shape.
- `/district/:id/leaderboards` doesn't exist — Sprint 3 (#571) created `/divisions` and `/rankings` only.

The component reads `ClubTrend.charterDate`, which two sibling components on `DistrictDetailPage` already consume. That's the durable anchor; placing the new surface there preserves the IA, audience, and recognition-planner narrative. Captured in Lesson 80.

### Test surface

- 8 new component tests cover sort order, alphabetical tie-break, limit (default + custom), empty state, link wiring, and label formatting.
- Full frontend suite green locally: **161 files / 2361 tests passing**.

## Test plan

- [ ] `/district/61` renders a "Longest-serving clubs" panel below the Notable Dates cluster.
- [ ] The Top-10 list is sorted oldest first; each row shows `#N · ClubName · Ny · Mon YYYY`.
- [ ] Clicking a club name navigates to `/club/:id?district=61`.
- [ ] On a district whose snapshot lacks charter data, the empty state renders.
- [ ] Dark mode + 375 / 768 / 1280 widths look reasonable.

Refs #449 (epic #443) · Sprint 17 of #574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)