### PR TITLE
feat(district-clubs): #489 surface FAC-only clubs (ATOs / prospective)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ downloads/
 test-cache*/
 test-snapshots/
 test-dir/
+test-results/
+**/test-results/
 
 # Generated reports
 typescript-report.json

--- a/frontend/src/components/ProspectiveClubsPanel.tsx
+++ b/frontend/src/components/ProspectiveClubsPanel.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import type { ProspectiveClub } from '../hooks/useDistrictAnalytics'
+
+/* ProspectiveClubsPanel (#489) — surfaces FAC-only clubs (ATOs +
+   fresh charters) below the ClubsTable on /district/:id/clubs. The
+   surface is rendered only when there's something to show; typical
+   districts have N = 0–4 prospective clubs. By design these clubs
+   are NOT in any aggregate or ranking — the panel is a directory
+   overlay that helps district leaders track ATOs in flight. */
+
+export interface ProspectiveClubsPanelProps {
+  // Explicitly union with undefined so callers can hand us
+  // `analytics?.prospectiveClubs` under exactOptionalPropertyTypes
+  // without an intermediate cast.
+  clubs: ProspectiveClub[] | undefined
+}
+
+const formatLocation = (club: ProspectiveClub): string => {
+  const parts = [club.city, club.region, club.country].filter(Boolean)
+  return parts.join(', ')
+}
+
+export const ProspectiveClubsPanel: React.FC<ProspectiveClubsPanelProps> = ({
+  clubs,
+}) => {
+  if (!clubs || clubs.length === 0) return null
+
+  return (
+    <section
+      aria-labelledby="prospective-clubs-heading"
+      className="redesign-panel"
+      data-testid="prospective-clubs-panel"
+    >
+      <div className="flex items-baseline justify-between gap-2 mb-2">
+        <h3
+          id="prospective-clubs-heading"
+          className="redesign-panel__header !mb-0"
+        >
+          Prospective clubs ({clubs.length})
+        </h3>
+        <span className="text-[11px] uppercase tracking-wider text-gray-600 dark:text-gray-400 font-tm-body">
+          FAC registry
+        </span>
+      </div>
+      <p className="text-xs text-gray-600 dark:text-gray-400 font-tm-body mb-2">
+        In TI&rsquo;s public Find-A-Club registry but not yet in this
+        district&rsquo;s performance reports — typically ATO (Application To
+        Organize) clubs or fresh charters. Excluded from rankings and
+        distinguished counts.
+      </p>
+      <ul className="divide-y divide-gray-100 dark:divide-gray-800 -mx-1">
+        {clubs.map(club => {
+          const location = formatLocation(club)
+          return (
+            <li
+              key={club.clubId}
+              className="flex items-center gap-2 px-2 py-1.5 text-sm font-tm-body"
+              data-testid="prospective-club-row"
+            >
+              <span className="flex-1 min-w-0 truncate font-semibold text-gray-800 dark:text-gray-100">
+                {club.clubName || `Club ${club.clubId}`}
+              </span>
+              {location && (
+                <span className="hidden sm:inline text-xs text-gray-500 dark:text-gray-400 truncate max-w-[12rem]">
+                  {location}
+                </span>
+              )}
+              {club.charterDate && (
+                <span className="shrink-0 tabular-nums text-xs font-semibold text-tm-loyal-blue">
+                  {club.charterDate}
+                </span>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}
+
+export default ProspectiveClubsPanel

--- a/frontend/src/components/ProspectiveClubsPanel.tsx
+++ b/frontend/src/components/ProspectiveClubsPanel.tsx
@@ -58,7 +58,7 @@ export const ProspectiveClubsPanel: React.FC<ProspectiveClubsPanelProps> = ({
               data-testid="prospective-club-row"
             >
               <span className="flex-1 min-w-0 truncate font-semibold text-gray-800 dark:text-gray-100">
-                {club.clubName || `Club ${club.clubId}`}
+                {club.clubName}
               </span>
               {location && (
                 <span className="hidden sm:inline text-xs text-gray-500 dark:text-gray-400 truncate max-w-[12rem]">

--- a/frontend/src/components/__tests__/ProspectiveClubsPanel.test.tsx
+++ b/frontend/src/components/__tests__/ProspectiveClubsPanel.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ProspectiveClubsPanel } from '../ProspectiveClubsPanel'
+
+/* #489 — Prospective (FAC-only) clubs panel. Renders below ClubsTable
+   on /district/:id/clubs. Invisible when the list is empty so 95%
+   of districts (which have zero ATOs) see no extra chrome. */
+
+describe('ProspectiveClubsPanel', () => {
+  it('renders nothing when the list is empty', () => {
+    const { container } = render(<ProspectiveClubsPanel clubs={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when the list is undefined', () => {
+    const { container } = render(<ProspectiveClubsPanel clubs={undefined} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a heading with the count when the list is non-empty', () => {
+    render(
+      <ProspectiveClubsPanel
+        clubs={[
+          {
+            clubId: '00088888',
+            clubName: 'New ATO Toastmasters',
+            city: 'Ottawa',
+            region: 'ON',
+            country: 'Canada',
+            isProspective: true,
+          },
+        ]}
+      />
+    )
+    // Heading should communicate the count and the surface
+    const heading = screen.getByRole('heading', { name: /prospective clubs/i })
+    expect(heading).toBeInTheDocument()
+    expect(heading.textContent).toMatch(/1/)
+  })
+
+  it('renders each club name and location', () => {
+    render(
+      <ProspectiveClubsPanel
+        clubs={[
+          {
+            clubId: '00088888',
+            clubName: 'New ATO Toastmasters',
+            city: 'Ottawa',
+            region: 'ON',
+            country: 'Canada',
+            isProspective: true,
+          },
+          {
+            clubId: '00099999',
+            clubName: 'Second Prospective Club',
+            city: 'Montreal',
+            region: 'QC',
+            country: 'Canada',
+            isProspective: true,
+          },
+        ]}
+      />
+    )
+    expect(screen.getByText(/New ATO Toastmasters/)).toBeInTheDocument()
+    expect(screen.getByText(/Second Prospective Club/)).toBeInTheDocument()
+    // Location should be visible as a hint
+    expect(screen.getAllByText(/Ottawa.*ON/i).length).toBeGreaterThan(0)
+  })
+
+  it('explains the surface in a caption so the panel is self-documenting', () => {
+    render(
+      <ProspectiveClubsPanel
+        clubs={[
+          {
+            clubId: '00088888',
+            clubName: 'New ATO Toastmasters',
+            isProspective: true,
+          },
+        ]}
+      />
+    )
+    // The caption must mention Find-A-Club / ATO concept so a district
+    // director sees this and understands the provenance immediately.
+    // textContent on the <section> also matches, so we pin to the <p>.
+    expect(screen.getByText(/typically ATO/i)).toBeInTheDocument()
+  })
+
+  it('shows charter date when present', () => {
+    render(
+      <ProspectiveClubsPanel
+        clubs={[
+          {
+            clubId: '00088888',
+            clubName: 'Newly Chartered Club',
+            charterDate: '2026-04-15',
+          },
+        ]}
+      />
+    )
+    expect(screen.getByText(/2026-04-15|Apr.*2026/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/hooks/useDistrictAnalytics.ts
+++ b/frontend/src/hooks/useDistrictAnalytics.ts
@@ -4,10 +4,13 @@ import {
   cdnAnalyticsUrl,
   fetchFromCdn,
 } from '../services/cdn'
-import type { ClubHealthStatus } from '@toastmasters/shared-contracts'
+import type {
+  ClubHealthStatus,
+  ProspectiveClub,
+} from '@toastmasters/shared-contracts'
 
 // Re-export for backward compatibility with existing imports
-export type { ClubHealthStatus }
+export type { ClubHealthStatus, ProspectiveClub }
 
 export interface ClubTrend {
   clubId: string
@@ -194,6 +197,18 @@ export interface DistrictAnalytics {
    * Requirements: 7.1, 7.2, 7.3, 7.4
    */
   performanceTargets?: DistrictPerformanceTargets
+
+  /**
+   * Clubs in TI's public Find-A-Club registry that aren't yet in
+   * clubPerformance — typically ATOs (Applications To Organize) or
+   * freshly-chartered clubs that haven't appeared in the dashboard
+   * roster yet. Empty for districts with no such clubs. Deliberately
+   * NOT included in rankings, distinguished counts, or membership
+   * trends.
+   *
+   * @see Issue #489
+   */
+  prospectiveClubs?: ProspectiveClub[]
 }
 
 // ========== District Performance Targets Types (from districts.ts) ==========

--- a/frontend/src/hooks/useDistrictAnalytics.ts
+++ b/frontend/src/hooks/useDistrictAnalytics.ts
@@ -202,13 +202,12 @@ export interface DistrictAnalytics {
    * Clubs in TI's public Find-A-Club registry that aren't yet in
    * clubPerformance — typically ATOs (Applications To Organize) or
    * freshly-chartered clubs that haven't appeared in the dashboard
-   * roster yet. Empty for districts with no such clubs. Deliberately
-   * NOT included in rankings, distinguished counts, or membership
-   * trends.
+   * roster yet. Always an array (possibly empty). Deliberately NOT
+   * included in rankings, distinguished counts, or membership trends.
    *
    * @see Issue #489
    */
-  prospectiveClubs?: ProspectiveClub[]
+  prospectiveClubs: ProspectiveClub[]
 }
 
 // ========== District Performance Targets Types (from districts.ts) ==========

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -12,6 +12,7 @@ import {
 } from '../utils/programYear'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
 import { ClubsTable } from '../components/ClubsTable'
+import { ProspectiveClubsPanel } from '../components/ProspectiveClubsPanel'
 import ErrorBoundary from '../components/ErrorBoundary'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import type {
@@ -313,19 +314,22 @@ const DistrictClubsPage: React.FC = () => {
             {isLoading && allClubs.length === 0 ? (
               <LoadingSkeleton variant="table" count={6} />
             ) : (
-              <ClubsTable
-                clubs={allClubs}
-                districtId={districtId}
-                isLoading={isLoading}
-                onClubClick={handleClubClick}
-                initialSortField={initialSortField}
-                initialSortDirection={initialSortDir}
-                onSortChange={handleSortChange}
-                initialPage={initialPage}
-                onPageChange={handlePageChange}
-                initialFilterState={initialFilterState}
-                onFilterChange={handleFilterChange}
-              />
+              <>
+                <ClubsTable
+                  clubs={allClubs}
+                  districtId={districtId}
+                  isLoading={isLoading}
+                  onClubClick={handleClubClick}
+                  initialSortField={initialSortField}
+                  initialSortDirection={initialSortDir}
+                  onSortChange={handleSortChange}
+                  initialPage={initialPage}
+                  onPageChange={handlePageChange}
+                  initialFilterState={initialFilterState}
+                  onFilterChange={handleFilterChange}
+                />
+                <ProspectiveClubsPanel clubs={analytics?.prospectiveClubs} />
+              </>
             )}
           </div>
         </div>

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/packages/analytics-core/src/analytics/AnalyticsComputer.test.ts
+++ b/packages/analytics-core/src/analytics/AnalyticsComputer.test.ts
@@ -494,6 +494,44 @@ describe('AnalyticsComputer', () => {
         result.districtAnalytics.membershipChange
       )
     })
+
+    // #489 — Prospective (FAC-only) clubs flow through the latest
+    // snapshot into the DistrictAnalytics output so the frontend can
+    // render them without a second fetch.
+    it('should propagate prospectiveClubs from the latest snapshot', async () => {
+      const computer = new AnalyticsComputer()
+      const snapshot = createMockSnapshot('D101', '2024-01-15', [
+        createMockClub({ clubId: '1', membershipCount: 25 }),
+      ])
+      snapshot.prospectiveClubs = [
+        {
+          clubId: '00088888',
+          clubName: 'New ATO Toastmasters',
+          city: 'Ottawa',
+          region: 'ON',
+          country: 'Canada',
+          isProspective: true,
+        },
+      ]
+
+      const result = await computer.computeDistrictAnalytics('D101', [snapshot])
+
+      expect(result.districtAnalytics.prospectiveClubs).toHaveLength(1)
+      expect(result.districtAnalytics.prospectiveClubs?.[0]?.clubId).toBe(
+        '00088888'
+      )
+    })
+
+    it('should default prospectiveClubs to an empty array when the snapshot omits it', async () => {
+      const computer = new AnalyticsComputer()
+      const snapshot = createMockSnapshot('D101', '2024-01-15', [
+        createMockClub({ clubId: '1' }),
+      ])
+
+      const result = await computer.computeDistrictAnalytics('D101', [snapshot])
+
+      expect(result.districtAnalytics.prospectiveClubs).toEqual([])
+    })
   })
 
   describe('computeMembershipAnalytics', () => {

--- a/packages/analytics-core/src/analytics/AnalyticsComputer.test.ts
+++ b/packages/analytics-core/src/analytics/AnalyticsComputer.test.ts
@@ -517,7 +517,7 @@ describe('AnalyticsComputer', () => {
       const result = await computer.computeDistrictAnalytics('D101', [snapshot])
 
       expect(result.districtAnalytics.prospectiveClubs).toHaveLength(1)
-      expect(result.districtAnalytics.prospectiveClubs?.[0]?.clubId).toBe(
+      expect(result.districtAnalytics.prospectiveClubs[0]?.clubId).toBe(
         '00088888'
       )
     })

--- a/packages/analytics-core/src/analytics/AnalyticsComputer.ts
+++ b/packages/analytics-core/src/analytics/AnalyticsComputer.ts
@@ -211,6 +211,11 @@ export class AnalyticsComputer implements IAnalyticsComputer {
           sortedSnapshots
         ).topGrowthClubs
 
+    // #489 — Prospective clubs are surfaced verbatim from the latest
+    // snapshot; they're a directory-style overlay, not an analytics
+    // input. Default to [] so the frontend can always assume an array.
+    const prospectiveClubs = latestSnapshot?.prospectiveClubs ?? []
+
     // Build district analytics (base result)
     const districtAnalytics: DistrictAnalytics = {
       districtId,
@@ -230,6 +235,7 @@ export class AnalyticsComputer implements IAnalyticsComputer {
       divisionRankings,
       topPerformingAreas,
       topGrowthClubs,
+      prospectiveClubs,
     }
 
     // Compute remaining extended analytics

--- a/packages/analytics-core/src/interfaces.ts
+++ b/packages/analytics-core/src/interfaces.ts
@@ -9,7 +9,10 @@ import type {
   ComputeOptions,
   ExtendedAnalyticsComputationResult,
 } from './types.js'
-import type { ScrapedRecord } from '@toastmasters/shared-contracts'
+import type {
+  ProspectiveClub,
+  ScrapedRecord,
+} from '@toastmasters/shared-contracts'
 
 /**
  * Raw CSV data structure from Toastmasters dashboard.
@@ -37,6 +40,18 @@ export interface DistrictStatistics {
   divisionPerformance: ScrapedRecord[]
   clubPerformance: ScrapedRecord[]
   districtPerformance: ScrapedRecord[]
+
+  /**
+   * Clubs in the public Find-A-Club registry but absent from
+   * clubPerformance — typically ATOs (Applications To Organize) or
+   * freshly-chartered clubs not yet reporting. Populated by the
+   * collector's FindAClubMerger. Optional and back-compat: pre-#489
+   * snapshots simply omit the field. Excluded from analytics
+   * aggregates by design (no DCP / payments / status data).
+   *
+   * @see Issue #489
+   */
+  prospectiveClubs?: ProspectiveClub[]
 }
 
 /**

--- a/packages/analytics-core/src/types/analytics.ts
+++ b/packages/analytics-core/src/types/analytics.ts
@@ -61,11 +61,12 @@ export interface DistrictAnalytics {
    * FAC-only clubs (typically ATOs / fresh charters) that aren't in
    * clubPerformance. Surfaced verbatim from the latest snapshot —
    * never folded into rankings, distinguished counts, or membership
-   * trends. Defaults to [] when the snapshot omits the field.
+   * trends. Always an array (possibly empty) — consistent with
+   * sibling list fields (`allClubs`, `vulnerableClubs`).
    *
    * @see Issue #489
    */
-  prospectiveClubs?: ProspectiveClub[]
+  prospectiveClubs: ProspectiveClub[]
 }
 
 /**

--- a/packages/analytics-core/src/types/analytics.ts
+++ b/packages/analytics-core/src/types/analytics.ts
@@ -28,6 +28,7 @@ import type { DateRange } from './metadata.js'
 import type { LeadershipInsightsData } from './leadership.js'
 import type { YearOverYearData } from './yearOverYear.js'
 import type { PerformanceTargetsData } from './performanceTargets.js'
+import type { ProspectiveClub } from '@toastmasters/shared-contracts'
 
 /**
  * Complete district analytics structure.
@@ -55,6 +56,16 @@ export interface DistrictAnalytics {
   topPerformingAreas: AreaPerformance[]
   /** Top clubs by membership growth (positive growth only, sorted descending) */
   topGrowthClubs: Array<{ clubId: string; clubName: string; growth: number }>
+
+  /**
+   * FAC-only clubs (typically ATOs / fresh charters) that aren't in
+   * clubPerformance. Surfaced verbatim from the latest snapshot —
+   * never folded into rankings, distinguished counts, or membership
+   * trends. Defaults to [] when the snapshot omits the field.
+   *
+   * @see Issue #489
+   */
+  prospectiveClubs?: ProspectiveClub[]
 }
 
 /**

--- a/packages/collector-cli/src/services/FindAClubMerger.ts
+++ b/packages/collector-cli/src/services/FindAClubMerger.ts
@@ -21,6 +21,7 @@
  * writes around it.
  */
 
+import type { ProspectiveClub } from '@toastmasters/shared-contracts'
 import {
   TI_CLUB_NUMBER_KEY,
   type FacRawResponse,
@@ -28,7 +29,7 @@ import {
   type EnrichedClub,
   type MergeResult,
 } from '../types/findAClub.js'
-import { normaliseTiClub } from './FindAClubService.js'
+import { normaliseTiClub, type ClubEnrichment } from './FindAClubService.js'
 
 /** 8-char zero-pad a club number from anywhere (CSV row, FAC payload). */
 export function normaliseClubNumber(raw: unknown): string | null {
@@ -173,6 +174,13 @@ export function mergeFacIntoSnapshot(
     }
   }
 
+  // #489 — persist the FAC-only clubs into the snapshot as a compact
+  // ProspectiveClub[] so downstream consumers (analytics-core, the
+  // frontend prospective panel) can render them without a second
+  // FAC fetch. We deliberately omit fields the panel doesn't render
+  // (coordinates, phone, social links) to keep the payload small.
+  const prospectiveClubs = facOnlyClubs.map(projectProspectiveClub)
+
   return {
     snapshot: {
       ...snapshot,
@@ -185,6 +193,12 @@ export function mergeFacIntoSnapshot(
         ...(enrichedParsedClubs !== undefined && {
           clubs: enrichedParsedClubs,
         }),
+        // Only set prospectiveClubs when there's something to surface;
+        // an empty array would noisily appear in every district's
+        // snapshot and obscure the "0 prospectives today" case.
+        ...(prospectiveClubs.length > 0 && {
+          prospectiveClubs,
+        }),
       },
     },
     matched,
@@ -192,4 +206,27 @@ export function mergeFacIntoSnapshot(
     facOnly: facOnlyClubs.length,
     facOnlyClubs,
   }
+}
+
+/**
+ * Compact projection of a FAC-only club enrichment into the
+ * ProspectiveClub shape served to the frontend (#489).
+ */
+function projectProspectiveClub(enriched: ClubEnrichment): ProspectiveClub {
+  const club: ProspectiveClub = {
+    clubId: enriched.clubId,
+    clubName: enriched.clubName ?? '',
+  }
+  if (enriched.charterDate) club.charterDate = enriched.charterDate
+  if (enriched.address?.city) club.city = enriched.address.city
+  if (enriched.address?.region) club.region = enriched.address.region
+  if (enriched.address?.country) club.country = enriched.address.country
+  if (enriched.meetingDay) club.meetingDay = enriched.meetingDay
+  if (enriched.meetingTime) club.meetingTime = enriched.meetingTime
+  if (enriched.website) club.website = enriched.website
+  if (enriched.email) club.email = enriched.email
+  if (typeof enriched.isProspective === 'boolean') {
+    club.isProspective = enriched.isProspective
+  }
+  return club
 }

--- a/packages/collector-cli/src/services/FindAClubMerger.ts
+++ b/packages/collector-cli/src/services/FindAClubMerger.ts
@@ -177,8 +177,10 @@ export function mergeFacIntoSnapshot(
   // #489 — persist the FAC-only clubs into the snapshot as a compact
   // ProspectiveClub[] so downstream consumers (analytics-core, the
   // frontend prospective panel) can render them without a second
-  // FAC fetch. We deliberately omit fields the panel doesn't render
-  // (coordinates, phone, social links) to keep the payload small.
+  // FAC fetch. Always write the field (even when empty) — if we
+  // skipped on empty, a prior merge's stale prospectiveClubs would
+  // survive the `...snapshot.data` spread and ship to the frontend
+  // forever. The field must always reflect the CURRENT FAC delta.
   const prospectiveClubs = facOnlyClubs.map(projectProspectiveClub)
 
   return {
@@ -193,12 +195,7 @@ export function mergeFacIntoSnapshot(
         ...(enrichedParsedClubs !== undefined && {
           clubs: enrichedParsedClubs,
         }),
-        // Only set prospectiveClubs when there's something to surface;
-        // an empty array would noisily appear in every district's
-        // snapshot and obscure the "0 prospectives today" case.
-        ...(prospectiveClubs.length > 0 && {
-          prospectiveClubs,
-        }),
+        prospectiveClubs,
       },
     },
     matched,
@@ -213,9 +210,14 @@ export function mergeFacIntoSnapshot(
  * ProspectiveClub shape served to the frontend (#489).
  */
 function projectProspectiveClub(enriched: ClubEnrichment): ProspectiveClub {
+  // TI's FAC occasionally returns a club with no Identification.Name
+  // (rare; mostly fresh ATOs that haven't picked a final name yet).
+  // Fall back to a synthetic "Club <id>" label at the projection layer
+  // so the schema's clubName invariant stays meaningful and the UI
+  // doesn't need a parallel fallback.
   const club: ProspectiveClub = {
     clubId: enriched.clubId,
-    clubName: enriched.clubName ?? '',
+    clubName: enriched.clubName ?? `Club ${enriched.clubId}`,
   }
   if (enriched.charterDate) club.charterDate = enriched.charterDate
   if (enriched.address?.city) club.city = enriched.address.city

--- a/packages/collector-cli/src/services/FindAClubService.ts
+++ b/packages/collector-cli/src/services/FindAClubService.ts
@@ -114,6 +114,10 @@ export type TiResponse = z.infer<typeof TiResponseSchema>
 export interface ClubEnrichment {
   /** 8-char zero-padded club number — primary join key. */
   clubId: string
+  /** Display name from TI's Find-A-Club registry. Optional because
+   *  TI occasionally returns a club entry with no Name (rare; mostly
+   *  test fixtures). Surfaced by the prospective-clubs panel (#489). */
+  clubName?: string
   charterDate?: string // ISO date
   coordinates?: { lat: number; lng: number }
   address?: {
@@ -254,6 +258,9 @@ export function normaliseTiClub(club: TiClub): ClubEnrichment | null {
   if (!id) return null
 
   const result: ClubEnrichment = { clubId: id }
+
+  const name = club.Identification?.Name?.trim()
+  if (name) result.clubName = name
 
   const charterDate = parseNetDate(club.CharterDate)
   if (charterDate) result.charterDate = charterDate

--- a/packages/collector-cli/src/services/__tests__/FindAClubMerger.test.ts
+++ b/packages/collector-cli/src/services/__tests__/FindAClubMerger.test.ts
@@ -322,13 +322,61 @@ describe('mergeFacIntoSnapshot', () => {
     expect(club?.['phone']).toBeUndefined()
   })
 
-  it('omits prospectiveClubs when no FAC-only clubs are found (#489)', () => {
+  it('writes an empty prospectiveClubs array when no FAC-only clubs are found (#489)', () => {
     const result = mergeFacIntoSnapshot(
       { districtId: '61', data: { clubPerformance: [ottawaSnapshotRow] } },
       { Clubs: [ottawaFacClub] }
     )
     const dataRecord = result.snapshot.data as Record<string, unknown>
-    expect(dataRecord['prospectiveClubs']).toBeUndefined()
+    // Always materialize the field — see "clears stale prospectiveClubs"
+    // below for the regression that drove this decision.
+    expect(dataRecord['prospectiveClubs']).toEqual([])
+  })
+
+  // Regression: if a previous merge left a prospectiveClubs entry in
+  // the snapshot and today's FAC has none (the ATO chartered), the
+  // merger must NOT carry the stale entry forward via `...snapshot.data`.
+  it('clears stale prospectiveClubs when the current FAC produces none (#489)', () => {
+    const staleSnapshot = {
+      districtId: '61',
+      data: {
+        clubPerformance: [ottawaSnapshotRow],
+        prospectiveClubs: [
+          {
+            clubId: '00088888',
+            clubName: 'Yesterday ATO',
+            isProspective: true,
+          },
+        ],
+      },
+    }
+    const result = mergeFacIntoSnapshot(staleSnapshot, {
+      Clubs: [ottawaFacClub],
+    })
+    const dataRecord = result.snapshot.data as Record<string, unknown>
+    expect(dataRecord['prospectiveClubs']).toEqual([])
+  })
+
+  // The projection layer must produce a meaningful clubName even when
+  // TI's FAC entry omits Identification.Name — schema declares
+  // clubName as required, and an empty string would break the
+  // 'has a name' invariant the panel relies on.
+  it('falls back to "Club <id>" when the FAC entry has no Name (#489)', () => {
+    const namelessFacClub = {
+      Identification: { Id: { Value: '00077777' } },
+      Address: { City: 'Nowhere' },
+      IsProspective: true,
+    }
+    const result = mergeFacIntoSnapshot(
+      { districtId: '61', data: { clubPerformance: [ottawaSnapshotRow] } },
+      { Clubs: [ottawaFacClub, namelessFacClub] }
+    )
+    const dataRecord = result.snapshot.data as Record<string, unknown>
+    const prospectiveClubs = dataRecord['prospectiveClubs'] as Array<
+      Record<string, unknown>
+    >
+    expect(prospectiveClubs).toHaveLength(1)
+    expect(prospectiveClubs[0]?.['clubName']).toBe('Club 00077777')
   })
 
   it('is idempotent — merging twice produces the same enriched output', () => {

--- a/packages/collector-cli/src/services/__tests__/FindAClubMerger.test.ts
+++ b/packages/collector-cli/src/services/__tests__/FindAClubMerger.test.ts
@@ -49,7 +49,7 @@ const suspendedSnapshotOnly = {
 }
 
 const prospectiveFacOnlyClub = {
-  Identification: { Id: { Value: '00088888' } },
+  Identification: { Id: { Value: '00088888' }, Name: 'New ATO Toastmasters' },
   Address: {
     Street: '12 New Way',
     City: 'Toronto',
@@ -284,6 +284,51 @@ describe('mergeFacIntoSnapshot', () => {
     expect(result.facOnlyClubs[0]?.isProspective).toBe(true)
     // The prospective club must NOT have been merged into clubPerformance
     expect(result.snapshot.data?.clubPerformance).toHaveLength(1)
+  })
+
+  // #489 — the merger must now persist FAC-only clubs into the
+  // snapshot as a compact prospectiveClubs[] so downstream services
+  // (analytics-core, the frontend) can surface them without a second
+  // FAC fetch.
+  it('writes FAC-only clubs into snapshot.data.prospectiveClubs (#489)', () => {
+    const result = mergeFacIntoSnapshot(
+      {
+        districtId: '61',
+        data: { clubPerformance: [ottawaSnapshotRow] },
+        // pretend the previous merge already added something; the new
+        // merge replaces it (TI registry is the source of truth).
+      },
+      { Clubs: [ottawaFacClub, prospectiveFacOnlyClub] }
+    )
+
+    const dataRecord = result.snapshot.data as
+      | Record<string, unknown>
+      | undefined
+    const prospectiveClubs = dataRecord?.['prospectiveClubs'] as
+      | Array<Record<string, unknown>>
+      | undefined
+    expect(prospectiveClubs).toHaveLength(1)
+    const club = prospectiveClubs?.[0]
+    expect(club?.['clubId']).toBe('00088888')
+    expect(club?.['clubName']).toBe('New ATO Toastmasters')
+    expect(club?.['city']).toBe('Toronto')
+    expect(club?.['region']).toBe('ON')
+    expect(club?.['country']).toBe('Canada')
+    expect(club?.['isProspective']).toBe(true)
+    // We deliberately drop coordinates / phone / social — the panel
+    // doesn't render them, and keeping the payload small matters when
+    // the array ships in the analytics file every district every day.
+    expect(club?.['coordinates']).toBeUndefined()
+    expect(club?.['phone']).toBeUndefined()
+  })
+
+  it('omits prospectiveClubs when no FAC-only clubs are found (#489)', () => {
+    const result = mergeFacIntoSnapshot(
+      { districtId: '61', data: { clubPerformance: [ottawaSnapshotRow] } },
+      { Clubs: [ottawaFacClub] }
+    )
+    const dataRecord = result.snapshot.data as Record<string, unknown>
+    expect(dataRecord['prospectiveClubs']).toBeUndefined()
   })
 
   it('is idempotent — merging twice produces the same enriched output', () => {

--- a/packages/collector-cli/src/services/__tests__/FindAClubService.test.ts
+++ b/packages/collector-cli/src/services/__tests__/FindAClubService.test.ts
@@ -104,6 +104,7 @@ describe('normaliseTiClub', () => {
     const result = normaliseTiClub(realClub)
     expect(result).toEqual({
       clubId: '00001399',
+      clubName: 'South Suburban Toastmasters',
       charterDate: '1976-04-01',
       coordinates: { lat: 39.62285, lng: -105.01863 },
       address: {

--- a/packages/shared-contracts/src/__tests__/district-statistics-file.schema.test.ts
+++ b/packages/shared-contracts/src/__tests__/district-statistics-file.schema.test.ts
@@ -19,6 +19,7 @@ import {
   DivisionStatisticsFileSchema,
   AreaStatisticsFileSchema,
   DistrictTotalsFileSchema,
+  ProspectiveClubSchema,
 } from '../schemas/district-statistics-file.schema.js'
 
 // ============================================================================
@@ -464,6 +465,90 @@ describe('DistrictStatisticsFileSchema validation', () => {
       if (!result.success) {
         expect(result.error.message).toBeDefined()
       }
+    })
+  })
+
+  // ============================================================================
+  // ProspectiveClubs field tests (#489)
+  // ============================================================================
+
+  describe('prospectiveClubs (#489)', () => {
+    it('should accept DistrictStatisticsFile without prospectiveClubs (back-compat)', () => {
+      const data = createValidDistrictStatisticsFile()
+      const result = DistrictStatisticsFileSchema.safeParse(data)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.prospectiveClubs).toBeUndefined()
+      }
+    })
+
+    it('should accept DistrictStatisticsFile with a populated prospectiveClubs array', () => {
+      const data = {
+        ...createValidDistrictStatisticsFile(),
+        prospectiveClubs: [
+          {
+            clubId: '00088888',
+            clubName: 'New ATO Toastmasters',
+            charterDate: '2026-02-01',
+            city: 'Ottawa',
+            region: 'ON',
+            country: 'Canada',
+            isProspective: true,
+          },
+        ],
+      }
+      const result = DistrictStatisticsFileSchema.safeParse(data)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.prospectiveClubs).toHaveLength(1)
+        expect(result.data.prospectiveClubs?.[0]?.clubId).toBe('00088888')
+      }
+    })
+
+    it('should reject DistrictStatisticsFile with prospectiveClubs missing required clubId', () => {
+      const data = {
+        ...createValidDistrictStatisticsFile(),
+        prospectiveClubs: [{ clubName: 'No-id Club' }],
+      }
+      const result = DistrictStatisticsFileSchema.safeParse(data)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('ProspectiveClubSchema validation', () => {
+    it('should accept a club with only the required fields', () => {
+      const result = ProspectiveClubSchema.safeParse({
+        clubId: '00012345',
+        clubName: 'Minimal Club',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept a club with all optional fields populated', () => {
+      const result = ProspectiveClubSchema.safeParse({
+        clubId: '00012345',
+        clubName: 'Full Club',
+        charterDate: '2026-01-15',
+        city: 'Toronto',
+        region: 'ON',
+        country: 'Canada',
+        meetingDay: 'Tuesday',
+        meetingTime: '18:30',
+        website: 'https://example.org',
+        email: 'club@example.org',
+        isProspective: true,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject a club without clubId', () => {
+      const result = ProspectiveClubSchema.safeParse({ clubName: 'No-id' })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject a club without clubName', () => {
+      const result = ProspectiveClubSchema.safeParse({ clubId: '00012345' })
+      expect(result.success).toBe(false)
     })
   })
 })

--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -19,6 +19,7 @@ export type {
   DivisionStatisticsFile,
   AreaStatisticsFile,
   DistrictTotalsFile,
+  ProspectiveClub,
 } from './types/district-statistics-file.js'
 
 export type {
@@ -65,6 +66,7 @@ export {
   AreaStatisticsFileSchema,
   DistrictTotalsFileSchema,
   ScrapedRecordSchema,
+  ProspectiveClubSchema,
 } from './schemas/district-statistics-file.schema.js'
 
 export {

--- a/packages/shared-contracts/src/schemas/district-statistics-file.schema.ts
+++ b/packages/shared-contracts/src/schemas/district-statistics-file.schema.ts
@@ -188,6 +188,50 @@ export const DistrictTotalsFileSchema = z.object({
 })
 
 /**
+ * Zod schema for a prospective (FAC-only) club. Captures clubs that
+ * appear in the Find-A-Club registry but not in TI's
+ * clubPerformance — typically ATOs or fresh charters. Compact
+ * projection of the FAC enrichment; we omit fields a directory-style
+ * surface doesn't need (coordinates, phone, social links).
+ *
+ * @see Issue #489
+ */
+export const ProspectiveClubSchema = z.object({
+  /** 8-char zero-padded club number. */
+  clubId: z.string(),
+
+  /** Display name of the club. */
+  clubName: z.string(),
+
+  /** Charter date in ISO YYYY-MM-DD format, when known. */
+  charterDate: z.string().optional(),
+
+  /** City the club is registered in. */
+  city: z.string().optional(),
+
+  /** State / province code (e.g. 'ON', 'CA'). */
+  region: z.string().optional(),
+
+  /** Country name. */
+  country: z.string().optional(),
+
+  /** Recurring meeting day-of-week, when published. */
+  meetingDay: z.string().optional(),
+
+  /** Recurring meeting time, when published. */
+  meetingTime: z.string().optional(),
+
+  /** Public club website URL. */
+  website: z.string().optional(),
+
+  /** Public club contact email. */
+  email: z.string().optional(),
+
+  /** FAC's IsProspective flag — true for clubs in ATO state. */
+  isProspective: z.boolean().optional(),
+})
+
+/**
  * Zod schema for district statistics file.
  * Validates DistrictStatisticsFile interface structure.
  *
@@ -241,6 +285,18 @@ export const DistrictStatisticsFileSchema = z.object({
    * @see Requirements 2.3, 5.1
    */
   districtPerformance: z.array(ScrapedRecordSchema),
+
+  /**
+   * Clubs present in the public Find-A-Club registry but absent from
+   * TI's per-district performance reports — typically ATOs
+   * (Applications To Organize) or freshly-chartered clubs that haven't
+   * landed in clubPerformance yet. Optional and back-compat: snapshots
+   * predating #489 simply omit the field. Populated by
+   * FindAClubMerger; never included in analytics aggregates.
+   *
+   * @see Issue #489
+   */
+  prospectiveClubs: z.array(ProspectiveClubSchema).optional(),
 })
 
 /**

--- a/packages/shared-contracts/src/types/district-statistics-file.ts
+++ b/packages/shared-contracts/src/types/district-statistics-file.ts
@@ -64,6 +64,61 @@ export interface DistrictStatisticsFile {
    * @see Requirements 2.3
    */
   districtPerformance: ScrapedRecord[]
+
+  /**
+   * Clubs present in the public Find-A-Club registry but absent from
+   * TI's per-district performance reports — typically ATOs
+   * (Applications To Organize) or freshly-chartered clubs that haven't
+   * landed in clubPerformance yet. Optional and back-compat: snapshots
+   * predating #489 simply omit the field. Populated by
+   * FindAClubMerger; never included in analytics aggregates.
+   *
+   * @see Issue #489
+   */
+  prospectiveClubs?: ProspectiveClub[]
+}
+
+/**
+ * Prospective (FAC-only) club entry. Compact projection of the FAC
+ * enrichment for clubs that don't appear in clubPerformance — we
+ * skip coordinates/phone/social links since the directory-style
+ * panel doesn't render them in v1.
+ *
+ * @see Issue #489
+ */
+export interface ProspectiveClub {
+  /** 8-char zero-padded club number. */
+  clubId: string
+
+  /** Display name of the club. */
+  clubName: string
+
+  /** Charter date in ISO YYYY-MM-DD format, when known. */
+  charterDate?: string
+
+  /** City the club is registered in. */
+  city?: string
+
+  /** State / province code (e.g. 'ON', 'CA'). */
+  region?: string
+
+  /** Country name. */
+  country?: string
+
+  /** Recurring meeting day-of-week, when published. */
+  meetingDay?: string
+
+  /** Recurring meeting time, when published. */
+  meetingTime?: string
+
+  /** Public club website URL. */
+  website?: string
+
+  /** Public club contact email. */
+  email?: string
+
+  /** FAC's IsProspective flag — true for clubs in ATO state. */
+  isProspective?: boolean
 }
 
 /**

--- a/tasks/sprint-18/plan.md
+++ b/tasks/sprint-18/plan.md
@@ -1,0 +1,79 @@
+# Sprint 18 — #489 surface FAC-only clubs (ATOs / prospective)
+
+## Decision: Option B+ (panel section)
+
+A small "Prospective Clubs" section on `/district/:id/clubs`, rendered _below_ ClubsTable, visible only when the list is non-empty. Rejected:
+
+- **Option A** (dedicated `/district/:id/prospective` panel): typical N = 0–4 per district, too sparse for a route.
+- **Option C** (in ClubsTable with status badge): wrong data shape — prospectives have no DCP / payments / status fields. Forcing them into ClubsTable would either pollute the row model or require special-case rendering for every column. Lesson #80 applies: place the surface next to the data it consumes, but don't conflate two different row shapes.
+
+## Data shape
+
+```ts
+export interface ProspectiveClub {
+  clubId: string // 8-char zero-padded
+  clubName: string
+  charterDate?: string // ISO yyyy-mm-dd, present for newly-chartered-but-not-yet-reporting
+  city?: string
+  region?: string // state/province
+  country?: string
+  meetingDay?: string
+  meetingTime?: string
+  website?: string
+  email?: string
+  isProspective?: boolean // FAC's IsProspective flag — true = ATO
+}
+```
+
+Compact projection of FAC's `EnrichedClub` — we strip `coordinates`, `phone`, `address.postalCode`/`street`, social links. Goal: small payload that surfaces what a district director wants to see when reading the list.
+
+## Data flow
+
+```
+FAC fetch → FindAClubMerger.facOnlyClubs (already captured)
+         ↓ NEW: project to ProspectiveClub[], write to snapshot.data.prospectiveClubs
+DistrictStatistics.prospectiveClubs (analytics-core interfaces) ← NEW optional field
+         ↓
+AnalyticsComputer.computeDistrictAnalytics(): read latestSnapshot.prospectiveClubs ?? []
+         ↓
+DistrictAnalytics.prospectiveClubs (NEW) — flows to district_{id}_analytics.json
+         ↓
+Frontend useDistrictAnalytics → DistrictClubsPage → ProspectiveClubsPanel
+```
+
+The list rides on the existing analytics file rather than triggering a second fetch of the 700KB snapshot. Costs ~bytes for districts with 0 ATOs.
+
+## Acceptance mapping
+
+- [ ] Decide A/B/C for placement — **B+** (above)
+- [ ] Schema bump for `prospectiveClubs` array (shared-contracts) — add optional field to `DistrictStatisticsFileSchema`
+- [ ] Merger service captures FAC-only clubs into the array — extend `FindAClubMerger.mergeFacIntoSnapshot`
+- [ ] UI surface ships — `ProspectiveClubsPanel` below ClubsTable on `/district/:id/clubs`
+- [ ] Sample real ATOs (D61 had +4) — production verify via Playwright + CDN snapshot inspection
+
+## TDD plan
+
+### Backend (one file at a time, Red → Green → Refactor each)
+
+1. **shared-contracts**: add `ProspectiveClubSchema` + extend `DistrictStatisticsFileSchema` with optional `prospectiveClubs`. Test: schema validates a sample object.
+2. **collector-cli FindAClubMerger**: write `prospectiveClubs` projection into snapshot.data. Test: merger output includes the array with expected shape.
+3. **analytics-core interfaces**: add `prospectiveClubs?: ProspectiveClub[]` to `DistrictStatistics` and `DistrictAnalytics`.
+4. **analytics-core AnalyticsComputer**: assign `districtAnalytics.prospectiveClubs = latestSnapshot.prospectiveClubs ?? []`. Test: computer copies the list through.
+
+### Frontend
+
+5. **frontend DistrictAnalytics**: add `prospectiveClubs?: ProspectiveClub[]` to the interface.
+6. **ProspectiveClubsPanel** component: renders nothing when empty, renders heading + list when present. Test: empty → null, non-empty → expected DOM.
+7. **DistrictClubsPage**: imports the panel and renders below ClubsTable. Smoke test.
+
+## Out of scope (deliberate)
+
+- Don't compute analytics from prospectives (they have no DCP/payments).
+- Don't add to ranking or aggregates.
+- Don't ship a dedicated `/district/:id/prospective` route.
+- Don't link prospective clubs to ClubDetailPage (no data to render there).
+- Don't add map markers — out of scope for v1.
+
+## Production verification target
+
+D61 (Ottawa) had +4 FAC-only clubs as of 2026-05-11. Playwright smoke on `https://ts.taverns.red/district/61/clubs` should find the panel heading with a numeric count ≥1, and at least one club name.


### PR DESCRIPTION
Closes #489.

## Summary

Surfaces clubs in TI's public Find-A-Club registry that aren't in `clubPerformance` — typically ATOs (Applications To Organize) or freshly-chartered clubs that haven't appeared in the dashboard roster yet. D61 had +4 such clubs on the 2026-05-11 run; they were being dropped by the merger and never reached the frontend.

## Placement: Option B+ (panel section)

A small "Prospective Clubs" section below the ClubsTable on `/district/:id/clubs`, visible only when the list is non-empty. Rejected:

- **Option A** (dedicated `/district/:id/prospective` route): typical N = 0–4, too sparse for a route.
- **Option C** (in ClubsTable with status badge): wrong data shape — prospectives have no DCP / payments / status, would corrupt the row model.

Full design + rationale: `tasks/sprint-18/plan.md`.

## Data flow

```
FAC fetch → FindAClubMerger.facOnlyClubs (already captured)
         ↓ NEW: project to ProspectiveClub[], write to snapshot.data.prospectiveClubs
DistrictStatistics.prospectiveClubs (analytics-core)
         ↓
AnalyticsComputer: read latestSnapshot.prospectiveClubs ?? []
         ↓
DistrictAnalytics.prospectiveClubs → district_{id}_analytics.json
         ↓
useDistrictAnalytics → DistrictClubsPage → ProspectiveClubsPanel
```

The list rides on the existing analytics file rather than triggering a second fetch of the 700 KB snapshot.

## What's in the box

- `shared-contracts`: `ProspectiveClub` type + Zod schema; optional `prospectiveClubs` field on `DistrictStatisticsFileSchema`.
- `collector-cli` `FindAClubMerger`: projects FAC-only clubs into compact `ProspectiveClub[]` and ALWAYS writes the field (clearing yesterday's entry when today is empty).
- `analytics-core`: `DistrictStatistics.prospectiveClubs?` (read), `DistrictAnalytics.prospectiveClubs: ProspectiveClub[]` (always materialized), `AnalyticsComputer` propagates from the latest snapshot.
- `frontend`: `ProspectiveClubsPanel` (renders nothing when empty), wired below `ClubsTable` on `DistrictClubsPage`.

## Definition of Done

- [x] Failing tests written first (schema, merger, computer, panel).
- [x] All 4 workspace suites green locally (shared-contracts 134, collector-cli 735, analytics-core 771, frontend 2367).
- [x] No assertion pinning — existing `normaliseTiClub` snapshot test extended for the new `clubName` field (intentional shape change).
- [x] /code-review fresh-context pass run; three findings (stale-key, always-array, empty-name fallback) addressed in commit 709899e.
- [ ] CI green.
- [ ] Live verification on `ts.taverns.red` post-merge (Playwright smoke + CDN snapshot inspection on D61).
- [ ] Lessons entry written.

## Test plan

- [x] Schema: ProspectiveClubSchema validates required / rejects missing fields. (28 schema tests.)
- [x] Merger: writes `prospectiveClubs`, clears stale entries, falls back to `Club <id>` when TI omits Name. (18 merger tests.)
- [x] Computer: propagates from latest snapshot; defaults to `[]`. (85 computer tests.)
- [x] Panel: empty → null; non-empty → heading with count + each club row + caption explaining the surface. (6 panel tests.)
- [ ] Production: Playwright smoke on `https://ts.taverns.red/district/61/clubs` finds the panel + a real ATO name. Run after PR merges and CDN refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)