### PR TITLE
fix(awards): #608 Awards section dark-mode contrast sweep

### DIFF
--- a/frontend/src/__tests__/accessibility/AwardsDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/AwardsDarkModeContrast.test.ts
@@ -107,6 +107,7 @@ const TEXT_ELEMENTS: ReadonlyArray<{ sel: string; large: boolean }> = [
   { sel: '.awards-race__title', large: false },
   { sel: '.awards-race__meta', large: false },
   { sel: '.awards-race-card__title', large: false },
+  { sel: '.awards-race-card__description', large: false },
   { sel: '.awards-race-card__threshold', large: false },
   { sel: '.awards-race-card__leader-link', large: false },
   { sel: '.awards-race-card__leader-value', large: true },
@@ -123,6 +124,8 @@ const TEXT_ELEMENTS: ReadonlyArray<{ sel: string; large: boolean }> = [
   { sel: '.awards-page-card__value', large: false },
   { sel: '.awards-page-card__empty', large: false },
   { sel: '.awards-page__empty', large: false },
+  // The AwardsPage header's "Methodology" link reuses this shared class.
+  { sel: '.districts-methodology-callout__link', large: false },
 ]
 
 describe('Awards section dark-mode contrast (#608)', () => {

--- a/frontend/src/__tests__/accessibility/AwardsDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/AwardsDarkModeContrast.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Awards dark-mode contrast audit (#608, epic #574 Track D).
+ *
+ * The Awards section/route (`/awards` AwardsPage + the Districts-page Awards
+ * Race section) must reach dark-mode parity with District Detail: every text
+ * colour and the progress-fill graphic must clear WCAG AA on the dark surface.
+ *
+ * Rather than rely on jest-axe (which can't compute real contrast in jsdom —
+ * no layout engine), this reads the *actual* CSS source, resolves each awards
+ * foreground token through the `[data-theme='dark']` override map, and checks
+ * the ratio with the shipped `contrastCalculator`. It is falsifiable: a token
+ * that doesn't remap in dark (e.g. `--loyal-500` = #004165) fails here.
+ *
+ * Lives in `__tests__/accessibility/` so it routes to the integration project
+ * (vitest.shared.mjs / Lesson 090). It's pure computation, so it's fast.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { calculateContrastRatio } from '../../utils/contrastCalculator'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const stylesDir = resolve(here, '../../styles')
+
+// Strip /* … */ comments so a brace inside prose (e.g. `--green-{500,600}`)
+// can't be mistaken for a block close by the naive brace scan below.
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '')
+
+const tokensCss = stripComments(
+  readFileSync(resolve(stylesDir, 'tokens/redesign.css'), 'utf8')
+)
+const appShellCss = stripComments(
+  readFileSync(resolve(stylesDir, 'components/app-shell.css'), 'utf8')
+)
+
+/** Extract the `--name: value;` declarations from the first block whose
+ *  selector matches `selectorLiteral` exactly (e.g. `:root`). */
+function parseTokenBlock(
+  css: string,
+  selectorLiteral: string
+): Map<string, string> {
+  // Anchor to a real rule (line start + `{`) so a comment that merely mentions
+  // the selector (e.g. the `[data-theme='dark']` note in the file header)
+  // doesn't get parsed as the block.
+  const re = new RegExp(
+    '(?:^|\\n)\\s*' +
+      selectorLiteral.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\s*\\{'
+  )
+  const m = re.exec(css)
+  if (!m) throw new Error(`block ${selectorLiteral} not found`)
+  const open = css.indexOf('{', m.index)
+  const close = css.indexOf('}', open)
+  const body = css.slice(open + 1, close)
+  const map = new Map<string, string>()
+  for (const m of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    map.set(m[1].trim(), m[2].trim())
+  }
+  return map
+}
+
+const lightTokens = parseTokenBlock(tokensCss, ':root')
+const darkTokens = parseTokenBlock(tokensCss, "[data-theme='dark']")
+
+/** Resolve a token (or `var(--x)` chain) to a hex string, in dark mode
+ *  (dark map wins, falls back to the light :root value). */
+function resolveDark(value: string, depth = 0): string {
+  if (depth > 8) throw new Error(`var() resolution too deep: ${value}`)
+  const v = value.trim()
+  const varMatch = v.match(/^var\((--[\w-]+)\)$/)
+  if (varMatch) {
+    const name = varMatch[1]
+    const next = darkTokens.get(name) ?? lightTokens.get(name)
+    if (!next) throw new Error(`token ${name} undefined`)
+    return resolveDark(next, depth + 1)
+  }
+  return v
+}
+
+/** Pull the value of `prop` from the first rule that names `selector` exactly
+ *  (so `__status` never matches `__status--won`/`__status-dot`) and declares
+ *  that property. Returns the raw declaration value (e.g. `var(--link)`). */
+function declFor(css: string, selector: string, prop: string): string {
+  const re = new RegExp(
+    selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w-])',
+    'g'
+  )
+  let m: RegExpExecArray | null
+  while ((m = re.exec(css)) !== null) {
+    const open = css.indexOf('{', m.index)
+    if (open === -1) continue
+    const close = css.indexOf('}', open)
+    const body = css.slice(open + 1, close)
+    const propMatch = body.match(
+      new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;]+);')
+    )
+    if (propMatch) return propMatch[1].trim()
+  }
+  throw new Error(`no ${prop} for ${selector}`)
+}
+
+// Every awards text element → the surface it sits on. All awards cards sit on
+// `--surface` (page card sets it directly; race card is transparent over the
+// `--surface` `.awards-race` wrapper). isLargeText flags 18px+ or 14px+ bold.
+const TEXT_ELEMENTS: ReadonlyArray<{ sel: string; large: boolean }> = [
+  { sel: '.awards-race__title', large: false },
+  { sel: '.awards-race__meta', large: false },
+  { sel: '.awards-race-card__title', large: false },
+  { sel: '.awards-race-card__threshold', large: false },
+  { sel: '.awards-race-card__leader-link', large: false },
+  { sel: '.awards-race-card__leader-value', large: true },
+  { sel: '.awards-race-card__status', large: false },
+  { sel: '.awards-race-card__status--won', large: false },
+  { sel: '.awards-race-card__empty', large: false },
+  { sel: '.awards-page-card__title', large: false },
+  { sel: '.awards-page-card__description', large: false },
+  { sel: '.awards-page-card__achieved', large: false },
+  { sel: '.awards-page-card__methodology-link', large: false },
+  { sel: '.awards-page-card__rank', large: false },
+  { sel: '.awards-page-card__district', large: false },
+  { sel: '.awards-page-card__region', large: false },
+  { sel: '.awards-page-card__value', large: false },
+  { sel: '.awards-page-card__empty', large: false },
+  { sel: '.awards-page__empty', large: false },
+]
+
+describe('Awards section dark-mode contrast (#608)', () => {
+  const surfaceDark = resolveDark('var(--surface)')
+
+  it.each(TEXT_ELEMENTS)(
+    '$sel text clears WCAG AA on the dark surface',
+    ({ sel, large }) => {
+      const fg = resolveDark(declFor(appShellCss, sel, 'color'))
+      const ratio = calculateContrastRatio(fg, surfaceDark)
+      const required = large ? 3.0 : 4.5
+      expect(
+        ratio,
+        `${sel}: ${fg} on ${surfaceDark} = ${ratio.toFixed(2)}:1 (need ${required}:1)`
+      ).toBeGreaterThanOrEqual(required)
+    }
+  )
+
+  it('progress fill is visible against its track (graphical 3:1)', () => {
+    const fill = resolveDark(
+      declFor(
+        appShellCss,
+        '.awards-race-card__progress-fill',
+        'background-color'
+      )
+    )
+    const track = resolveDark(
+      declFor(
+        appShellCss,
+        '.awards-race-card__progress-track',
+        'background-color'
+      )
+    )
+    const ratio = calculateContrastRatio(fill, track)
+    expect(
+      ratio,
+      `progress fill ${fill} on track ${track} = ${ratio.toFixed(2)}:1 (need 3:1)`
+    ).toBeGreaterThanOrEqual(3.0)
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -1991,7 +1991,10 @@
     font-family: var(--serif);
     font-weight: 700;
     font-size: 14px;
-    color: var(--loyal-500);
+    /* --link, not --loyal-500: --loyal-500 (#004165) has no dark remap and
+       renders ~1.6:1 on the dark surface. --link is loyal-500 in light
+       (identical) and #60a5d8 in dark (#608, R10). */
+    color: var(--link);
     text-decoration: none;
   }
 
@@ -2019,7 +2022,9 @@
 
   .awards-race-card__progress-fill {
     height: 100%;
-    background-color: var(--loyal-500);
+    /* --link (dark-remapping) — see leader-link note. --loyal-500 was a
+       near-invisible navy fill on the dark track (#608). */
+    background-color: var(--link);
     border-radius: 2px;
     transition: width 400ms ease;
   }

--- a/tasks/608-awards-dark-mode-plan.md
+++ b/tasks/608-awards-dark-mode-plan.md
@@ -1,0 +1,43 @@
+# Sprint 12 (#608) — Awards page dark-mode sweep
+
+## Scope (ron-pm / ron-ux)
+
+The "Awards section/route" = two surfaces:
+
+- **`/awards` route** — `AwardsPage.tsx` (`.awards-page*` / `.awards-page-card*`).
+- **Awards Race section** — `AwardsRaceSection.tsx` (`.awards-race*`), the 3-card
+  contender summary on the Districts leaderboard that defers to `/awards`.
+
+`EducationalAwardsChart` is a district-detail chart, not part of the Awards
+section/route — out of scope.
+
+## Audit result (evidence over intuition)
+
+Both CSS blocks are already token-driven (R10) — no hardcoded rgba. Resolved
+every text token against the dark surface (`--surface` = `#111922`) using
+`contrastCalculator`. All pass AA **except**:
+
+- `.awards-race-card__leader-link` — `color: var(--loyal-500)` = `#004165`.
+  `--loyal-500` has **no `[data-theme='dark']` remap**, so a near-black navy
+  link renders on the dark surface (~1.3:1). FAIL.
+- `.awards-race-card__progress-fill` — `background-color: var(--loyal-500)`
+  (same token), a near-invisible fill on the dark track. Graphical-object
+  contrast (<3:1). FAIL.
+
+`AwardsPage` (`/awards`) is already clean: it uses `--link` / `--green-600` /
+`--ink*` which all remap in dark.
+
+## Fix
+
+Swap both `--loyal-500` usages → `--link`. In **light** mode
+`--link: var(--loyal-500)` → identical `#004165` (zero regression). In **dark**
+`--link: #60a5d8` (~6.6:1 text / ~6:1 graphic). Semantically correct: the leader
+link _is_ a link. Pure R10 — use the token that already remaps.
+
+## TDD
+
+- **Red:** `src/__tests__/accessibility/AwardsDarkModeContrast.test.ts` — parses
+  the real CSS, resolves each awards foreground token in dark mode, asserts AA
+  (text) / 3:1 (progress fill). Fails on the two `--loyal-500` usages.
+- **Green:** the two-token CSS swap.
+- **Verify:** full suite + browser-based axe smoke on prod after deploy.

--- a/tasks/lessons/093-a-token-that-doesnt-remap-in-dark-is-a-trap-for-any-non-link-consumer.md
+++ b/tasks/lessons/093-a-token-that-doesnt-remap-in-dark-is-a-trap-for-any-non-link-consumer.md
@@ -1,0 +1,72 @@
+# Lesson 093 — A token that doesn't remap in dark is a trap for every consumer that isn't `--link`
+
+**Date:** 2026-05-23
+**Issue:** #608 (Awards page dark-mode sweep, epic #574 Track D)
+**Tags:** dark-mode, tokens, contrast, R10, css, verification
+
+## What happened
+
+The Awards dark-mode sweep looked like it would be a big audit. It wasn't:
+both the `/awards` page CSS and the Awards Race section CSS were already
+fully token-driven (no hardcoded rgba), and almost every token they use
+(`--surface`, `--ink*`, `--link`, `--green-600`) has a `[data-theme='dark']`
+remap. The whole defect surface was **two** declarations:
+
+- `.awards-race-card__leader-link { color: var(--loyal-500) }`
+- `.awards-race-card__progress-fill { background-color: var(--loyal-500) }`
+
+`--loyal-500` (#004165) is a brand navy with **no dark remap**. On the dark
+`--surface` (#111922) the link rendered at ~1.6:1 — effectively invisible.
+
+## The non-obvious bit
+
+`--link` is _defined as_ `var(--loyal-500)` in `:root` but is independently
+remapped to `#60a5d8` under `[data-theme='dark']`. So the moment a value is a
+link, the codebase already has the dark-safe token — `--link`. The bug was a
+component reaching past the semantic token (`--link`) to the raw brand token
+(`--loyal-500`) it happens to equal _in light mode only_. The two are
+identical in light, which is exactly why the regression is invisible until you
+toggle the theme.
+
+**Principle:** a raw palette token with no dark remap is safe only for things
+that are theme-invariant (a fixed logo, a decorative tint that's light enough
+either way). The instant it colours text or a meaningful graphic, use the
+_semantic_ token that remaps (`--link`, `--ink`, `--green-600`), even if it
+resolves to the same hex in light. The fix here was a pure R10 win: swap to the
+remapping token, **zero** light-mode change (same `#004165`), dark fixed — no
+component-level `[data-theme]` override needed at all.
+
+## How I found it without a browser
+
+jest-axe can't compute contrast in jsdom (no layout). Instead the test reads
+the _real_ CSS, resolves each awards foreground token through the parsed
+`[data-theme='dark']` map, and runs `calculateContrastRatio` against the dark
+surface. Falsifiable (old `--loyal-500` computes 1.6:1 → fails) and fast (pure
+computation). Two parser footguns worth remembering for any "read the CSS in a
+test" approach:
+
+1. **A comment that merely mentions the selector poisons `indexOf`.** The file
+   header had `[data-theme='dark']` in prose; `indexOf` matched it and parsed
+   the wrong block. Anchor the selector match to a real rule (`^\s*<sel>\s*{`).
+2. **Prose braces close blocks.** A comment containing `--green-{500,600}` has
+   a literal `}` that a naive `indexOf('}')` treats as the block end, silently
+   truncating the token map. Strip `/* … */` before scanning.
+
+## How to apply
+
+- Grep new dark-mode work for raw palette tokens used as `color` /
+  `background-color`: `grep -nE 'color: var\(--(loyal|maroon|gray)-[0-9]'`.
+  Each is a candidate trap — confirm it either remaps in dark or is provably
+  theme-invariant.
+- Prefer the semantic remapping token over the raw one even when they're equal
+  in light. "Equal in light" is the camouflage, not an excuse.
+- When a test parses CSS/source, strip comments first and anchor block matches
+  to rule starts — a tokenizer that trusts `indexOf` will lie to you.
+
+## Related
+
+- [[092-reskin-the-tool-already-in-the-file-not-the-one-the-ticket-named]] —
+  R10: let theme-reactivity pick the primitive; CSS-addressable colours cost
+  one block, not N branches.
+- [[081-phase-gated-deferral-tests-move-with-the-spec]] — fidelity/spec work
+  where the source of truth is the design, not the author's instinct.


### PR DESCRIPTION
Closes #608 — Sprint 12 of epic #574 (Track D, dark-mode coverage beyond District Detail).

## Audit result

Both Awards CSS surfaces — the `/awards` route (`AwardsPage`) and the Districts-page **Awards Race** section (`AwardsRaceSection`) — were already token-driven (no hardcoded rgba). Resolving every awards foreground token against the dark surface (`--surface` = `#111922`) found exactly **two** defects, both the same root cause:

| Selector | Was | Dark ratio | Fix |
|---|---|---|---|
| `.awards-race-card__leader-link` (text) | `var(--loyal-500)` #004165 | **1.64:1** ❌ | `var(--link)` → 6.64:1 ✅ |
| `.awards-race-card__progress-fill` (graphic) | `var(--loyal-500)` #004165 | **1.46:1** ❌ | `var(--link)` → 5.93:1 ✅ |

`--loyal-500` has no `[data-theme='dark']` remap. `--link` **is** `var(--loyal-500)` in `:root` (so light renders identical `#004165` — zero regression) and `#60a5d8` in dark. Pure R10: use the semantic token that already remaps, no component-level override.

`AwardsPage` (`/awards`) was already clean (`--link`/`--green-600`/`--ink*` all remap).

## Acceptance criteria

- [x] Awards section passes contrast in both themes — new falsifiable test resolves every awards token through the dark map and asserts AA (text) / 3:1 (progress fill). 22 cases.
- [x] All text/badges/pills/leaderboard elements respond to `[data-theme='dark']` via tokens — the two raw-token holdouts now use `--link`.
- [x] No light-mode regression — `--link` ≡ `--loyal-500` in `:root`.
- [ ] Manual smoke at 375/768/1280 both modes — Playwright + axe on prod after deploy (per #444 pattern); screenshots to follow on the issue.

## TDD

- **Red** (`00190626`): contrast audit fails on the two `--loyal-500` usages.
- **Green** (`4ed06ac9`): two-token swap.
- **Review** (`ce4b2f56`): fresh-context review closed two coverage gaps (`__description`, methodology link).
- **Lesson 093** (`eb8254b3`).

## Notes
- Test reads real CSS rather than relying on jest-axe (which can't compute contrast in jsdom). Routes to the integration project per `vitest.shared.mjs`.
- Full suite green: 1999 unit + 104 targeted integration + 22 new; partition guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)