### PR TITLE
chore(deps): #612 bump TypeScript 5 → 6.0.3 (mini-epic #597 Sprint 1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
     "jest-axe": "^10.0.0",
     "jsdom": "^29.0.2",
     "postcss": "^8.5.14",
-    "typescript": "^5.2.2",
+    "typescript": "^6.0.3",
     "vite": "^7.3.2",
     "vitest": "^4.0.18"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       }
     },
     "frontend": {
-      "version": "2.12.0",
+      "version": "2.13.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.2.2",
@@ -58,7 +58,7 @@
         "jest-axe": "^10.0.0",
         "jsdom": "^29.0.2",
         "postcss": "^8.5.14",
-        "typescript": "^5.2.2",
+        "typescript": "^6.0.3",
         "vite": "^7.3.2",
         "vitest": "^4.0.18"
       }
@@ -7488,9 +7488,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7993,7 +7993,7 @@
     },
     "packages/analytics-core": {
       "name": "@toastmasters/analytics-core",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@toastmasters/shared-contracts": "^1.0.0",
@@ -8007,7 +8007,7 @@
         "eslint": "^9.0.0",
         "fast-check": "^4.6.0",
         "globals": "^17.4.0",
-        "typescript": "^5.2.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.0.18"
       },
       "engines": {
@@ -8204,7 +8204,7 @@
     },
     "packages/collector-cli": {
       "name": "@toastmasters/collector-cli",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.19.0",
@@ -8227,7 +8227,7 @@
         "fast-check": "^4.6.0",
         "globals": "^17.4.0",
         "tsx": "^4.7.0",
-        "typescript": "^5.2.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.0.18"
       },
       "engines": {
@@ -8424,7 +8424,7 @@
     },
     "packages/shared-contracts": {
       "name": "@toastmasters/shared-contracts",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"
@@ -8437,7 +8437,7 @@
         "eslint": "^9.0.0",
         "fast-check": "^4.6.0",
         "globals": "^17.4.0",
-        "typescript": "^5.2.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.0.18"
       },
       "engines": {

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -46,7 +46,7 @@
     "eslint": "^9.0.0",
     "fast-check": "^4.6.0",
     "globals": "^17.4.0",
-    "typescript": "^5.2.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.18"
   },
   "engines": {

--- a/packages/analytics-core/tsconfig.cjs.json
+++ b/packages/analytics-core/tsconfig.cjs.json
@@ -5,6 +5,6 @@
     "moduleResolution": "node",
     "outDir": "./dist/cjs",
     "declaration": false,
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "6.0"
   }
 }

--- a/packages/analytics-core/tsconfig.json
+++ b/packages/analytics-core/tsconfig.json
@@ -3,6 +3,9 @@
     "target": "ES2020",
     "lib": ["ES2020"],
     "moduleResolution": "node",
+    // node10 (formerly "node") is deprecated in TS6, removed in TS7 (#612).
+    // Migrating resolution to node16/bundler is its own task; tracked in #597.
+    "ignoreDeprecations": "6.0",
     "rootDir": "./src",
     // TypeScript Steering Document Requirements - Strict Mode
     "strict": true,

--- a/packages/collector-cli/package.json
+++ b/packages/collector-cli/package.json
@@ -36,7 +36,7 @@
     "fast-check": "^4.6.0",
     "globals": "^17.4.0",
     "tsx": "^4.7.0",
-    "typescript": "^5.2.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.18"
   },
   "engines": {

--- a/packages/collector-cli/tsconfig.json
+++ b/packages/collector-cli/tsconfig.json
@@ -4,6 +4,9 @@
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "es2022.error"],
     "moduleResolution": "node",
+    // node10 (formerly "node") is deprecated in TS6, removed in TS7 (#612).
+    // Migrating resolution to node16/bundler is its own task; tracked in #597.
+    "ignoreDeprecations": "6.0",
     "rootDir": "./src",
     "outDir": "./dist",
     // TypeScript Steering Document Requirements - Strict Mode

--- a/packages/shared-contracts/package.json
+++ b/packages/shared-contracts/package.json
@@ -45,7 +45,7 @@
     "eslint": "^9.0.0",
     "fast-check": "^4.6.0",
     "globals": "^17.4.0",
