### PR TITLE
fix(club): #610 ClubDetailPage dark-mode contrast sweep

### DIFF
--- a/frontend/src/__tests__/accessibility/ClubDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/ClubDarkModeContrast.test.ts
@@ -88,8 +88,11 @@ function resolveVar(value: string, depth = 0): string {
   return resolveVar(next, depth + 1)
 }
 
-/** Value of `prop` from the first `[data-theme='dark'] <selector> { … }` rule,
- *  or null if none. `selector` is matched literally (escaped). */
+/** Value of `prop` from the `[data-theme='dark'] <selector> { … }` rule that
+ *  WINS the cascade — i.e. the LAST matching rule that sets `prop`, not the
+ *  first. (`.bg-blue-50` is declared twice in dark-mode.css with different
+ *  alphas; the browser renders the last, so the audit must too.) Null if none.
+ *  `selector` is matched literally (escaped). */
 function darkRuleValue(
   css: string,
   selector: string,
@@ -99,16 +102,19 @@ function darkRuleValue(
     "\\[data-theme='dark'\\]\\s*" +
       selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
       // allow the selector to sit in a comma-group: consume to `{`.
-      '(?![\\w-])[^{}]*\\{'
+      '(?![\\w-])[^{}]*\\{',
+    'g'
   )
-  const m = re.exec(css)
-  if (!m) return null
-  const open = css.indexOf('{', m.index)
-  const close = css.indexOf('}', open)
-  const pm = css
-    .slice(open + 1, close)
-    .match(new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;!]+)'))
-  return pm ? pm[1].trim() : null
+  let winner: string | null = null
+  for (const m of css.matchAll(re)) {
+    const open = css.indexOf('{', m.index)
+    const close = css.indexOf('}', open)
+    const pm = css
+      .slice(open + 1, close)
+      .match(new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;!]+)'))
+    if (pm) winner = pm[1].trim()
+  }
+  return winner
 }
 
 /** Composite an `rgba(r,g,b,a)` over an opaque hex base; pass hex through. */
