### PR TITLE
Sprint 3 (#650): per-sprint relevant-lessons manifest in sub-issue body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ A sprint sub-issue body **SHOULD** include a `## Relevant lessons` section when 
 - [Lesson 092](tasks/lessons/092-workspace-package-dist-is-gitignored-and-not-auto-rebuilt.md) — rebuild workspace dist before tests
 ```
 
-Dry-run what a session would load with `scripts/relevant-lessons.sh <issue#>` (or `--stdin`): it prints each resolved path and exits non-zero if a listed lesson file is missing.
+Only the strict `- [text](path)` (or `* [text](path)`) bullet form is recognized — a colon separator or a space before `(` is silently skipped. Dry-run what a session would load with `scripts/relevant-lessons.sh <issue#>` (or `--stdin`): it prints each resolved path and exits non-zero if a listed lesson file is missing.
 
 ## Key Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,22 @@ Read `tasks/rules.md` completely before every task. Key rules:
 
 ## Learning Artifacts
 
-- `tasks/lessons.md` — Append-only log of discoveries (38+ entries). Read last 5 before each task.
+- `tasks/lessons/` — Per-file lessons (one discovery each, tagged frontmatter). `tasks/lessons/INDEX.md` is the always-loadable tag index (regenerate with `npm run lessons:index`).
 - `tasks/rules.md` — Curated high-signal rules distilled from lessons. Read completely before each task.
 - `docs/product-spec.md` — Shipped features, business rules, product decisions.
+
+### Per-sprint relevant-lessons manifest (#650)
+
+A sprint sub-issue body **SHOULD** include a `## Relevant lessons` section when there are specific lessons the spawned session must read. The bootstrap prompt (step 1) loads these in full — operator curation wins over the loader's tag inference. Format (one bullet per lesson; the trailing reason is optional but recommended):
+
+```markdown
+## Relevant lessons
+
+- [Lesson 087](tasks/lessons/087-spawned-sessions-need-their-own-worktree-not-shared-checkout.md) — branch a long-lived worktree from origin/main, not the stale base
+- [Lesson 092](tasks/lessons/092-workspace-package-dist-is-gitignored-and-not-auto-rebuilt.md) — rebuild workspace dist before tests
+```
+
+Dry-run what a session would load with `scripts/relevant-lessons.sh <issue#>` (or `--stdin`): it prints each resolved path and exits non-zero if a listed lesson file is missing.
 
 ## Key Conventions
 

--- a/scripts/lib/__tests__/relevantLessons.test.ts
+++ b/scripts/lib/__tests__/relevantLessons.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the per-sprint relevant-lessons manifest parser (#650, epic #647).
+ *
+ * Sprint sub-issue bodies MAY carry a `## Relevant lessons` section listing the
+ * lessons a spawned session must read in full. The bootstrap prompt honors it.
+ * This parser extracts that manifest from an issue body so a session (or the
+ * dry-run CLI) knows exactly which lesson files to load.
+ *
+ * Format (one bullet per lesson, markdown link + optional reason):
+ *   ## Relevant lessons
+ *   - [Lesson 083](tasks/lessons/083-exit-trap.md) — EXIT trap return value
+ *   - [Lesson 092](tasks/lessons/092-workspace-package-dist.md) — rebuild dist
+ *
+ * RED phase: written before scripts/lib/relevantLessons.ts exists.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  parseRelevantLessons,
+  resolveRelevantLessons,
+  type RelevantLessonRef,
+} from '../relevantLessons'
+
+const BODY_WITH_MANIFEST = `Part of epic #647.
+
+## Scope
+
+Do the thing.
+
+## Relevant lessons
+
+- [Lesson 083](tasks/lessons/083-exit-trap.md) — EXIT trap return value is the script's exit code
+- [Lesson 092](tasks/lessons/092-workspace-package-dist-is-gitignored-and-not-auto-rebuilt.md) — rebuild workspace dist before tests
+
+## Acceptance
+
+- [ ] It works.
+`
+
+describe('parseRelevantLessons', () => {
+  it('returns [] when there is no manifest section', () => {
+    expect(parseRelevantLessons('Just a plain body.\n\n## Scope\n\nx')).toEqual(
+      []
+    )
+  })
+
+  it('extracts each lesson link with its path, label, and reason', () => {
+    const refs = parseRelevantLessons(BODY_WITH_MANIFEST)
+    expect(refs).toEqual<RelevantLessonRef[]>([
+      {
+        label: 'Lesson 083',
+        path: 'tasks/lessons/083-exit-trap.md',
+        reason: "EXIT trap return value is the script's exit code",
+      },
+      {
+        label: 'Lesson 092',
+        path: 'tasks/lessons/092-workspace-package-dist-is-gitignored-and-not-auto-rebuilt.md',
+        reason: 'rebuild workspace dist before tests',
+      },
+    ])
+  })
+
+  it('stops at the next heading and does not bleed into later sections', () => {
+    const refs = parseRelevantLessons(BODY_WITH_MANIFEST)
+    expect(refs).toHaveLength(2)
+    expect(refs.some(r => r.path.includes('Acceptance'))).toBe(false)
+  })
+
+  it('parses a bullet with no reason (null reason)', () => {
+    const body = `## Relevant lessons\n\n- [Lesson 070](tasks/lessons/070-router.md)\n`
+    expect(parseRelevantLessons(body)).toEqual([
+      {
+        label: 'Lesson 070',
+        path: 'tasks/lessons/070-router.md',
+        reason: null,
+      },
+    ])
+  })
+
+  it('matches the heading case-insensitively and tolerates "Relevant Lessons"', () => {
+    const body = `## Relevant Lessons\n\n- [L1](tasks/lessons/001-a.md) — r\n`
+    expect(parseRelevantLessons(body)).toHaveLength(1)
+  })
+
+  it('ignores non-link bullets inside the section', () => {
+    const body = `## Relevant lessons\n\n- this is prose, not a link\n- [L1](tasks/lessons/001-a.md) — r\n`
+    const refs = parseRelevantLessons(body)
+    expect(refs).toHaveLength(1)
+    expect(refs[0].path).toBe('tasks/lessons/001-a.md')
+  })
+
+  it('accepts asterisk bullets as well as dashes', () => {
+    const body = `## Relevant lessons\n\n* [L1](tasks/lessons/001-a.md) — r\n`
+    expect(parseRelevantLessons(body)).toHaveLength(1)
+  })
+})
+
+describe('resolveRelevantLessons', () => {
+  const refs: RelevantLessonRef[] = [
+    { label: 'L1', path: 'tasks/lessons/001-a.md', reason: 'r1' },
+    { label: 'L2', path: 'tasks/lessons/999-missing.md', reason: 'r2' },
+  ]
+
+  it('partitions refs into found and missing by an existence predicate', () => {
+    const { found, missing } = resolveRelevantLessons(
+      refs,
+      p => p === 'tasks/lessons/001-a.md'
+    )
+    expect(found.map(r => r.path)).toEqual(['tasks/lessons/001-a.md'])
+    expect(missing.map(r => r.path)).toEqual(['tasks/lessons/999-missing.md'])
+  })
+
+  it('treats a non-lessons path as missing even if the predicate says it exists', () => {
+    const escape: RelevantLessonRef[] = [
+      { label: 'X', path: '../../etc/passwd', reason: null },
+    ]
+    const { found, missing } = resolveRelevantLessons(escape, () => true)
+    expect(found).toEqual([])
+    expect(missing).toHaveLength(1)
+  })
+})

--- a/scripts/lib/relevantLessons.ts
+++ b/scripts/lib/relevantLessons.ts
@@ -1,0 +1,88 @@
+/**
+ * Per-sprint relevant-lessons manifest parser — Pure Functions (#650, epic #647).
+ *
+ * Sprint sub-issue bodies MAY carry a `## Relevant lessons` section that lists
+ * the lessons a spawned session must read in full, curated by the operator
+ * during grooming. The bootstrap prompt (step 1) honors it: listed lessons load
+ * in addition to tag-matched + 2-newest. This module turns that section of an
+ * issue body into a structured list so a session — or the dry-run CLI in
+ * scripts/relevant-lessons.ts — knows exactly which files to load.
+ *
+ * Manifest format (one bullet per lesson, markdown link + optional em-dash reason):
+ *
+ *   ## Relevant lessons
+ *   - [Lesson 083](tasks/lessons/083-exit-trap.md) — EXIT trap return value …
+ *   - [Lesson 092](tasks/lessons/092-workspace-package-dist.md) — rebuild dist
+ *
+ * All functions are pure (no filesystem I/O) so they unit-test cleanly; the IO
+ * entry point lives in scripts/relevant-lessons.ts.
+ */
+
+export interface RelevantLessonRef {
+  /** Link text, e.g. "Lesson 083". */
+  label: string
+  /** Repo-relative path the link points at, e.g. "tasks/lessons/083-…md". */
+  path: string
+  /** Trailing em-dash reason, or null when the bullet has none. */
+  reason: string | null
+}
+
+/** Heading that opens the manifest section, case-insensitive. */
+const MANIFEST_HEADING_RE = /^##\s+relevant\s+lessons\s*$/im
+/** Any markdown ATX heading line — used to bound the section. */
+const HEADING_RE = /^#{1,6}\s/
+
+/**
+ * A manifest bullet: `- [label](path)` optionally followed by an em-dash (or
+ * hyphen) reason. Em-dash "—" is the documented separator; a plain " - " is
+ * tolerated. Bullets that aren't links are ignored by the caller.
+ */
+const BULLET_RE = /^\s*[-*]\s+\[([^\]]+)\]\(([^)]+)\)\s*(?:[—–-]\s*(.+?))?\s*$/
+
+/**
+ * Extract the `## Relevant lessons` manifest from an issue body. Returns [] when
+ * the section is absent. Parsing stops at the next markdown heading so it never
+ * bleeds into a following section (e.g. `## Acceptance`).
+ */
+export function parseRelevantLessons(body: string): RelevantLessonRef[] {
+  const lines = body.split('\n')
+  const start = lines.findIndex(l => MANIFEST_HEADING_RE.test(l))
+  if (start === -1) return []
+
+  const refs: RelevantLessonRef[] = []
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (HEADING_RE.test(line)) break // next section — stop
+    const m = line.match(BULLET_RE)
+    if (!m) continue // prose, blank, or non-link bullet
+    const [, label, path, reason] = m
+    refs.push({
+      label: label.trim(),
+      path: path.trim(),
+      reason: reason ? reason.trim() : null,
+    })
+  }
+  return refs
+}
+
+/**
+ * Partition refs into those whose files exist and those that don't, using the
+ * supplied existence predicate (injected so this stays pure / testable). A ref
+ * whose path escapes `tasks/lessons/` is always treated as missing — a manifest
+ * must only point at lesson files, never at arbitrary paths (path-traversal
+ * guard, per the Path.join tripwire in rules.md).
+ */
+export function resolveRelevantLessons(
+  refs: RelevantLessonRef[],
+  exists: (path: string) => boolean
+): { found: RelevantLessonRef[]; missing: RelevantLessonRef[] } {
+  const found: RelevantLessonRef[] = []
+  const missing: RelevantLessonRef[] = []
+  for (const ref of refs) {
+    const safe =
+      ref.path.startsWith('tasks/lessons/') && !ref.path.includes('..')
+    if (safe && exists(ref.path)) found.push(ref)
+    else missing.push(ref)
+  }
+  return { found, missing }
+}

