### PR TITLE
fix(region): district chip dark-mode contrast (epic #683, Sprint 7) (#699)

### DIFF
--- a/frontend/src/__tests__/accessibility/RegionDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/RegionDarkModeContrast.test.ts
@@ -359,6 +359,36 @@ describe('Region pages dark-mode contrast (#609)', () => {
     ).toBeGreaterThanOrEqual(4.5)
   })
 
+  // District-number chip on each ranking row (#699). The pill bg (--loyal-50)
+  // remaps to #112432 in dark, but its text (--loyal-600 #003352) has NO dark
+  // remap → navy-on-navy ~1.2:1, illegible (lessons 093/096 trap). Fix is a
+  // scoped [data-theme='dark'] override to the dark-safe --link blue (#60a5d8).
+  it('district-number chip text clears AA on the dark pill (#699)', () => {
+    const bg = resolveVar(
+      ruleValue(
+        appShellCss,
+        '.districts-rankings-table__district-chip',
+        'background-color'
+      ) ?? ''
+    )
+    const override = darkRuleValue(
+      appShellCss,
+      '.districts-rankings-table__district-chip',
+      'color'
+    )
+    const base = ruleValue(
+      appShellCss,
+      '.districts-rankings-table__district-chip',
+      'color'
+    )
+    const fg = resolveVar(override ?? base ?? '')
+    const ratio = calculateContrastRatio(fg, bg)
+    expect(
+      ratio,
+      `district chip text ${fg} on ${bg} = ${ratio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
   it('scroll-cue overlay is themed, not a hardcoded colour (lesson 092)', () => {
     const bg = ruleValue(
       appShellCss,

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -875,6 +875,15 @@
     letter-spacing: 0.02em;
   }
 
+  /* #699: in dark mode --loyal-50 (the pill bg) remaps to #112432 but
+     --loyal-600 (the text) has NO dark remap — navy #003352 on navy #112432
+     is 1.21:1, illegible (lessons 093/096 trap). --link is the dark-safe blue
+     the theme already uses (#60a5d8 → 5.95:1); scoped to dark so light mode is
+     byte-identical. Border --loyal-200 already remaps (#1c4866). */
+  [data-theme='dark'] .districts-rankings-table__district-chip {
+    color: var(--link);
+  }
+
   .districts-rankings-table {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
Part of epic #683 (Sprint 7). Fixes the region detail table display defects from #699.

## Part A — District chip unreadable in dark mode (fixed)

The district-number chip on the region ranking table (`.districts-rankings-table__district-chip`) coloured its text with raw `--loyal-600` (#003352), which has **no `[data-theme='dark']` remap**, while its pill background `--loyal-50` **does** remap to #112432 in dark. Result: navy-on-navy at **1.21:1** — illegible (the lessons 093/096 trap).

**Fix (R10, CSS-level):** a `[data-theme='dark']`-scoped override to the dark-safe semantic token `--link` (#60a5d8 → **5.95:1**, clears WCAG AA). Light mode is byte-identical (purely additive rule); border `--loyal-200` already remaps. No component-level branch — `DistrictChipAndName.tsx` is untouched.

**Shared surface (intentional):** the chip class is also used on `/regions` (DistrictsPage) and the command palette. The same navy-on-navy bug existed on all three; this fix corrects them all — strictly an improvement, no regression.

## Part B — Percentage float precision (already resolved upstream)

The PAYMENT GROWTH / DISTINGUISHED % / CLUB GROWTH % columns the issue describes (raw floats like `+0.18999999999999995`) **no longer exist** — Sprint 5 (#688) replaced them with absolute "Remaining to Distinguished" counts. The only percent remaining on the page is the region-at-a-glance KPI card (`RegionPage.tsx`), which renders `percent.toFixed(1)` (≤2 decimals, no float tail). Acceptance criterion B is satisfied; no code change needed.

## Part C — Signed +/- coloring

Untouched. The `text-green-700` / `text-tm-true-maroon` tone logic for signed deltas is not modified by this diff.

## Testing
- TDD: added a failing contrast test to the existing CSS-parsing audit (`RegionDarkModeContrast.test.ts`) — Red at 1.21:1, Green at 5.95:1 after the fix.
- Full frontend suite: **2526 tests pass**, zero regressions.
- Fresh-context review: APPROVE, no High/Medium findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
