### PR TITLE
fix(regions): index findability — jump-to-region finder + dark focus/hover contrast (epic #683)

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -65,6 +65,14 @@ A data visualization platform for **Toastmasters district leaders** to track clu
 | Club anniversary badge      | Club hero pill: quiet / milestone-gold / upcoming countdown for charter anniversaries (#445)                                                                                                                                                                                                                                                                                                                                                                | ✅ Shipped |
 | Years Chartered column      | Sortable "Years" column in the Clubs table — years since charter, em-dash when unknown (#448)                                                                                                                                                                                                                                                                                                                                                               | ✅ Shipped |
 
+### Regions Overview (`/regions`)
+
+| Feature            | Description                                                                                                                                                                      | Status     |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| Region leaderboard | Sortable 14-region table (districts, paid clubs, payments, distinguished, score); aggregate of the per-district feed (#494, #496)                                                | ✅ Shipped |
+| Region cards grid  | 14 KPI cards with leading-district + requirements ribbon, each linking to `/region/:n` (#495)                                                                                    | ✅ Shipped |
+| Region finder bar  | Jump-to-region filter: numbered chips + "All regions" reset isolate one region across both leaderboard and grid — a region is one click away, not a scroll-and-hover hunt (#685) | ✅ Shipped |
+
 ### Region Page (`/region/:n`)
 
 | Feature                 | Description                                                                                                                                                           | Status     |

--- a/frontend/src/__tests__/accessibility/RegionDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/RegionDarkModeContrast.test.ts
@@ -272,6 +272,21 @@ describe('Region pages dark-mode contrast (#609)', () => {
     ).toBeGreaterThanOrEqual(4.5)
   })
 
+  it('finder chip FOCUS ring clears 3:1 on the dark surface (WCAG 1.4.11)', () => {
+    const outline =
+      ruleValue(appShellCss, '.region-finder__chip:focus-visible', 'outline') ??
+      ''
+    // outline shorthand: `2px solid var(--link)` — pull the var/color token.
+    const colorToken =
+      outline.match(/var\(--[\w-]+\)|#[0-9a-fA-F]{3,8}/)?.[0] ?? ''
+    const fg = resolveVar(colorToken)
+    const ratio = calculateContrastRatio(fg, surface)
+    expect(
+      ratio,
+      `focus ring ${fg} on ${surface} = ${ratio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(3)
+  })
+
   it('finder chip ACTIVE text clears AA on its brand background', () => {
     const fg = resolveVar(
       ruleValue(appShellCss, '.region-finder__chip--active', 'color') ?? ''

--- a/frontend/src/__tests__/accessibility/RegionDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/RegionDarkModeContrast.test.ts
@@ -225,4 +225,68 @@ describe('Region pages dark-mode contrast (#609)', () => {
       `${cls}: ${fg} on ${bg} = ${ratio.toFixed(2)}:1`
     ).toBeGreaterThanOrEqual(4.5)
   })
+
+  // RegionFinder jump-to-region chips (#685). Token-driven CSS rules (not
+  // dark-scoped overrides) — their dark colour is the dark remap of each var.
+  // The hover state is the trap: raw `--loyal-500` (#004165, no dark remap)
+  // would render ~1.6:1 navy-on-dark; `--link` (#60a5d8 in dark) clears AA.
+  /** Value of `prop` from the first plain (non-dark-scoped) `selector { … }`. */
+  function ruleValue(css: string, selector: string, prop: string) {
+    const re = new RegExp(
+      '(?:^|[\\n}])\\s*' +
+        selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+        '[^{]*\\{'
+    )
+    const m = re.exec(css)
+    if (!m) return null
+    const open = css.indexOf('{', m.index)
+    const close = css.indexOf('}', open)
+    const pm = css
+      .slice(open + 1, close)
+      .match(new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;!]+)'))
+    return pm ? pm[1].trim() : null
+  }
+
+  it('finder chip default text clears AA on the dark surface', () => {
+    const fg = resolveVar(
+      ruleValue(appShellCss, '.region-finder__chip', 'color') ?? ''
+    )
+    const bg = resolveVar(
+      ruleValue(appShellCss, '.region-finder__chip', 'background-color') ?? ''
+    )
+    const ratio = calculateContrastRatio(fg, bg)
+    expect(
+      ratio,
+      `chip ${fg} on ${bg} = ${ratio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('finder chip HOVER text clears AA on the dark surface', () => {
+    const fg = resolveVar(
+      ruleValue(appShellCss, '.region-finder__chip:hover', 'color') ?? ''
+    )
+    const ratio = calculateContrastRatio(fg, surface)
+    expect(
+      ratio,
+      `chip:hover ${fg} on ${surface} = ${ratio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('finder chip ACTIVE text clears AA on its brand background', () => {
+    const fg = resolveVar(
+      ruleValue(appShellCss, '.region-finder__chip--active', 'color') ?? ''
+    )
+    const bg = resolveVar(
+      ruleValue(
+        appShellCss,
+        '.region-finder__chip--active',
+        'background-color'
+      ) ?? ''
+    )
+    const ratio = calculateContrastRatio(fg, bg)
+    expect(
+      ratio,
+      `active ${fg} on ${bg} = ${ratio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(4.5)
+  })
 })

--- a/frontend/src/__tests__/accessibility/RegionsPage.axe.test.tsx
+++ b/frontend/src/__tests__/accessibility/RegionsPage.axe.test.tsx
@@ -1,0 +1,110 @@
+// Full-page axe scan of RegionsPage in light + dark (#685).
+//
+// Sprint 2 of epic #683 added the RegionFinder jump-to-region filter bar.
+// This guards its structural accessibility (role=group label, button
+// names, aria-pressed) and the rest of WCAG 2.1 AA across the index.
+//
+// Known JSDOM limitation (Lesson 075): axe's `color-contrast` rule is
+// auto-disabled under JSDOM. Contrast for this surface is covered by
+// RegionDarkModeContrast.test.ts; this file owns the structural rules.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import RegionsPage from '../../pages/RegionsPage'
+
+// @ts-expect-error - jest-axe matcher types vs vitest expect
+expect.extend(toHaveNoViolations)
+
+vi.mock('../../services/cdn', () => {
+  const baseRanking = (region: string, districtId: string, score: number) => ({
+    districtId,
+    districtName: `District ${districtId}`,
+    region,
+    paidClubs: 50,
+    paidClubBase: 48,
+    clubGrowthPercent: 4,
+    totalPayments: 2000,
+    paymentBase: 1900,
+    paymentGrowthPercent: 5,
+    activeClubs: 50,
+    distinguishedClubs: 20,
+    selectDistinguished: 5,
+    presidentsDistinguished: 3,
+    distinguishedPercent: 40,
+    clubsRank: 1,
+    paymentsRank: 1,
+    distinguishedRank: 1,
+    overallRank: 1,
+    aggregateScore: score,
+    smedleyDistinguished: 2,
+    dspSubmitted: true,
+    trainingMet: true,
+    marketAnalysisSubmitted: true,
+    communicationPlanSubmitted: true,
+    regionAdvisorVisitMet: true,
+    clubsWith20PlusMembers: 10,
+    newCharteredClubs: 1,
+    newPayments: 100,
+    aprilPayments: 200,
+    octoberPayments: 300,
+    latePayments: 0,
+    charterPayments: 0,
+  })
+  return {
+    fetchCdnRankings: vi.fn().mockResolvedValue({
+      date: '2026-05-12',
+      rankings: [
+        baseRanking('01', '01', 500),
+        baseRanking('07', '57', 350),
+        baseRanking('14', '88', 200),
+      ],
+    }),
+  }
+})
+
+const renderPage = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/regions']}>
+        <Routes>
+          <Route path="/regions" element={<RegionsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => document.documentElement.removeAttribute('data-theme'))
+afterEach(() => {
+  document.documentElement.removeAttribute('data-theme')
+  cleanup()
+})
+
+describe('RegionsPage axe scan (#685)', () => {
+  it('has no structural a11y violations in light mode', async () => {
+    const { container } = renderPage()
+    await screen.findByRole('table', { name: /region rankings/i })
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no structural a11y violations in dark mode', async () => {
+    document.documentElement.setAttribute('data-theme', 'dark')
+    const { container } = renderPage()
+    await screen.findByRole('table', { name: /region rankings/i })
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('stays axe-clean after a region is isolated via the finder', async () => {
+    const { container } = renderPage()
+    await screen.findByRole('table', { name: /region rankings/i })
+    await userEvent.click(screen.getByRole('button', { name: /^region 07$/i }))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/components/RegionFinder.tsx
+++ b/frontend/src/components/RegionFinder.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+
+/* RegionFinder (#685) — a small filter bar above the /regions index so a
+   user can jump straight to one region instead of scanning 14 rows
+   (Amy: "I have to scroll through each to find region seven").
+
+   "All regions" resets; each numbered chip isolates that region across
+   both the leaderboard and the card grid. State is owned by the parent
+   page (R3) and threaded into both surfaces as a filter step (R11).
+
+   Styling reuses the token-driven region-chip primitive (see
+   .region-finder in app-shell.css) so contrast remaps correctly in dark
+   mode without any Tailwind utility-pair asymmetry (Lesson 094). */
+
+export interface RegionFinderProps {
+  /** Zero-padded region ids, already sorted numerically. */
+  regions: ReadonlyArray<string>
+  /** Currently isolated region, or null for "All regions". */
+  selected: string | null
+  onSelect: (region: string | null) => void
+}
+
+export const RegionFinder: React.FC<RegionFinderProps> = ({
+  regions,
+  selected,
+  onSelect,
+}) => {
+  if (regions.length === 0) return null
+
+  return (
+    <div className="region-finder" role="group" aria-label="Find a region">
+      <span className="region-finder__label">Find a region:</span>
+      <button
+        type="button"
+        className={
+          'region-finder__chip' +
+          (selected === null ? ' region-finder__chip--active' : '')
+        }
+        aria-pressed={selected === null}
+        onClick={() => onSelect(null)}
+      >
+        All regions
+      </button>
+      {regions.map(region => {
+        const isActive = selected === region
+        return (
+          <button
+            key={region}
+            type="button"
+            className={
+              'region-finder__chip' +
+              (isActive ? ' region-finder__chip--active' : '')
+            }
+            aria-pressed={isActive}
+            aria-label={`Region ${region}`}
+            onClick={() => onSelect(region)}
+          >
+            {region}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/__tests__/RegionFinder.test.tsx
+++ b/frontend/src/components/__tests__/RegionFinder.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { RegionFinder } from '../RegionFinder'
+
+/* #685 — region index findability. A small filter bar so a user can
+   jump straight to a region (Amy: "I have to scroll through each to
+   find region seven") instead of scanning 14 rows. Red-first (Lesson 54). */
+
+afterEach(() => cleanup())
+
+const REGIONS = ['01', '02', '07', '14']
+
+describe('RegionFinder (#685)', () => {
+  it('renders an "All regions" control plus one button per region', () => {
+    render(
+      <RegionFinder regions={REGIONS} selected={null} onSelect={vi.fn()} />
+    )
+    const group = screen.getByRole('group', { name: /find a region/i })
+    // All + 4 regions = 5 buttons
+    expect(within(group).getAllByRole('button')).toHaveLength(5)
+    expect(
+      within(group).getByRole('button', { name: /all regions/i })
+    ).toBeInTheDocument()
+    expect(
+      within(group).getByRole('button', { name: /region 07/i })
+    ).toBeInTheDocument()
+  })
+
+  it('marks "All regions" as pressed when nothing is selected', () => {
+    render(
+      <RegionFinder regions={REGIONS} selected={null} onSelect={vi.fn()} />
+    )
+    expect(
+      screen.getByRole('button', { name: /all regions/i })
+    ).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /region 07/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+  })
+
+  it('marks the selected region as pressed and "All" as not pressed', () => {
+    render(<RegionFinder regions={REGIONS} selected="07" onSelect={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /region 07/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    expect(
+      screen.getByRole('button', { name: /all regions/i })
+    ).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('calls onSelect with the region id when a region button is clicked', async () => {
+    const onSelect = vi.fn()
+    render(
+      <RegionFinder regions={REGIONS} selected={null} onSelect={onSelect} />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /region 07/i }))
+    expect(onSelect).toHaveBeenCalledWith('07')
+  })
+
+  it('calls onSelect with null when "All regions" is clicked', async () => {
+    const onSelect = vi.fn()
+    render(<RegionFinder regions={REGIONS} selected="07" onSelect={onSelect} />)
+    await userEvent.click(screen.getByRole('button', { name: /all regions/i }))
+    expect(onSelect).toHaveBeenCalledWith(null)
+  })
+})

--- a/frontend/src/pages/RegionsPage.tsx
+++ b/frontend/src/pages/RegionsPage.tsx
@@ -43,15 +43,21 @@ const RegionsPage: React.FC = () => {
     [rollups]
   )
 
+  // Derive (don't sync) the effective selection: a stale selection that a
+  // refetch dropped self-heals to "All" at render time, so the user is never
+  // stranded on an empty leaderboard + grid — and no setState-in-effect.
+  const effectiveRegion =
+    selectedRegion && regionIds.includes(selectedRegion) ? selectedRegion : null
+
   // Filter step (R11): "All" (null) shows every region; a selection isolates
   // one across both the leaderboard and the grid so the user can jump
   // straight to it instead of scanning all 14 rows (#685).
   const displayedRollups = useMemo(
     () =>
-      selectedRegion
-        ? rollups.filter(r => r.region === selectedRegion)
+      effectiveRegion
+        ? rollups.filter(r => r.region === effectiveRegion)
         : rollups,
-    [rollups, selectedRegion]
+    [rollups, effectiveRegion]
   )
 
   const dnarCount = useMemo(
@@ -90,7 +96,7 @@ const RegionsPage: React.FC = () => {
 
       <RegionFinder
         regions={regionIds}
-        selected={selectedRegion}
+        selected={effectiveRegion}
         onSelect={setSelectedRegion}
       />
 

--- a/frontend/src/pages/RegionsPage.tsx
+++ b/frontend/src/pages/RegionsPage.tsx
@@ -1,9 +1,10 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { fetchCdnRankings } from '../services/cdn'
 import { aggregateRegions } from '../utils/aggregateRegions'
 import { RegionsLeaderboard } from '../components/RegionsLeaderboard'
 import { RegionGrid } from '../components/RegionGrid'
+import { RegionFinder } from '../components/RegionFinder'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 
@@ -29,9 +30,28 @@ const RegionsPage: React.FC = () => {
     staleTime: 15 * 60 * 1000,
   })
 
+  const [selectedRegion, setSelectedRegion] = useState<string | null>(null)
+
   const rollups = useMemo(
     () => (data?.rankings ? aggregateRegions(data.rankings) : []),
     [data]
+  )
+
+  // Available region ids for the finder, sorted numerically (01, 02, … 14).
+  const regionIds = useMemo(
+    () => rollups.map(r => r.region).sort((a, b) => Number(a) - Number(b)),
+    [rollups]
+  )
+
+  // Filter step (R11): "All" (null) shows every region; a selection isolates
+  // one across both the leaderboard and the grid so the user can jump
+  // straight to it instead of scanning all 14 rows (#685).
+  const displayedRollups = useMemo(
+    () =>
+      selectedRegion
+        ? rollups.filter(r => r.region === selectedRegion)
+        : rollups,
+    [rollups, selectedRegion]
   )
 
   const dnarCount = useMemo(
@@ -68,11 +88,17 @@ const RegionsPage: React.FC = () => {
         </div>
       </header>
 
+      <RegionFinder
+        regions={regionIds}
+        selected={selectedRegion}
+        onSelect={setSelectedRegion}
+      />
+
       <section className="my-6" aria-labelledby="regions-leaderboard-heading">
         <h2 id="regions-leaderboard-heading" className="sr-only">
           Region leaderboard
         </h2>
-        <RegionsLeaderboard rollups={rollups} />
+        <RegionsLeaderboard rollups={displayedRollups} />
       </section>
 
       <section className="my-8" aria-labelledby="regions-grid-heading">
@@ -82,7 +108,7 @@ const RegionsPage: React.FC = () => {
         >
           Region cards
         </h2>
-        <RegionGrid rollups={rollups} />
+        <RegionGrid rollups={displayedRollups} />
       </section>
 
       {dnarCount > 0 && (

--- a/frontend/src/pages/__tests__/RegionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionsPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -114,5 +115,45 @@ describe('RegionsPage (#496)', () => {
     expect(
       screen.getByText(/1 district.*not.*assigned to a region/i)
     ).toBeInTheDocument()
+  })
+
+  it('renders a "Find a region" filter bar with the available regions (#685)', async () => {
+    renderPage()
+    await screen.findByRole('table', { name: /region rankings/i })
+    const group = screen.getByRole('group', { name: /find a region/i })
+    expect(group).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /all regions/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /^region 01$/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /^region 07$/i })
+    ).toBeInTheDocument()
+  })
+
+  it('isolates a single region across leaderboard + grid when selected (#685)', async () => {
+    renderPage()
+    await screen.findByRole('table', { name: /region rankings/i })
+    // Both regions visible initially (leaderboard chip + grid eyebrow).
+    expect(screen.getAllByText(/Region 01/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Region 07/).length).toBeGreaterThan(0)
+
+    await userEvent.click(screen.getByRole('button', { name: /^region 07$/i }))
+
+    // Region 01 content is filtered out; Region 07 remains.
+    expect(screen.queryByText(/Region 01/)).not.toBeInTheDocument()
+    expect(screen.getAllByText(/Region 07/).length).toBeGreaterThan(0)
+  })
+
+  it('restores all regions when "All regions" is clicked (#685)', async () => {
+    renderPage()
+    await screen.findByRole('table', { name: /region rankings/i })
+    await userEvent.click(screen.getByRole('button', { name: /^region 07$/i }))
+    expect(screen.queryByText(/Region 01/)).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /all regions/i }))
+    expect(screen.getAllByText(/Region 01/).length).toBeGreaterThan(0)
   })
 })

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -606,6 +606,59 @@
     color: #ffffff;
   }
 
+  /* Region finder (#685) — jump-to-region filter bar on the /regions index.
+     Token-driven so contrast remaps in dark mode (Lesson 094); mirrors the
+     districts-toolbar region-chip primitive for cross-page consistency. */
+  .region-finder {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  .region-finder__label {
+    font-family: var(--sans);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    margin-right: 4px;
+  }
+
+  .region-finder__chip {
+    border: 1px solid var(--line);
+    background-color: var(--surface);
+    color: var(--ink-2);
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 500;
+    padding: 6px 12px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background-color 150ms, border-color 150ms, color 150ms;
+    min-width: 40px;
+    text-align: center;
+  }
+
+  .region-finder__chip:hover {
+    border-color: var(--loyal-200);
+    color: var(--loyal-500);
+  }
+
+  .region-finder__chip--active,
+  .region-finder__chip--active:hover {
+    background-color: var(--loyal-500);
+    border-color: var(--loyal-500);
+    color: #ffffff;
+  }
+
+  .region-finder__chip:focus-visible {
+    outline: 2px solid var(--loyal-500);
+    outline-offset: 2px;
+  }
+
   /* Search input */
   .districts-toolbar__search {
     position: relative;

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -644,7 +644,10 @@
 
   .region-finder__chip:hover {
     border-color: var(--loyal-200);
-    color: var(--loyal-500);
+    /* --link, not raw --loyal-500: --loyal-500 (#004165) has no dark remap,
+       so it would render navy-on-dark (~1.6:1) on hover. --link remaps to
+       #60a5d8 in dark while staying the same navy in light (Lesson 093/096). */
+    color: var(--link);
   }
 
   .region-finder__chip--active,

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -658,7 +658,10 @@
   }
 
   .region-finder__chip:focus-visible {
-    outline: 2px solid var(--loyal-500);
+    /* --link, not --loyal-500: the focus ring must clear 3:1 against the dark
+       surface too (WCAG 1.4.11). Raw --loyal-500 has no dark remap → ~1.6:1
+       navy-on-dark; --link remaps to #60a5d8 in dark (Lesson 093/096). */
+    outline: 2px solid var(--link);
     outline-offset: 2px;
   }
 


### PR DESCRIPTION
Closes #685. Sprint 2 of epic #683 (region pages).

## Problem (Amy)
"I cannot read any of the fonts… white font on the gray background of a specific region… only visible when I put my mouse over top… I have to scroll through each to find region seven."

## What I found (reproduce-first)
Measured **every** text node on `/regions` at rest in light + dark via a headless contrast scan: **0 sub-AA nodes**. The "invisible until hover" contrast was already fixed by the recent Region dark-mode sweep (#609 / Lesson 094). So **acceptance criterion 1 (legible at rest, AA, light+dark) was already satisfied** — evidence below. The genuinely unmet need was **criterion 2: a quick way to locate/select a specific region** (the scroll-and-hover hunt for Region 7).

## What this ships
- **RegionFinder** — a "Find a region" filter bar above the leaderboard: numbered chips (`01`–`14`) + an "All regions" reset. Selecting a region isolates it across **both** the leaderboard and the card grid; "All" restores the full comparison view (the default).
  - Real `<button>`s, `role="group"`, `aria-pressed`, `aria-label="Region NN"`, visible focus ring, `flex-wrap` (no horizontal scroll at 375px).
  - State owned by the page (R3); inserted as a filter step, original `rollups` preserved (R11).
  - Token-driven CSS mirroring the proven `districts-toolbar` region-chip primitive — remaps in dark (R10, Lesson 094). Selection self-heals (derived, not synced) if a refetch drops the isolated region.

## Contrast correctness (caught in fresh-context review)
The chip's `:hover` **and** `:focus-visible` colors initially used raw `--loyal-500` (#004165, **no dark remap**) → ~1.6:1 navy-on-dark — the exact Lesson 093/096 trap, ironic for a "legible without hover" fix. Both now use `--link` (#60a5d8 in dark, same navy in light). Falsifiable guard added (fails at 1.64:1 with `--loyal-500`, passes with `--link`).

## Tests (TDD, red-first)
- `RegionFinder.test.tsx` — 5 unit tests (render, aria-pressed, onSelect).
- `RegionsPage.test.tsx` — +3 integration (finder renders, isolates region across both surfaces, restores on All).
- `RegionsPage.axe.test.tsx` — page-level axe scan, light + dark + post-filter (Lesson 075).
- `RegionDarkModeContrast.test.ts` — +4 (chip default/hover/focus/active contrast in dark; hover & focus empirically falsified).
- Full suite: **2497 frontend tests green**, partition guard OK (R20).

## Acceptance criteria
- [x] All region labels legible without hover, light + dark, AA — verified pre-met (0 sub-AA nodes scanned at rest) + guarded.
- [x] A quick way to locate/select a specific region — RegionFinder.
- [x] Verified 375/768/1280 + dark; axe clean.

Live prod verification on `ts.taverns.red` to follow after merge + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)