### PR TITLE
feat(district-ia): back-to-district breadcrumb on every routed sub-page (#577)

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -75,9 +75,10 @@ A data visualization platform for **Toastmasters district leaders** to track clu
 
 ### Cross-page chrome
 
-| Feature         | Description                                                                                       | Status     |
-| --------------- | ------------------------------------------------------------------------------------------------- | ---------- |
-| DataControlsBar | Tight 3-chip cluster (data-fresh pill, PY chip, date chip) on /districts and /district/:id (#528) | ✅ Shipped |
+| Feature           | Description                                                                                                                                                            | Status     |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| DataControlsBar   | Tight 3-chip cluster (data-fresh pill, PY chip, date chip) on /districts and /district/:id (#528)                                                                      | ✅ Shipped |
+| SubpageBreadcrumb | Back-to-district breadcrumb on routed sub-pages — `District N` on /clubs,/divisions,/rankings; `District N › Clubs › <club>` on club detail (filter round-trip) (#577) | ✅ Shipped |
 
 ### Observability
 

--- a/frontend/src/components/SubpageBreadcrumb.tsx
+++ b/frontend/src/components/SubpageBreadcrumb.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+/* #577 — Back-to-district breadcrumb for routed district sub-pages.
+
+   Epic #568's IA migration converts in-tab views into routed sub-pages
+   (`/district/:id/clubs`, `/divisions`, `/rankings`, `/club/:cid`). Each
+   loses a clickable way back up the hierarchy, because DistrictDetailHeader's
+   own breadcrumb was removed in #442 (it collided with the AppShell's
+   "Districts" nav on the *landing* page — a collision that does NOT exist on
+   sub-pages, where the crumb reads "District 61 › Clubs", not the duplicate
+   "Districts › District 61").
+
+   This is the single source of that affordance. Sub-pages opt in; the bare
+   district landing opts out (preserving #442). Phase 3 pages (#571) drop it
+   in with one line. See tasks/lessons/ entry for #577. */
+
+export interface BreadcrumbCrumb {
+  /** Visible text for the crumb. */
+  label: string
+  /** Target route. Omit on the final crumb to render it as the current page. */
+  to?: string
+  /** Optional React Router navigation state (e.g. filter round-trip). */
+  state?: unknown
+}
+
+interface SubpageBreadcrumbProps {
+  crumbs: BreadcrumbCrumb[]
+}
+
+export const SubpageBreadcrumb: React.FC<SubpageBreadcrumbProps> = ({
+  crumbs,
+}) => {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="mb-4 font-tm-body text-sm"
+      data-testid="subpage-breadcrumb"
+    >
+      <ol className="flex flex-wrap items-center gap-2">
+        {crumbs.map((crumb, i) => {
+          const isLast = i === crumbs.length - 1
+          return (
+            <li key={`${crumb.label}-${i}`} className="flex items-center gap-2">
+              {crumb.to ? (
+                <Link
+                  to={crumb.to}
+                  state={crumb.state}
+                  className="text-tm-loyal-blue font-medium hover:underline"
+                >
+                  {crumb.label}
+                </Link>
+              ) : (
+                <span
+                  className="font-medium text-gray-900 dark:text-gray-100"
+                  aria-current="page"
+                >
+                  {crumb.label}
+                </span>
+              )}
+              {!isLast && (
+                <span aria-hidden="true" className="text-gray-400">
+                  ›
+                </span>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/frontend/src/components/__tests__/SubpageBreadcrumb.test.tsx
+++ b/frontend/src/components/__tests__/SubpageBreadcrumb.test.tsx
@@ -1,0 +1,99 @@
+/* #577 — Back-to-district breadcrumb for routed district sub-pages.
+   The component is the single source of the breadcrumb affordance the
+   District IA migration (epic #568) needs on every routed sub-page.
+   Phase 3 pages (#571) drop it in with one line. */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import { SubpageBreadcrumb } from '../SubpageBreadcrumb'
+
+expect.extend(toHaveNoViolations)
+
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>)
+
+describe('SubpageBreadcrumb (#577)', () => {
+  it('renders a nav labelled "Breadcrumb"', () => {
+    renderWithRouter(
+      <SubpageBreadcrumb
+        crumbs={[{ label: 'District 61', to: '/district/61' }]}
+      />
+    )
+    expect(
+      screen.getByRole('navigation', { name: 'Breadcrumb' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders a linked crumb pointing at its target', () => {
+    renderWithRouter(
+      <SubpageBreadcrumb
+        crumbs={[{ label: 'District 61', to: '/district/61' }]}
+      />
+    )
+    const link = screen.getByRole('link', { name: 'District 61' })
+    expect(link).toHaveAttribute('href', '/district/61')
+    // Strong affordance — not the weak text-gray-500 of the old crumb.
+    expect(link).toHaveClass('text-tm-loyal-blue')
+  })
+
+  it('renders the final crumb (no `to`) as the current page, not a link', () => {
+    renderWithRouter(
+      <SubpageBreadcrumb
+        crumbs={[
+          { label: 'District 61', to: '/district/61' },
+          { label: 'Clubs', to: '/district/61/clubs' },
+          { label: 'Ottawa Club' },
+        ]}
+      />
+    )
+    const current = screen.getByText('Ottawa Club')
+    expect(current).toHaveAttribute('aria-current', 'page')
+    expect(
+      screen.queryByRole('link', { name: 'Ottawa Club' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('links intermediate crumbs (the Clubs step)', () => {
+    renderWithRouter(
+      <SubpageBreadcrumb
+        crumbs={[
+          { label: 'District 61', to: '/district/61' },
+          { label: 'Clubs', to: '/district/61/clubs?status=vulnerable' },
+          { label: 'Ottawa Club' },
+        ]}
+      />
+    )
+    expect(screen.getByRole('link', { name: 'Clubs' })).toHaveAttribute(
+      'href',
+      '/district/61/clubs?status=vulnerable'
+    )
+  })
+
+  it('renders separators between crumbs but hides them from a11y tree', () => {
+    const { container } = renderWithRouter(
+      <SubpageBreadcrumb
+        crumbs={[
+          { label: 'District 61', to: '/district/61' },
+          { label: 'Clubs', to: '/district/61/clubs' },
+          { label: 'Ottawa Club' },
+        ]}
+      />
+    )
+    const seps = container.querySelectorAll('[aria-hidden="true"]')
+    expect(seps.length).toBe(2)
+  })
+
+  it('has no axe violations', async () => {
+    const { container } = renderWithRouter(
+      <SubpageBreadcrumb
+        crumbs={[
+          { label: 'District 61', to: '/district/61' },
+          { label: 'Clubs', to: '/district/61/clubs' },
+          { label: 'Ottawa Club' },
+        ]}
+      />
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useParams, useNavigate, Link } from 'react-router-dom'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useDistricts } from '../hooks/useDistricts'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
@@ -14,6 +14,7 @@ import { formatDisplayDate } from '../utils/dateFormatting'
 import { formatCharterDate } from '../utils/formatCharterDate'
 import { getClubAnniversary } from '../utils/clubAnniversary'
 import { ClubAnniversaryBadge } from '../components/ClubAnniversaryBadge'
+import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
 import {
   isProvisionallyDistinguished,
   getConfirmedLevel,
@@ -204,6 +205,17 @@ const ClubDetailPage: React.FC = () => {
     clubId: string
   }>()
   const navigate = useNavigate()
+  const location = useLocation()
+
+  // #577 — Filter round-trip: when the user arrived from a filtered clubs
+  // list, ClubsTable passed the prior search via navigation state. The
+  // "Clubs" breadcrumb prefers it so going back restores their filters;
+  // deep links without state fall back to the unfiltered clubs route.
+  const fromClubsSearch =
+    typeof (location.state as { fromClubsSearch?: unknown } | null)
+      ?.fromClubsSearch === 'string'
+      ? (location.state as { fromClubsSearch: string }).fromClubsSearch
+      : ''
 
   const { selectedProgramYear } = useUrlProgramYear()
 
@@ -398,26 +410,20 @@ const ClubDetailPage: React.FC = () => {
     <ErrorBoundary>
       <div className="min-h-screen">
         <div className="container mx-auto px-4 py-4 sm:py-8">
-          {/* Breadcrumbs — leading 'Home' crumb removed per #442 (the
-              AppShell's 'Districts' active nav already serves as the
-              top-level location signal). Trail starts at the parent
-              district so 'back to district' navigation stays one click
-              away. */}
-          <nav
-            className="flex items-center gap-2 text-sm text-gray-500 mb-6 font-tm-body"
-            aria-label="Breadcrumb"
-          >
-            <Link
-              to={`/district/${districtId}`}
-              className="hover:text-tm-loyal-blue transition-colors"
-            >
-              {districtName}
-            </Link>
-            <span aria-hidden="true">›</span>
-            <span className="text-gray-900 font-medium" aria-current="page">
-              {club.clubName}
-            </span>
-          </nav>
+          {/* Breadcrumbs (#577) — leading 'Home' crumb removed per #442
+              (the AppShell's 'Districts' active nav is the top-level
+              signal). Trail: District › Clubs › <club>. The Clubs crumb
+              restores the user's prior filtered list (filter round-trip). */}
+          <SubpageBreadcrumb
+            crumbs={[
+              { label: districtName, to: `/district/${districtId}` },
+              {
+                label: 'Clubs',
+                to: `/district/${districtId}/clubs${fromClubsSearch}`,
+              },
+              { label: club.clubName },
+            ]}
+          />
 
           {/* Redesigned hero per handoff (#23 follow-up). Loyal-blue panel
               with charter-style eyebrow + h1 + sub-line + right-side
@@ -912,28 +918,9 @@ const ClubDetailPage: React.FC = () => {
             isLoading={isLoadingStats}
           />
 
-          {/* Back to District button */}
-          <div className="flex justify-center py-4">
-            <button
-              onClick={() => navigate(`/district/${districtId}`)}
-              className="flex items-center gap-2 px-6 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors font-medium font-tm-body"
-            >
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 19l-7-7 7-7"
-                />
-              </svg>
-              Back to {districtName}
-            </button>
-          </div>
+          {/* Bottom "Back to District" button removed (#577) — the
+              breadcrumb at the top supersedes it. One back affordance,
+              not two. */}
         </div>
       </div>
     </ErrorBoundary>

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useMemo } from 'react'
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from 'react-router-dom'
 import { useDistricts } from '../hooks/useDistricts'
 import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
@@ -11,6 +16,7 @@ import {
   isDateInProgramYear,
 } from '../utils/programYear'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
+import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
 import { ClubsTable } from '../components/ClubsTable'
 import { ProspectiveClubsPanel } from '../components/ProspectiveClubsPanel'
 import ErrorBoundary from '../components/ErrorBoundary'
@@ -96,6 +102,7 @@ const filterStateToUrlPatch = (
 const DistrictClubsPage: React.FC = () => {
   const { districtId } = useParams<{ districtId: string }>()
   const navigate = useNavigate()
+  const location = useLocation()
   const [searchParams, setSearchParams] = useSearchParams()
 
   // Sort / page URL state -- mirrors DistrictDetailPage's conventions so
@@ -273,9 +280,13 @@ const DistrictClubsPage: React.FC = () => {
 
   const handleClubClick = useCallback(
     (club: ClubTrend) => {
-      navigate(`/district/${districtId}/club/${club.clubId}`)
+      // #577 — carry the current filter/search so the club page's "Clubs"
+      // breadcrumb can round-trip back to this exact filtered list.
+      navigate(`/district/${districtId}/club/${club.clubId}`, {
+        state: { fromClubsSearch: location.search },
+      })
     },
-    [navigate, districtId]
+    [navigate, districtId, location.search]
   )
 
   if (!districtId) {
@@ -300,15 +311,9 @@ const DistrictClubsPage: React.FC = () => {
             }
           />
 
-          <nav aria-label="District subview" className="mb-4">
-            <button
-              type="button"
-              onClick={() => navigate(`/district/${districtId}`)}
-              className="text-tm-loyal-blue hover:underline font-tm-headline font-medium"
-            >
-              ← Back to {districtName}
-            </button>
-          </nav>
+          <SubpageBreadcrumb
+            crumbs={[{ label: districtName, to: `/district/${districtId}` }]}
+          />
 
           <div className="space-y-4 sm:space-y-6">
             {isLoading && allClubs.length === 0 ? (

--- a/frontend/src/pages/DistrictDivisionsPage.tsx
+++ b/frontend/src/pages/DistrictDivisionsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useDistricts } from '../hooks/useDistricts'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
 import { useDistrictStatistics } from '../hooks/useMembershipData'
@@ -12,6 +12,7 @@ import {
 } from '../utils/programYear'
 import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
+import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
 import { DivisionPerformanceCards } from '../components/DivisionPerformanceCards'
 import DistinguishedProgramCriteriaExplainer from '../components/DistinguishedProgramCriteriaExplainer'
 import { DivisionAreaRecognitionPanel } from '../components/DivisionAreaRecognitionPanel'
@@ -25,7 +26,6 @@ import ErrorBoundary from '../components/ErrorBoundary'
 
 const DistrictDivisionsPage: React.FC = () => {
   const { districtId } = useParams<{ districtId: string }>()
-  const navigate = useNavigate()
 
   const {
     selectedProgramYear,
@@ -129,15 +129,9 @@ const DistrictDivisionsPage: React.FC = () => {
             }
           />
 
-          <nav aria-label="District subview" className="mb-4">
-            <button
-              type="button"
-              onClick={() => navigate(`/district/${districtId}`)}
-              className="text-tm-loyal-blue hover:underline font-tm-headline font-medium"
-            >
-              ← Back to {districtName}
-            </button>
-          </nav>
+          <SubpageBreadcrumb
+            crumbs={[{ label: districtName, to: `/district/${districtId}` }]}
+          />
 
           <div className="space-y-4 sm:space-y-6">
             {districtStatistics ? (

--- a/frontend/src/pages/DistrictRankingsPage.tsx
+++ b/frontend/src/pages/DistrictRankingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useDistricts } from '../hooks/useDistricts'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
@@ -10,6 +10,7 @@ import {
   isDateInProgramYear,
 } from '../utils/programYear'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
+import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
 import GlobalRankingsTab from '../components/GlobalRankingsTab'
 import ErrorBoundary from '../components/ErrorBoundary'
 
@@ -20,7 +21,6 @@ import ErrorBoundary from '../components/ErrorBoundary'
 
 const DistrictRankingsPage: React.FC = () => {
   const { districtId } = useParams<{ districtId: string }>()
-  const navigate = useNavigate()
 
   const {
     selectedProgramYear,
@@ -118,15 +118,9 @@ const DistrictRankingsPage: React.FC = () => {
             }
           />
 
-          <nav aria-label="District subview" className="mb-4">
-            <button
-              type="button"
-              onClick={() => navigate(`/district/${districtId}`)}
-              className="text-tm-loyal-blue hover:underline font-tm-headline font-medium"
-            >
-              ← Back to {districtName}
-            </button>
-          </nav>
+          <SubpageBreadcrumb
+            crumbs={[{ label: districtName, to: `/district/${districtId}` }]}
+          />
 
           <div className="space-y-4 sm:space-y-6">
             <GlobalRankingsTab

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -98,12 +98,21 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
 
-function renderWithRoute(clubId: string = '00000606') {
+function renderWithRoute(
+  clubId: string = '00000606',
+  fromClubsSearch?: string
+) {
+  const entry = fromClubsSearch
+    ? {
+        pathname: `/district/61/club/${clubId}`,
+        state: { fromClubsSearch },
+      }
+    : `/district/61/club/${clubId}`
   return render(
     <QueryClientProvider client={queryClient}>
       <ProgramYearProvider>
         <DarkModeProvider>
-          <MemoryRouter initialEntries={[`/district/61/club/${clubId}`]}>
+          <MemoryRouter initialEntries={[entry]}>
             <Routes>
               <Route
                 path="/district/:districtId/club/:clubId"
@@ -136,6 +145,41 @@ describe('ClubDetailPage (#208)', () => {
     expect(screen.queryByText('Home')).not.toBeInTheDocument()
     const breadcrumbLink = screen.getByRole('link', { name: 'District 61' })
     expect(breadcrumbLink).toHaveAttribute('href', '/district/61')
+  })
+
+  it('renders the District › Clubs › Club trail with a Clubs crumb (#577)', () => {
+    renderWithRoute()
+
+    // Intermediate Clubs crumb links to the clubs subview so users coming
+    // from a filtered list keep their context.
+    const clubsCrumb = screen.getByRole('link', { name: 'Clubs' })
+    expect(clubsCrumb).toHaveAttribute('href', '/district/61/clubs')
+
+    // The club name is the current page, not a link.
+    const current = screen.getByText('St Lawrence Toastmasters', {
+      selector: '[aria-current="page"]',
+    })
+    expect(current).toBeInTheDocument()
+  })
+
+  it('round-trips the prior clubs filter into the Clubs crumb (#577)', () => {
+    renderWithRoute('00000606', '?status=vulnerable')
+
+    expect(screen.getByRole('link', { name: 'Clubs' })).toHaveAttribute(
+      'href',
+      '/district/61/clubs?status=vulnerable'
+    )
+  })
+
+  it('no longer renders a redundant bottom "Back to District" button (#577)', () => {
+    renderWithRoute()
+
+    // The breadcrumb supersedes the old bottom button — one back
+    // affordance, not two. The District 61 crumb remains the back path.
+    const backButtons = screen.queryAllByRole('button', {
+      name: /Back to District 61/i,
+    })
+    expect(backButtons).toHaveLength(0)
   })
 
   it('renders membership stats grid with correct net change', () => {

--- a/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
@@ -186,6 +186,12 @@ const renderAt = (initialUrl: string) => {
         </Suspense>
       ),
     },
+    // Stub club-detail route so row-click navigation resolves and we can
+    // assert the navigation state (filter round-trip, #577).
+    {
+      path: '/district/:districtId/club/:clubId',
+      element: <div>club detail stub</div>,
+    },
   ]
 
   const router = createMemoryRouter(routes, { initialEntries: [initialUrl] })
@@ -216,6 +222,37 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
 
     expect(await screen.findByText(/alpha toastmasters/i)).toBeInTheDocument()
     expect(screen.getByText(/beta speakers/i)).toBeInTheDocument()
+  })
+
+  it('shows a back-to-district breadcrumb crumb, not the old back button (#577)', async () => {
+    renderAt('/district/61/clubs')
+
+    await screen.findByText(/alpha toastmasters/i)
+
+    // The District 61 crumb links back to the overview.
+    const crumb = screen.getByRole('link', { name: 'District 61' })
+    expect(crumb).toHaveAttribute('href', '/district/61')
+
+    // The ad-hoc "← Back to District 61" button is gone — the breadcrumb
+    // is the single back affordance.
+    expect(
+      screen.queryByRole('button', { name: /Back to District 61/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('round-trips the current filter into club navigation state (#577)', async () => {
+    const user = userEvent.setup()
+    const { router } = renderAt('/district/61/clubs?status=vulnerable')
+
+    // Only Beta Speakers is vulnerable; click its row.
+    const beta = await screen.findByText(/beta speakers/i)
+    await user.click(beta)
+
+    expect(router.state.location.pathname).toBe('/district/61/club/1002')
+    expect(
+      (router.state.location.state as { fromClubsSearch?: string } | null)
+        ?.fromClubsSearch
+    ).toBe('?status=vulnerable')
   })
 
   it('applies ?status=vulnerable to filter clubs on load', async () => {

--- a/frontend/src/pages/__tests__/DistrictDivisionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDivisionsPage.test.tsx
@@ -169,6 +169,19 @@ describe('DistrictDivisionsPage (#571 — Phase 3)', () => {
     ).toBeInTheDocument()
   })
 
+  it('shows a back-to-district breadcrumb, not the old back button (#577)', async () => {
+    renderAt('/district/61/divisions')
+    await screen.findByTestId('division-performance-cards')
+
+    expect(screen.getByRole('link', { name: 'District 61' })).toHaveAttribute(
+      'href',
+      '/district/61'
+    )
+    expect(
+      screen.queryByRole('button', { name: /Back to District 61/i })
+    ).not.toBeInTheDocument()
+  })
+
   it('redirects /district/:id?tab=divisions to /district/:id/divisions', async () => {
     const { router } = renderAt('/district/61?tab=divisions')
 

--- a/frontend/src/pages/__tests__/DistrictRankingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictRankingsPage.test.tsx
@@ -158,6 +158,19 @@ describe('DistrictRankingsPage (#571 — Phase 3)', () => {
     expect(await screen.findByTestId('global-rankings-tab')).toBeInTheDocument()
   })
 
+  it('shows a back-to-district breadcrumb, not the old back button (#577)', async () => {
+    renderAt('/district/61/rankings')
+    await screen.findByTestId('global-rankings-tab')
+
+    expect(screen.getByRole('link', { name: 'District 61' })).toHaveAttribute(
+      'href',
+      '/district/61'
+    )
+    expect(
+      screen.queryByRole('button', { name: /Back to District 61/i })
+    ).not.toBeInTheDocument()
+  })
+
   it('defaults metric to aggregate when ?metric is absent', async () => {
     renderAt('/district/61/rankings')
     expect(await screen.findByTestId('metric-value')).toHaveTextContent(

--- a/tasks/lessons/084-meta-epic-format-examples-arent-just-documentation.md
+++ b/tasks/lessons/084-meta-epic-format-examples-arent-just-documentation.md
@@ -34,8 +34,8 @@ indistinguishable from real input**.
 
 ## Fix
 
-Strip the example lines from the META_EPIC body. Describe the format in
-prose and in a fenced code block (which the regex _also_ doesn't understand,
+Strip the example lines from the META*EPIC body. Describe the format in
+prose and in a fenced code block (which the regex \_also* doesn't understand,
 but fenced lines start with backticks, not `- [ ]`, so they don't match).
 
 ## How to apply

--- a/tasks/lessons/085-subpage-breadcrumb-the-collision-442-feared-doesnt-exist-on-sub-pages.md
+++ b/tasks/lessons/085-subpage-breadcrumb-the-collision-442-feared-doesnt-exist-on-sub-pages.md
@@ -1,0 +1,66 @@
+# Lesson 085 — A breadcrumb removed to fix a collision on ONE page should not stay removed on pages where the collision can't occur
+
+**Date:** 2026-05-23
+**Issue:** #577 (back-to-district breadcrumb on routed sub-pages, epic #568 / #615)
+**Tags:** ux, navigation, accessibility, react-router, district-ia
+
+## What happened
+
+#442 removed the breadcrumb from `DistrictDetailHeader` because, on the
+district **landing** page (`/district/:id`), the crumb read
+`Districts › District 61` and visually collided with the AppShell's active
+`Districts` nav tab — redundant chrome saying the same thing twice.
+
+The District IA migration (epic #568) then converted in-tab views into routed
+sub-pages (`/clubs`, `/divisions`, `/rankings`, `/club/:cid`). Every sub-page
+reuses `DistrictDetailHeader`, so every sub-page **inherited the absence** and
+lost any clickable way back to the overview. The stopgap was an ad-hoc
+`← Back to {districtName}` button hand-rolled into three pages, plus a weak
+`text-gray-500` breadcrumb on ClubDetailPage that skipped the `Clubs` step.
+
+## Root cause / the reframe
+
+The #442 removal was correct **for the page it was reasoning about**, but its
+justification didn't generalise. On a sub-page the equivalent crumb is
+`District 61 › Clubs` — different words, no duplicate-of-the-nav collision.
+A fix scoped to one page's chrome was silently applied to a whole family of
+pages that don't share the constraint.
+
+## Fix
+
+One reusable `SubpageBreadcrumb` component (`nav[aria-label=Breadcrumb] > ol`):
+
+- Linked crumbs use the strong `text-tm-loyal-blue` affordance (not the weak
+  `text-gray-500` the old crumb used); the final crumb is `aria-current="page"`.
+- Sub-pages opt in (`[{ label: districtName, to: /district/:id }]`); the bare
+  landing page stays crumbless, preserving #442.
+- ClubDetailPage gets the full `District › Clubs › <club>` trail, and the
+  `Clubs` crumb round-trips the user's prior filtered list via React Router
+  navigation `state` (`fromClubsSearch`), falling back to the unfiltered route
+  on deep links.
+
+## How to apply
+
+- **When you remove UI to fix a problem, write down the precondition for the
+  problem.** "#442 removed the crumb because it duplicated the nav" is missing
+  the load-bearing qualifier: "..._on the landing page, where the nav already
+  names this location._" Without the qualifier, the next person reuses the
+  component on a page where the precondition is false and inherits a regression.
+- **A single-item breadcrumb that is a link (no `aria-current`) is fine** — the
+  current page simply isn't represented as a crumb. axe passes. AC's
+  "aria-current on the last crumb" applies only when there _is_ a current-page
+  crumb (the multi-crumb club-detail trail).
+- **Filter round-trip belongs in navigation `state`, not the URL** — it's
+  ephemeral context for one back-hop, not a shareable address. Guard the read
+  with `typeof === 'string'` so deep links without state degrade gracefully.
+- Phase 3 / future routed pages: drop `<SubpageBreadcrumb crumbs={[{ label:
+districtName, to: '/district/' + districtId }]} />` under the header. One line.
+
+## Related
+
+- `frontend/src/components/SubpageBreadcrumb.tsx` — the component.
+- #442 — original removal (the scoped-but-overgeneralised fix).
+- [[080-longest-serving-leaderboard-lives-with-its-data]] — sibling: a surface's
+  right home/behaviour comes from current reality, not a stale prior decision.
+- Lesson 81 — a removed thing can encode a real constraint; here the constraint
+  was real but page-specific, so the removal should have been page-specific too.

--- a/tasks/plan-577-subpage-breadcrumb.md
+++ b/tasks/plan-577-subpage-breadcrumb.md
@@ -1,0 +1,60 @@
+# Plan — #577 Back-to-district breadcrumb on routed sub-pages
+
+## Problem (regression from #570)
+
+Routed district sub-pages (`/district/:id/clubs|divisions|rankings`) and
+`/district/:id/club/:cid` lost a clear, clickable way back to the district
+overview. Today each sub-page has an ad-hoc `← Back to {districtName}` button
+(inconsistent, not a breadcrumb); ClubDetailPage has a visually weak
+`text-gray-500` breadcrumb that skips the `Clubs` step, plus a redundant bottom
+"Back to District" button.
+
+## Design (UX persona)
+
+One reusable accessible component, `SubpageBreadcrumb`:
+
+- `<nav aria-label="Breadcrumb"><ol>` of crumbs.
+- Each crumb: `{ label, to?, state? }`. A crumb with `to` renders a `<Link>`
+  (styled `text-tm-loyal-blue hover:text-tm-loyal-blue-80`, strong affordance).
+  The final crumb with no `to` renders `<span aria-current="page">`.
+- `›` separators are `aria-hidden`.
+
+Wiring:
+
+| Page                                          | Crumbs                                                                                                        |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `/district/:id/clubs` (+ divisions, rankings) | `District 61` → `/district/:id`                                                                               |
+| `/district/:id/club/:cid`                     | `District 61` → overview · `Clubs` → `/district/:id/clubs` (with filter round-trip) · `Ottawa Club` (current) |
+| `/district/:id` (landing)                     | none (preserve #442)                                                                                          |
+
+Replace the three sub-pages' `← Back to` button navs and ClubDetailPage's weak
+breadcrumb + bottom button with `SubpageBreadcrumb`. One back affordance.
+
+### Filter round-trip
+
+`ClubsTable` row click → `DistrictClubsPage.handleClubClick` passes
+`{ state: { fromClubsSearch: location.search } }` to `navigate`. ClubDetailPage's
+`Clubs` crumb prefers `state.fromClubsSearch`, falls back to `/district/:id/clubs`.
+
+## TDD steps
+
+1. RED: `SubpageBreadcrumb.test.tsx` — renders crumbs, link hrefs, aria-current
+   on last, nav aria-label, separators, axe pass. → component (GREEN).
+2. RED: ClubDetailPage breadcrumb shows 3 crumbs incl. `Clubs` link; bottom
+   button removed. → wire (GREEN).
+3. RED: DistrictClubsPage shows single `District 61` crumb (replaces back btn).
+   → wire (GREEN). Divisions/Rankings analogous.
+4. RED: filter round-trip — Clubs crumb href carries search when state present.
+   → wire ClubsTable + ClubDetailPage (GREEN).
+5. Refactor / /simplify / review / push / CI / live verify.
+6. Lesson in `tasks/lessons/` for Phase 3 (#571) reuse.
+
+## Acceptance criteria → test mapping
+
+- AC1 clubs crumb → DistrictClubsPage test
+- AC2 club-detail trail + filter round-trip → ClubDetailPage test
+- AC3 strong styling → component test (link class)
+- AC4 bottom button removed → ClubDetailPage test (queryBy absent)
+- AC5 no crumb on landing → DistrictDetailPage unaffected (no SubpageBreadcrumb)
+- AC6 axe → component test
+- AC7 pattern doc → lesson file


### PR DESCRIPTION
Closes #577. Sprint 1 of epic #615 (regression from #570).

## Problem
Routed district sub-pages (`/district/:id/clubs|divisions|rankings`, `/club/:cid`) lost a clear clickable way back to the overview. #442 removed `DistrictDetailHeader`'s breadcrumb to fix a nav collision **on the landing page** — but every sub-page that reuses the header inherited the absence. Stopgaps were ad-hoc `← Back to District` buttons + a weak `text-gray-500` crumb on club detail that skipped the `Clubs` step.

## Change
- New reusable, accessible `SubpageBreadcrumb` (`nav[aria-label=Breadcrumb] > ol`; strong `text-tm-loyal-blue` links; `aria-current="page"` on the final crumb).
- Club detail: `District 61 › Clubs › <club>` trail. The `Clubs` crumb round-trips the user's prior filtered list via React Router navigation `state` (`fromClubsSearch`), falling back to the unfiltered route on deep links.
- Clubs/Divisions/Rankings: single `District 61` crumb → overview, replacing the ad-hoc back buttons.
- Removed the redundant bottom "Back to District" button on club detail (one affordance, not two).
- Landing page stays crumbless, preserving #442.

## Acceptance criteria
- [x] AC1 `/clubs` shows `District 61` crumb → `/district/:id`
- [x] AC2 club detail `District 61 › Clubs › <club>`, Clubs links to `/clubs` with filter round-trip
- [x] AC3 strong styling (asserted in tests — `text-tm-loyal-blue`)
- [x] AC4 bottom back button removed
- [x] AC5 no crumb on `/district/:id` landing
- [x] AC6 axe-clean (`aria-label`, `aria-current`)
- [x] AC7 pattern documented — `tasks/lessons/085-*.md`

## Tests (TDD)
6 new `SubpageBreadcrumb` unit tests (incl. axe) + page-level tests for the trail, filter round-trip, and button removal. Full frontend suite green: **2387 passed**.

## Fresh-context review
Verdict APPROVE-WITH-NITS. Medium (missing lesson/AC7) — **fixed** in `c9215907`. Low nits accepted (single-link crumb has no `aria-current` by design; `React` import matches project convention).

## Note
First commit (`30cee2d8`) is an isolated prerequisite: `main` was red on `format:check` (lesson 084 from #605 had unformatted markdown), which blocked all deploys and would fail this PR's CI. No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)