### PR TITLE
fix(region): Net Club Growth shows signed net change, not distinguished-gap (#684)

### DIFF
--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -96,6 +96,28 @@ const CountdownTd: React.FC<{
   </td>
 )
 
+/* Net Club Growth = the SIGNED actual net change in paid clubs this
+   program year (paidClubs − paidClubBase). Growth is green +N, loss is
+   maroon −N, matching the KpiCard delta convention above. This is a
+   distinct quantity from the clamped distinguished-gap that used to
+   render here and made a shrinking district look like it was growing
+   (#684). */
+const NetGrowthTd: React.FC<{ value: number }> = ({ value }) => {
+  const sign = value >= 0 ? '+' : ''
+  const tone = value >= 0 ? 'text-green-700' : 'text-tm-true-maroon'
+  return (
+    <td
+      data-testid="countdown-netClubGrowth"
+      className="px-3 py-4 whitespace-nowrap text-sm text-right"
+    >
+      <span className={`${tone} font-semibold tabular-nums`}>
+        {sign}
+        {value}
+      </span>
+    </td>
+  )
+}
+
 /* Per-tier display label + chip style. Pre-Distinguished districts get
    an em-dash; achieved tiers get a colored chip matching the tier. */
 type AchievedTier = Exclude<DistinguishedDistrictTier, 'NotDistinguished'>
@@ -153,13 +175,14 @@ const TierTd: React.FC<{ tier: DistinguishedDistrictTier | null }> = ({
    sub-components. */
 const DistinguishedCells: React.FC<{
   districtId: string
+  netClubGrowth: number
   awards: import('../services/cdn').CompetitiveAwardStandings | null
-}> = ({ districtId, awards }) => {
+}> = ({ districtId, netClubGrowth, awards }) => {
   const c = getDistinguishedCountdown(districtId, awards)
   const tier = awards?.distinguishedDistrict?.[districtId]?.currentTier ?? null
   return (
     <>
-      <CountdownTd metric="netClubGrowth" cell={c?.netClubGrowth ?? null} />
+      <NetGrowthTd value={netClubGrowth} />
       <CountdownTd metric="paymentGrowth" cell={c?.paymentGrowth ?? null} />
       <CountdownTd
         metric="distinguishedPercent"
@@ -408,6 +431,11 @@ const RegionPage: React.FC = () => {
                     </td>
                     <DistinguishedCells
                       districtId={d.districtId}
+                      netClubGrowth={
+                        awards?.distinguishedDistrict?.[d.districtId]
+                          ?.netClubGrowth ??
+                        (d.paidClubs ?? 0) - (d.paidClubBase ?? 0)
+                      }
                       awards={awards ?? null}
                     />
                   </tr>

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -293,7 +293,7 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
     ).toHaveTextContent(/\+4/)
   })
 
-  it('renders gap values as +N for numeric countdowns', async () => {
+  it('renders gap values as +N for the prerequisite-gap countdowns', async () => {
     mockedFetchCdnRankings.mockResolvedValueOnce({
       rankings: [mkRanking({ districtId: '61', region: '2' })],
       date: '2026-05-12',
@@ -304,15 +304,113 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
     const row = (await screen.findByTestId('district-number-chip-D61')).closest(
       'tr'
     )!
-    expect(
-      within(row).getByTestId('countdown-netClubGrowth')
-    ).toHaveTextContent(/\+3/)
+    // Payment growth + Distinguished % remain tier-gap countdowns.
     expect(
       within(row).getByTestId('countdown-paymentGrowth')
     ).toHaveTextContent(/\+12/)
     expect(
       within(row).getByTestId('countdown-distinguishedPercent')
     ).toHaveTextContent(/\+8/)
+  })
+
+  // #684 (epic #683 F1): the Net Club Growth column shows the SIGNED
+  // actual net change (paidClubs − paidClubBase), not the clamped
+  // distinguished-gap. A shrinking district must read negative.
+  it('renders Net Club Growth as the signed net change, negative for a shrinking district', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      // D48 shape: lost 8 clubs (79 → 71). Pre-fix this rendered +8.
+      rankings: [
+        mkRanking({
+          districtId: '48',
+          region: '2',
+          paidClubs: 71,
+          paidClubBase: 79,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValue(awardsFixture())
+    renderRegion('2')
+
+    const row = (await screen.findByTestId('district-number-chip-D48')).closest(
+      'tr'
+    )!
+    const cell = within(row).getByTestId('countdown-netClubGrowth')
+    expect(cell).toHaveTextContent(/-8/)
+    expect(cell).not.toHaveTextContent(/\+8/)
+  })
+
+  it('renders Net Club Growth as +N for a growing district', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      // 90 → 100 = +10 net growth.
+      rankings: [
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          paidClubs: 100,
+          paidClubBase: 90,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValue(awardsFixture())
+    renderRegion('2')
+
+    const row = (await screen.findByTestId('district-number-chip-D61')).closest(
+      'tr'
+    )!
+    expect(
+      within(row).getByTestId('countdown-netClubGrowth')
+    ).toHaveTextContent(/\+10/)
+  })
+
+  it('prefers the snapshot netClubGrowth field when present (post-pipeline)', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      // Ranking-derived would be +10; the snapshot field wins.
+      rankings: [
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          paidClubs: 100,
+          paidClubBase: 90,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValue(
+      awardsFixture({
+        distinguishedDistrict: {
+          '61': {
+            districtId: '61',
+            currentTier: 'NotDistinguished',
+            allPrerequisitesMet: false,
+            netClubGrowth: -3,
+            prerequisites: {
+              dspSubmitted: false,
+              trainingMet: false,
+              marketAnalysisSubmitted: false,
+              communicationPlanSubmitted: false,
+              regionAdvisorVisitMet: false,
+            },
+            nextTierGap: {
+              tier: 'Distinguished',
+              netClubGrowthGap: 3,
+              paymentGrowthGap: 0,
+              distinguishedPercentGap: 0,
+              clubGrowthGap: 0,
+            },
+          },
+        },
+      })
+    )
+    renderRegion('2')
+
+    const row = (await screen.findByTestId('district-number-chip-D61')).closest(
+      'tr'
+    )!
+    const cell = within(row).getByTestId('countdown-netClubGrowth')
+    expect(cell).toHaveTextContent(/-3/)
+    expect(cell).not.toHaveTextContent(/\+10/)
   })
 
   it('renders ✓ for officer-award booleans when met, em-dash when not', async () => {
@@ -368,17 +466,29 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
     const row = (await screen.findByTestId('district-number-chip-D61')).closest(
       'tr'
     )!
-    expect(
-      within(row).getByTestId('countdown-netClubGrowth')
-    ).toHaveTextContent(/✓/)
+    // Payment growth is a tier-gap countdown → ✓ when met. Net Club
+    // Growth is no longer a gap; it shows the signed net change
+    // (mkRanking default 100 − 90 = +10).
     expect(
       within(row).getByTestId('countdown-paymentGrowth')
     ).toHaveTextContent(/✓/)
+    expect(
+      within(row).getByTestId('countdown-netClubGrowth')
+    ).toHaveTextContent(/\+10/)
   })
 
-  it('renders em-dashes when the awards JSON is null (legacy snapshot)', async () => {
+  it('renders Net Club Growth from the rankings row even when the awards JSON is null (#684)', async () => {
+    // Net growth is sourced from the rankings snapshot, not the awards
+    // snapshot — so a legacy/missing awards file does not blank it.
     mockedFetchCdnRankings.mockResolvedValueOnce({
-      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      rankings: [
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          paidClubs: 100,
+          paidClubBase: 90,
+        }),
+      ],
       date: '2026-05-12',
     })
     mockedFetchCdnAwards.mockResolvedValue(null)
@@ -389,7 +499,7 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
     )!
     expect(
       within(row).getByTestId('countdown-netClubGrowth')
-    ).toHaveTextContent(/—/)
+    ).toHaveTextContent(/\+10/)
   })
 })
 

--- a/frontend/src/services/cdn.ts
+++ b/frontend/src/services/cdn.ts
@@ -217,6 +217,14 @@ export interface DistinguishedDistrictStatus {
   allPrerequisitesMet: boolean
   prerequisites: DistinguishedDistrictPrerequisites
   nextTierGap: DistinguishedDistrictGap | null
+  /**
+   * Signed actual net change in paid clubs this program year
+   * (`paidClubs − paidClubBase`). Distinct from `nextTierGap`'s
+   * clamped `netClubGrowthGap` (#684). Optional to tolerate CDN
+   * snapshots written before the field existed — consumers fall back
+   * to deriving it from the rankings row.
+   */
+  netClubGrowth?: number
 }
 
 /**

--- a/frontend/src/utils/__tests__/distinguishedCountdown.test.ts
+++ b/frontend/src/utils/__tests__/distinguishedCountdown.test.ts
@@ -70,11 +70,13 @@ const ddStatus = (
 })
 
 describe('getDistinguishedCountdown (#516 #534)', () => {
-  it('returns the four numeric gaps + two officer-award booleans', () => {
+  it('returns the three numeric gaps + two officer-award booleans', () => {
+    // netClubGrowth is no longer part of the countdown — the region
+    // table renders the signed net change from the rankings row, not
+    // the clamped tier-gap (#684).
     const awards = mkAwards(ddStatus(), false, true)
     const c = getDistinguishedCountdown('61', awards)
     expect(c).not.toBeNull()
-    expect(c!.netClubGrowth).toEqual({ kind: 'gap', value: 3 })
     expect(c!.paymentGrowth).toEqual({ kind: 'gap', value: 12 })
     expect(c!.distinguishedPercent).toEqual({ kind: 'gap', value: 8 })
     // #534 — the fourth numeric DD prerequisite, distinct from the
@@ -111,18 +113,17 @@ describe('getDistinguishedCountdown (#516 #534)', () => {
     })
     const awards = mkAwards(status, false, false)
     const c = getDistinguishedCountdown('61', awards)
-    expect(c!.netClubGrowth).toEqual({ kind: 'met' })
     expect(c!.paymentGrowth).toEqual({ kind: 'met' })
     expect(c!.distinguishedPercent).toEqual({ kind: 'gap', value: 4 })
   })
 
-  it('returns "met" for all three numeric metrics when nextTierGap is null (district at Smedley)', () => {
+  it('returns "met" for the numeric metrics when nextTierGap is null (district at Smedley)', () => {
     const status = ddStatus({ currentTier: 'Smedley', nextTierGap: null })
     const awards = mkAwards(status, true, true)
     const c = getDistinguishedCountdown('61', awards)
-    expect(c!.netClubGrowth).toEqual({ kind: 'met' })
     expect(c!.paymentGrowth).toEqual({ kind: 'met' })
     expect(c!.distinguishedPercent).toEqual({ kind: 'met' })
+    expect(c!.clubGrowthPercent).toEqual({ kind: 'met' })
   })
 
   it('returns null when the district has no Distinguished District status entry', () => {

--- a/frontend/src/utils/distinguishedCountdown.ts
+++ b/frontend/src/utils/distinguishedCountdown.ts
@@ -11,7 +11,6 @@ export type CountdownCell =
   | { kind: 'boolean'; met: boolean }
 
 export interface DistinguishedCountdown {
-  netClubGrowth: CountdownCell
   paymentGrowth: CountdownCell
   distinguishedPercent: CountdownCell
   /** % Club Growth threshold (DD prerequisite #4 — distinct from the
@@ -37,19 +36,14 @@ export function getDistinguishedCountdown(
   const gap = status.nextTierGap
   const numeric: Pick<
     DistinguishedCountdown,
-    | 'netClubGrowth'
-    | 'paymentGrowth'
-    | 'distinguishedPercent'
-    | 'clubGrowthPercent'
+    'paymentGrowth' | 'distinguishedPercent' | 'clubGrowthPercent'
   > = gap
     ? {
-        netClubGrowth: gapCell(gap.netClubGrowthGap),
         paymentGrowth: gapCell(gap.paymentGrowthGap),
         distinguishedPercent: gapCell(gap.distinguishedPercentGap),
         clubGrowthPercent: gapCell(gap.clubGrowthGap),
       }
     : {
-        netClubGrowth: { kind: 'met' },
         paymentGrowth: { kind: 'met' },
         distinguishedPercent: { kind: 'met' },
         clubGrowthPercent: { kind: 'met' },

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.test.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.test.ts
@@ -245,6 +245,45 @@ describe('DistinguishedDistrictCalculator', () => {
     })
   })
 
+  describe('Net club growth — signed actual net change (#684)', () => {
+    // F1 (epic #683): the region table conflated `netClubGrowthGap`
+    // (distance to the next tier's net-growth rule) with the actual
+    // signed net change. A shrinking district (D48: 79 → 71) rendered
+    // as +8 because the gap is `max(0, required − netChange)`. The
+    // status must expose the signed actual net change separately.
+    it('reports a negative netClubGrowth when the district lost clubs (D48: 79 → 71)', () => {
+      const ranking = buildRanking({
+        districtId: '48',
+        paidClubs: 71,
+        paidClubBase: 79,
+      })
+
+      const result = calculator.calculate(ranking)
+
+      expect(result.netClubGrowth).toBe(-8)
+      // The distinguished-gap concept is a distinct number: a
+      // NotDistinguished district's gap to the 'no-loss' rule is
+      // max(0, 0 − (−8)) = 8. The two must not be confused.
+      expect(result.nextTierGap?.netClubGrowthGap).toBe(8)
+    })
+
+    it('reports a positive netClubGrowth when the district gained clubs', () => {
+      const ranking = buildRanking({ paidClubs: 105, paidClubBase: 100 })
+
+      const result = calculator.calculate(ranking)
+
+      expect(result.netClubGrowth).toBe(5)
+    })
+
+    it('reports zero netClubGrowth when paid clubs are unchanged', () => {
+      const ranking = buildRanking({ paidClubs: 100, paidClubBase: 100 })
+
+      const result = calculator.calculate(ranking)
+
+      expect(result.netClubGrowth).toBe(0)
+    })
+  })
+
   describe('Bulk calculation', () => {
     it('should calculate tiers for multiple districts', () => {
       const rankings: DistrictRanking[] = [

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
@@ -83,6 +83,16 @@ export interface DistinguishedDistrictStatus {
   prerequisites: DistinguishedDistrictPrerequisites
   /** Gap to the next higher tier (null if at Smedley) */
   nextTierGap: DistinguishedDistrictGap | null
+  /**
+   * Signed actual net change in paid clubs this program year
+   * (`paidClubs − paidClubBase`). Distinct from `nextTierGap`'s
+   * `netClubGrowthGap`, which is the clamped distance to the next tier's
+   * net-growth rule (`max(0, required − netChange)`) and can never be
+   * negative. A shrinking district has a negative `netClubGrowth` but a
+   * positive `netClubGrowthGap` — conflating the two made D48 (79 → 71)
+   * render as +8 "growth" (#684).
+   */
+  netClubGrowth: number
 }
 
 // ========== Tier Thresholds ==========
@@ -162,6 +172,7 @@ export class DistinguishedDistrictCalculator {
       allPrerequisitesMet,
       prerequisites,
       nextTierGap,
+      netClubGrowth: ranking.paidClubs - ranking.paidClubBase,
     }
   }
 

--- a/tasks/lessons/102-a-clamped-gap-is-not-a-signed-delta.md
+++ b/tasks/lessons/102-a-clamped-gap-is-not-a-signed-delta.md
@@ -1,0 +1,73 @@
+---
+id: '102'
+category: lesson
+tags: [analytics, frontend, dcp, data-pipeline]
+auto_load: true
+date: 2026-05-24
+issues: [684, 683]
+---
+
+# Lesson 102 — A clamped tier-gap is not a signed delta; don't render `max(0, …)` under a "growth/change" label
+
+**Date:** 2026-05-24
+**Issue:** #684 (epic #683 Sprint 1 — region pages)
+**PR:** [#695](https://github.com/taverns-red/toast-stats/pull/695)
+
+## What happened
+
+The `/region/:n` table's "Net Club Growth" column was wired to
+`DistinguishedDistrictGap.netClubGrowthGap`, which is
+`Math.max(0, requiredNetChange − netChange)` — the clamped distance to
+the next Distinguished tier's net-growth rule. District 48 lost 8 clubs
+(paidClubs 79 → 71, net change **−8**) and the column rendered **+8**. A
+shrinking district looked like it was growing, on a P0 surface a district
+director uses to judge health.
+
+The giveaway: the displayed number was the exact magnitude of the loss,
+but positive. `max(0, 0 − (−8)) = 8`. The clamp turned a regression into
+a goal-distance and the sign flipped as a side effect.
+
+## The trap
+
+A **gap** and a **signed delta** are different quantities that happen to
+share units and, for a shrinking district, share magnitude:
+
+- **Signed delta** (`current − base`): the actual change. Can be
+  negative. This is what a column named _growth / change / net_ must show.
+- **Clamped gap** (`max(0, required − current)`): "how far to a target."
+  **Can never be negative** — that's the whole point of the clamp. Useful
+  for a countdown column, useless (worse: misleading) as a "growth" value.
+
+When a clamped gap is displayed under a signed-quantity label, every
+regression is silently rendered as a non-negative number. The clamp
+**is** the bug surface: `max(0, …)` guarantees you can never see a loss.
+
+## How to apply
+
+- **A column whose name implies a sign (growth, change, net, Δ, +/−) must
+  render the signed actual** (`current − base`), not a gap. If you see
+  `max(0, …)` feeding a "growth" cell, that's the bug.
+- **Keep the gap and the actual as separate named fields.** Here the fix
+  added a distinct `netClubGrowth` (signed) to `DistinguishedDistrictStatus`
+  alongside the existing `netClubGrowthGap` (clamped). One field, one
+  meaning — don't overload a gap to also serve as the actual.
+- **Source the signed value from authoritative stock fields, not by
+  un-clamping the gap.** `−netClubGrowthGap` is wrong in general (the clamp
+  is lossy). The actual is `paidClubs − paidClubBase`; those fields already
+  ride the rankings snapshot, so the frontend can render the correct value
+  on the **current live snapshot** without waiting for a pipeline re-run,
+  while the new analytics field becomes the canonical source going forward.
+- **Test the shrinking case explicitly.** A growing-district test passes
+  for both the right formula and the clamped-gap bug (both positive). Only
+  a loss (D48: −8, not +8) distinguishes them. The falsifying test is the
+  negative case.
+
+## Related
+
+- [[057-year-cumulative-metrics-have-base-zero]] — base semantics: a
+  _stock_ (paid clubs) has a real PY-start base; the signed delta is
+  `current − base`.
+- [[060-trust-the-program-rules-on-percentage-denominators]] — adjacent
+  family: the displayed number must mean exactly what its label claims.
+- `packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts`
+  — `netClubGrowth` (signed) vs `nextTierGap.netClubGrowthGap` (clamped).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -60,3 +60,4 @@
 - **099** [typescript, build, deps, monorepo, tsconfig] — `ignoreDeprecations` is the sanctioned staging path for a TS major bump, not a suppression (#612, #597) _(ref-only)_
 - **100** [deps, vite, rolldown, build, ci, verification] — Vite 8 is Rolldown; verify breakage empirically, not from the migration guide (#613, #597)
 - **101** [deps, eslint, build, ci, monorepo, verification] — A major bump that unbundles a sub-package breaks every import that relied on the transitive copy (#614, #597)
+- **102** [analytics, frontend, dcp, data-pipeline] — A clamped tier-gap is not a signed delta; don't render `max(0, …)` under a "growth/change" label (#684, #683)


### PR DESCRIPTION
## Summary

Fixes the **P0 data-correctness bug** in epic #683 (F1): the "Net Club Growth" column on `/region/:n` rendered the *distinguished tier gap* `netClubGrowthGap = max(0, requiredNetChange − netChange)` instead of the actual signed net change. **District 48 lost 8 clubs (79 → 71, net −8) but the column showed +8** — a shrinking district looked like it was growing.

## Root cause

Semantic conflation, not a sign error. The column was wired to the clamped tier-gap, which can never be negative. The actual signed net change (`paidClubs − paidClubBase`) was never surfaced as its own quantity.

## Fix (source-first)

- **analytics-core** — added a canonical `netClubGrowth: number` (signed `paidClubs − paidClubBase`) to `DistinguishedDistrictStatus`, distinct from the existing `nextTierGap.netClubGrowthGap`. Serialized into the snapshot via `TransformService` (single producer; no parallel copy — L61 verified).
- **cdn.ts** — added optional `netClubGrowth?: number` to the snapshot type (rollout-tolerant, per #555 precedent).
- **distinguishedCountdown util** — dropped `netClubGrowth` (it was the conflated gap mapping); the 3 real prerequisite-gap cells stay.
- **RegionPage** — new `NetGrowthTd` renderer: signed value, green `+N` / maroon `−N` matching the page's `KpiCard` delta convention. Value = `status?.netClubGrowth ?? (paidClubs − paidClubBase)` — prefers the snapshot field, falls back to the rankings row the page already loads, so it is **correct on the current live snapshot without waiting for a collector re-run**.

## Acceptance criteria

- [x] Failing test reproduces D48 showing +8 before the fix (TDD) — `DistinguishedDistrictCalculator.test.ts` + `RegionPage.test.tsx`.
- [x] Net growth renders signed: D48 = −8; a growing district shows +N.
- [x] No regression to the distinguished tier/prerequisite logic (analytics-core 781 + collector-cli 735 green).
- [ ] Verified against live snapshot for several Region 7 districts — **post-merge live verification** on ts.taverns.red.

## Tests

Full suite green: frontend 2489, analytics-core 781, shared-contracts 134, collector-cli 735.

## Fresh-context review

APPROVE-WITH-NITS — no High/Medium findings. Confirmed not assertion-pinning (the column's *meaning* changed), source-fix complete across packages, no second un-fixed copy. Low nits (not fixed — cosmetic / defensible):
- `NetGrowthTd` renders a `+0` (green) for a district exactly at base. Defensible as "no change"; product can revisit styling later.
- D48 test uses substring regex `/-8/`; could anchor for precision.
- `(d.paidClubs ?? 0) - (d.paidClubBase ?? 0)` — `?? 0` is dead-defensive (both fields required on the rankings type).

Closes #684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