@@ -185,6 +191,20 @@ describe('ClubDetailPage dark-mode contrast (#610)', () => {
     expect(
       ratio,
       `${token} = ${fg} on ${surface} = ${ratio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  // --ink-4 is a global token; lightening it for the club page must also clear
+  // AA on the LIGHTEST dark surface it lands on app-wide (--surface-3 #1a2330),
+  // or other consumers (e.g. the nav "soon" badge) silently stay sub-AA. This
+  // locks the bound the bump was sized against (review finding, #610).
+  it('muted --ink-4 clears AA on the lightest dark surface', () => {
+    const fg = resolveVar('var(--ink-4)')
+    const bg = resolveVar('var(--surface-3)')
+    const ratio = calculateContrastRatio(fg, bg)
+    expect(
+      ratio,
+      `--ink-4 ${fg} on --surface-3 ${bg} = ${ratio.toFixed(2)}:1`
     ).toBeGreaterThanOrEqual(4.5)
   })
 })

--- a/frontend/src/__tests__/accessibility/ClubDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/ClubDarkModeContrast.test.ts
@@ -1,0 +1,190 @@
+/**
+ * ClubDetailPage dark-mode contrast audit (#610, epic #574 Track D).
+ *
+ * Brings the club page (`/district/:id/club/:clubId`) to dark-mode parity: the
+ * anniversary badge variants, the CSP status pip, the per-stat values, and the
+ * membership-chart axis labels must all clear WCAG AA on the dark backgrounds
+ * they actually render on.
+ *
+ * Like the Awards (#608) and Region (#609) audits, this reads the *real* CSS
+ * (jest-axe can't compute contrast in jsdom — no layout) and resolves each
+ * foreground through the `[data-theme='dark']` cascade. Two surfaces matter:
+ *
+ *   - the page surface `--surface` (#111922) — stat cards / panels / chart, and
+ *   - the club-hero gradient base `--loyal-500` (#004165, fixed in BOTH themes
+ *     per #618) — the anniversary badge pills sit on the hero, not the surface.
+ *
+ * It is falsifiable. Before the #610 fix these fail:
+ *   - the milestone badge (`bg-yellow-100 text-yellow-900`): the bg has a dark
+ *     remap but `.text-yellow-900` has none (only 700/800 do), so the dark
+ *     Tailwind brown #713f12 lands on the darkened amber pill — ~1.2:1. The
+ *     Lesson 94 asymmetry: bg remapped, text didn't.
+ *   - the upcoming badge (`bg-blue-50 text-blue-900`): same shape — dark navy
+ *     #1e3a8a on the darkened blue pill.
+ *   - the CSP "—" pip and the chart axis labels (`var(--ink-4)` #5d6878): 3.1:1
+ *     on `--surface`, below AA for the small informational text they carry.
+ *
+ * Lives in `__tests__/accessibility/` so it routes to the integration project
+ * (Lesson 090). Pure computation, so it's fast.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { calculateContrastRatio } from '../../utils/contrastCalculator'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const stylesDir = resolve(here, '../../styles')
+
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '')
+const read = (p: string) =>
+  stripComments(readFileSync(resolve(stylesDir, p), 'utf8'))
+
+const redesignCss = read('tokens/redesign.css')
+const darkModeCss = read('dark-mode.css')
+
+/** Tailwind palette defaults for utilities that may have NO dark override.
+ *  A utility absent from dark-mode.css falls back here (framework constants). */
+const TAILWIND: Record<string, string> = {
+  'text-yellow-900': '#713f12',
+  'text-blue-900': '#1e3a8a',
+}
+
+/** Parse `--name: value;` declarations from the first rule whose selector
+ *  matches `selectorLiteral` exactly. Anchored to a real rule start so a
+ *  comment mentioning the selector can't poison the match (Lesson 093). */
+function parseTokenBlock(css: string, selectorLiteral: string) {
+  const re = new RegExp(
+    '(?:^|\\n)\\s*' +
+      selectorLiteral.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\s*\\{'
+  )
+  const m = re.exec(css)
+  if (!m) return new Map<string, string>()
+  const open = css.indexOf('{', m.index)
+  const close = css.indexOf('}', open)
+  const map = new Map<string, string>()
+  for (const d of css
+    .slice(open + 1, close)
+    .matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g))
+    map.set(d[1].trim(), d[2].trim())
+  return map
+}
+
+const lightTokens = parseTokenBlock(redesignCss, ':root')
+const darkTokens = new Map([
+  ...parseTokenBlock(redesignCss, "[data-theme='dark']"),
+  ...parseTokenBlock(darkModeCss, "[data-theme='dark']"),
+])
+
+/** Resolve a `var(--x)` chain to a literal (hex or rgba) in dark mode. */
+function resolveVar(value: string, depth = 0): string {
+  if (depth > 8) throw new Error(`var() too deep: ${value}`)
+  const v = value.trim()
+  const m = v.match(/^var\((--[\w-]+)\)$/)
+  if (!m) return v
+  const next = darkTokens.get(m[1]) ?? lightTokens.get(m[1])
+  if (!next) throw new Error(`token ${m[1]} undefined`)
+  return resolveVar(next, depth + 1)
+}
+
+/** Value of `prop` from the first `[data-theme='dark'] <selector> { … }` rule,
+ *  or null if none. `selector` is matched literally (escaped). */
+function darkRuleValue(
+  css: string,
+  selector: string,
+  prop: string
+): string | null {
+  const re = new RegExp(
+    "\\[data-theme='dark'\\]\\s*" +
+      selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      // allow the selector to sit in a comma-group: consume to `{`.
+      '(?![\\w-])[^{}]*\\{'
+  )
+  const m = re.exec(css)
+  if (!m) return null
+  const open = css.indexOf('{', m.index)
+  const close = css.indexOf('}', open)
+  const pm = css
+    .slice(open + 1, close)
+    .match(new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;!]+)'))
+  return pm ? pm[1].trim() : null
+}
+
+/** Composite an `rgba(r,g,b,a)` over an opaque hex base; pass hex through. */
+function compositeOver(value: string, baseHex: string): string {
+  const m = value.match(/rgba?\(([^)]+)\)/)
+  if (!m) return value
+  const [r, g, b, a = 1] = m[1].split(',').map(s => parseFloat(s.trim()))
+  const base = baseHex.replace('#', '')
+  const [br, bg, bb] = [0, 2, 4].map(i => parseInt(base.slice(i, i + 2), 16))
+  const mix = (f: number, k: number) =>
+    Math.round(f * Number(a) + k * (1 - Number(a)))
+  const h = (n: number) => n.toString(16).padStart(2, '0')
+  return `#${h(mix(r, br))}${h(mix(g, bg))}${h(mix(b, bb))}`
+}
+
+/** Dark-mode colour for a Tailwind utility class on a given background: its
+ *  `[data-theme='dark']` override (resolved + composited) if present, else the
+ *  Tailwind default. */
+function utilityDark(
+  className: string,
+  prop: 'color' | 'background-color',
+  bgHex: string
+): string {
+  const override = darkRuleValue(darkModeCss, `.${className}`, prop)
+  if (override) return compositeOver(resolveVar(override), bgHex)
+  const def = TAILWIND[className]
+  if (!def)
+    throw new Error(`no dark override or Tailwind default for .${className}`)
+  return def
+}
+
+const surface = resolveVar('var(--surface)') // #111922 page surface
+const heroBg = resolveVar('var(--loyal-500)') // #004165 hero gradient base
+
+describe('ClubDetailPage dark-mode contrast (#610)', () => {
+  // ── Anniversary badge variants (#445), on the fixed loyal-blue hero ────────
+  // Each variant is `bg-* text-*` Tailwind utilities. Under the manual
+  // [data-theme='dark'] toggle the `dark:` variants are inert (Lesson 73), so
+  // the base classes apply and dark-mode.css overrides drive the colours. Text
+  // and bg must remap together (Lesson 94).
+  const BADGES: ReadonlyArray<{ name: string; bg: string; text: string }> = [
+    { name: 'milestone (gold)', bg: 'bg-yellow-100', text: 'text-yellow-900' },
+    { name: 'upcoming (countdown)', bg: 'bg-blue-50', text: 'text-blue-900' },
+    { name: 'quiet', bg: 'bg-gray-100', text: 'text-gray-600' },
+  ]
+
+  it.each(BADGES)('$name badge text clears AA on the hero', ({ bg, text }) => {
+    const bgHex = utilityDark(bg, 'background-color', heroBg)
+    const fg = utilityDark(text, 'color', bgHex)
+    const ratio = calculateContrastRatio(fg, bgHex)
+    expect(
+      ratio,
+      `${bg}+${text}: ${fg} on ${bgHex} = ${ratio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  // ── Token-driven foregrounds on the dark page surface ──────────────────────
+  // The stat strip, CSP pip, and membership-chart labels colour via CSS vars
+  // (R10), so they're resolved straight through the dark token map. --ink-4 is
+  // the regression target: the muted CSP "—" pip and the chart axis labels use
+  // it, and at #5d6878 it sits at ~3.1:1 on --surface, below AA.
+  const TOKENS: ReadonlyArray<{ name: string; token: string }> = [
+    { name: 'CSP ✓ pip / stat positive', token: 'var(--green-600)' },
+    { name: 'CSP ✗ pip / stat negative', token: 'var(--red-600)' },
+    { name: 'CSP "—" pip / muted stat value', token: 'var(--ink-4)' },
+    { name: 'membership-chart axis label', token: 'var(--ink-4)' },
+    { name: 'chart key-date label / panel meta', token: 'var(--ink-3)' },
+    { name: 'panel body / stat value', token: 'var(--ink)' },
+  ]
+
+  it.each(TOKENS)('$name clears AA on the dark surface', ({ token }) => {
+    const fg = resolveVar(token)
+    const ratio = calculateContrastRatio(fg, surface)
+    expect(
+      ratio,
+      `${token} = ${fg} on ${surface} = ${ratio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+})

--- a/frontend/src/__tests__/css-migration/redesign-tokens.test.ts
+++ b/frontend/src/__tests__/css-migration/redesign-tokens.test.ts
@@ -119,7 +119,9 @@ describe('Redesign token system (#353)', () => {
       expect(block).toMatch(/--ink:\s*#eef2f7/i)
       expect(block).toMatch(/--ink-2:\s*#c8d1dd/i)
       expect(block).toMatch(/--ink-3:\s*#8a96a6/i)
-      expect(block).toMatch(/--ink-4:\s*#5d6878/i)
+      // #610: lightened from #5d6878 (3.13:1 on --surface, below AA) to clear
+      // AA for the muted CSP pip / chart axis labels it carries.
+      expect(block).toMatch(/--ink-4:\s*#7e8896/i)
       expect(block).toMatch(/--link:\s*#60a5d8/i)
       expect(block).toMatch(/--loyal-50:\s*#112432/i)
       expect(block).toMatch(/--loyal-100:\s*#16344a/i)

--- a/frontend/src/__tests__/css-migration/redesign-tokens.test.ts
+++ b/frontend/src/__tests__/css-migration/redesign-tokens.test.ts
@@ -120,8 +120,9 @@ describe('Redesign token system (#353)', () => {
       expect(block).toMatch(/--ink-2:\s*#c8d1dd/i)
       expect(block).toMatch(/--ink-3:\s*#8a96a6/i)
       // #610: lightened from #5d6878 (3.13:1 on --surface, below AA) to clear
-      // AA for the muted CSP pip / chart axis labels it carries.
-      expect(block).toMatch(/--ink-4:\s*#7e8896/i)
+      // AA on every dark surface for the muted text it carries (CSP pip, chart
+      // axis labels, and app-wide --ink-4 consumers on the lighter surfaces).
+      expect(block).toMatch(/--ink-4:\s*#828c9c/i)
       expect(block).toMatch(/--link:\s*#60a5d8/i)
       expect(block).toMatch(/--loyal-50:\s*#112432/i)
       expect(block).toMatch(/--loyal-100:\s*#16344a/i)

--- a/frontend/src/__tests__/css-migration/unmitigated-color-utilities.test.ts
+++ b/frontend/src/__tests__/css-migration/unmitigated-color-utilities.test.ts
@@ -72,8 +72,8 @@ const EXPECTED_FAILURES = new Set<string>([
   // lighter shade override in dark mode.
   'text-red-900',
   'text-green-900',
-  'text-yellow-900',
-  'text-blue-900',
+  // text-yellow-900 / text-blue-900 mitigated in Sprint 14 (#610) — the club
+  // anniversary badge consumes them, now remapped light in the dark block.
   // High-saturation fill colors — text-on-fill contrast may degrade on the
   // dark surface; needs a per-callsite check before override.
   'bg-red-500',

--- a/frontend/src/styles/dark-mode.css
+++ b/frontend/src/styles/dark-mode.css
@@ -370,8 +370,13 @@
     color: #F87171 !important;
 }
 
+/* #610: -900 joins the group. The club anniversary badge (the only consumer)
+   pairs text-yellow-900 with bg-yellow-100, whose dark remap darkens the pill;
+   without remapping the text too it stayed Tailwind #713f12 -> ~1.2:1 on the
+   darkened amber (Lesson 94 — fg and bg must remap together). */
 [data-theme='dark'] .text-yellow-700,
-[data-theme='dark'] .text-yellow-800 {
+[data-theme='dark'] .text-yellow-800,
+[data-theme='dark'] .text-yellow-900 {
     color: #FDE68A !important;
 }
 
@@ -388,8 +393,11 @@
     color: #4ADE80 !important;
 }
 
+/* #610: -900 joins the group — see the yellow note above. The upcoming-
+   anniversary badge pairs text-blue-900 with bg-blue-50 (dark-remapped). */
 [data-theme='dark'] .text-blue-700,
-[data-theme='dark'] .text-blue-800 {
+[data-theme='dark'] .text-blue-800,
+[data-theme='dark'] .text-blue-900 {
     color: #93C5FD !important;
 }
 

--- a/frontend/src/styles/tokens/redesign.css
+++ b/frontend/src/styles/tokens/redesign.css
@@ -70,10 +70,12 @@
   --ink-3: #8a96a6;
   /* #610: was #5d6878 — 3.13:1 on --surface, below WCAG AA for the small
      informational text it carries (the CSP "—" / muted stat values and the
-     membership-chart axis labels). Lightened to clear AA (~4.9:1 on --surface)
-     while staying perceptibly dimmer than --ink-3. Dark-only, fg/stroke-only
-     consumers, so monotonic-safe — same shape as the #609 muted-gray fix. */
-  --ink-4: #7e8896;
+     membership-chart axis labels). Lightened to clear AA on every dark surface
+     it can land on — 5.18:1 on --surface, 4.89:1 on --surface-2, 4.67:1 on
+     --surface-3 — while staying perceptibly dimmer than --ink-3. Dark-only,
+     fg/stroke-only consumers, so monotonic-safe — same shape as the #609
+     muted-gray fix. */
+  --ink-4: #828c9c;
   --link: #60a5d8;
   --loyal-50: #112432;
   --loyal-100: #16344a;

--- a/frontend/src/styles/tokens/redesign.css
+++ b/frontend/src/styles/tokens/redesign.css
@@ -68,7 +68,12 @@
   --ink: #eef2f7;
   --ink-2: #c8d1dd;
   --ink-3: #8a96a6;
-  --ink-4: #5d6878;
+  /* #610: was #5d6878 — 3.13:1 on --surface, below WCAG AA for the small
+     informational text it carries (the CSP "—" / muted stat values and the
+     membership-chart axis labels). Lightened to clear AA (~4.9:1 on --surface)
+     while staying perceptibly dimmer than --ink-3. Dark-only, fg/stroke-only
+     consumers, so monotonic-safe — same shape as the #609 muted-gray fix. */
+  --ink-4: #7e8896;
   --link: #60a5d8;
   --loyal-50: #112432;
   --loyal-100: #16344a;

--- a/tasks/lessons/095-darkmode-token-bumps-must-be-sized-for-the-lightest-surface.md
+++ b/tasks/lessons/095-darkmode-token-bumps-must-be-sized-for-the-lightest-surface.md
@@ -1,0 +1,76 @@
+# Lesson 095 — A global dark-token bump must be sized for the LIGHTEST surface it lands on
+
+**Date:** 2026-05-24
+**Issue:** #610 (ClubDetailPage dark-mode sweep, epic #574 Track D)
+**Tags:** dark-mode, tokens, contrast, R10, tailwind, verification, review
+
+## What happened
+
+The ClubDetailPage sweep had two defect families, both already catalogued by
+the Track-D predecessors:
+
+1. **The anniversary badge's `dark:` variants are inert.** The badge wears
+   `bg-yellow-100 text-yellow-900 dark:bg-yellow-900/40 dark:text-yellow-100`.
+   Under the project's **manual** `[data-theme='dark']` toggle the `dark:`
+   utilities never fire (they only emit under `prefers-color-scheme`, Lesson
+   73). So the base classes apply — and `bg-yellow-100` HAS a dark remap (it
+   darkens) while `.text-yellow-900` does NOT (only 700/800 were in the dark
+   text group). Dark Tailwind brown #713f12 on the darkened amber pill → ~1.2:1.
+   The exact **Lesson 94 asymmetry**: bg remapped, text didn't. Fix: add
+   `.text-yellow-900` / `.text-blue-900` to the existing 700/800 dark groups.
+   Confirmed only the badge consumes those two utilities, so zero light-mode
+   blast radius.
+
+2. **A muted token mis-valued for dark.** The CSP "—" pip and the membership-
+   chart axis labels colour via `var(--ink-4)`, which in dark was #5d6878 —
+   3.13:1 on `--surface`, below AA for small informational text. Same root cause
+   and same fix shape as the #609 muted-gray bump: lighten the token (dark-only,
+   fg/stroke-only consumers → monotonic-safe).
+
+## The bit worth keeping: size the bump for the lightest surface, not the one in front of you
+
+My first `--ink-4` value (#7e8896) was tuned to clear AA on `--surface`
+(#111922, 4.93:1) — the background of _the club page's_ `--ink-4` consumers.
+The fresh-context reviewer caught that `--ink-4` is a **global** token, and one
+off-page consumer (the nav "soon" badge) sits on the lighter `--surface-3`
+(#1a2330), where #7e8896 is only **4.41:1 — still sub-AA**. Improving a global
+token to "passes where I happened to look" leaves every consumer on a lighter
+dark surface quietly failing.
+
+The binding constraint for any global muted-token bump is the **lightest** dark
+background it can ever land on (here `--surface-3`), not the page's own surface.
+#828c9c clears AA on all three dark surfaces (5.18 / 4.89 / 4.67:1) while staying
+perceptibly dimmer than `--ink-3`. I locked it with an audit assertion against
+`--surface-3` so a future under-sized bump can't silently regress off-page
+consumers. (This mirrors Lesson 94's "solve muted contrast against the lightest
+dark background, not the darkest" — but at the **token** scope, where the set of
+backgrounds is the whole app, not one page.)
+
+## A second review catch: audit the rule the CASCADE renders, not the first match
+
+`.bg-blue-50` is declared **twice** in `dark-mode.css` with different alphas.
+The CSS-parsing audit's `darkRuleValue` returned the _first_ match; the browser
+renders the _last_. Both happened to pass AA, so the verdict was right by luck —
+but the test was asserting a background the page never shows. Fixed the helper to
+return the cascade-winning (last) rule. **When a test re-implements CSS
+resolution, it must model the cascade's last-wins rule, or it audits a fiction.**
+
+## How to apply
+
+- A `dark:` Tailwind class in this repo is a dead selector under the manual
+  toggle (Lesson 73). The real lever is the base class + its `[data-theme=dark]`
+  override. Audit the base/override pair, not the `dark:` the author wrote.
+- Before lightening a **global** muted token, enumerate every dark surface it
+  lands on and size the value to the **lightest** one. Add a test asserting that
+  bound so the guarantee is falsifiable.
+- A CSS-reading test must resolve the way the browser does: last-declared rule
+  wins. First-match parsing silently audits the wrong declaration.
+
+## Related
+
+- [[094-darkmode-utilities-fail-by-asymmetry-text-and-bg-must-remap-together]] —
+  the badge fix is a textbook instance; this lesson adds the token-scope
+  "lightest surface" corollary and the cascade-last-wins audit fix.
+- [[093-a-token-that-doesnt-remap-in-dark-is-a-trap-for-any-non-link-consumer]]
+- [[073-opacity-variant-utilities-need-explicit-dark-mode-overrides]] — why
+  `dark:` and opacity variants are inert under the manual toggle.


### PR DESCRIPTION
Sprint 14 of epic #574 (Track D — dark-mode coverage beyond District Detail). Closes #610.

## What was broken in dark mode

ClubDetailPage is mostly token-driven and already dark-covered from #618–#621. Two defect families remained, both predicted by the Track-D lessons:

1. **Anniversary badge milestone + upcoming variants** — the badge uses `dark:` Tailwind variants, which are **inert** under the project's manual `[data-theme='dark']` toggle (Lesson 73). So the base classes apply: `bg-yellow-100`/`bg-blue-50` HAVE dark remaps (they darken) but `text-yellow-900`/`text-blue-900` did **not** (only 700/800 were in the dark text groups). Dark text on a darkened pill → **1.16:1 (milestone)** / **1.02:1 (upcoming)** — the Lesson 94 asymmetry (fg and bg must remap together).
2. **CSP "—" pip + membership-chart axis labels** — colour via `var(--ink-4)`, which in dark was `#5d6878` = **3.13:1 on `--surface`**, below AA for small informational text.

## Fix (dark-only, R10 — zero light-mode change)

- Added `.text-yellow-900` → `#FDE68A` and `.text-blue-900` → `#93C5FD` to the existing 700/800 dark text groups in `dark-mode.css`. **Only the anniversary badge** consumes these utilities → zero external blast radius. Removed from the unmitigated-utility allowlist (tracked Track-D debt, now resolved).
- Lightened dark `--ink-4` from `#5d6878` → `#828c9c`. A global token, so sized for the **lightest** dark surface it lands on (`--surface-3` #1a2330): clears AA on all three (**5.18 / 4.89 / 4.67:1** on surface / surface-2 / surface-3) while staying dimmer than `--ink-3`. fg/stroke-only consumers → monotonic-safe, same shape as the #609 muted-gray fix.

## Verification

- New falsifiable audit `frontend/src/__tests__/accessibility/ClubDarkModeContrast.test.ts` parses the real CSS, resolves each foreground through the dark cascade (badge pills composited over the fixed loyal-blue hero `#004165`; stat/pip/chart over `--surface`), and asserts WCAG AA. **10/10 green** (4 fail before the fix at exactly the ratios above).
- Full frontend suite: **2472 passed, 0 failures**.
- Fresh-context `/review` (APPROVE-WITH-NITS) caught two issues, both fixed in this branch: the `--ink-4` value was first sized only for `--surface` (sub-AA on `--surface-3`), and the audit helper read the first `.bg-blue-50` rule rather than the cascade-winning last one.
- **Manual smoke at 375 / 768 / 1280 in both themes**: to be run on the deployed preview/prod after merge (live verification per the sprint protocol), screenshots posted to #610.

## Lesson

`tasks/lessons/095-darkmode-token-bumps-must-be-sized-for-the-lightest-surface.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)