### PR TITLE
chore(ci): skip CI + Deploy on docs/lessons-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,23 @@ name: CI
 on:
   push:
     branches: [develop]
+    # Skip CI when a push touches only non-code artifacts (lessons, docs,
+    # markdown, ignore/license). Runs whenever ANY changed file is outside
+    # these globs, so mixed code+docs changes are still fully gated.
+    paths-ignore:
+      - '**/*.md'
+      - 'tasks/**'
+      - 'docs/**'
+      - '.gitignore'
+      - 'LICENSE'
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'tasks/**'
+      - 'docs/**'
+      - '.gitignore'
+      - 'LICENSE'
   workflow_call:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,16 @@ name: Deploy
 on:
   push:
     branches: [main]
+    # Don't rebuild + redeploy prod when a merge touches only non-code
+    # artifacts (lessons, docs, markdown, ignore/license) — the deployed
+    # site would be byte-identical. workflow_dispatch still allows a
+    # manual deploy from any state.
+    paths-ignore:
+      - '**/*.md'
+      - 'tasks/**'
+      - 'docs/**'
+      - '.gitignore'
+      - 'LICENSE'
   workflow_dispatch:
 
 # Prevent concurrent deployments


### PR DESCRIPTION
Stops the CI and Deploy workflows from burning cycles on changes that can't affect code quality (lessons, docs, markdown, .gitignore).

## Change
`paths-ignore` added to:
- `ci.yml` — `push` (develop) and `pull_request` (main/develop) triggers
- `deploy.yml` — `push` (main) trigger (keeps `workflow_dispatch` for manual deploys)

Ignored globs: `**/*.md`, `tasks/**`, `docs/**`, `.gitignore`, `LICENSE`.

## Why it's safe
- `paths-ignore` skips a run only when **every** changed file matches, so any code change (or a mixed code+lesson sprint PR) still triggers full CI + deploy.
- `main` currently has **no required status checks** (verified via the branch-protection API), so there's no risk of a path-ignored required check hanging a merge. If required checks are added later, switch to the skip-job pattern.
- This very PR touches `.github/workflows/**` (not ignored), so CI runs on it — confirming code/workflow changes are still gated.

## Not in scope (follow-up)
Gating **prod** deploy on release-please releases (with staging staying continuous-on-main) — discussed separately; ADR-worthy because it couples to the autonomous runner's live-verification DoD.

Closes #703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)