### PR TITLE
feat(region): table base → current → Δ column model (epic #683, Sprint 4)

### DIFF
--- a/frontend/src/__tests__/accessibility/RegionPage.axe.test.tsx
+++ b/frontend/src/__tests__/accessibility/RegionPage.axe.test.tsx
@@ -1,0 +1,94 @@
+// Full-page axe scan of RegionPage (`/region/:n`) in light + dark (#687).
+//
+// Sprint 4 of epic #683 restructured the district table into a two-tier
+// grouped header (rowSpan=2 liked columns + colSpan=3 metric groups over
+// Base/Current/Δ sub-headers). This guards that the new header structure
+// stays WCAG 2.1 AA clean — scope attributes, header/cell association, and
+// the table's accessible name.
+//
+// Known JSDOM limitation (Lesson 075): axe's `color-contrast` rule is
+// auto-disabled under JSDOM. Contrast for this surface is covered by
+// RegionDarkModeContrast.test.ts; this file owns the structural rules.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import RegionPage from '../../pages/RegionPage'
+
+// @ts-expect-error - jest-axe matcher types vs vitest expect
+expect.extend(toHaveNoViolations)
+
+vi.mock('../../services/cdn', () => {
+  const ranking = (districtId: string, region: string, score: number) => ({
+    districtId,
+    districtName: `District ${districtId}`,
+    region,
+    paidClubs: 50,
+    paidClubBase: 48,
+    clubGrowthPercent: 4,
+    totalPayments: 2000,
+    paymentBase: 1900,
+    paymentGrowthPercent: 5,
+    activeClubs: 50,
+    distinguishedClubs: 20,
+    selectDistinguished: 5,
+    presidentsDistinguished: 3,
+    distinguishedPercent: 40,
+    clubsRank: 1,
+    paymentsRank: 1,
+    distinguishedRank: 1,
+    overallRank: 1,
+    aggregateScore: score,
+  })
+  return {
+    fetchCdnRankings: vi.fn().mockResolvedValue({
+      date: '2026-05-12',
+      rankings: [ranking('60', '07', 500), ranking('61', '07', 350)],
+    }),
+    fetchCdnCompetitiveAwards: vi.fn().mockResolvedValue(null),
+    fetchCdnManifest: vi
+      .fn()
+      .mockResolvedValue({
+        latestSnapshotDate: '2026-05-12',
+        generatedAt: 'x',
+      }),
+  }
+})
+
+const renderPage = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/region/07']}>
+        <Routes>
+          <Route path="/region/:n" element={<RegionPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => document.documentElement.removeAttribute('data-theme'))
+afterEach(() => {
+  document.documentElement.removeAttribute('data-theme')
+  cleanup()
+})
+
+describe('RegionPage axe scan (#687)', () => {
+  it('has no structural a11y violations in light mode', async () => {
+    const { container } = renderPage()
+    await screen.findByRole('table', { name: /district rankings/i })
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no structural a11y violations in dark mode', async () => {
+    document.documentElement.setAttribute('data-theme', 'dark')
+    const { container } = renderPage()
+    await screen.findByRole('table', { name: /district rankings/i })
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/__tests__/accessibility/RegionPage.axe.test.tsx
+++ b/frontend/src/__tests__/accessibility/RegionPage.axe.test.tsx
@@ -48,12 +48,10 @@ vi.mock('../../services/cdn', () => {
       rankings: [ranking('60', '07', 500), ranking('61', '07', 350)],
     }),
     fetchCdnCompetitiveAwards: vi.fn().mockResolvedValue(null),
-    fetchCdnManifest: vi
-      .fn()
-      .mockResolvedValue({
-        latestSnapshotDate: '2026-05-12',
-        generatedAt: 'x',
-      }),
+    fetchCdnManifest: vi.fn().mockResolvedValue({
+      latestSnapshotDate: '2026-05-12',
+      generatedAt: 'x',
+    }),
   }
 })
 

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -87,36 +87,60 @@ const renderCountdownInner = (cell: CountdownCell | null): React.ReactNode => {
 const CountdownTd: React.FC<{
   metric: keyof import('../utils/distinguishedCountdown').DistinguishedCountdown
   cell: CountdownCell | null
-}> = ({ metric, cell }) => (
+  groupStart?: boolean
+}> = ({ metric, cell, groupStart }) => (
   <td
     data-testid={`countdown-${metric}`}
-    className="px-3 py-4 whitespace-nowrap text-sm text-right"
+    className={`px-3 py-4 whitespace-nowrap text-sm text-right${
+      groupStart ? ' border-l border-[var(--line)]' : ''
+    }`}
   >
     {renderCountdownInner(cell)}
   </td>
 )
 
-/* Net Club Growth = the SIGNED actual net change in paid clubs this
-   program year (paidClubs − paidClubBase). Growth is green +N, loss is
-   maroon −N, matching the KpiCard delta convention above. This is a
-   distinct quantity from the clamped distinguished-gap that used to
-   render here and made a shrinking district look like it was growing
-   (#684). */
-const NetGrowthTd: React.FC<{ value: number }> = ({ value }) => {
+/* Signed Δ cell for a base→current→Δ metric group (#687). Renders the
+   SIGNED actual change: growth green +N, loss maroon −N, matching the
+   KpiCard delta convention above. Distinct from the clamped
+   distinguished-gap that once rendered here and made a shrinking district
+   look like it was growing (#684) — `value` must already be the signed
+   `current − base`, never a `max(0, …)` gap (lesson 102). */
+const SignedDeltaTd: React.FC<{ value: number; testid: string }> = ({
+  value,
+  testid,
+}) => {
   const sign = value >= 0 ? '+' : ''
   const tone = value >= 0 ? 'text-green-700' : 'text-tm-true-maroon'
   return (
     <td
-      data-testid="countdown-netClubGrowth"
+      data-testid={testid}
       className="px-3 py-4 whitespace-nowrap text-sm text-right"
     >
       <span className={`${tone} font-semibold tabular-nums`}>
         {sign}
-        {value}
+        {value.toLocaleString()}
       </span>
     </td>
   )
 }
+
+/* Base / Current numeric cell for a metric group (#687). `groupStart`
+   draws the left separator that visually binds each base→current→Δ
+   triple (border uses var(--line), so it remaps in dark mode). */
+const MetricValueTd: React.FC<{
+  value: number
+  testid: string
+  groupStart?: boolean
+}> = ({ value, testid, groupStart }) => (
+  <td
+    data-testid={testid}
+    className={`px-3 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums${
+      groupStart ? ' border-l border-[var(--line)]' : ''
+    }`}
+  >
+    {value.toLocaleString()}
+  </td>
+)
 
 /* Per-tier display label + chip style. Pre-Distinguished districts get
    an em-dash; achieved tiers get a colored chip matching the tier. */
@@ -170,20 +194,23 @@ const TierTd: React.FC<{ tier: DistinguishedDistrictTier | null }> = ({
   )
 }
 
-/* Trailing six cells (5 countdown + 1 tier) for one district row.
-   Folds the awards lookup so the row map stays a clean list of
+/* Trailing five countdown + 1 tier cells for one district row (#687
+   moved the former Net Club Growth cell into the Paid Clubs group as its
+   signed Δ). Folds the awards lookup so the row map stays a clean list of
    sub-components. */
 const DistinguishedCells: React.FC<{
   districtId: string
-  netClubGrowth: number
   awards: import('../services/cdn').CompetitiveAwardStandings | null
-}> = ({ districtId, netClubGrowth, awards }) => {
+}> = ({ districtId, awards }) => {
   const c = getDistinguishedCountdown(districtId, awards)
   const tier = awards?.distinguishedDistrict?.[districtId]?.currentTier ?? null
   return (
     <>
-      <NetGrowthTd value={netClubGrowth} />
-      <CountdownTd metric="paymentGrowth" cell={c?.paymentGrowth ?? null} />
+      <CountdownTd
+        metric="paymentGrowth"
+        cell={c?.paymentGrowth ?? null}
+        groupStart
+      />
       <CountdownTd
         metric="distinguishedPercent"
         cell={c?.distinguishedPercent ?? null}
@@ -334,60 +361,132 @@ const RegionPage: React.FC = () => {
       <div className="districts-rankings-table-wrap">
         <div className="overflow-x-auto">
           <table className="districts-rankings-table">
+            {/* Two-tier header (#687). The four liked single columns span
+                both rows; each metric is a base→current→Δ group with a
+                colspan group label over Base / Current / Δ sub-headers. */}
             <thead>
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th
+                  rowSpan={2}
+                  scope="col"
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider align-bottom"
+                >
                   Region Rank
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th
+                  rowSpan={2}
+                  scope="col"
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider align-bottom"
+                >
                   District
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th
+                  rowSpan={2}
+                  scope="col"
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider align-bottom"
+                >
                   World Rank
                 </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Paid Clubs
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Distinguished
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th
+                  rowSpan={2}
+                  scope="col"
+                  className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider align-bottom"
+                >
                   Score
                 </th>
-                {/* Show the gap to the next Distinguished tier per
-                    district: numeric for the three DD prerequisites that
-                    the pipeline calculates a delta for, ✓ / em-dash for
-                    the two officer-award booleans. */}
-                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Net Club Growth
+                {/* Three base→current→Δ metric groups (Amy's request). */}
+                <th
+                  colSpan={3}
+                  scope="colgroup"
+                  className="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider border-l border-[var(--line)]"
+                >
+                  Paid Clubs
                 </th>
-                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th
+                  colSpan={3}
+                  scope="colgroup"
+                  className="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider border-l border-[var(--line)]"
+                >
+                  Membership Payments
+                </th>
+                <th
+                  colSpan={3}
+                  scope="colgroup"
+                  className="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider border-l border-[var(--line)]"
+                >
+                  Distinguished Clubs
+                </th>
+                {/* Distinguished-prerequisite countdown columns (Sprint 5
+                    territory) — left untouched by #687. */}
+                <th
+                  rowSpan={2}
+                  scope="col"
+                  className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider align-bottom border-l border-[var(--line)]"
+                >
                   Payment Growth
                 </th>
-                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th
+                  rowSpan={2}
+                  scope="col"
+                  className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider align-bottom"
+                >
                   Distinguished %
                 </th>
-                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th
+                  rowSpan={2}
+                  scope="col"
+                  className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider align-bottom"
+                >
                   Club Growth %
                 </th>
-                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th
+                  rowSpan={2}
+                  scope="col"
+                  className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider align-bottom"
+                >
                   Education / Training
                 </th>
                 {/* CGD = Club Growth Director — TI officer award. Renamed
                     from "Club Growth" to disambiguate from the % Club
-                    Growth prerequisite immediately to its left. Title
-                    attribute spells out the acronym for non-TM viewers. */}
+                    Growth prerequisite to its left. */}
                 <th
-                  className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  rowSpan={2}
+                  scope="col"
+                  className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider align-bottom"
                   title="Club Growth Director — officer award"
                 >
                   CGD
                 </th>
                 {/* Current Distinguished tier when achieved; em-dash
                     for districts still below. */}
-                <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th
+                  rowSpan={2}
+                  scope="col"
+                  className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider align-bottom"
+                >
                   Tier
                 </th>
+              </tr>
+              {/* Sub-header row: Base / Current / Δ under each metric group. */}
+              <tr>
+                {[
+                  'Paid Clubs',
+                  'Membership Payments',
+                  'Distinguished Clubs',
+                ].flatMap(group =>
+                  ['Base', 'Current', 'Δ'].map((sub, j) => (
+                    <th
+                      key={`${group}-${sub}`}
+                      scope="col"
+                      title={`${group} — ${sub === 'Δ' ? 'change vs base' : sub}`}
+                      className={`px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider${
+                        j === 0 ? ' border-l border-[var(--line)]' : ''
+                      }`}
+                    >
+                      {sub}
+                    </th>
+                  ))
+                )}
               </tr>
             </thead>
             <tbody>
@@ -420,22 +519,59 @@ const RegionPage: React.FC = () => {
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                       #{d.overallRank}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900">
-                      {d.paidClubs}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900">
-                      {d.distinguishedClubs}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
+                    <td
+                      data-testid="score-cell"
+                      className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums"
+                    >
                       {d.aggregateScore}
                     </td>
-                    <DistinguishedCells
-                      districtId={d.districtId}
-                      netClubGrowth={
+                    {/* Paid Clubs: base → current → signed net growth (#1).
+                        Net growth prefers the snapshot field, falling back
+                        to paidClubs − paidClubBase (lesson 102). */}
+                    <MetricValueTd
+                      testid="paid-base"
+                      value={d.paidClubBase ?? 0}
+                      groupStart
+                    />
+                    <MetricValueTd
+                      testid="paid-current"
+                      value={d.paidClubs ?? 0}
+                    />
+                    <SignedDeltaTd
+                      testid="countdown-netClubGrowth"
+                      value={
                         awards?.distinguishedDistrict?.[d.districtId]
                           ?.netClubGrowth ??
                         (d.paidClubs ?? 0) - (d.paidClubBase ?? 0)
                       }
+                    />
+                    {/* Membership Payments: base → current → signed Δ. */}
+                    <MetricValueTd
+                      testid="payments-base"
+                      value={d.paymentBase ?? 0}
+                      groupStart
+                    />
+                    <MetricValueTd
+                      testid="payments-current"
+                      value={d.totalPayments ?? 0}
+                    />
+                    <SignedDeltaTd
+                      testid="payments-delta"
+                      value={(d.totalPayments ?? 0) - (d.paymentBase ?? 0)}
+                    />
+                    {/* Distinguished Clubs: year-cumulative, so base = 0 and
+                        Δ = current (lesson 57). */}
+                    <MetricValueTd testid="dist-base" value={0} groupStart />
+                    <MetricValueTd
+                      testid="dist-current"
+                      value={d.distinguishedClubs ?? 0}
+                    />
+                    <SignedDeltaTd
+                      testid="dist-delta"
+                      value={d.distinguishedClubs ?? 0}
+                    />
+                    <DistinguishedCells
+                      districtId={d.districtId}
                       awards={awards ?? null}
                     />
                   </tr>

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -360,7 +360,10 @@ const RegionPage: React.FC = () => {
 
       <div className="districts-rankings-table-wrap">
         <div className="overflow-x-auto">
-          <table className="districts-rankings-table">
+          <table
+            className="districts-rankings-table"
+            aria-label={`Region ${region} district rankings`}
+          >
             {/* Two-tier header (#687). The four liked single columns span
                 both rows; each metric is a base→current→Δ group with a
                 colspan group label over Base / Current / Δ sub-headers. */}

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -230,11 +230,10 @@ describe('RegionPage Distinguished countdown columns (#516 #513)', () => {
     mockedFetchCdnAwards.mockResolvedValue(awardsFixture())
     renderRegion('2')
 
+    // #687: "Net Club Growth" is no longer a standalone countdown header —
+    // it became the Δ sub-column of the Paid Clubs base→current→Δ group.
     expect(
-      await screen.findByRole('columnheader', { name: /net club growth/i })
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('columnheader', { name: /payment growth/i })
+      await screen.findByRole('columnheader', { name: /payment growth/i })
     ).toBeInTheDocument()
     expect(
       screen.getByRole('columnheader', { name: /distinguished %/i })
@@ -627,6 +626,136 @@ describe('RegionPage KPI strip — base / current / Δ / ±% (#514 #513)', () =>
   })
 })
 
+describe('RegionPage base → current → Δ column model (#687 epic #683)', () => {
+  const row61 = () =>
+    screen
+      .findByTestId('district-number-chip-D61')
+      .then(el => el.closest('tr')!)
+
+  it('renders grouped headers for the three metrics', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    renderRegion('2')
+
+    expect(
+      await screen.findByRole('columnheader', { name: /^paid clubs$/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /membership payments/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /distinguished clubs/i })
+    ).toBeInTheDocument()
+  })
+
+  it('retains the liked single columns (region rank, district, world rank, score)', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '61', region: '2' })],
+      date: '2026-05-12',
+    })
+    renderRegion('2')
+
+    expect(
+      await screen.findByRole('columnheader', { name: /region rank/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /^district$/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /world rank/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /^score$/i })
+    ).toBeInTheDocument()
+  })
+
+  it('renders Paid Clubs as base → current → signed Δ', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          paidClubs: 100,
+          paidClubBase: 90,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    mockedFetchCdnAwards.mockResolvedValue(null)
+    renderRegion('2')
+
+    const row = await row61()
+    expect(within(row).getByTestId('paid-base')).toHaveTextContent('90')
+    expect(within(row).getByTestId('paid-current')).toHaveTextContent('100')
+    // Δ is the signed net growth, reusing the #684 cell testid.
+    expect(
+      within(row).getByTestId('countdown-netClubGrowth')
+    ).toHaveTextContent(/\+10/)
+  })
+
+  it('renders Membership Payments as base → current → signed Δ', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          totalPayments: 5000,
+          paymentBase: 4500,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('2')
+
+    const row = await row61()
+    expect(within(row).getByTestId('payments-base')).toHaveTextContent('4,500')
+    expect(within(row).getByTestId('payments-current')).toHaveTextContent(
+      '5,000'
+    )
+    const delta = within(row).getByTestId('payments-delta')
+    expect(delta).toHaveTextContent(/\+500/)
+    expect(delta.querySelector('span')).toHaveClass('text-green-700')
+  })
+
+  it('renders a shrinking Payments Δ as a negative maroon value', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({
+          districtId: '61',
+          region: '2',
+          totalPayments: 4200,
+          paymentBase: 4500,
+        }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('2')
+
+    const row = await row61()
+    const delta = within(row).getByTestId('payments-delta')
+    expect(delta).toHaveTextContent(/-300/)
+    expect(delta).not.toHaveTextContent(/\+300/)
+    expect(delta.querySelector('span')).toHaveClass('text-tm-true-maroon')
+  })
+
+  it('treats Distinguished Clubs as year-cumulative — base 0, Δ = current', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [
+        mkRanking({ districtId: '61', region: '2', distinguishedClubs: 48 }),
+      ],
+      date: '2026-05-12',
+    })
+    renderRegion('2')
+
+    const row = await row61()
+    expect(within(row).getByTestId('dist-base')).toHaveTextContent('0')
+    expect(within(row).getByTestId('dist-current')).toHaveTextContent('48')
+    expect(within(row).getByTestId('dist-delta')).toHaveTextContent(/\+48/)
+  })
+})
+
 describe('RegionPage rank-within-region column (#515 #513)', () => {
   it('renders a "Region Rank" column header on the district table', async () => {
     mockedFetchCdnRankings.mockResolvedValueOnce({
@@ -668,15 +797,15 @@ describe('RegionPage rank-within-region column (#515 #513)', () => {
     renderRegion('2')
 
     const rows = await screen.findAllByRole('row')
-    // skip header row at index 0
-    const rank1 = within(rows[1]!).getByTestId('region-rank-cell')
-    const rank2 = within(rows[2]!).getByTestId('region-rank-cell')
-    const rank3 = within(rows[3]!).getByTestId('region-rank-cell')
+    // skip the two header rows (#687 added a Base/Current/Δ sub-header row)
+    const rank1 = within(rows[2]!).getByTestId('region-rank-cell')
+    const rank2 = within(rows[3]!).getByTestId('region-rank-cell')
+    const rank3 = within(rows[4]!).getByTestId('region-rank-cell')
     expect(rank1.textContent).toContain('#1')
     expect(rank2.textContent).toContain('#2')
     expect(rank3.textContent).toContain('#3')
     // D61 (score 300) ranks #1 within region 2.
-    expect(within(rows[1]!).getByText(/D61/)).toBeInTheDocument()
+    expect(within(rows[2]!).getByText(/D61/)).toBeInTheDocument()
   })
 
   it('marks tied region ranks (same aggregateScore) as tied', async () => {
@@ -700,11 +829,12 @@ describe('RegionPage rank-within-region column (#515 #513)', () => {
     renderRegion('3')
 
     const rows = await screen.findAllByRole('row')
-    expect(
-      within(rows[1]!).getByTestId('region-rank-cell').textContent
-    ).toMatch(/#1.*tied/i)
+    // skip the two header rows (#687 Base/Current/Δ sub-header row)
     expect(
       within(rows[2]!).getByTestId('region-rank-cell').textContent
+    ).toMatch(/#1.*tied/i)
+    expect(
+      within(rows[3]!).getByTestId('region-rank-cell').textContent
     ).toMatch(/#1.*tied/i)
   })
 
@@ -723,12 +853,13 @@ describe('RegionPage rank-within-region column (#515 #513)', () => {
     renderRegion('6')
 
     const rows = await screen.findAllByRole('row')
-    const districtCell = within(rows[1]!).getByTestId(
+    // skip the two header rows (#687 Base/Current/Δ sub-header row)
+    const districtCell = within(rows[2]!).getByTestId(
       'district-number-chip-D86'
     )
     expect(districtCell).toHaveTextContent('D86')
     // The bare "86" name should NOT render as a sibling span — the chip
     // already conveys the number.
-    expect(within(rows[1]!).queryByText(/^86$/)).not.toBeInTheDocument()
+    expect(within(rows[2]!).queryByText(/^86$/)).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes #687. Epic #683 Sprint 4 (depends on #1 signed net growth, shipped in #684).

## What
Restructures the `/region/:n` district table into a **two-tier grouped header**. The four columns Amy likes — Region Rank, District, World Rank, Score — span both header rows; each of the three metrics renders as a **base → current → Δ** triple under a `colSpan=3` group label with a Base / Current / Δ sub-header row.

| Metric | Base | Current | Δ |
|---|---|---|---|
| **Paid Clubs** | `paidClubBase` | `paidClubs` | signed net growth (`netClubGrowth` field, fallback `paidClubs − paidClubBase`) |
| **Membership Payments** | `paymentBase` | `totalPayments` | signed `current − base` |
| **Distinguished Clubs** | 0 | `distinguishedClubs` | Δ = current (year-cumulative, base 0) |

The former standalone **Net Club Growth** column becomes the Paid Clubs Δ cell (keeps its `countdown-netClubGrowth` testid and the signed, never-clamped value from #684 / lesson 102). The Distinguished-prerequisite countdown columns are left untouched — that's Sprint 5 (#688) territory.

## Acceptance criteria
- [x] Each metric shows base, current, and signed delta.
- [x] Liked columns retained (region rank 1st, district 2nd, world rank, score).
- [x] Net growth uses the signed value from #1.
- [x] Sort still works (region rank by aggregateScore desc); light + dark.

## Notes
- Δ uses **sign + colour** (green `+N` / maroon `−N`), not colour alone — consistent with the existing `KpiCard` convention.
- Group separators use `border-[var(--line)]` (semantic token → remaps in dark, avoiding the lesson 92-96 trap). No new colour utilities; the dark-mode contrast test already covers every class reused.
- Added an `aria-label` + dedicated jest-axe scan (light + dark) for the new two-tier header.

## Test plan
- `RegionPage.test.tsx`: +6 tests for the triples + grouped headers (27 total green).
- `RegionPage.axe.test.tsx`: new — 2 axe scans, no structural violations.
- Full region/dark-mode suite green (58); production build green; pre-push unit suite green (2004).

🤖 Generated with [Claude Code](https://claude.com/claude-code)