--- a/scripts/relevant-lessons.sh
+++ b/scripts/relevant-lessons.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Dry-run the per-sprint relevant-lessons manifest of a sprint sub-issue (#650).
+# Thin wrapper around scripts/relevant-lessons.ts.
+#
+#   scripts/relevant-lessons.sh 650        # fetch issue #650 body via gh
+#   scripts/relevant-lessons.sh --stdin    # read an issue body from stdin
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec npx tsx scripts/relevant-lessons.ts "$@"

--- a/scripts/relevant-lessons.ts
+++ b/scripts/relevant-lessons.ts
@@ -15,13 +15,14 @@
 
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
   parseRelevantLessons,
   resolveRelevantLessons,
 } from './lib/relevantLessons'
 
-const REPO_ROOT = join(__dirname, '..')
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 
 function readIssueBody(arg: string): string {
   if (arg === '--stdin') return readFileSync(0, 'utf8')
@@ -70,4 +71,7 @@ function main(): void {
   }
 }
 
-main()
+// Only run when invoked as a script, not when imported by a test.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main()
+}

--- a/scripts/relevant-lessons.ts
+++ b/scripts/relevant-lessons.ts
@@ -1,0 +1,73 @@
+/**
+ * Dry-run the per-sprint relevant-lessons manifest (#650, epic #647).
+ *
+ * Prints the lessons a spawned session WOULD load from a sprint sub-issue's
+ * `## Relevant lessons` section — useful before a sprint launches to confirm the
+ * operator's curation resolves to real files.
+ *
+ *   scripts/relevant-lessons.sh 650            # fetch issue #650 body via gh
+ *   scripts/relevant-lessons.sh --stdin        # read an issue body from stdin
+ *
+ * Stdout carries the structured result (one found lesson path per line) so it
+ * composes with `| while read`; all human-facing logging goes to stderr (R4).
+ * Exits non-zero if any listed lesson is missing on disk, so it can gate.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  parseRelevantLessons,
+  resolveRelevantLessons,
+} from './lib/relevantLessons'
+
+const REPO_ROOT = join(__dirname, '..')
+
+function readIssueBody(arg: string): string {
+  if (arg === '--stdin') return readFileSync(0, 'utf8')
+  const issue = arg.replace(/^#/, '')
+  if (!/^\d+$/.test(issue)) {
+    throw new Error(`Expected an issue number or --stdin, got: ${arg}`)
+  }
+  return execFileSync(
+    'gh',
+    ['issue', 'view', issue, '--json', 'body', '--jq', '.body'],
+    { encoding: 'utf8' }
+  )
+}
+
+function main(): void {
+  const arg = process.argv[2]
+  if (!arg) {
+    console.error('Usage: relevant-lessons.sh <issue-number>|--stdin')
+    process.exit(2)
+  }
+
+  const refs = parseRelevantLessons(readIssueBody(arg))
+  if (refs.length === 0) {
+    console.error('No `## Relevant lessons` section found — nothing to load.')
+    return
+  }
+
+  const { found, missing } = resolveRelevantLessons(refs, p =>
+    existsSync(join(REPO_ROOT, p))
+  )
+
+  console.error(`Manifest lists ${refs.length} lesson(s):`)
+  for (const r of found) {
+    console.error(`  ✓ ${r.path}${r.reason ? ` — ${r.reason}` : ''}`)
+  }
+  for (const r of missing) {
+    console.error(`  ✗ MISSING: ${r.path}`)
+  }
+
+  // Structured output: the resolved paths a session should read, one per line.
+  for (const r of found) console.log(r.path)
+
+  if (missing.length > 0) {
+    console.error(`\n${missing.length} listed lesson(s) not found on disk.`)
+    process.exit(1)
+  }
+}
+
+main()

--- a/scripts/sprint-bootstrap.prompt
+++ b/scripts/sprint-bootstrap.prompt
@@ -8,8 +8,9 @@ Do these steps in order, and stop if any check fails:
 
 1. **Re-read the rules, then load RELEVANT lessons (not just newest).** Required reading per CLAUDE.md Phase 1:
    - `tasks/rules.md` in full.
+   - **Per-sprint manifest (preferred):** if the sub-issue body has a `## Relevant lessons` section, read **in full** every lesson it lists — the operator curated these during grooming, so they win over tag inference. Dry-run what would load with `scripts/relevant-lessons.sh {{TARGET_ISSUE}}` (prints each resolved path, exits non-zero if a listed file is missing). When a manifest is present you may skip the tag-inference step below, but still read the 2 newest.
    - `tasks/lessons/INDEX.md` in full — it lists every per-file lesson with its tags. `_(ref-only)_` entries are `auto_load: false` (incident/superseded/noise): searchable, but do NOT auto-load them.
-   - Infer this sprint's work-type tags from the sub-issue's title / labels / body (e.g. a CSS sprint → `css`, `dark-mode`, `frontend`; a runner sprint → `bash`, `automation`, `sprint-runner`). Read **in full** every auto-loadable lesson in INDEX whose tags intersect that set. (When Sprint 3 ships the per-sprint `## Relevant lessons` manifest, prefer it over inference.)
+   - **Tag inference (fallback, when there's no manifest):** infer this sprint's work-type tags from the sub-issue's title / labels / body (e.g. a CSS sprint → `css`, `dark-mode`, `frontend`; a runner sprint → `bash`, `automation`, `sprint-runner`). Read **in full** every auto-loadable lesson in INDEX whose tags intersect that set.
    - Read the **2 newest** lessons (highest filename numbers) regardless of tag — they are operationally fresh.
    - Stop after that. Do not bulk-read the whole corpus.
 

--- a/tasks/lessons/098-curated-lesson-manifest-beats-tag-inference-when-the-operator-knows.md
+++ b/tasks/lessons/098-curated-lesson-manifest-beats-tag-inference-when-the-operator-knows.md
@@ -1,0 +1,84 @@
+---
+id: '098'
+category: principle
+tags: [process, lessons, automation, sprint-runner, prompts]
+auto_load: true
+date: 2026-05-24
+issues: [650, 647]
+---
+
+# Lesson 098 — A curated manifest beats tag inference when the operator knows better
+
+**Date:** 2026-05-24
+**Issue:** #650 (epic #647 Sprint 3 — per-sprint relevant-lessons manifest)
+
+## What happened
+
+Sprint 1 (#648) made the bootstrap prompt load lessons by **inferring** work-type
+tags from the sub-issue's title/labels/body and intersecting them with the
+INDEX. That's a good default, but it's a guess: the loader can't know that a
+TypeScript-major sprint specifically needs Lesson 092 (workspace `dist/`
+rebuild) and Lesson 087 (branch from `origin/main`) — those don't share an
+obvious tag with "TypeScript 6 bump." Sprint 3 added an operator-curatable
+`## Relevant lessons` section to sprint sub-issue bodies that the bootstrap reads
+**in full**, and which **wins over** tag inference when present.
+
+The principle: **inference is the fallback; human curation is the source of
+truth.** When someone who groomed the sprint already knows which prior
+incidents will bite, encode that knowledge in the artifact rather than hoping a
+tag-overlap heuristic rediscovers it.
+
+## Two design decisions worth keeping
+
+1. **Parse pure, resolve with an injected predicate.** The manifest parser
+   (`scripts/lib/relevantLessons.ts`) is a pure function over the issue body;
+   `resolveRelevantLessons` takes an `exists(path)` predicate so the
+   path-existence check is testable without touching the filesystem — the same
+   shape as the `lessonsIndex.ts` generator. The IO (gh fetch, `existsSync`)
+   lives only in the CLI entry point.
+
+2. **The path-traversal guard belongs at the resolve boundary, not the parse
+   boundary.** A manifest line is external input; `resolveRelevantLessons`
+   rejects any path that isn't under `tasks/lessons/` or contains `..` even if
+   the existence predicate says it's there. (Same family as the `Path.join`
+   tripwire in rules.md.) Note this means any _future_ caller of
+   `parseRelevantLessons` that does its own IO must re-apply the guard.
+
+## The honest-verification angle
+
+This sprint ships nothing to `ts.taverns.red`, so the usual Playwright + CDN
+live-check doesn't apply. The strongest available end-to-end check was running
+the dry-run CLI against the **real, freshly-annotated** issues over the live
+`gh` API (`scripts/relevant-lessons.sh 612` / `614`) and confirming it resolved
+each listed path to a file on disk with exit 0. That exercises the exact path a
+future session walks (gh fetch → parse → resolve → would-load list) — the
+process analogue of "verify against a real production record, not a fixture."
+
+## A permission-boundary note
+
+Annotating #612/#614 was acceptance criterion #2, but the auto-mode classifier
+blocked `gh issue edit` on issues not created this session (reasonable default:
+external writes outside the named task look like scope creep). The fix wasn't to
+work around it — it was to surface the conflict to the operator with the
+criterion cited and get a one-time approval. **When an automation guardrail
+collides with an explicit acceptance criterion, escalate the specific decision;
+don't silently widen your own scope.**
+
+## How to apply
+
+- Add a `## Relevant lessons` section to a sprint sub-issue whenever you know,
+  at grooming time, which prior lessons will bite. Format:
+  `- [Lesson NNN](tasks/lessons/NNN-….md) — why it matters here`.
+- Dry-run it before launch: `scripts/relevant-lessons.sh <issue#>`.
+- For new "read external input → resolve to a file" code, guard the path at the
+  resolve boundary and inject the existence check so it stays unit-testable.
+
+## Related
+
+- [[091-bootstrap-prompt-scope-must-be-explicit-or-runs-diverge]] — the same
+  bootstrap step; explicit-scope theme.
+- [[097-promote-the-always-relevant-invariant-not-every-principle]] — the
+  rules side of "what context should a session load."
+- [[087-spawned-sessions-need-their-own-worktree-not-shared-checkout]] — caught
+  again here: this worktree's base was 10 commits stale; branched from
+  `origin/main`.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -56,3 +56,4 @@
 - **095** [dark-mode, css, accessibility] — A global dark-token bump must be sized for the LIGHTEST surface it lands on (#610, #574)
 - **096** [dark-mode, css, accessibility] — The catch-all dark-mode sweep is where the brand-token traps hide (#611, #574)
 - **097** [process, lessons, automation, sprint-runner] — Promote the always-relevant invariant, not every `category: principle` (#649, #647)
+- **098** [process, lessons, automation, sprint-runner, prompts] — A curated manifest beats tag inference when the operator knows better (#650, #647)


### PR DESCRIPTION
## Summary

Sprint 3 of epic #647 (lesson curation). Adds an operator-curatable `## Relevant lessons` section to sprint sub-issue bodies that the sprint-runner bootstrap prompt honors — curated lessons load in full and win over the loader's tag inference (added in Sprint 1 / #648).

## What changed

- **`scripts/lib/relevantLessons.ts`** — pure parser: `parseRelevantLessons` extracts the manifest (bounded at the next heading), `resolveRelevantLessons` partitions refs into found/missing with a `tasks/lessons/` path-traversal guard. Mirrors the `lessonsIndex.ts` pure-functions pattern.
- **`scripts/relevant-lessons.{ts,sh}`** — dry-run CLI: `scripts/relevant-lessons.sh <issue#>|--stdin` prints which lessons a session would load and exits non-zero if any listed file is missing. Logs to stderr (R4); resolved paths to stdout.
- **`scripts/sprint-bootstrap.prompt`** — step 1 now reads the manifest in full (preferred over tag inference) and points at the dry-run CLI. Resolves the Sprint-1 forward-reference.
- **`CLAUDE.md`** — documents the convention + bullet format.
- **`tasks/lessons/098-…md`** + regenerated `INDEX.md`.

## Acceptance (#650)

- [x] Bootstrap step 1 reads manifest lessons from the sub-issue body when present.
- [x] ≥2 in-flight sprint sub-issues annotated — #612 (TS 5→6) and #614 (ESLint 9→10), operator-approved.
- [x] Convention documented in CLAUDE.md.
- [x] Loader path verified end-to-end: `relevant-lessons.sh 612`/`614` resolve every listed path via live `gh` with exit 0 (the exact path a future session walks). Full trace-based verification lands when the next manifest-annotated sprint launches.

## Testing

- 9 new unit tests for the parser (`npm run test:scripts`: 79/79).
- Full pre-push suite green: 1999/1999.
- Fresh-context review: APPROVE-WITH-NITS; both medium findings applied (ESM entry-point parity with sibling).

Closes #650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
