### PR TITLE
chore(deps): #375 activate react-hooks/set-state-in-effect (7.0.1→7.1.1) + sentinel

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "@vitest/coverage-v8": "^4.1.3",
     "autoprefixer": "^10.4.27",
     "eslint": "^9.0.0",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.0",
     "fast-check": "^4.6.0",
     "globals": "^17.4.0",

--- a/frontend/src/__tests__/lint/set-state-in-effect.test.ts
+++ b/frontend/src/__tests__/lint/set-state-in-effect.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { ESLint } from 'eslint'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Resolve the frontend workspace root from this file's own location so the
+// test is independent of the runner's cwd (root `npm run test` launches from
+// the repo root; the frontend workspace run launches from frontend/).
+const frontendDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..'
+)
+
+const RULE = 'react-hooks/set-state-in-effect'
+
+// The exact anti-pattern #340 removed from DateRangeSelector and the three
+// column filters: mirror a prop into local state via a useEffect setter.
+// eslint-plugin-react-hooks 7.0.1 declares this rule at error in its
+// recommended config but does NOT actually detect this pattern (inert);
+// 7.1.1 activates real detection (#375). A config-severity assertion alone
+// would have passed against the inert 7.0.1 rule, so this sentinel lints a
+// known-bad snippet through the project's real ESLint config to prove the
+// rule is genuinely catching the anti-pattern. If a future dependency or
+// config change makes the rule inert again, this fails loudly instead of
+// silently re-admitting the pattern. See tasks/lessons/082.
+const OFFENDING_SOURCE = `import { useState, useEffect } from 'react'
+export function MirrorPropIntoState({ value }: { value: string }) {
+  const [local, setLocal] = useState(value)
+  useEffect(() => {
+    setLocal(value)
+  }, [value])
+  return local
+}
+`
+
+describe('react-hooks/set-state-in-effect enforcement (#375)', () => {
+  // ESLint loads the full flat config (typescript-eslint + react-hooks
+  // plugins) on first run, which is heavier than a unit test — allow headroom
+  // over the 5s global default rather than risk a cold-CI-runner flake.
+  it('flags a setState-in-effect violation as an error', async () => {
+    const eslint = new ESLint({ cwd: frontendDir })
+    const [result] = await eslint.lintText(OFFENDING_SOURCE, {
+      filePath: path.join(
+        frontendDir,
+        'src/__sentinel__/MirrorPropIntoState.tsx'
+      ),
+    })
+
+    const errors = result.messages.filter(
+      m => m.ruleId === RULE && m.severity === 2
+    )
+
+    expect(errors.length).toBeGreaterThan(0)
+  }, 20000)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       }
     },
     "frontend": {
-      "version": "2.10.0",
+      "version": "2.12.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.2.2",
@@ -51,7 +51,7 @@
         "@vitest/coverage-v8": "^4.1.3",
         "autoprefixer": "^10.4.27",
         "eslint": "^9.0.0",
-        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.0",
         "fast-check": "^4.6.0",
         "globals": "^17.4.0",
@@ -4312,9 +4312,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4328,7 +4328,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
@@ -8022,7 +8022,7 @@
     },
     "packages/analytics-core": {
       "name": "@toastmasters/analytics-core",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@toastmasters/shared-contracts": "^1.0.0",
@@ -8233,7 +8233,7 @@
     },
     "packages/collector-cli": {
       "name": "@toastmasters/collector-cli",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.19.0",

--- a/tasks/lessons/082-a-lint-rule-can-be-present-but-inert-assert-behavior-not-severity.md
+++ b/tasks/lessons/082-a-lint-rule-can-be-present-but-inert-assert-behavior-not-severity.md
@@ -1,0 +1,140 @@
+---
+name: A lint rule can be declared-at-error yet inert across a minor version — a sentinel must lint a known-bad snippet, not assert config severity
+description: #375 wanted to "unblock dependabot" by fixing setState-in-effect
+  violations so eslint-plugin-react-hooks could bump. But the violations were
+  already fixed (#340), and the installed 7.0.1 already listed
+  react-hooks/set-state-in-effect at "error" in its recommended config — so a
+  naive config-severity contract test (calculateConfigForFile → severity === 2)
+  PASSED while the rule produced ZERO diagnostics on a textbook violation. The
+  rule was declared-but-inert at 7.0.1; 7.1.1 is the version that actually
+  detects the pattern. The only test that distinguishes the two states lints a
+  known-bad snippet through the real config (ESLint.lintText) and asserts the
+  rule fires. Assert behavior, not declared severity, when the whole point is
+  enforcement.
+type: feedback
+---
+
+# Lesson 82 — A lint rule can be present-but-inert; assert behavior, not severity
+
+**Date:** 2026-05-23
+**Issue:** #375 (Sprint 20 — unblock dependabot #345/#348: setState-in-effect)
+**PR:** [#596](https://github.com/taverns-red/toast-stats/pull/596)
+
+## What happened
+
+#375 read as "fix 6 `react-hooks/set-state-in-effect` violations so the
+`eslint-plugin-react-hooks` 7.0.1 → 7.1.1 bump (bundled in dependabot
+#348) merges clean." Two facts on the ground had already moved:
+
+1. **The 6 violations were already fixed under #340** (closed). Every site
+   — `DateRangeSelector` + the three column filters + the migration test —
+   now uses the render-phase setState pattern
+   (`if (prop !== tracked) { setTracked(prop); ... }`).
+2. **#348 was closed**, superseded by fresh group PRs #589 (patch-and-minor,
+   contains the react-hooks bump) and #588 (dev-deps, contains the TS6/Vite8
+   majors).
+
+So the _code_ work was done. The remaining deliverable was to actually
+land the dependency that makes the rule **enforce**, and to lock that
+enforcement against future regression.
+
+### The trap: the rule was already "error" — but inert
+
+The installed `eslint-plugin-react-hooks@7.0.1` already lists
+`react-hooks/set-state-in-effect: "error"` in `configs.recommended.rules`,
+and the project spreads that config. So:
+
+```js
+// calculateConfigForFile('src/whatever.tsx').rules['react-hooks/set-state-in-effect']
+// => [2]   ← "error", at 7.0.1
+```
+
+A contract test asserting the resolved severity is `2` would have passed.
+**But linting a textbook violation produced zero diagnostics:**
+
+```ts
+// 7.0.1: ESLint.lintText(<mirror prop into state via useEffect>) → 0 hits
+// 7.1.1: same snippet → 1 hit, severity 2, at the setState line
+```
+
+At 7.0.1 the rule is _declared but inert_ — registered in the config,
+counted as "on," yet detecting nothing. The detection logic ships in
+7.1.1. A severity-only assertion is blind to this entire failure mode:
+it would have reported the rule "enforced" while real violations sailed
+through.
+
+## How to apply
+
+**Rule:** When a test exists to prove a lint rule is _enforcing_, lint a
+known-bad snippet through the real config and assert the rule fires. Do
+not assert the rule's declared severity — a rule can be present at
+`"error"` and still detect nothing.
+
+**Why:** "Is the rule configured?" and "does the rule catch the bug?" are
+different questions. Plugins gate detection behind versions, feature
+flags, parser options, or `languageOptions`; the recommended config can
+list a rule before its implementation lands (exactly what happened across
+react-hooks 7.0.1 → 7.1.1). The severity field tells you the _intent_;
+only a lint-against-a-fixture tells you the _behavior_. When the sprint's
+entire purpose is enforcement, test the behavior.
+
+**How to apply:**
+
+1. Use the project's real config: `new ESLint({ cwd: <workspace root> })`
+   so plugin/parser resolution matches CI — don't hand-build a config.
+2. Resolve the workspace root from `import.meta.url`, not `process.cwd()`,
+   so the test passes whether the runner launches from the repo root
+   (`npm run test`) or the workspace (`npm run test:frontend`).
+3. `lintText` a minimal snippet that _is_ the anti-pattern, with a
+   `filePath` under a path the config's `files` globs match (and that no
+   `ignores` pattern excludes). `lintText` never touches disk, so the
+   path can be virtual (`src/__sentinel__/Foo.tsx`).
+4. Assert `messages.filter(m => m.ruleId === RULE && m.severity === 2)`
+   is non-empty. This goes **red** on a downgrade, a removal, _or_ an
+   inert rule — all three are the regression you care about.
+
+## TDD note — this gave a genuine red→green tied to the bump
+
+Because 7.0.1 is inert, the sentinel committed **red** (`expected 0 to be
+greater than 0`) before any fix, and the 7.1.1 bump turned it **green**.
+No manufactured failure (cf. Lesson 78) — the dependency upgrade is the
+production change, and the sentinel is its falsifiable test.
+
+## What I explicitly did NOT do
+
+- Did **not** re-fix the 5 component sites — #340 already did, and full
+  lint at 7.1.1 is clean (0 errors), so the fixes hold under the now-live
+  rule. Re-touching them would be churn against work already shipped.
+- Did **not** bump `eslint` to 10 to take the bump. react-hooks 7.1.1
+  peer-deps include `^9.0.0`, so it works with the installed 9.39.4. The
+  eslint-10 / TS-6 / Vite-8 majors are coupled, higher-blast-radius, and
+  deferred to their own scoping issue (#597) per #375's plan.
+- Did **not** write a `calculateConfigForFile` severity assertion — it
+  would have false-passed against the inert 7.0.1 rule (the whole point
+  of this lesson).
+- Did **not** merge the 24-package #589 group as "the fix." The single
+  package that was the named blocker is bumped here in a focused PR;
+  #589's remaining 23 are dependabot's to land.
+
+## Telltale signs you're at this trap
+
+- The sprint goal is "turn on / enforce a lint rule," and the rule's name
+  already appears in a spread `configs.recommended.rules`.
+- A bump's changelog says it _introduces_ a rule, but the rule string is
+  already resolvable in the older version's config (declared early,
+  implemented later).
+- Your guard test is green before you've made any change — check whether
+  it's actually exercising detection or just reading config metadata.
+
+## Related
+
+- `frontend/src/__tests__/lint/set-state-in-effect.test.ts` — the sentinel.
+- `frontend/package.json` — `eslint-plugin-react-hooks` `^7.1.1`.
+- #340 — fixed the 6 violations (render-phase setState pattern).
+- #588 / #597 — the deferred dev-deps majors (TS6, Vite8, plugin-react6,
+  ESLint10).
+- Lesson 78 — the inverse discipline: _don't_ manufacture a fix for a
+  non-reproducing symptom. Here the symptom (inert rule) reproduces 100%,
+  so a real red→green is honest.
+- Lesson 81 — sibling "a test encodes a real constraint" lesson; both are
+  about reading what a test _actually_ asserts vs. what its name implies.