-    "typescript": "^5.2.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.18"
   },
   "engines": {

--- a/packages/shared-contracts/tsconfig.cjs.json
+++ b/packages/shared-contracts/tsconfig.cjs.json
@@ -5,6 +5,6 @@
     "moduleResolution": "node",
     "outDir": "./dist/cjs",
     "declaration": false,
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "6.0"
   }
 }

--- a/packages/shared-contracts/tsconfig.json
+++ b/packages/shared-contracts/tsconfig.json
@@ -3,6 +3,9 @@
     "target": "ES2020",
     "lib": ["ES2020"],
     "moduleResolution": "node",
+    // node10 (formerly "node") is deprecated in TS6, removed in TS7 (#612).
+    // Migrating resolution to node16/bundler is its own task; tracked in #597.
+    "ignoreDeprecations": "6.0",
     "rootDir": "./src",
     // TypeScript Steering Document Requirements - Strict Mode
     "strict": true,

--- a/tasks/lessons/099-ignoredeprecations-is-the-sanctioned-staging-path-for-ts-major-bumps.md
+++ b/tasks/lessons/099-ignoredeprecations-is-the-sanctioned-staging-path-for-ts-major-bumps.md
@@ -1,0 +1,85 @@
+---
+id: '099'
+category: principle
+tags: [typescript, build, deps, monorepo, tsconfig]
+auto_load: false
+date: 2026-05-24
+issues: [612, 597]
+---
+
+# Lesson 099 — `ignoreDeprecations` is the sanctioned staging path for a TS major bump, not a suppression
+
+**Date:** 2026-05-24
+**Issue:** #612 (TypeScript 5 → 6 major bump, mini-epic #597 Sprint 1)
+**Tags:** typescript, build, deps, monorepo, tsconfig
+
+## What happened
+
+Bumping `typescript ^5.2.2 → ^6.0.3` across all four workspaces produced a
+single, uniform compile error from every `tsc` invocation that resolved a
+config with `moduleResolution: "node"`:
+
+```
+error TS5107: Option 'moduleResolution=node10' is deprecated and will stop
+functioning in TypeScript 7.0. Specify compilerOption
+'"ignoreDeprecations": "6.0"' to silence this error.
+```
+
+TS6 internally renamed the legacy `"node"` resolution to `"node10"` and
+flagged it deprecated. Crucially, **removal is slated for TS _7.0_, not 6.0** —
+under TS6 `node10` still resolves modules exactly as before. The two CJS build
+configs already carried `ignoreDeprecations: "5.0"` (from the 5.0 bump); TS6
+no longer accepts `"5.0"` as a silencer and demands `"6.0"`.
+
+## The decision: stage, don't migrate (this sprint)
+
+Two ways to clear the error:
+
+1. **`ignoreDeprecations: "6.0"`** — the migration value TypeScript's own error
+   message tells you to use. Acknowledges the deprecation and defers the real
+   work to before TS7.
+2. **Migrate the resolution mode** — `node` → `node16`/`nodenext`/`bundler`.
+   This is the _eventual_ fix, but it changes module-resolution semantics
+   (node16/nodenext require explicit `.js` extensions on relative imports,
+   affect the dual CJS/ESM `exports` map, and can shift type inference). Real
+   blast radius; its own falsifiable experiment.
+
+Chose (1) for the version-bump sprint. The manifesto forbids "suppressing
+compiler warnings via flags," but `ignoreDeprecations` here is **not hiding a
+bug in our code** — it is the documented mechanism for staging a multi-version
+migration, and the thing it silences (`node10`) is fully functional in TS6.
+#597 explicitly warns against bundling unrelated changes into a major bump;
+folding a resolution-mode migration into the TS6 PR would do exactly that.
+Left a breadcrumb comment in each tsconfig and a `node→node16/bundler` TODO
+tracked under #597 so the TS7-prep task is discoverable.
+
+## How to apply
+
+- **A TS major bump's first error is usually a deprecation, not a real type
+  error.** Read whether removal is _this_ major or a _later_ one. If later,
+  `ignoreDeprecations: "<this-major>"` is the intended staging move — clear it
+  now, migrate the underlying option in a dedicated task before the removal
+  major.
+- **`ignoreDeprecations` values don't auto-carry across majors.** A `"5.0"`
+  left from the last bump becomes invalid at 6.0; grep every tsconfig for it
+  when bumping, not just the ones that error first.
+- **In a monorepo, the same deprecation fires from every entry point that
+  resolves the deprecated option.** Map _all_ `tsc` invocations (build:esm,
+  build:cjs, each `typecheck` with no `-p` falling through to the base
+  `tsconfig.json`) — fixing only the config that errored first leaves the
+  others red. Here that was 3 base configs + 2 CJS overrides.
+- **Suppression vs. staging is about whether the thing being silenced is a bug.
+  ** A flag that hides a real failure in your code is forbidden; a flag the
+  tool itself prescribes for an orderly version migration is the correct path.
+  Document the distinction in the PR so a reviewer reads it as a deliberate
+  trade.
+
+## Related
+
+- [[092-workspace-package-dist-is-gitignored-and-not-auto-rebuilt]] — same
+  sprint family: after touching `packages/*/src` (or its build config),
+  rebuild `dist/` before tests (R16). The TS6 build outputs are what the
+  frontend imports.
+- [[081-phase-gated-deferral-tests-move-with-the-spec]] — deferring part of a
+  change to a later phase with a tracked breadcrumb, rather than doing it all
+  at once.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -57,3 +57,4 @@
 - **096** [dark-mode, css, accessibility] — The catch-all dark-mode sweep is where the brand-token traps hide (#611, #574)
 - **097** [process, lessons, automation, sprint-runner] — Promote the always-relevant invariant, not every `category: principle` (#649, #647)
 - **098** [process, lessons, automation, sprint-runner, prompts] — A curated manifest beats tag inference when the operator knows better (#650, #647)
+- **099** [typescript, build, deps, monorepo, tsconfig] — `ignoreDeprecations` is the sanctioned staging path for a TS major bump, not a suppression (#612, #597) _(ref-only)_


### PR DESCRIPTION
## Summary

Sprint 1 of mini-epic #597 (dev-deps majors). Bumps `typescript ^5.2.2 → ^6.0.3` across all four workspaces — the largest blast radius of the three majors, sequenced first.

Closes #612.

## Changes

- **`typescript ^5.2.2 → ^6.0.3`** in `frontend`, `collector-cli`, `analytics-core`, `shared-contracts`. Lockfile reconciled (also absorbs pre-existing workspace self-version drift — `2.12.0→2.13.0`, `1.5.1→1.6.0`, `1.3.x→1.4.0` — no dependency change, just npm syncing the lockfile to the already-committed package.json versions).
- **TS6 deprecation handling.** TS6 renames `moduleResolution: "node"` → `node10` and deprecates it (`error TS5107`). Removal is slated for **TS 7.0, not 6.0** — `node10` still resolves fully under TS6. Added `ignoreDeprecations: "6.0"` (the value TS's own error prescribes) to the three package base tsconfigs, and bumped the two CJS configs' stale `"5.0"` → `"6.0"`.

## Why not migrate resolution mode now?

Migrating `node → node16/nodenext/bundler` is the eventual fix but changes module-resolution semantics (explicit `.js` extensions, dual CJS/ESM `exports` map, inference shifts) — real blast radius. Per #597's explicit "don't bundle majors" guidance, the resolution-mode migration is left to a dedicated TS7-prep task; a breadcrumb comment is in each tsconfig and the rationale is captured in [Lesson 099](tasks/lessons/099-ignoredeprecations-is-the-sanctioned-staging-path-for-ts-major-bumps.md). `ignoreDeprecations` here is sanctioned staging, not bug suppression — `node10` is functional in TS6.

## Verification (local, TS 6.0.3)

| Gate | Result |
| --- | --- |
| `build:shared-contracts` | ✅ |
| `build:analytics-core` | ✅ |
| `build:frontend` (tsc + vite) | ✅ |
| `pre-commit` (typecheck + lint + yaml) | ✅ 0 errors |
| `npm run test` | ✅ 174 + 33 + 35 + 6 test files — identical pass counts to TS5 baseline, zero regressions |

## Acceptance criteria (#612)

- [x] `build:shared-contracts` clean
- [x] `build:frontend` clean
- [x] `build:analytics-core` clean
- [x] `pre-commit` clean
- [x] `npm run test` all green
- [x] No new `tsc` warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)