### PR TITLE
Sprint 2 (#649): promote lessons 083-092 to R13-R20 in rules.md

### DIFF
--- a/tasks/lessons/083-exit-trap-return-value-is-the-scripts-exit-code.md
+++ b/tasks/lessons/083-exit-trap-return-value-is-the-scripts-exit-code.md
@@ -9,6 +9,8 @@ issues: [603]
 
 # Lesson 083 — A bash EXIT trap's return value becomes the script's exit code
 
+> **Promoted to R13** (2026-05-24, #649). This file is preserved for historical context.
+
 **Date:** 2026-05-23
 **Issue:** #603 (sprint-runner hardening)
 **Tags:** bash, traps, exit-codes

--- a/tasks/lessons/086-close-then-tick-ordering-can-trigger-duplicate-sprint-launches.md
+++ b/tasks/lessons/086-close-then-tick-ordering-can-trigger-duplicate-sprint-launches.md
@@ -9,6 +9,8 @@ issues: [626]
 
 # Lesson 086 — Close-then-tick ordering invites a duplicate-launch race
 
+> **Promoted to R15** (2026-05-24, #649). This file is preserved for historical context.
+
 **Date:** 2026-05-23
 **Issue:** #626 (sprint-runner reaps in-flight session)
 **Tags:** automation, race-conditions, sprint-runner, distributed-state

--- a/tasks/lessons/087-spawned-sessions-need-their-own-worktree-not-shared-checkout.md
+++ b/tasks/lessons/087-spawned-sessions-need-their-own-worktree-not-shared-checkout.md
@@ -9,6 +9,8 @@ issues: [625]
 
 # Lesson 087 — Spawned automation sessions need their own git worktree
 
+> **Promoted to R19** (2026-05-24, #649). This file is preserved for historical context.
+
 **Date:** 2026-05-23
 **Issue:** #625 (sprint-runner worktree isolation)
 **Tags:** automation, git-worktree, concurrency, sprint-runner

--- a/tasks/lessons/088-single-action-per-tick-was-a-false-virtue.md
+++ b/tasks/lessons/088-single-action-per-tick-was-a-false-virtue.md
@@ -9,6 +9,8 @@ issues: [627]
 
 # Lesson 088 — "Single action per tick" was a false virtue in the autonomous runner
 
+> **Promoted to R18** (2026-05-24, #649). This file is preserved for historical context.
+
 **Date:** 2026-05-23
 **Issue:** #627 (sprint-runner cascade)
 **Tags:** automation, sprint-runner, design-philosophy

--- a/tasks/lessons/089-pipefail-plus-screen-ls-exit-1-poisons-every-pipeline.md
+++ b/tasks/lessons/089-pipefail-plus-screen-ls-exit-1-poisons-every-pipeline.md
@@ -9,6 +9,8 @@ issues: [633, 634]
 
 # Lesson 089 — `set -o pipefail` + macOS `screen -ls` exit 1 = silently broken detection
 
+> **Promoted to R14** (2026-05-24, #649). This file is preserved for historical context.
+
 **Date:** 2026-05-23
 **Issues:** #633 (verify retry), #634 (critical orphan false-positive)
 **Tags:** macOS, screen, bash, pipefail, false-diagnoses

--- a/tasks/lessons/090-vitest-project-split-needs-a-partition-guard.md
+++ b/tasks/lessons/090-vitest-project-split-needs-a-partition-guard.md
@@ -9,6 +9,8 @@ issues: [482, 616]
 
 # Lesson 090 — Splitting one test suite into named projects needs a partition guard, or files silently fall out of both
 
+> **Promoted to R20** (partition guard) **and R19** (branch-from-remote-tip catch) (2026-05-24, #649). This file is preserved for historical context.
+
 **Date:** 2026-05-23
 **Issue:** #482 (test-infra: first-class vitest unit/integration projects, epic #616)
 **Tags:** testing, vitest, test-infra, ci, falsifiability

--- a/tasks/lessons/091-bootstrap-prompt-scope-must-be-explicit-or-runs-diverge.md
+++ b/tasks/lessons/091-bootstrap-prompt-scope-must-be-explicit-or-runs-diverge.md
@@ -9,6 +9,8 @@ issues: [636]
 
 # Lesson 091 — Bootstrap prompt scope must be explicit, or runs diverge
 
+> **Promoted to R17** (2026-05-24, #649). This file is preserved for historical context.
+
 **Date:** 2026-05-23
 **Issue:** #636 (epic auto-closure gap)
 **Tags:** automation, prompts, sprint-runner, underspecification

--- a/tasks/lessons/092-workspace-package-dist-is-gitignored-and-not-auto-rebuilt.md
+++ b/tasks/lessons/092-workspace-package-dist-is-gitignored-and-not-auto-rebuilt.md
@@ -9,6 +9,8 @@ issues: [645]
 
 # Lesson 092 — Workspace-package `dist/` is gitignored; local pre-push does not auto-rebuild
 
+> **Promoted to R16** (2026-05-24, #649). This file is preserved for historical context.
+
 **Date:** 2026-05-23
 **Issue:** #645 (bootstrap prompt — require workspace-package rebuild after source edits)
 **Tags:** monorepo, npm-workspaces, build, pre-push, sprint-runner

--- a/tasks/lessons/097-promote-the-always-relevant-invariant-not-every-principle.md
+++ b/tasks/lessons/097-promote-the-always-relevant-invariant-not-every-principle.md
@@ -1,0 +1,68 @@
+---
+id: '097'
+category: principle
+tags: [process, lessons, automation, sprint-runner]
+auto_load: true
+date: 2026-05-24
+issues: [649, 647]
+---
+
+# Lesson 097 — Promote the always-relevant invariant, not every `category: principle`
+
+**Date:** 2026-05-24
+**Issue:** #649 (epic #647 Sprint 2 — graduate stable lessons to R-rules)
+
+## What happened
+
+Sprint 1 (#648) tagged every lesson with a `category` (principle / lesson /
+incident / noise). The naive read of Sprint 2 was "promote every
+`category: principle` lesson to a rule." But 20 lessons carry that category,
+and `tasks/rules.md` is the _always-loaded, every-task_ file — promoting all
+20 would defeat the epic's whole purpose (relevance-driven loading) by bloating
+the one artifact that can't be filtered.
+
+## The promotion criterion (the actual decision)
+
+A lesson graduates to a rule only if it is an **always-relevant invariant** —
+something a session should check _regardless of which surface it's working on_.
+A `category: principle` lesson that is only relevant inside one surface stays a
+**tag-loaded lesson**, surfaced by Sprint 1's mechanism when that surface is
+touched.
+
+| Promote → rule (cross-cutting)                     | Keep → tag-loaded lesson (surface-specific)                 |
+| -------------------------------------------------- | ----------------------------------------------------------- |
+| 083 trap `return 0`, 089 pipefail, 086 dual-signal | 057 year-cumulative base=0 (only when touching analytics)   |
+| 091 explicit conditionals, 088 cadence vs progress | 060 percentage denominators (only DCP math)                 |
+| R16 workspace rebuild, R19 branch-from-remote-tip  | 066 JSDOM can't assert layout (only when writing CSS tests) |
+
+The split mirrors the epic's thesis: **permanence ≠ relevance.** `rules.md` is
+for permanent-AND-universal; tag-loaded lessons are for permanent-BUT-situational.
+`category: principle` only proves the first half; the rule decision needs the
+second.
+
+## Two smaller catches
+
+- **The ticket's rule numbers were a sketch.** #649 said "R12 onwards," but
+  R1–R12 already existed. Started at R13. Same shape as
+  [[092-ticket-helper-signatures-bend-to-the-real-data-shape]]: a ticket's
+  identifiers are intent, not contract — bind them to the live state.
+- **A "Promoted to R-N" back-reference is body content, not frontmatter, so it
+  doesn't perturb `INDEX.md`.** Verified with the `--check` mode of the
+  regeneration script after editing — the index stayed byte-identical, so no
+  regen commit was needed. When you touch a generated artifact's _inputs_,
+  always run the generator's check mode rather than assuming.
+
+## How to apply
+
+- When deciding whether a lesson becomes a rule, ask: "would a session working
+  on a _completely unrelated_ part of the codebase still need this?" If no, it's
+  a tag-loaded lesson, not a rule — no matter how true it is.
+- Keep `rules.md` ruthlessly universal. Every line there is paid for by every
+  session, every task. Situational truth has a cheaper home now (tags).
+
+## Related
+
+- [[091-bootstrap-prompt-scope-must-be-explicit-or-runs-diverge]] — promoted to
+  R17 here; same "explicit beats implicit" family.
+- [[092-ticket-helper-signatures-bend-to-the-real-data-shape]] — ticket
+  identifiers are sketches.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -55,3 +55,4 @@
 - **094** [dark-mode, css, accessibility] — In a Tailwind-utility dark theme, text and background must remap _together_; the asymmetry is the bug (#609, #574)
 - **095** [dark-mode, css, accessibility] — A global dark-token bump must be sized for the LIGHTEST surface it lands on (#610, #574)
 - **096** [dark-mode, css, accessibility] — The catch-all dark-mode sweep is where the brand-token traps hide (#611, #574)
+- **097** [process, lessons, automation, sprint-runner] — Promote the always-relevant invariant, not every `category: principle` (#649, #647)

--- a/tasks/rules.md
+++ b/tasks/rules.md
@@ -54,6 +54,45 @@ When multiple issues touch the same root cause (e.g., responsive table at 375px)
 
 ---
 
+## 🤖 Automation, Shell & Monorepo Discipline
+
+<!-- R13–R20 promoted from lessons 083–092 (epic #647 Sprint 2, #649). -->
+<!-- Sprint-runner / CI / bash / worktree surfaces. Each links its origin lesson. -->
+
+**R13 — End every trap-wired cleanup function with `return 0` (or `:`).**
+Bash uses an `EXIT` trap's final return value as the script's exit code. A trailing conditional (`[[ -n "$X" ]] && rm ...`) that evaluates false makes the trap — and thus a script with an explicit `exit 0` — return 1. Never let a conditional be the last statement in a trap unless you mean to mask the exit code. (Lesson 083 / #603)
+_Trigger:_ writing or editing any function wired to `trap ... EXIT|INT|TERM`.
+
+**R14 — Don't trust a command's exit code inside a `pipefail` predicate; absorb it with `|| true`.**
+`set -o pipefail` propagates the rightmost non-zero status. macOS `screen -ls` exits 1 even when sessions exist, so `screen -ls | grep -q …` always reports "not found" under pipefail — silently inverting detection logic (and nearly triggering a live-worktree GC). Verify exit semantics for every case you care about, drop pipefail locally, or append `|| true`. Prefer `pgrep -f` over `screen -ls` for liveness. (Lesson 089 / #633, #634)
+_Trigger:_ piping any command into a `pipefail` pipeline used as a boolean predicate.
+
+**R15 — When two pieces of distributed state must agree before automation acts, require BOTH signals and write the strongest one LAST.**
+"Sprint done" needs the sub-issue CLOSED _and_ the epic checkbox ticked. A consumer keying off only the close signal fires inside the gap before the tick lands — the close-then-tick duplicate-launch race. Tick the epic (weak, revertible string PATCH) first; close the issue (strong, irreversible) last; have the consumer require both. (Lesson 086 / #626)
+_Trigger:_ ordering writes to issue/epic/label state, or designing automation that triggers off issue state.
+
+**R16 — After touching `packages/*/src/`, run `npm run build:<package>` before tests or pre-push.**
+The frontend imports workspace packages from their built `dist/` (gitignored, not auto-rebuilt). CI rebuilds in a clean checkout; the local pre-push hook does not. Skip the rebuild and your tests pass against stale `dist/` while every fresh operator pull breaks with `X is not a function`. (Lesson 092 / #645)
+_Trigger:_ any change under `packages/*/src/`.
+
+**R17 — Every conditional in an automated workflow needs an explicit case for every value.**
+"Do X if Y" in a prompt or script must also state what happens when Y is false — even if the answer is "do nothing." Implicit scope invites divergence: two sessions ran the same bootstrap prompt and ended in different states (epic closed vs left open) because the "last sprint?" case was unstated. (Lesson 091 / #636)
+_Trigger:_ writing a conditional instruction in a prompt, routine, or shell script.
+
+**R18 — Decouple scheduling cadence from forward progress.**
+A cron interval sets the cadence of _attempts_, not of _progress_. "One visible action per tick" couples them and leaves work queued during idle ticks. Each tick should make as much _valid_ forward progress as it safely can, bounded by a sane cap (e.g. an 8-iteration cascade guard). (Lesson 088 / #627)
+_Trigger:_ designing or tuning any periodic automation loop.
+
+**R19 — Branch a long-lived worktree from the fetched remote tip, not its possibly-stale base.**
+A spawned session's worktree is detached at whatever commit the runner left it on; `origin/main` may be several commits ahead. Branching from the stale base silently _reverts_ intervening work and deletes files you never touched. `git fetch`, branch from `origin/main`, and diff `origin/main..HEAD` before opening the PR. (Lessons 087, 090 / #625, #482)
+_Trigger:_ starting work in a spawned/automation worktree, or before opening a PR from a long-lived branch.
+
+**R20 — When you partition a test suite (projects, shards, tags), add an exhaustiveness guard sourced from the tool itself.**
+A file matching no project's include/exclude stops running in every gate, silently — coverage dips, a regression sails through weeks later, nothing points at the cause. Assert the partition is disjoint _and_ exhaustive using the tool's own resolution (`vitest list --json`), never a re-implemented glob walk that can drift. (Lesson 090 / #482)
+_Trigger:_ splitting a test suite into projects/shards, or adding a top-level test directory.
+
+---
+
 ## ⚠️ Active Tripwires
 
 - `SnapshotBuilder.build()` has **two** district-tracking code paths (success + validation-failure). Changing district discovery must update both.


### PR DESCRIPTION
Part of epic #647 (Lesson curation). Closes #649.

## What

Graduates 8 stable, **always-relevant** patterns from the sprint-runner / CI / bash / monorepo lesson corpus into R-numbered rules in \`tasks/rules.md\`. Rules are always-loaded and don't age out — this separates permanent-AND-universal invariants from permanent-BUT-situational lessons (which Sprint 1's tag mechanism loads on demand).

| Rule | Pattern | Source lesson |
|------|---------|---------------|
| **R13** | Trap-wired cleanup must end with \`return 0\` | 083 (#603) |
| **R14** | Don't trust exit codes in a \`pipefail\` predicate; \`\|\| true\` | 089 (#633, #634) |
| **R15** | Dual-signal agreement; write the strongest signal LAST | 086 (#626) |
| **R16** | Rebuild \`packages/*/dist/\` before tests/pre-push | 092 (#645) |
| **R17** | Every conditional needs an explicit case for every value | 091 (#636) |
| **R18** | Decouple scheduling cadence from forward progress | 088 (#627) |
| **R19** | Branch a long-lived worktree from the fetched remote tip | 087, 090 (#625, #482) |
| **R20** | Test-suite partitions need an exhaustiveness guard | 090 (#482) |

## Acceptance (#649)

- [x] ≥5 R-rules added (8: R13–R20). Issue said "R12 onwards" — R1–R12 already exist, so promotions start at R13 (ticket numbering is a sketch; bent to live state).
- [x] Each promoted lesson has a "Promoted to R-N" header note (083, 086, 087, 088, 089, 090, 091, 092-workspace).
- [x] \`tasks/rules.md\` stays under ~300 lines (now **102**).
- [x] Bootstrap "Read rules.md in full" loads the new rules with no further changes (same file, more rules).

## Verification

- Fresh-context fidelity review of the full diff: all 8 rule↔lesson mappings accurate, no swapped R-numbers, 090 correctly dual-noted (R20 + R19), no factual distortion.
- \`scripts/regenerate-lessons-index.sh --check\` green (header notes are body content; INDEX unperturbed). New lesson 097 added to INDEX.
- \`prettier --check\` clean on all \`tasks/**/*.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)