### PR DESCRIPTION
## Summary

Closes the remaining work on **#375** (Sprint 20 of epic #574).

The 6 `setState-in-effect` violations #375 describes were already fixed under **#340** (closed). What never landed was the dependency that makes the rule actually *enforce* them: at `eslint-plugin-react-hooks@7.0.1` the `react-hooks/set-state-in-effect` rule is present in the recommended config but **inert** — it produces zero diagnostics on a textbook prop-mirror-into-state violation. `7.1.1` activates real detection. That bump was bundled in dependabot PR #348 (now superseded by the still-open #589), which #348's closing comment confirms was "parked pending #375."

This PR:
- **Bumps `eslint-plugin-react-hooks` 7.0.1 → 7.1.1** (peer-compatible with the installed eslint 9.39.4 — no eslint major bump needed).
- **Adds a regression sentinel** (`set-state-in-effect.test.ts`) that lints a known-bad snippet through the project's real ESLint config and asserts the rule fires at error. A config-severity assertion alone would have passed against the *inert* 7.0.1 rule — the behavioral lint proves genuine detection, and fails loudly if a future dep/config change makes the rule inert again.

TDD trail: the sentinel was committed red (fails at 7.0.1, `expected 0 to be greater than 0`), then the bump turned it green.

The lockfile also syncs two stale local-workspace version fields (root `2.10.0→2.12.0`, analytics-core `1.5.0→1.5.1`) that lagged `package.json` on main — npm corrects these on install.

## Verification
- Full frontend suite: **164 files, 2374 tests pass**.
- `npm run lint`: **0 errors** (45 pre-existing warnings, unchanged) — #340's fixes hold under the now-active rule.
- Typecheck: clean.
- Fresh-context diff review: no findings.

## Out of scope (deferred)
- The dev-deps majors from dependabot #588 (TypeScript 6, Vite 8, @vitejs/plugin-react 6) — tracked separately per #375's plan. Filed as a follow-up scoping issue.

## Test plan
- [x] Sentinel test fails at 7.0.1, passes at 7.1.1
- [x] Full suite + lint + typecheck green locally
- [ ] CI green
- [ ] Live-verify filter components on ts.taverns.red (behavior-preserving, already live via #340)

🤖 Generated with [Claude Code](https://claude.com/claude-code)