### PR TITLE
docs: planning artifacts for region/district/clubs epics + gitignore scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ logs.txt
 # Agent tooling
 .kiro/
 .agent/
+.routine-tmp/
 
 # Data (local-only)
 data/

--- a/tasks/clubs-table-redesign-epic.md
+++ b/tasks/clubs-table-redesign-epic.md
@@ -1,0 +1,121 @@
+# Epic recommendation — Clubs page: adopt redesign look-and-feel + single-table (remove pagination)
+
+**Date:** 2026-05-24
+**Author:** Claude (ron-ux + ron-pm personas)
+**Status:** Filed — epic #665; sub-issues #667–#672.
+**Parent context:** Club redesign meta-epic #606; clubs moved to own page in epic #568 / #570; redesign handoff in `docs/design/club-redesign-2026-05/HANDOFF.md`.
+
+---
+
+## Why this epic
+
+The clubs table is now a standalone page (`/district/:districtId/clubs`) but is the **last major district surface still on the legacy gray Tailwind chrome** while the rest of the club/district redesign has migrated to the `--loyal` / `--ink` / `--surface` token system (sprints #618–#621). It also still paginates at 25/page — a control that fragments scanning when a district has ~300 clubs and the user's mental model is "show me all my clubs, let me sort/filter."
+
+Two goals, one epic:
+
+1. **Adopt the redesign look-and-feel** specified in the handoff (tokens, sticky chrome, segmented filter, chips, DCP bar, tier pills, 640px card collapse, `[data-theme]` dark mode).
+2. **Eliminate pagination** — render all clubs (district max ~300) in a single sticky-header table; sort/filter/search operate over the full set.
+
+### PM cohesion test
+
+- **Simpler to explain?** Yes — "every club, sortable, in one view" beats "25 per page, click next."
+- **Easier to use?** Yes — `Cmd-F`, sort, and filter all work over the whole dataset; no losing your place across pages.
+- **Reinforces core value?** Yes — the product's promise is district-wide visibility; pagination undercut it.
+
+### Scope guardrail (Lesson 092 — replace, don't augment)
+
+This is a **re-skin + structural simplification**, so net surface should **shrink**: `usePagination` and `Pagination.tsx` usage drop out of this page, legacy gray classes get replaced (not layered). Inventory before adding. Do not build a parallel table.
+
+---
+
+## Open product decisions (recommended answers baked in)
+
+| Decision                                                              | Options                                                                   | Recommendation                                                                                                                                                                                                                           |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Scroll model**                                                      | (a) whole-page scroll; (b) fixed-height scroll container inside the panel | **(b)** capped-height scroll region (e.g. `max-height: calc(100vh - controls)`) with a **sticky `<thead>`**, so headers and the status/search controls stay visible while scanning 300 rows. Whole-page scroll loses the column headers. |
+| **Virtualization**                                                    | now / defer                                                               | **Defer.** User is fine with 300 rows in the DOM; 300×~12 cells renders well under budget. Keep a perf-budget test as the tripwire; add `@tanstack/virtual` only if a real district exceeds budget. Document as a deferred safety valve. |
+| **"Extra" columns not in handoff** (`Club Status`, `Years Chartered`) | trim to handoff / keep                                                    | **Keep**, but treat the handoff column set + order as the spine and append the two extras at the end. They shipped deliberately (#448, club-status work) and removing them is a separate product call. Note the divergence in the spec.  |
+| **`?page=` URL param**                                                | silently ignore / redirect                                                | **Strip + redirect.** Drop `page` from the param contract; add a one-line cleanup so legacy `…?page=3` links land on the live single table without a dead param.                                                                         |
+
+---
+
+## Sub-issues (TDD slices, each leaves green)
+
+Ordered structural-first (functional change), then visual, so each slice is independently shippable.
+
+### Sub-issue 1 — Remove pagination: single sticky-header table
+
+**Type:** feat · **Labels:** ui/ux, frontend, redesign
+
+- Remove `usePagination` from `ClubsTable.tsx`; render **all** sorted+filtered rows.
+- Replace the `Pagination` component render with a results counter: "Showing N of M clubs" (reuse the existing count line at ClubsTable.tsx:397).
+- Sticky `<thead>` (`position: sticky; top: 0`) inside a capped-height scroll container; header stays put while scrolling.
+- Drop `?page=` from the param contract in `DistrictClubsPage.tsx`; add legacy-param cleanup in `legacyTabRedirect.ts`.
+- **Tests (the spec change):** rewrite `ClubsTable.performance.test.tsx` — assertions move from `tableRows.length === 26` to "renders all rows" with a render-time budget over a realistic 300-club set (and a 1000-club stress measurement, logged not gated). This is a deliberate spec change, comment it with the issue # (Lesson 092 — not assertion pinning). Update `ClubsTable.test.tsx` / `.integration.test.tsx` pagination cases.
+- **AC:** no pagination controls; all clubs visible by scroll; sort/filter/search span the full set; sticky header verified; `?page=` no longer written; legacy `?page=` link resolves cleanly; full suite green.
+
+### Sub-issue 2 — Re-skin table chrome to redesign tokens
+
+**Type:** feat · **Labels:** ui/ux, frontend, redesign
+
+- Replace legacy gray Tailwind (`text-gray-900`, `bg-gray-50`, `border-gray-200`, `divide-gray-200`, `font-tm-headline`) on the panel, header, and rows with redesign tokens: panel `--surface` / `--line`, header `--surface-2`, row hover `--surface-3`, text `--ink` / `--ink-3`, headings Montserrat per handoff §215.
+- Dark mode via `[data-theme='dark']` at the **CSS level** (R10), not component branches — follow project convention over the handoff's `prefers-color-scheme` wording.
+- Move row/header styling into a dedicated CSS block (e.g. `app-shell.css` `#clubs-table` rules already referenced by the handoff) rather than inline utilities.
+- **AC:** zero legacy `*-gray-*` classes left on the table; light + dark both match tokens; Playwright screenshots at 1280/768/375 + dark compared to handoff (visual-audit-2026-05-10 rule).
+
+### Sub-issue 3 — Column model to match handoff (DCP bar, cur/base, status & tier pills)
+
+**Type:** feat · **Labels:** ui/ux, frontend, redesign
+
+- Reconcile column set/order to handoff §8: **Club, Div, Area, Status, Members (cur/base), Needed, New, Oct Renew, Apr Renew, DCP (bar), Tier**, then append kept extras (Club Status, Years).
+- Render **Status** and **Tier (Distinguished)** as pills (DCP tier color map: Smedley `--maroon-500`, President's `--loyal-500`, Select `--loyal-400`, Distinguished `--green-600`, projected striped yellow, not-yet neutral — HANDOFF §259).
+- Render **DCP** as an inline progress bar; **Members** as current/base. Wire to real pipeline fields (`extractDcpGoalProgress`, `clubPerformance`), never the mockup's illustrative copy (Lesson 092); honour the DCP-independence tripwire.
+- **AC:** columns match spec order; pills/bar render with correct token colors; sort still works on every column; no Goals-1-N inference.
+
+### Sub-issue 4 — Re-skin the controls row (search, segmented status filter, quick chips)
+
+**Type:** feat · **Labels:** ui/ux, frontend, redesign
+
+- Re-skin `clubs-status-segmented` and `clubs-quick-filter-chip*` to redesign tokens (active = `--loyal-500` text on `--loyal-50`, hover `--surface-3`).
+- Search input adopts redesign input styling; keep counts on the segmented control.
+- Controls row sticks with the header in the scroll model from sub-issue 1.
+- **AC:** segmented + chips + search match handoff styling in light/dark; keyboard + ARIA tablist semantics preserved (already present at ClubsTable.tsx:444+).
+
+### Sub-issue 5 — Responsive: 640px card collapse + re-skinned cards
+
+**Type:** feat · **Labels:** ui/ux, frontend, redesign
+
+- Align table→card collapse to **640px** (handoff §126); current code collapses at 768px — reconcile.
+- Re-skin the mobile card view (ClubsTable.tsx:721-787) to redesign tokens; ensure no horizontal scroll at 375px and ≥44px touch targets on chips/sort controls.
+- With pagination gone, mobile is one long card list — verify status filter + search adequately narrow it; sticky controls help.
+- **AC:** verified at 375 / 640 / 768 / 1280 in light + dark; no overflow; touch targets pass.
+
+### Sub-issue 6 — A11y + verification pass
+
+**Type:** chore/test · **Labels:** ui/ux, frontend, a11y
+
+- Contrast audit to WCAG AA on new token combos (pills, chips, ink-3 on surface).
+- Keyboard: sort via header still reachable; sticky header doesn't trap focus; scroll region is keyboard-scrollable.
+- Empty/loading states re-skinned (the existing empty state at ClubsTable.tsx:697 uses gray classes).
+- Final Playwright prod-vs-handoff screenshot comparison (visual-audit lesson — don't declare done without it).
+- **AC:** axe clean; manual keyboard pass; screenshots archived; lessons entry added.
+
+---
+
+## Risks & mitigations
+
+- **Perf regression at scale** — mitigate with the render-budget test (sub-issue 1) as a tripwire; virtualization is the documented fallback if a district ever exceeds budget.
+- **Assertion-pinning false alarm** — the perf-test rewrite is a spec change; comment it with the issue # so review doesn't read it as pinning (Lesson 092).
+- **Token-migration coexistence** — `--loyal`/redesign.css coexists with legacy `--color-tm-*`; migrate the table fully so it doesn't end up half-and-half (Lesson 092 "replace, don't augment").
+- **Two-code-path tripwires** — none of the SnapshotBuilder/DCP-independence tripwires are touched by chrome, but sub-issue 3 reads DCP fields: use the canonical util.
+
+## What we're NOT doing
+
+- Not migrating to the `--rt-*` Red Taverns brand chrome (blocked on rename, ops#37) — this rides the `--loyal` redesign tokens that are actively shipping.
+- Not adding virtualization (deferred).
+- Not removing the Club Status / Years columns (separate product call).
+- Not touching the data pipeline or other district tabs.
+
+## Sequencing
+
+1 → 2 → 3 → 4 → 5 → 6. Slice 1 is the user's headline ask (kill pagination) and ships value immediately; 2–6 land the look-and-feel incrementally, each green.

--- a/tasks/district-page-ux-audit.md
+++ b/tasks/district-page-ux-audit.md
@@ -1,0 +1,126 @@
+# District page — UX audit & way forward
+
+**Date:** 2026-05-24
+**Author:** Claude (ron-ux persona)
+**Method:** Live Playwright screenshots of `/district/93` (top-ranked, fully populated) at 1440 / 768 / 375px in light + dark, against `docs/design/club-redesign-2026-05/HANDOFF.md`. Screenshots in `.routine-tmp/ux-audit/`.
+**Scope:** `DistrictDetailPage.tsx` (the Overview/narrative page), not the routed sub-pages.
+
+> Dev caveat: localhost can't read the prod CDN (CORS) — screenshots were taken with web-security disabled so real data loads. Two findings below (charts stuck "Loading chart…", white-block dark mode) reproduce with data present and should be re-verified on prod, but the dark-mode theming defect is real regardless of data.
+
+---
+
+## Root-cause framing — why it "feels off"
+
+The handoff specified a **tabbed** district page: `Overview · Clubs · Divisions & Areas · Trends · Analytics · Global Rankings`, tabs swapping one viewport of content. Epic #571 (IA Phase 3) **retired the tab strip** and turned the page into a **single scrolling narrative** (Overview → Trends → Top clubs → Analytics → Divisions → Vs world) plus three routed sub-pages (clubs/divisions/rankings) reached by CTAs at the very bottom, plus an "On this page" anchor rail on the right (≥1024px only).
+
+That one decision is the source of every complaint:
+
+- The page now tries to be **both a narrative and a hub**, so it's enormous.
+- The right rail is a **band-aid** for the resulting length — and it's the thing you hate.
+- On mobile the rail is hidden, so the length has **zero wayfinding** → "terrible."
+
+**The fix is an IA decision, not a styling pass.** Re-skinning won't help a 19,000px page.
+
+---
+
+## Findings by severity
+
+### P0 — Mobile is an endless scroll with no wayfinding
+
+- The mobile page is **~18,900px tall** (≈50 phone screens) — every section expanded, nothing collapsed. Evidence: `district-mobile-light.png` (1504×18936).
+- The only section navigation (the "On this page" rail) is `display:none` below 1024px (`district-narrative.css:147`). So on the device class that needs jump-nav most, there is none.
+- Header control cluster (Data-fresh pill + PY dropdown + as-of-date dropdown + Export + Share) crowds and wraps at 375px.
+
+### P0 — Trend charts stuck on "Loading chart…" (white blocks)
+
+- All three Trends charts render the loading placeholder indefinitely (0 `<svg>`) even though time-series JSON returns 200. Evidence: `charts.mjs` output, the gray/white mid-page mass in every full-page shot.
+- In **dark mode these placeholders are bright white** — large glaring rectangles on a dark page (`district-desktop-dark.png`). The chart/plot container background is hardcoded, not `[data-theme]`-aware → **R10 violation**.
+
+### P1 — The "On this page" right rail (the one you hate)
+
+- It's a 200px column in a `minmax(0,1fr) 200px` grid (`district-narrative.css:153`), sticky at `top:80px`, but it starts level with the _Overview_ heading — leaving a **large empty void** in the top-right above it and an asymmetric layout. Evidence: `district-desktop-fold.png`.
+- It duplicates wayfinding already provided by (a) scrolling and (b) the bottom CTAs, and it only exists on wide screens. Low value for the visual cost. **Recommend deleting it** as part of the IA fix below.
+
+### P1 — KPI strip diverges from spec and is dense
+
+- Shows **3 cards** (Paid Clubs, Membership Payments, Distinguished Clubs); handoff specs **4** (add **Net Member Change**).
+- Each card stacks a rank badge ("09: #1"), "#1 of 128 · 1st percentile", and a cryptic horizontal gauge with `D S P 5m` tick marks at raw numbers. Too many encodings per card; the gauge needs a legend or removal.
+
+### P2 — Header action cluster overloaded
+
+- Five controls top-right (freshness pill, PY select, as-of-date select, Export CSV, Share). On desktop it's busy; on mobile it wraps. Consolidate Export/Share into an overflow "⋯" menu; consider merging PY + as-of date into one "time window" control.
+
+### P2 — Breakpoint reconciliation
+
+- Handoff: 2-col grids collapse at **980px**, tables→cards at **640px**. Current code uses 1024px for the rail and 640/768 for KPI. Align to the handoff system so the whole redesign is consistent.
+
+### P2 — Dark-mode panel inconsistencies
+
+- Besides the white charts, "Achievement Highlights" / "Education Levels" panels read lighter than surrounding surfaces in dark mode — audit all panels for token-driven backgrounds (R10).
+
+---
+
+## Way forward — full subpage IA (decided: no tabs)
+
+**Decision (Ron, 2026-05-24): no client-side tabs.** Tabs collapse multiple views onto one URL, which breaks the back button, deep links, and per-view filter/sort state. Real routes ("subpages") preserve all three. #571 started this but only half-committed — it added subpages _and_ kept an everything-scroll at `/district/:id`. The fix is to **commit fully to subpages** and make the landing route a lean hub.
+
+### Target route map
+
+| Route                     | Content                                                                                                                                                              | Status                                                                  |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `/district/:id`           | **Overview hub** — KPI strip, Distinguished District status, composition cards, anniversaries/milestones, and _top-5 preview_ lists that link out. Short, scannable. | reshape (trim)                                                          |
+| `/district/:id/clubs`     | Clubs table                                                                                                                                                          | exists (epic #665 reskin)                                               |
+| `/district/:id/divisions` | Divisions & areas                                                                                                                                                    | exists — **remove the duplicate inline Divisions section from the hub** |
+| `/district/:id/rankings`  | Global rankings + "vs world"                                                                                                                                         | exists — **move inline "Vs world" here**                                |
+| `/district/:id/trends`    | Membership + payment trend charts (3yr)                                                                                                                              | **NEW** — lift the heavy Trends section off the hub                     |
+| `/district/:id/analytics` | Top growth clubs + Top DCP achievers (full)                                                                                                                          | **NEW or fold previews into hub** — settle in the IA issue              |
+
+### Navigation between subpages — real links, not tab state
+
+A persistent **secondary nav** under the district header: `Overview · Clubs · Divisions · Trends · Analytics · Rankings`. It may _look_ like a tab strip, but every item is an `<a href>`/`<Link>` to a real route — so browsing, back button, deep links, and each page's URL-encoded filters all keep working. The active route is highlighted. On mobile it's a horizontally-scrolling link row (handoff §126) or a `<select>` that navigates on change.
+
+### What this fixes
+
+- **Mobile:** each route is one short page → drops from ~50 screens to a few; the secondary nav gives wayfinding at every width (the old rail was hidden < 1024px).
+- **The right rail you hate:** **deleted** — the secondary route-nav replaces it.
+- **Desktop "off" feeling:** the hub becomes a lean, symmetric landing instead of a 19k-px dumping ground; no more empty 200px gutter.
+- **Browsing/filtering:** preserved and _improved_ — Trends/Analytics get their own shareable URLs and filter state, same as Clubs already has.
+
+### Open sub-decisions (settle in the IA issue)
+
+- Analytics: own route vs. top-5 previews on the hub linking to Rankings/Clubs.
+- Where the secondary nav lives: its own primitive, or reuse the breadcrumb component's row (#615).
+- Whether the hub keeps a compact trends sparkline as a teaser that links to `/trends`.
+
+### Cross-cutting fixes (apply under either decision)
+
+1. Fix the charts stuck on "Loading chart…" (root-cause the lazy chart chunk); make the loading/empty placeholder **theme-aware** (R10).
+2. Add the 4th KPI card (Net Member Change) or formally drop it from the spec; add a legend to (or remove) the KPI gauge.
+3. Consolidate the header cluster (overflow menu for Export/Share; unify time-window controls).
+4. Reconcile breakpoints to the handoff (980 / 640).
+5. Full dark-mode panel audit (token-driven backgrounds only).
+
+---
+
+## Proposed epic — "District page UX: commit to subpage IA + mobile + chart/theme fixes"
+
+Sequenced so the highest-pain, lowest-risk fixes ship first, then the IA map, then the migration.
+
+1. **fix(district): trend charts stuck on "Loading chart…" + theme-aware placeholder** _(P0, bug)_ — root-cause the never-resolving chart load; loading/empty state uses `[data-theme]` tokens, no white-on-dark.
+2. **fix(district): consolidate header action cluster + mobile overflow** _(P1)_ — overflow menu for Export/Share, unify time-window controls, no wrap at 375px.
+3. **design: district subpage IA map + secondary route-nav (ADR)** _(P1)_ — lock the route map above; decide Analytics placement and the nav primitive; **delete the "On this page" rail** from the plan. Real `<Link>`s, no client tab-state. **Blocks 4–6.**
+4. **feat(district): secondary route-nav primitive** _(P0)_ — persistent links `Overview · Clubs · Divisions · Trends · Analytics · Rankings`, active-route highlight, mobile horizontal-scroll/select; replaces the deleted rail. Works at all widths.
+5. **feat(district): lean Overview hub** _(P0 for mobile)_ — trim `/district/:id` to KPIs + Distinguished status + composition + anniversaries + top-5 previews-with-links; **remove inline Divisions/Vs-world duplication**; delete `DistrictAnchorToc`.
+6. **feat(district): promote Trends (+ Analytics) to own routes** _(P1)_ — new `/district/:id/trends` (and `/analytics` per the ADR); move the heavy charts/lists off the hub; each gets URL-encoded state like Clubs has.
+7. **feat(district): KPI strip to spec** _(P1)_ — 4th card (Net Member Change) or documented drop; simplify/legend the D/S/P gauge.
+8. **chore(district): breakpoint reconciliation + dark-mode panel audit + verification** _(P2)_ — align to 980/640; all panels token-driven; Playwright prod-vs-handoff at 375/640/980/1280 + dark.
+
+---
+
+## Evidence index (`.routine-tmp/ux-audit/`)
+
+- `district-desktop-fold.png` — right-rail void, KPI density, header cluster.
+- `district-desktop-dark.png` — white chart blocks on dark.
+- `district-mobile-light.png` — the ~18,900px scroll.
+- `district-tablet-light.png` — rail hidden, empty charts.
+- `shoot.mjs`, `charts.mjs` — repeatable capture scripts (run with web-security disabled for local CDN).

--- a/tasks/region-pages-feedback-epic.md
+++ b/tasks/region-pages-feedback-epic.md
@@ -1,0 +1,67 @@
+# Region pages — feedback analysis & epic
+
+**Date:** 2026-05-24
+**Source:** Amy voice note (`.routine-tmp/region-feedback/transcript.md`) + spreadsheet mock (Region 7).
+**Personas:** ron-pm + ron-ux. Grounded in code via Explore + live-data validation.
+
+## Two surfaces
+
+- **Regions index** (`/regions` → `RegionsPage.tsx`, `RegionGrid.tsx`, `RegionsLeaderboard`).
+- **Region detail** (`/region/:n` → `RegionPage.tsx`), a per-district table (13 cols today).
+
+## What Amy likes (keep — do not regress)
+
+Districts at top; Paid Clubs; region-at-a-glance (lost/down for paid, payments, distinguished); region-rank column (1st); district-number column (2nd); world-rank comparison.
+
+## Findings (code + live data)
+
+### F1 — "Net Club Growth" shows the wrong number (data correctness, P0)
+
+The column renders the **distinguished gap** `Math.max(0, requiredNetChange − netChange)` (`DistinguishedDistrictCalculator.ts:255`, rendered `RegionPage.tsx:162,70-84`), not the actual signed net change. District 48 _lost_ 8 clubs (paidClubs 79→71, net **−8**) but the column shows **+8**. A district that is shrinking appears to be growing — actively misleading. Validated against live `v1/rankings.json`.
+
+### F2 — Regions index unreadable until hover (a11y, P0/P1)
+
+Amy: "I cannot read any of the fonts… white font on the gray background of a specific region… only [visible] when I put my mouse over top… I have to scroll through each to find region seven." Code reading was inconclusive on the exact element (`RegionGrid.tsx:37` cards vs leaderboard rows) — **reproduce at `/regions` with a screenshot first**, then fix contrast to WCAG AA at rest (not only on hover) and make finding a specific region easy (highlight / search / jump-to-region).
+
+### F3 — Wants base → current → Δ per metric (P1)
+
+Today Paid Clubs shows current only (`d.paidClubs`). Amy wants, per metric:
+
+- **Paid Clubs:** base → current → net growth (signed, from F1).
+- **Membership Payments:** base → current → ± delta.
+- **Distinguished Clubs:** base → current → Δ.
+
+Data is available in `CdnRankingsData`: `paidClubBase`, `paidClubs`, `paymentBase`, `totalPayments`, `distinguishedClubs`, `activeClubs`.
+
+### F4 — Three "remaining to minimum distinguished" columns, absolute not % (P1, headline)
+
+Keep the ✓ when the minimum distinguished metric is met. When not met, show the **absolute number remaining** to the minimum Distinguished tier — one column each for **paid clubs, payments (memberships), distinguished clubs**. Today the gap is shown in **percentage points** (e.g. "+4.1%" = `paymentGrowthPercent`); Amy wants the count.
+
+**Validated formula (Distinguished tier minimums: payment growth ≥ +1%, distinguished ≥ 45% of active clubs, net no-loss):**
+
+```
+payments_remaining      = max(0, ceil(paymentBase × 1.01) − totalPayments)
+distinguished_remaining = max(0, ceil(activeClubs × 0.45) − distinguishedClubs)
+paidclub_remaining      = clubs to regain base + required net growth   # calibrate with Amy vs the spreadsheet
+```
+
+Live checks (today's snapshot): **D47 payments_remaining = 277 ✓**, **D37 = 170 ✓** (exact match to audio + spreadsheet). Distinguished-clubs and paid-clubs counts are close to the spreadsheet but not exact (the mock was an earlier snapshot) — **calibrate the paid-club + distinguished formulas with Amy against the spreadsheet before locking**. Thresholds live in `DistinguishedDistrictCalculator.TIER_THRESHOLDS`; `DistinguishedDistrictGap` already carries `paidClubBase`/`paymentBase` and the percentage gaps.
+
+---
+
+## Epic — "Region pages: net-growth fix + readability + base/current/Δ + distinguished-remaining"
+
+Sequenced: the P0 correctness/readability fixes first, then the analytics that the new columns depend on, then the table redesign.
+
+1. **fix(region): net club growth shows the distinguished-gap, not signed net change (P0, bug).** Make the net-growth value `paidClubs − paidClubBase` (signed); D48 → **−8**. Decide whether to keep a separate gap concept (it moves into the F4 columns). TDD with D48 (−8) and a growing-district case. Trace `DistinguishedDistrictCalculator.ts:238-255`, `RegionPage.tsx:70-84,162`.
+2. **fix(regions): index readability — regions legible at rest + easy to find (P0/P1, a11y).** Reproduce at `/regions` (screenshot 1280/768/375 + dark), fix the white-on-gray element to WCAG AA without requiring hover, add a way to find/jump to a region. **Relevant lessons:** R10 (theme at CSS level).
+3. **feat(analytics): district "remaining to minimum distinguished" as absolute counts (P1, data — blocks #5).** In `analytics-core`, derive payments/distinguished/paid-club remaining counts from base + tier minimums; expose new fields on `DistinguishedDistrictGap` / the CDN payload. Calibration anchors: D47 payments = 277, D37 = 170. Calibrate paid-club + distinguished formulas with Amy vs the spreadsheet. Honour the DCP/Distinguished tripwires; raw fields only.
+4. **feat(region): table column model — base → current → Δ for Paid Clubs, Payments, Distinguished Clubs (P1).** Restructure the table to the grouped base|current|Δ shape; keep the liked columns (region rank #1, district #2, world rank, score, glance). Uses the signed net growth from #1. Depends on #1.
+5. **feat(region): three Distinguished-remaining columns, absolute not % (P1).** ✓ when met; else the absolute count from #3, one each for paid clubs / payments / distinguished clubs. Mirrors the spreadsheet mock. Depends on #3 (and visually on #4).
+6. **chore(region): dark-mode + responsive (wide table → mobile) + verification + docs (P2).** Redesign tokens, AA contrast, mobile collapse for the now-wider table, Playwright prod-vs-design verification, update `docs/product-spec.md` Region section + a lessons entry.
+
+### Open decisions
+
+- Paid-club & distinguished-club "remaining" exact formulas — calibrate with Amy against the spreadsheet (#3).
+- Whether the old percentage-point columns (`paymentGrowth %`, `clubGrowth %`, `distinguished %`) are removed or kept alongside the new absolute columns (#5).
+- Mobile strategy for a wider table (card collapse à la clubs table, or horizontal scroll).


### PR DESCRIPTION
Lands the planning artifacts produced while scoping three UX epics this session, and stops the autonomy-routine scratch dir from being tracked.

## What's here
- `tasks/clubs-table-redesign-epic.md` — epic #665 (clubs table: adopt redesign look-and-feel + remove pagination)
- `tasks/district-page-ux-audit.md` — epic #674 (district page: subpage IA + mobile + chart/theme fixes; based on live Playwright screenshots)
- `tasks/region-pages-feedback-epic.md` — epic #683 (region pages: net-growth fix + readability + base/current/Δ + distinguished-remaining; from Amy's voice feedback, validated against live data)
- `.gitignore` — add `.routine-tmp/` (autonomy-routine scratch: audit screenshots, audio, transcription model — never meant to be tracked)

## Notes
- Docs-only + gitignore; no source/business-logic changes. These match the existing tracked `tasks/*-plan.md` / `tasks/*-audit.md` convention.
- Epics #665, #674, #683 are filed and sequenced on roadmap #606 (#597 → #683 → #665 → #674).

Refs #665, #674, #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)