### PR TITLE
feat(club): #618 Sprint 1 — gradient hero, 8-stat grid, back-link

### DIFF
--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useParams, useNavigate, useLocation } from 'react-router-dom'
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom'
 import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useDistricts } from '../hooks/useDistricts'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
@@ -409,7 +409,10 @@ const ClubDetailPage: React.FC = () => {
   return (
     <ErrorBoundary>
       <div className="min-h-screen">
-        <div className="container mx-auto px-4 py-4 sm:py-8">
+        {/* #618 — page container locked to the reference 1280px max-width
+            with 24px padding (16px ≤640px), replacing Tailwind's `container`
+            (which widens to 1536px at 2xl). */}
+        <div className="mx-auto max-w-[1280px] px-4 py-4 sm:px-6 sm:py-6">
           {/* Breadcrumbs (#577) — leading 'Home' crumb removed per #442
               (the AppShell's 'Districts' active nav is the top-level
               signal). Trail: District › Clubs › <club>. The Clubs crumb
@@ -561,25 +564,43 @@ const ClubDetailPage: React.FC = () => {
               </section>
             )}
 
-          {/* Stats Grid */}
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+          {/* 8-stat strip (#618) — pixel-perfect to club-reference.html.
+              Dedicated `.club-stats-grid` lays out 8 columns on desktop,
+              collapsing to 4 (≤640px) then 2 (≤420px) in CSS. Stat value
+              colour is carried by a `--pos/--neg/--muted/--tick/--cross`
+              modifier so the cross-cutting dark-mode override lives in CSS
+              (R10), not inline Tailwind classes. Net Δ and CSP keep their
+              sign / ✓✗ glyph so colour is never the only signal. */}
+          <div className="club-stats-grid">
             {[
               { label: 'Base', value: baseMembership },
               { label: 'Current', value: latestMembership },
               {
-                label: 'Net Change',
+                label: 'Net Δ',
                 value: `${membershipChange > 0 ? '+' : ''}${membershipChange}`,
-                color:
+                valClass:
                   membershipChange > 0
-                    ? 'text-green-600'
+                    ? 'pos'
                     : membershipChange < 0
-                      ? 'text-red-600'
+                      ? 'neg'
                       : '',
               },
               { label: 'DCP Goals', value: `${latestDcpGoals}/10` },
-              { label: 'Oct Renewals', value: club.octoberRenewals ?? '—' },
-              { label: 'Apr Renewals', value: club.aprilRenewals ?? '—' },
-              { label: 'New Members', value: club.newMembers ?? '—' },
+              {
+                label: 'Oct Renewals',
+                value: club.octoberRenewals ?? '—',
+                valClass: club.octoberRenewals === undefined ? 'muted' : '',
+              },
+              {
+                label: 'Apr Renewals',
+                value: club.aprilRenewals ?? '—',
+                valClass: club.aprilRenewals === undefined ? 'muted' : '',
+              },
+              {
+                label: 'New Members',
+                value: club.newMembers ?? '—',
+                valClass: club.newMembers === undefined ? 'muted' : '',
+              },
               {
                 label: 'CSP',
                 value:
@@ -588,12 +609,12 @@ const ClubDetailPage: React.FC = () => {
                     : club.cspSubmitted
                       ? '✓'
                       : '✗',
-                color:
+                valClass:
                   club.cspSubmitted === undefined
-                    ? 'text-gray-400'
+                    ? 'muted'
                     : club.cspSubmitted
-                      ? 'text-green-600'
-                      : 'text-red-600',
+                      ? 'tick'
+                      : 'cross',
                 title:
                   club.cspSubmitted === undefined
                     ? 'CSP data not available for this program year'
@@ -604,15 +625,15 @@ const ClubDetailPage: React.FC = () => {
             ].map(stat => (
               <div
                 key={stat.label}
-                className="bg-white rounded-lg shadow-sm p-3 border border-gray-200 text-center"
+                className="club-stat"
                 title={'title' in stat ? (stat.title as string) : undefined}
               >
-                <div className="text-xs text-gray-500 font-tm-body mb-1">
-                  {stat.label}
-                </div>
+                <div className="club-stat__label">{stat.label}</div>
                 <div
-                  className={`text-lg font-semibold font-tm-body tabular-nums ${
-                    'color' in stat && stat.color ? stat.color : 'text-gray-900'
+                  className={`club-stat__val tabular-nums${
+                    'valClass' in stat && stat.valClass
+                      ? ` club-stat__val--${stat.valClass}`
+                      : ''
                   }`}
                 >
                   {stat.value}
@@ -918,9 +939,30 @@ const ClubDetailPage: React.FC = () => {
             isLoading={isLoadingStats}
           />
 
-          {/* Bottom "Back to District" button removed (#577) — the
-              breadcrumb at the top supersedes it. One back affordance,
-              not two. */}
+          {/* Bottom back-link (#618) — the redesign reintroduces a footer
+              back affordance as an anchor (reference `.back-link` <a>), so a
+              user who has scrolled the full page can return without scrolling
+              back up to the breadcrumb. #577 removed the old *button*; this is
+              a single styled link, not a duplicate button. */}
+          <Link to={`/district/${districtId}`} className="club-back-link">
+            <svg
+              className="club-back-link__icon"
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.8}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10 13L5 8l5-5"
+              />
+            </svg>
+            Back to {districtName}
+          </Link>
         </div>
       </div>
     </ErrorBoundary>

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -171,28 +171,43 @@ describe('ClubDetailPage (#208)', () => {
     )
   })
 
-  it('no longer renders a redundant bottom "Back to District" button (#577)', () => {
+  it('renders a bottom "Back to District" link (#618 redesign re-adds it as an anchor)', () => {
     renderWithRoute()
 
-    // The breadcrumb supersedes the old bottom button — one back
-    // affordance, not two. The District 61 crumb remains the back path.
-    const backButtons = screen.queryAllByRole('button', {
+    // #577 removed the old bottom *button* as redundant with the breadcrumb.
+    // The #618 redesign (operator-confirmed, pixel-perfect to
+    // club-reference.html) reintroduces a bottom back affordance — but as an
+    // anchor link (reference uses a `.back-link` <a>), not a button. The
+    // breadcrumb's District crumb still provides top-of-page back nav.
+    const backLink = screen.getByRole('link', {
       name: /Back to District 61/i,
     })
-    expect(backButtons).toHaveLength(0)
+    expect(backLink).toHaveAttribute('href', '/district/61')
+
+    // Still no *button* affordance — the reference is an anchor, and we keep
+    // a single styled treatment.
+    expect(
+      screen.queryAllByRole('button', { name: /Back to District 61/i })
+    ).toHaveLength(0)
   })
 
   it('renders membership stats grid with correct net change', () => {
     renderWithRoute()
 
-    // Stats labels
+    // Stats labels — #618 renames "Net Change" → "Net Δ" to match the
+    // pixel-perfect club-reference.html stat strip.
     expect(screen.getByText('Base')).toBeInTheDocument()
     expect(screen.getByText('Current')).toBeInTheDocument()
-    expect(screen.getByText('Net Change')).toBeInTheDocument()
+    expect(screen.getByText('Net Δ')).toBeInTheDocument()
     expect(screen.getByText('DCP Goals')).toBeInTheDocument()
 
-    // Net Change = -5 (appears in stats grid + chart)
+    // Net Δ = -5 (appears in stats grid + chart)
     expect(screen.getAllByText('-5').length).toBeGreaterThanOrEqual(1)
+
+    // The 8-stat strip uses the dedicated responsive grid class (#618):
+    // 8-col desktop → 4-col ≤640px → 2-col ≤420px (enforced in CSS).
+    const grid = screen.getByText('Base').closest('.club-stats-grid')
+    expect(grid).not.toBeNull()
   })
 
   it('renders not found state for invalid club ID', () => {

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -877,10 +877,13 @@
   }
 
   /* #618 — match the reference Thriving pill: green text on the white pill,
-     paired with the green dot (colour is never the only signal). */
+     paired with the green dot (colour is never the only signal). The pill
+     background is a fixed white in BOTH themes, so the text uses the literal
+     reference green (#0d6b2f) rather than --green-600 — the dark-mode token
+     lifts to #22c55e, which drops below 4.5:1 on white. */
   .club-hero__pill--thriving,
   .club-hero__pill--healthy {
-    color: var(--green-600);
+    color: #0d6b2f;
   }
 
   .club-hero__pill--thriving .club-hero__pill-dot {

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -787,9 +787,17 @@
     gap: 12px;
     padding: 24px 28px;
     margin-bottom: 20px;
+    /* #618 — gradient per club-reference.html (was a flat fill). --loyal-500
+       and --loyal-600 are NOT dark-overridden in redesign.css, so the hero
+       stays loyal-blue in both themes (acceptance criterion). */
     background-color: var(--loyal-500);
+    background-image: linear-gradient(
+      135deg,
+      var(--loyal-500) 0%,
+      var(--loyal-600) 100%
+    );
     color: #ffffff;
-    border-radius: var(--rds-radius-lg);
+    border-radius: var(--rds-radius-md);
     box-shadow: var(--rds-shadow);
   }
 
@@ -813,15 +821,15 @@
     font-size: 11px;
     letter-spacing: 0.14em;
     text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.78);
+    color: rgba(255, 255, 255, 0.7);
   }
 
   .club-hero__title {
     margin: 8px 0 6px;
     font-family: var(--serif);
     font-weight: 800;
-    font-size: 30px;
-    line-height: 1.1;
+    font-size: 28px;
+    line-height: 1.15;
     letter-spacing: -0.015em;
     color: #ffffff;
   }
@@ -832,8 +840,8 @@
     flex-wrap: wrap;
     gap: 10px;
     font-family: var(--sans);
-    font-size: 13px;
-    color: rgba(255, 255, 255, 0.85);
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.78);
   }
 
   .club-hero__sub-divider {
@@ -866,6 +874,13 @@
     height: 8px;
     border-radius: 50%;
     flex-shrink: 0;
+  }
+
+  /* #618 — match the reference Thriving pill: green text on the white pill,
+     paired with the green dot (colour is never the only signal). */
+  .club-hero__pill--thriving,
+  .club-hero__pill--healthy {
+    color: var(--green-600);
   }
 
   .club-hero__pill--thriving .club-hero__pill-dot {
@@ -960,6 +975,99 @@
   .club-close-to-distinguished__copy strong {
     color: var(--ink);
     font-weight: 600;
+  }
+
+  /* 8-stat strip (#618) — pixel-perfect to club-reference.html. 8 columns
+     on desktop, 4 at ≤640px, 2 at ≤420px. Surface cards with hairline
+     borders; values in the display face. All colours via tokens so the
+     dark-mode cascade (redesign.css) applies without per-element overrides. */
+  .club-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    gap: 8px;
+    margin-bottom: 20px;
+  }
+
+  .club-stat {
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-sm);
+    padding: 12px 14px;
+    text-align: center;
+  }
+
+  .club-stat__label {
+    font-size: 10.5px;
+    font-weight: 600;
+    color: var(--ink-3);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 4px;
+  }
+
+  .club-stat__val {
+    font-family: var(--serif);
+    font-weight: 800;
+    font-size: 20px;
+    line-height: 1;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+  }
+
+  .club-stat__val--pos,
+  .club-stat__val--tick {
+    color: var(--green-600);
+  }
+
+  .club-stat__val--neg,
+  .club-stat__val--cross {
+    color: var(--red-600);
+  }
+
+  .club-stat__val--muted {
+    color: var(--ink-4);
+  }
+
+  @media (max-width: 640px) {
+    .club-stats-grid {
+      grid-template-columns: repeat(4, 1fr);
+    }
+
+    .club-stat__val {
+      font-size: 16px;
+    }
+  }
+
+  @media (max-width: 420px) {
+    .club-stats-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  /* Bottom back-link (#618) — neutral surface chip, anchor (not button). */
+  .club-back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 24px;
+    padding: 8px 14px;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-sm);
+    color: var(--ink-2);
+    font-family: var(--sans);
+    font-size: 13px;
+    text-decoration: none;
+  }
+
+  .club-back-link:hover {
+    background-color: var(--surface-3);
+    color: var(--ink);
+    text-decoration: none;
+  }
+
+  .club-back-link__icon {
+    flex-shrink: 0;
   }
 
   /* Distinguished Program criteria explainer (#362). Collapsible

--- a/tasks/618-plan.md
+++ b/tasks/618-plan.md
@@ -1,0 +1,51 @@
+# Sprint 1 (#618) — Club page: Hero + 8-stat grid + back-link
+
+Epic #617. Pixel-perfect against `docs/design/club-redesign-2026-05/club-reference.html`.
+
+## Gap analysis (current → reference)
+
+| Item           | Current                               | Reference                                                   | Action                                |
+| -------------- | ------------------------------------- | ----------------------------------------------------------- | ------------------------------------- |
+| Hero bg        | solid `var(--loyal-500)`              | `linear-gradient(135deg, --loyal-500 0%, --loyal-600 100%)` | add gradient                          |
+| Hero radius    | `--rds-radius-lg` (12px)              | `--radius` (8px) → `--rds-radius-md`                        | 12→8px                                |
+| Hero h1        | 30px                                  | 28px                                                        | 30→28px                               |
+| Eyebrow alpha  | .78                                   | .70                                                         | adjust                                |
+| Sub alpha      | .85                                   | .78                                                         | adjust                                |
+| Stats grid     | Tailwind `grid-cols-2 sm:grid-cols-4` | 8-col → 4-col ≤640 → 2-col ≤420, `.stat` cards              | new `club-stats-grid`/`club-stat` CSS |
+| Net Δ label    | "Net Change"                          | "Net Δ"                                                     | rename                                |
+| Stat val color | Tailwind text-green/red               | `.stat-val.pos/.neg/.tick/.cross`                           | new classes                           |
+| Page width     | `container mx-auto` (≤1536 at 2xl)    | max-width 1280, padding 24                                  | fixed 1280 wrapper                    |
+| Back-link      | removed (#577)                        | `.back-link` anchor at bottom                               | re-add as `<Link>`                    |
+
+## Deliberate deviations from reference (documented in PR)
+
+- **Breadcrumb trail kept as `District N › Clubs › Club`** (the #615 `SubpageBreadcrumb`, already wired).
+  Reference shows `Districts › District 57 › Club`. We keep the existing trail because #442 removed
+  the leading Districts/Home crumb (AppShell active-nav is the top-level signal) and #577 added the
+  Clubs crumb for filter round-trip. These are deliberate, later product decisions; pixel-fidelity on
+  the hero/stats does not justify regressing them. Build item "wire breadcrumb from #615" is satisfied.
+- **Back-link re-added** despite #577 removing it ("one back affordance"). #618 explicitly lists it as
+  build item #4 and the operator confirmed pixel-perfect against the reference (which has it). The
+  redesign reintroduces it as an anchor link at the page bottom. Spec evolution (Lesson 081), not
+  assertion pinning — the #577 test is updated to assert the link, not its absence.
+
+## TDD (jsdom-testable structure; CSS verified live)
+
+- **Red**: in `ClubDetailPage.test.tsx`
+  - "Net Change" → "Net Δ" assertion
+  - stats container has `club-stats-grid` class
+  - bottom back-link: `<Link>` role=link name=/Back to District 61/ href=/district/61
+  - update #577 test: assert the back-link link exists (reference uses anchor, not button)
+- **Green**: update `ClubDetailPage.tsx` JSX (stat classes, Net Δ, val pos/neg/tick/cross, back-link,
+  1280 page wrapper) + add CSS in `app-shell.css` (gradient, radius, typography, `club-stats-grid`,
+  `club-stat*`, `club-back-link`).
+- **Refactor**: /simplify + review.
+- **Verify**: full `npm run test:frontend`, build, then live Playwright smoke + screenshots at
+  375/768/1280 × light/dark + axe.
+
+## UX gates (ron-ux)
+
+- No horizontal scroll at 375px; 8/4/2-col confirmed.
+- Net Δ keeps +/- sign; CSP keeps ✓/✗ glyph (don't-rely-on-color-alone).
+- White-on-loyal-gradient, green/red-on-surface all ≥4.5:1; axe pass light+dark.
+- Hero gradient stays loyal-blue in dark (tokens --loyal-500/600 not dark-overridden).


### PR DESCRIPTION
Sprint 1 of the Club detail redesign (epic #617). Pixel-perfect against `docs/design/club-redesign-2026-05/club-reference.html`.

## What changed

- **Hero card** — `135deg` gradient `--loyal-500 → --loyal-600` (was a flat fill), radius `--rds-radius-md` (8px), h1 28px/1.15, eyebrow `rgba(255,255,255,.7)`, sub 14px/`.78`. Thriving pill text pinned to the reference `#0d6b2f` for AA on the white pill in both themes.
- **8-stat strip** — new `.club-stats-grid` (8-col → 4-col ≤640px → 2-col ≤420px) + `.club-stat` cards. `Net Change` → `Net Δ`. Value colours (`pos/neg/tick/cross/muted`) carried by CSS modifiers on tokens, so the dark-mode cascade applies without inline Tailwind (R10).
- **Back-link** — re-added at page bottom as an anchor `<Link>` (`.club-back-link`).
- **Page container** — locked to 1280px max-width / 24px padding (was Tailwind `container`, which widened to 1536px at 2xl).

## Deliberate deviations from the reference (and why)

1. **Breadcrumb trail kept as `District N › Clubs › Club`** (the #615 `SubpageBreadcrumb`, already wired) rather than the reference's `Districts › District 57 › Club`. #442 removed the leading crumb (the AppShell active-nav is the top-level signal) and #577 added the Clubs crumb for the filter round-trip. Pixel-fidelity on the hero/stats doesn't justify regressing those decisions. The build item "wire the breadcrumb from #615" is satisfied.
2. **Back-link re-added** despite #577 having removed it. #618 explicitly lists it as build item #4 and the operator confirmed pixel-perfect to the reference (which has it). Reintroduced as an *anchor* (not a button). The #577 test was rewritten to assert the link — spec evolution (Lesson 081), not assertion pinning.

## TDD / verification

- Red → Green → Refactor commits. Failing tests proven first (Net Δ label, `.club-stats-grid` container, bottom back-link).
- `npm run test:frontend`: **2387/2387 pass**, zero regressions.
- Typecheck clean; production build clean.
- Fresh-context `/review`: APPROVE-WITH-NITS. The one Medium finding (dark-mode pill contrast) is **fixed** in commit `fae7f0d4`.
- Live verification on `ts.taverns.red` (375/768/1280 × light/dark + axe + CDN data-path) to follow after deploy.

## Low-priority nit (triage)

- `.club-hero__pill--healthy` is styled but never emitted by the JSX (the status ternary produces only `--thriving/--watch/--at-risk`). Pre-existing defensive/dead selector; left as-is to keep the diff focused.

Closes #618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)