### PR TITLE
fix(infra): #580 staging bucket CORS to unblock PR preview channels

### DIFF
--- a/docs/architecture-decisions/003-staging-bucket-cors-preview-channels.md
+++ b/docs/architecture-decisions/003-staging-bucket-cors-preview-channels.md
@@ -1,0 +1,86 @@
+# ADR-003: Staging Bucket CORS for Firebase Preview Channels
+
+**Status**: Accepted
+**Date**: 2026-05-24
+**Issue**: #580 (epic #657)
+**Context**: [ADR-002](002-staging-environment.md) introduced the staging GCS
+bucket `gs://toast-stats-data-staging`, read directly by the staging frontend
+via `https://storage.googleapis.com/toast-stats-data-staging`. Firebase Hosting
+also mints **per-PR preview channels** (e.g.
+`https://staging-toast-stats--pr-579-59y97tum.web.app`) that build with the
+staging CDN config and therefore fetch from the same staging bucket.
+
+The staging bucket's CORS config listed only fixed origins
+(`staging-toast-stats.web.app`, `staging.ts.taverns.red`, `ts.taverns.red`,
+`localhost:3000`). Preview-channel hostnames are **dynamic** —
+`staging-toast-stats--pr-<N>-<hash>.web.app`, a fresh random hash per channel —
+so they were never in the allowlist. Every data fetch from a preview channel
+returned `200` with **no `Access-Control-Allow-Origin` header**, so the browser
+blocked the read. Result: preview channels rendered chrome but no charts, KPIs,
+or district analytics — making them **non-verifiable for any data-dependent PR**
+(surfaced live-auditing PR #579, the #572 sticky-KPI work).
+
+## Decision
+
+Set the staging bucket's CORS `origin` to the wildcard `["*"]` (GET/HEAD only).
+
+```json
+[
+  {
+    "origin": ["*"],
+    "method": ["GET", "HEAD"],
+    "responseHeader": ["Content-Type", "Content-Encoding", "Content-Length", "Cache-Control", "ETag"],
+    "maxAgeSeconds": 3600
+  }
+]
+```
+
+Applied (config-as-code lives at `scripts/staging-cors.json`):
+
+```bash
+gsutil cors set scripts/staging-cors.json gs://toast-stats-data-staging
+```
+
+## Why `*` and not the ticket's `https://*.staging-toast-stats.web.app`
+
+The issue suggested a subdomain-wildcard origin. **GCS CORS does not support
+subdomain wildcards** — the `origin` field accepts only exact origins or the
+single `*` ("any origin"). Verified against the official docs
+(<https://cloud.google.com/storage/docs/cross-origin>): "You can supply a
+wildcard value that grants access to all origins: `*`." There is no
+`*.example.com` form. So `https://*.staging-toast-stats.web.app` would have
+matched **nothing** and left previews just as broken. (Also note the preview
+host `staging-toast-stats--pr-...web.app` is not even a DNS subdomain of
+`staging-toast-stats.web.app` — the `--` is part of a single label under
+`web.app`.) Since the set of preview hostnames is unbounded and unpredictable,
+exact enumeration is impossible. `*` is the only mechanism that works.
+
+## Why `*` is safe here
+
+- **The bucket is already world-readable.** Anonymous `GET` with no `Origin`
+  header returns the data today. CORS only governs **browser cross-origin JS
+  reads**; it adds no access-control gate for non-browser clients. So `*` does
+  not widen *who* can read the data — it is already public.
+- **The data is non-sensitive** — public Toastmasters district performance
+  stats, the same data served on the public production site.
+- **GET/HEAD only, anonymous (no credentials).** `Access-Control-Allow-Origin:
+  *` is only dangerous when combined with credentialed requests; these are not.
+- **Production is untouched.** Production data is served from the *separate*
+  bucket `gs://toast-stats-data-ca` via `cdn.taverns.red`, which keeps its
+  narrow exact-origin allowlist (`ts.taverns.red`, `localhost:5173`). This ADR
+  changes only `gs://toast-stats-data-staging`.
+
+## Maintenance note
+
+**Do not "tighten" the staging origin back to an exact/subdomain list** — that
+re-breaks every preview channel and is the exact regression this ADR fixes. If
+a future requirement demands narrowing staging CORS, the only correct lever is
+a credentialed/signed-URL scheme, not an origin allowlist, because preview
+hostnames cannot be enumerated.
+
+## Consequences
+
+- Preview channels now render full data; visual review on previews is
+  trustworthy again.
+- Any website can `fetch()` the staging JSON from a browser — acceptable, as the
+  data is already public and read-only.

--- a/docs/architecture-decisions/003-staging-bucket-cors-preview-channels.md
+++ b/docs/architecture-decisions/003-staging-bucket-cors-preview-channels.md
@@ -29,7 +29,13 @@ Set the staging bucket's CORS `origin` to the wildcard `["*"]` (GET/HEAD only).
   {
     "origin": ["*"],
     "method": ["GET", "HEAD"],
-    "responseHeader": ["Content-Type", "Content-Encoding", "Content-Length", "Cache-Control", "ETag"],
+    "responseHeader": [
+      "Content-Type",
+      "Content-Encoding",
+      "Content-Length",
+      "Cache-Control",
+      "ETag"
+    ],
     "maxAgeSeconds": 3600
   }
 ]
@@ -60,12 +66,12 @@ exact enumeration is impossible. `*` is the only mechanism that works.
 - **The bucket is already world-readable.** Anonymous `GET` with no `Origin`
   header returns the data today. CORS only governs **browser cross-origin JS
   reads**; it adds no access-control gate for non-browser clients. So `*` does
-  not widen *who* can read the data — it is already public.
+  not widen _who_ can read the data — it is already public.
 - **The data is non-sensitive** — public Toastmasters district performance
   stats, the same data served on the public production site.
 - **GET/HEAD only, anonymous (no credentials).** `Access-Control-Allow-Origin:
-  *` is only dangerous when combined with credentialed requests; these are not.
-- **Production is untouched.** Production data is served from the *separate*
+*` is only dangerous when combined with credentialed requests; these are not.
+- **Production is untouched.** Production data is served from the _separate_
   bucket `gs://toast-stats-data-ca` via `cdn.taverns.red`, which keeps its
   narrow exact-origin allowlist (`ts.taverns.red`, `localhost:5173`). This ADR
   changes only `gs://toast-stats-data-staging`.

--- a/scripts/staging-cors.json
+++ b/scripts/staging-cors.json
@@ -1,0 +1,14 @@
+[
+  {
+    "origin": ["*"],
+    "method": ["GET", "HEAD"],
+    "responseHeader": [
+      "Content-Type",
+      "Content-Encoding",
+      "Content-Length",
+      "Cache-Control",
+      "ETag"
+    ],
+    "maxAgeSeconds": 3600
+  }
+]

--- a/tasks/lessons/093-gcs-cors-has-no-subdomain-wildcard-so-dynamic-preview-hosts-need-star.md
+++ b/tasks/lessons/093-gcs-cors-has-no-subdomain-wildcard-so-dynamic-preview-hosts-need-star.md
@@ -1,0 +1,83 @@
+# Lesson 093 — GCS CORS has no subdomain wildcard; dynamic preview hosts force `*`
+
+**Date:** 2026-05-24
+**Issue:** #580 (epic #657 — PR preview channels can't load staging data)
+**Tags:** infra, gcs, cors, firebase-preview-channels, staging, ticket-vs-reality
+
+## What happened
+
+Firebase per-PR preview channels build with the staging CDN config and fetch
+from `gs://toast-stats-data-staging`. The bucket's CORS allowlist held only
+fixed origins (`staging-toast-stats.web.app`, `ts.taverns.red`, …). Preview
+hostnames are **dynamic** — `staging-toast-stats--pr-<N>-<hash>.web.app`, fresh
+random hash per channel — so they were never allowed. Every fetch returned
+`200` with **no `Access-Control-Allow-Origin` header**; the browser blocked the
+read. Previews showed chrome but no data → non-verifiable for any data PR.
+
+## The ticket's suggested fix was unimplementable
+
+#580 suggested `origin: ["https://*.staging-toast-stats.web.app"]`. Two ways
+that's wrong, both caught by checking the real constraint instead of trusting
+the sketch (cf. Lesson 092's "a ticket is a sketch, bend it to reality"):
+
+1. **GCS CORS does not support subdomain wildcards.** The `origin` field takes
+   only exact origins or the single `*`. Verified against the official docs
+   (cloud.google.com/storage/docs/cross-origin): "You can supply a wildcard
+   value that grants access to all origins: `*`." No `*.example.com` form
+   exists. So the suggested origin would have matched **nothing**.
+2. **The preview host isn't even a DNS subdomain.** `staging-toast-stats--pr-…`
+   is a single label under `web.app` (the `--` is literal), not a child of
+   `staging-toast-stats.web.app`. So even a hypothetical subdomain wildcard
+   wouldn't match it.
+
+Preview hostnames are unbounded/unpredictable → exact enumeration impossible →
+`*` is the **only** mechanism that works.
+
+## Why `*` was safe (and how to argue it)
+
+CORS only governs **browser cross-origin JS reads**; it is not an access gate
+for non-browser clients. The bucket was **already world-readable** (anonymous
+`curl` with no Origin returns the data), so `*` widened _nothing_ — it just lets
+the browser surface data that was always publicly fetchable. Data is public
+Toastmasters stats; GET/HEAD-only; anonymous (no credentials, so the
+credentialed-`*` footgun doesn't apply). Production is a **separate bucket**
+(`toast-stats-data-ca` via `cdn.taverns.red`) and kept its narrow exact-origin
+list — proven by capturing its CORS before/after (identical) and confirming the
+prod CDN still echoes `ts.taverns.red`, not `*`.
+
+**Key distinction for any "is `*` CORS dangerous?" decision:** the risk is about
+_credentials + write methods + private data_, not the wildcard itself. Public,
+read-only, anonymous data → `*` is the correct, safe answer.
+
+## Process notes
+
+- **The apply step (`gsutil cors set`) hit the auto-mode permission classifier**
+  and was denied as "unauthorized modification of shared infra." Correct
+  behaviour — a `*` CORS change on a shared bucket is exactly the
+  outward-facing, hard-to-self-authorize action that needs a human. Surfaced via
+  AskUserQuestion → operator authorized → applied. Don't work around an infra
+  permission gate; escalate it.
+- **TDD for infra = before/after live capture.** No unit test exists for a
+  bucket's CORS. The "Red" was a curl from a preview-style Origin returning no
+  ACAO; the "Green" was the same curl returning `Access-Control-Allow-Origin:
+*`. Config-as-code (`scripts/staging-cors.json`) + ADR-003 make it reproducible
+  and document the non-obvious `*` rationale so nobody "tightens" it back and
+  re-breaks previews.
+
+## How to apply
+
+- Before trusting a ticket's CORS/origin snippet, confirm the platform actually
+  supports that origin syntax. GCS: exact or `*` only.
+- For dynamic/ephemeral hostnames (preview channels, per-PR deploys), an origin
+  allowlist is structurally the wrong tool — use `*` if the data is public, or a
+  signed-URL/credential scheme if it isn't.
+- Prove "production unchanged" with a literal before/after capture, not an
+  assertion. Separate buckets make this clean.
+
+## Related
+
+- [[092-ticket-helper-signatures-bend-to-the-real-data-shape]] — same family:
+  the ticket specifies a _means_; verify it against reality and implement the
+  _contract_.
+- ADR-003 (`docs/architecture-decisions/003-staging-bucket-cors-preview-channels.md`)
+  — the decision record this lesson backs.


### PR DESCRIPTION
Closes #580 (epic #657)

## Problem

Firebase per-PR preview channels (`staging-toast-stats--pr-<N>-<hash>.web.app`) build with the staging CDN config and fetch from `gs://toast-stats-data-staging`. The bucket's CORS allowlist held only **fixed** origins, so the **dynamic** preview hostnames were never allowed. Every fetch returned `200` with **no `Access-Control-Allow-Origin` header** and the browser blocked the read — previews rendered chrome but no charts/KPIs/analytics, making them non-verifiable for any data-dependent PR (surfaced live-auditing PR #579).

## Fix

Set the staging bucket CORS `origin` to `["*"]` (GET/HEAD only). Config-as-code at `scripts/staging-cors.json`; rationale in **ADR-003**.

Applied out-of-band (the effect is on the live bucket, not produced by this PR's build):
```bash
gsutil cors set scripts/staging-cors.json gs://toast-stats-data-staging
```

### Why `*` and not the ticket's `https://*.staging-toast-stats.web.app`
GCS CORS supports **only exact origins or `*`** — no subdomain wildcards ([verified against official docs](https://cloud.google.com/storage/docs/cross-origin)). The ticket's suggested origin would have matched nothing. Preview hostnames are unbounded, so exact enumeration is impossible; `*` is the only viable mechanism.

### Why `*` is safe
- The bucket is **already world-readable** — anonymous GET (no Origin) returns the data today. CORS only governs browser cross-origin JS reads; it is not an access gate for non-browser clients. `*` widens nothing.
- Data is **public, non-sensitive** Toastmasters stats; **GET/HEAD-only, anonymous** (no credentials → no credentialed-`*` footgun).
- **Production is untouched** — prod data is served from the *separate* bucket `gs://toast-stats-data-ca` via `cdn.taverns.red`, which keeps its narrow exact-origin allowlist.

## Verification (data path)

| Check | Before (Red) | After (Green) |
|---|---|---|
| GET, preview-style Origin | `200`, **no ACAO** | `200`, `access-control-allow-origin: *` |
| OPTIONS preflight, preview Origin | `200`, no CORS headers | `200`, `ACAO: *` + methods/headers/max-age |
| Prod CDN (`ts.taverns.red` Origin) | echoes `ts.taverns.red` | **unchanged** — echoes `ts.taverns.red` (not `*`) |
| Prod bucket `toast-stats-data-ca` CORS | exact-origin list | **identical** before/after |

Live preview-channel render verification (District 61 full data, no console CORS errors) to follow on this PR's own preview channel, then posted to #580.

## DoD note
Config + docs only (no app source, no `packages/*/src/`, no tests/business logic). No workspace rebuild needed. Pre-commit (typecheck + lint + yaml) and prettier `format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)