### PR TITLE
fix(region): /regions leaderboard invisible when OS=dark + app=light (epic #683, Sprint 8)

### DIFF
--- a/frontend/e2e/regions-legibility.smoke.ts
+++ b/frontend/e2e/regions-legibility.smoke.ts
@@ -1,0 +1,113 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/* Regions leaderboard legibility guard (#710).
+ *
+ * Regression guard for Amy's bug: the /regions leaderboard rows went
+ * near-invisible when the OS preferred dark but the app showed light mode,
+ * because Tailwind `dark:` utilities fire on @media(prefers-color-scheme)
+ * not the app's [data-theme] toggle. #685 verified Chromium-at-rest only
+ * and missed it — this smoke runs in BOTH engines (see playwright.config)
+ * and across all four theme/OS quadrants, at rest AND on hover.
+ *
+ * Asserts every sampled leaderboard cell clears WCAG AA (4.5:1) against the
+ * background actually rendered behind it. */
+
+// sRGB relative luminance + WCAG contrast ratio.
+function luminance(r: number, g: number, b: number): number {
+  const f = (c: number) => {
+    const s = c / 255
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b)
+}
+function parseRgb(c: string): [number, number, number] {
+  const m = c.match(/rgba?\(([^)]+)\)/)
+  if (!m) throw new Error(`unparseable color: ${c}`)
+  const [r, g, b] = m[1].split(',').map(s => parseFloat(s.trim()))
+  return [r, g, b]
+}
+function contrast(fg: string, bg: string): number {
+  const l1 = luminance(...parseRgb(fg))
+  const l2 = luminance(...parseRgb(bg))
+  const [hi, lo] = l1 > l2 ? [l1, l2] : [l2, l1]
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+const AA = 4.5 // normal text
+
+const QUADRANTS = [
+  { store: 'light', os: 'light' as const },
+  { store: 'light', os: 'dark' as const }, // the #710 bug quadrant
+  { store: 'dark', os: 'light' as const },
+  { store: 'dark', os: 'dark' as const },
+]
+
+async function sampleRowContrasts(page: Page, hover: boolean) {
+  const table = page.locator('table[aria-label="Region rankings"]')
+  await table.waitFor({ state: 'visible', timeout: 20_000 })
+  const rows = table.locator('tbody tr')
+  const n = await rows.count()
+  const results: { label: string; ratio: number }[] = []
+  for (let i = 0; i < n; i++) {
+    if (hover) await rows.nth(i).hover()
+    // chip text, a numeric column, the score column
+    const row = rows.nth(i)
+    const chip = row.locator('span').first()
+    const num = row.locator('td').nth(1)
+    const score = row.locator('td').last()
+    for (const [label, loc] of [
+      ['chip', chip],
+      ['num', num],
+      ['score', score],
+    ] as const) {
+      const { color, bg } = await loc.evaluate(el => {
+        const fg = getComputedStyle(el).color
+        // Resolve the first FULLY OPAQUE ancestor background. Translucent
+        // overlays (e.g. the chip's loyal-blue/10, which the browser reports
+        // as oklab(.../0.1)) are skipped — the underlying surface is the
+        // conservative contrast baseline and is always an rgb token.
+        const isOpaqueRgb = (b: string) =>
+          /^rgba?\([^)]*\)$/.test(b) &&
+          !/,\s*0?\.\d+\s*\)$/.test(b) && // not rgba(...,0.x)
+          b !== 'rgba(0, 0, 0, 0)' &&
+          b !== 'transparent'
+        let node: HTMLElement | null = el as HTMLElement
+        let resolved = 'rgb(255, 255, 255)'
+        while (node) {
+          const b = getComputedStyle(node).backgroundColor
+          if (isOpaqueRgb(b)) {
+            resolved = b
+            break
+          }
+          node = node.parentElement
+        }
+        return { color: fg, bg: resolved }
+      })
+      results.push({ label: `row${i}.${label}`, ratio: contrast(color, bg) })
+    }
+  }
+  return results
+}
+
+for (const q of QUADRANTS) {
+  const label = `app-${q.store}_OS-${q.os}`
+  test(`regions leaderboard is AA-legible (${label})`, async ({ browser }) => {
+    const ctx = await browser.newContext({ colorScheme: q.os })
+    const page = await ctx.newPage()
+    await page.addInitScript(store => {
+      window.localStorage.setItem('theme', store as string)
+    }, q.store)
+    await page.goto('/regions', { waitUntil: 'networkidle' })
+
+    for (const hover of [false, true]) {
+      const samples = await sampleRowContrasts(page, hover)
+      const failing = samples.filter(s => s.ratio < AA)
+      expect(
+        failing,
+        `${label} ${hover ? 'hover' : 'rest'}: sub-AA cells ` +
+          failing.map(f => `${f.label}=${f.ratio.toFixed(2)}`).join(', ')
+      ).toEqual([])
+    }
+    await ctx.close()
+  })
+}

--- a/frontend/e2e/regions-legibility.smoke.ts
+++ b/frontend/e2e/regions-legibility.smoke.ts
@@ -63,9 +63,12 @@ async function sampleRowContrasts(page: Page, hover: boolean) {
       const { color, bg } = await loc.evaluate(el => {
         const fg = getComputedStyle(el).color
         // Resolve the first FULLY OPAQUE ancestor background. Translucent
-        // overlays (e.g. the chip's loyal-blue/10, which the browser reports
-        // as oklab(.../0.1)) are skipped — the underlying surface is the
-        // conservative contrast baseline and is always an rgb token.
+        // overlays (e.g. the chip's loyal-blue/10, reported as oklab(.../0.1))
+        // are skipped and we measure against the opaque surface beneath. This
+        // is an approximation: a translucent overlay slightly shifts the true
+        // contrast. It's adequate here because the only overlay is a ~10% tint
+        // and the bug under guard is a ~30x light/dark text flip, not a
+        // marginal few-tenths case.
         const isOpaqueRgb = (b: string) =>
           /^rgba?\([^)]*\)$/.test(b) &&
           !/,\s*0?\.\d+\s*\)$/.test(b) && // not rgba(...,0.x)

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,10 +1,15 @@
-import { defineConfig } from '@playwright/test'
+import { defineConfig, devices } from '@playwright/test'
 
 /**
  * Smoke test configuration for staging environment (#316)
  *
  * Runs against a deployed URL (staging or production).
  * Set BASE_URL env var to override the default staging URL.
+ *
+ * Two engines (#710): `smoke` runs in Chromium (default), `webkit` runs in
+ * WebKit/Safari. #685 verified contrast in Chromium-at-rest only and missed
+ * a Safari-visible regression; running smokes in WebKit too closes that
+ * blind spot. Run one engine with `--project=webkit`.
  */
 export default defineConfig({
   testDir: './e2e',
@@ -19,6 +24,11 @@ export default defineConfig({
     {
       name: 'smoke',
       testMatch: '**/*.smoke.ts',
+    },
+    {
+      name: 'webkit',
+      testMatch: '**/*.smoke.ts',
+      use: { ...devices['Desktop Safari'] },
     },
   ],
 })

--- a/frontend/src/__tests__/css-migration/region-dark-variant-scope.test.ts
+++ b/frontend/src/__tests__/css-migration/region-dark-variant-scope.test.ts
@@ -1,0 +1,59 @@
+// Region components must scope dark styling to the app theme, not the OS (#710)
+//
+// Root cause of #710 (Amy's "regions leaderboard near-invisible in Safari"):
+// Tailwind's `dark:` variant compiles to `@media (prefers-color-scheme: dark)`,
+// but this app's dark mode is a MANUAL `[data-theme='dark']` toggle
+// (DarkModeContext). When a user's OS prefers dark while the app shows light
+// (white surface), every `dark:` utility fires anyway — painting light text on
+// the light surface. The /regions leaderboard rows went invisible; only the
+// hovered row (which got `dark:hover:bg-gray-800`) stayed legible. This is the
+// inert-`dark:` trap of lesson 073, in reverse: it MISFIRES on OS preference.
+//
+// Fix: a `theme-dark:` custom variant keyed off `[data-theme='dark']`
+// (defined in `src/index.css`) so dark styling tracks the toggle, never the OS.
+// This guard fails if a region component reintroduces a raw `dark:` utility.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const FRONTEND_SRC = resolve(__dirname, '../..')
+
+// The two components that render the /regions page surface (#710 scope).
+const REGION_COMPONENTS = [
+  'components/RegionsLeaderboard.tsx',
+  'components/RegionGrid.tsx',
+]
+
+// Match a Tailwind `dark:` variant token (incl. stacked like
+// `dark:hover:`), but NOT our toggle-scoped `theme-dark:`. A `dark:`
+// token is bounded on the left by start/whitespace/quote and is not
+// preceded by `theme-`.
+const RAW_DARK_VARIANT = /(?<![\w-])dark:/g
+
+describe('region components scope dark styling to [data-theme], not the OS', () => {
+  it.each(REGION_COMPONENTS)(
+    '%s uses no raw prefers-color-scheme `dark:` utilities',
+    file => {
+      const src = readFileSync(resolve(FRONTEND_SRC, file), 'utf-8')
+      const matches = src.match(RAW_DARK_VARIANT) ?? []
+      expect(
+        matches.length,
+        `${file} contains ${matches.length} raw \`dark:\` utility(ies). ` +
+          'These fire via @media(prefers-color-scheme:dark) and misfire when ' +
+          'the OS is dark but the app shows light mode (#710). Use the ' +
+          'toggle-scoped `theme-dark:` variant instead.'
+      ).toBe(0)
+    }
+  )
+
+  it('defines the `theme-dark` custom variant in index.css', () => {
+    const indexCss = readFileSync(resolve(FRONTEND_SRC, 'index.css'), 'utf-8')
+    expect(
+      /@custom-variant\s+theme-dark\b/.test(indexCss),
+      'src/index.css must define `@custom-variant theme-dark` keyed off ' +
+        "[data-theme='dark'] so region components can scope dark styling to " +
+        'the manual toggle.'
+    ).toBe(true)
+  })
+})

--- a/frontend/src/components/RegionGrid.tsx
+++ b/frontend/src/components/RegionGrid.tsx
@@ -34,43 +34,43 @@ export const RegionGrid: React.FC<RegionGridProps> = ({ rollups }) => {
           key={r.region}
           to={`/region/${r.region}`}
           aria-label={`Region ${r.region} — ${r.districtCount} districts`}
-          className="block bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 hover:border-tm-loyal-blue dark:hover:border-blue-400 hover:shadow-sm transition-all focus-visible:outline-2 focus-visible:outline-tm-loyal-blue"
+          className="block bg-white theme-dark:bg-gray-800 rounded-lg p-4 border border-gray-200 theme-dark:border-gray-700 hover:border-tm-loyal-blue theme-dark:hover:border-blue-400 hover:shadow-sm transition-all focus-visible:outline-2 focus-visible:outline-tm-loyal-blue"
         >
           <header className="mb-3">
-            <p className="text-xs font-semibold uppercase tracking-wider text-tm-loyal-blue dark:text-blue-300">
+            <p className="text-xs font-semibold uppercase tracking-wider text-tm-loyal-blue theme-dark:text-blue-300">
               Region {r.region}
             </p>
-            <h3 className="text-sm font-tm-headline text-gray-900 dark:text-gray-50 mt-1">
+            <h3 className="text-sm font-tm-headline text-gray-900 theme-dark:text-gray-50 mt-1">
               leader: {r.leadingDistrictName}
             </h3>
           </header>
 
           <ul className="grid grid-cols-3 gap-2 text-xs mb-3" role="list">
             <li>
-              <span className="block text-gray-500 dark:text-gray-400">
+              <span className="block text-gray-500 theme-dark:text-gray-400">
                 {r.districtCount} districts
               </span>
             </li>
             <li>
-              <span className="block text-gray-900 dark:text-gray-100 font-semibold tabular-nums">
+              <span className="block text-gray-900 theme-dark:text-gray-100 font-semibold tabular-nums">
                 {r.paidClubs.toLocaleString()}
               </span>
-              <span className="block text-gray-500 dark:text-gray-400">
+              <span className="block text-gray-500 theme-dark:text-gray-400">
                 paid clubs
               </span>
             </li>
             <li>
-              <span className="block text-gray-900 dark:text-gray-100 font-semibold tabular-nums">
+              <span className="block text-gray-900 theme-dark:text-gray-100 font-semibold tabular-nums">
                 {Math.round(r.distinguishedPercent)}%
               </span>
-              <span className="block text-gray-500 dark:text-gray-400">
+              <span className="block text-gray-500 theme-dark:text-gray-400">
                 distinguished
               </span>
             </li>
           </ul>
 
           <div
-            className="flex items-center gap-1 pt-3 border-t border-gray-100 dark:border-gray-700"
+            className="flex items-center gap-1 pt-3 border-t border-gray-100 theme-dark:border-gray-700"
             aria-label="Requirements ribbon"
           >
             {REQUIREMENT_LABELS.map(({ key, label }) => {
@@ -87,8 +87,8 @@ export const RegionGrid: React.FC<RegionGridProps> = ({ rollups }) => {
                     className={
                       'inline-block w-2 h-2 rounded-full ' +
                       (met
-                        ? 'bg-green-500 dark:bg-green-400'
-                        : 'bg-gray-300 dark:bg-gray-600')
+                        ? 'bg-green-500 theme-dark:bg-green-400'
+                        : 'bg-gray-300 theme-dark:bg-gray-600')
                     }
                   />
                 </Tooltip>

--- a/frontend/src/components/RegionsLeaderboard.tsx
+++ b/frontend/src/components/RegionsLeaderboard.tsx
@@ -89,7 +89,7 @@ export const RegionsLeaderboard: React.FC<RegionsLeaderboardProps> = ({
           className="w-full text-sm font-tm-body"
           aria-label="Region rankings"
         >
-          <thead className="border-b border-gray-200 dark:border-gray-700">
+          <thead className="border-b border-gray-200 theme-dark:border-gray-700">
             <tr>
               {COLUMNS.map(col => {
                 const isActive = col.key === sortKey
@@ -99,7 +99,7 @@ export const RegionsLeaderboard: React.FC<RegionsLeaderboardProps> = ({
                     key={col.key}
                     scope="col"
                     className={
-                      'px-4 py-3 cursor-pointer select-none text-xs font-medium uppercase tracking-wider text-gray-600 dark:text-gray-300 ' +
+                      'px-4 py-3 cursor-pointer select-none text-xs font-medium uppercase tracking-wider text-gray-600 theme-dark:text-gray-300 ' +
                       (col.align === 'right' ? 'text-right' : 'text-left')
                     }
                     aria-sort={
@@ -118,11 +118,11 @@ export const RegionsLeaderboard: React.FC<RegionsLeaderboardProps> = ({
               })}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+          <tbody className="divide-y divide-gray-100 theme-dark:divide-gray-800">
             {sorted.map(r => (
               <tr
                 key={r.region}
-                className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+                className="hover:bg-gray-50 theme-dark:hover:bg-gray-800/50 transition-colors"
               >
                 <td className="px-4 py-3 text-left">
                   <Link
@@ -130,32 +130,32 @@ export const RegionsLeaderboard: React.FC<RegionsLeaderboardProps> = ({
                     className="flex items-center gap-3 text-tm-loyal-blue hover:underline"
                   >
                     <span
-                      className="inline-block px-2 py-0.5 text-xs font-mono rounded bg-tm-loyal-blue/10 text-tm-loyal-blue dark:bg-tm-loyal-blue/30 dark:text-blue-200"
+                      className="inline-block px-2 py-0.5 text-xs font-mono rounded bg-tm-loyal-blue/10 text-tm-loyal-blue theme-dark:bg-tm-loyal-blue/30 theme-dark:text-blue-200"
                       aria-hidden="true"
                     >
                       Region {r.region}
                     </span>
-                    <span className="text-gray-700 dark:text-gray-200 text-xs">
+                    <span className="text-gray-700 theme-dark:text-gray-200 text-xs">
                       leader: {r.leadingDistrictName}
                     </span>
                   </Link>
                 </td>
-                <td className="px-4 py-3 text-right tabular-nums text-gray-700 dark:text-gray-200">
+                <td className="px-4 py-3 text-right tabular-nums text-gray-700 theme-dark:text-gray-200">
                   {r.districtCount}
                 </td>
-                <td className="px-4 py-3 text-right tabular-nums text-gray-700 dark:text-gray-200">
+                <td className="px-4 py-3 text-right tabular-nums text-gray-700 theme-dark:text-gray-200">
                   {r.paidClubs.toLocaleString()}
                 </td>
-                <td className="px-4 py-3 text-right tabular-nums text-gray-700 dark:text-gray-200">
+                <td className="px-4 py-3 text-right tabular-nums text-gray-700 theme-dark:text-gray-200">
                   {r.totalPayments.toLocaleString()}
                 </td>
-                <td className="px-4 py-3 text-right tabular-nums text-gray-700 dark:text-gray-200">
+                <td className="px-4 py-3 text-right tabular-nums text-gray-700 theme-dark:text-gray-200">
                   {r.distinguishedClubs.toLocaleString()}
-                  <span className="text-gray-500 dark:text-gray-400 ml-1">
+                  <span className="text-gray-500 theme-dark:text-gray-400 ml-1">
                     · {Math.round(r.distinguishedPercent)}%
                   </span>
                 </td>
-                <td className="px-4 py-3 text-right tabular-nums font-semibold text-gray-900 dark:text-gray-50">
+                <td className="px-4 py-3 text-right tabular-nums font-semibold text-gray-900 theme-dark:text-gray-50">
                   {r.aggregateScore.toLocaleString()}
                 </td>
               </tr>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -46,6 +46,24 @@
 @import './styles/dark-mode.css';
 @import './styles/print.css';
 
+/* Toggle-scoped dark variant (#710).
+ *
+ * Tailwind's built-in `dark:` variant compiles to
+ * `@media (prefers-color-scheme: dark)` — keyed off the OS, not the app.
+ * But this app's dark mode is a MANUAL toggle that sets
+ * `[data-theme='dark']` on <html> (DarkModeContext). The two are
+ * decoupled: when a user's OS prefers dark while the app shows light
+ * (white surface), every `dark:` utility fires anyway and paints light
+ * text on the light surface — the /regions leaderboard went invisible
+ * (Amy's bug, #710). It's lesson 073's inert-`dark:` trap in reverse.
+ *
+ * `theme-dark:` keys off the manual toggle instead, so dark styling
+ * tracks the app theme and never the OS. `:where()` keeps specificity at
+ * a single class so it composes like a normal utility. Region components
+ * use this; the broader codebase migration off raw `dark:` is tracked
+ * separately (#710 follow-up). */
+@custom-variant theme-dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
 /* Tailwind v4 Theme Configuration - replaces tailwind.config.js */
 @theme {
   /* ========================================

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -61,7 +61,7 @@
  * tracks the app theme and never the OS. `:where()` keeps specificity at
  * a single class so it composes like a normal utility. Region components
  * use this; the broader codebase migration off raw `dark:` is tracked
- * separately (#710 follow-up). */
+ * separately (#715). */
 @custom-variant theme-dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 /* Tailwind v4 Theme Configuration - replaces tailwind.config.js */

--- a/tasks/lessons/107-tailwind-dark-variant-is-os-keyed-and-misfires-under-a-manual-theme-toggle.md
+++ b/tasks/lessons/107-tailwind-dark-variant-is-os-keyed-and-misfires-under-a-manual-theme-toggle.md
@@ -1,0 +1,90 @@
+---
+id: '107'
+category: principle
+tags: [dark-mode, css, accessibility, frontend, tailwind]
+auto_load: true
+date: 2026-05-25
+issues: [710, 683]
+---
+
+# Lesson 107 — Tailwind's `dark:` is OS-keyed; under a manual theme toggle it MISFIRES in the OS-dark + app-light quadrant
+
+**Date:** 2026-05-25
+**Issue:** #710 (epic #683 Sprint 8 — Amy: /regions leaderboard near-invisible in Safari)
+
+## What happened
+
+The `/regions` leaderboard rows were near-invisible — light-grey text on a
+white table — but only for some users, and #685's Chromium-at-rest axe scan
+had passed it clean. Not a Safari render bug, not state-based dimming, not a
+regression. The cause was a **theme-mechanism mismatch**:
+
+- Tailwind's `dark:` variant (with no config) compiles to
+  `@media (prefers-color-scheme: dark)` — keyed off the **OS**.
+- This app's dark mode is a **manual `[data-theme='dark']` toggle**
+  (DarkModeContext), and `getInitialTheme()` honors a stored `theme='light'`
+  even when the OS prefers dark.
+
+So in the quadrant **{app shows light, OS prefers dark}**, the white surface
+renders (data-theme=light) while every `dark:` utility fires anyway
+(prefers-color-scheme matches the OS) → `dark:text-gray-200` (#e5e7eb),
+`dark:text-gray-50` (#f9fafb), `dark:text-blue-200` chips, all painted on
+white. The hovered row got `dark:hover:bg-gray-800` (a dark bg) so its light
+text was legible — "only the emphasized row is readable," exactly the report.
+
+Lesson 073 noted `dark:` is **inert** under the manual toggle (won't fire when
+you _want_ it in app-dark). This is the **dual**: it _fires when you don't want
+it_. Both halves are the same root mismatch.
+
+## The principle
+
+**Dark mode has TWO independent inputs — the app's theme and the OS preference
+— so it has FOUR quadrants. A `dark:`-keyed style and a `[data-theme]`-keyed
+surface can disagree.** When the dark-mode mechanism is a manual `[data-theme]`
+toggle:
+
+- A raw Tailwind `dark:` utility is OS-keyed and will misfire in
+  {app-light, OS-dark} (light text on light) and {app-dark, OS-light} (the
+  inverse, where it's just inert and the surface stays light if no override).
+- **Verify every dark-mode surface in all four {app theme} × {OS preference}
+  quadrants**, not just app-dark with a matching OS. An at-rest scan run only
+  with `prefers-color-scheme: light` (the default) structurally cannot see the
+  {app-light, OS-dark} bug — that's the #685 blind spot.
+
+## The fix shape
+
+Scope dark styling to the toggle, not the OS. A Tailwind v4 custom variant
+does it without touching the global `dark:`:
+
+```css
+@custom-variant theme-dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+```
+
+Then `theme-dark:bg-gray-800` keys off `[data-theme='dark']`. `:where()` keeps
+specificity at one class so it composes like a normal utility. (Placing
+`@custom-variant` AFTER all `@import`s matters — imports must come first.) The
+existing `[data-theme='dark'] !important` text overrides still win for text;
+the variant's real work is on bg/border classes that had no override. The
+ideal root-cause fix is redefining the GLOBAL `dark` variant the same way, but
+that's app-wide blast radius against the Track-D override layer (#715) — an
+ADR-scoped follow-up, not a bug-fix sprint.
+
+## How to verify (falsifiable, both engines)
+
+A Playwright smoke that emulates `colorScheme` × seeds `localStorage.theme`
+across all four quadrants and asserts each cell clears WCAG AA against its
+rendered background — run in a **`webkit` project too**, since #685 proved
+Chromium-at-rest misses Safari-visible contrast. A static vitest guard (no raw
+`dark:` in the converted components) is the cheap CI recurrence guard;
+contrast itself can't be computed in JSDOM (lesson 075).
+
+## Related
+
+- [[073-opacity-variant-utilities-need-explicit-dark-mode-overrides]] — `dark:`
+  is inert under the manual toggle (the "won't fire" half); this is the
+  "fires when unwanted" dual.
+- [[075-axe-core-jsdom-no-contrast-pair-with-static-guard]] — why the guard is
+  static + a real-browser smoke, not JSDOM axe.
+- [[094-darkmode-utilities-fail-by-asymmetry-text-and-bg-must-remap-together]]
+  — surface and text must move together; here they're keyed off different
+  signals entirely.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -65,3 +65,4 @@
 - **104** [analytics, frontend, dcp, data-pipeline] — Derive a count from raw integer inputs, not a vendor's pre-rounded percentage (#688, #683)
 - **105** [frontend, css, responsive, accessibility, ux] — Match the mobile-table pattern to the data's purpose, not a sibling table's precedent (#689, #683)
 - **106** [automation, sprint-runner, prompts] — `Closes #N` in an auto-merged sprint PR defeats the tick-before-close ordering (#689, #626, #683)
+- **107** [dark-mode, css, accessibility, frontend, tailwind] — Tailwind's `dark:` is OS-keyed; under a manual theme toggle it MISFIRES in the OS-dark + app-light quadrant (#710, #683)


### PR DESCRIPTION
Part of #710 · epic #683 (Sprint 8)

## Root cause (confirmed by repro)
Amy reported the `/regions` leaderboard rows near-invisible in Safari (light mode). Reproduced deterministically: it's **not** Safari-specific rendering and **not** a regression — it's a **theme-mechanism mismatch**.

Tailwind's `dark:` variant compiles to `@media (prefers-color-scheme: dark)`. But this app's dark mode is a **manual `[data-theme='dark']` toggle** (DarkModeContext, which honors a stored `theme='light'` even when the OS prefers dark). When a user's **OS is dark but the app shows light** (white surface), every `dark:` utility fires anyway → light-grey text (`#e5e7eb`), near-white score (`#f9fafb`), light-blue chips on a white table = invisible. The hovered row got `dark:hover:bg-gray-800` (dark bg) so it stayed legible — exactly Amy's "only the emphasized row is readable." This is lesson 073's inert-`dark:` trap **in reverse**, and it's why #685's Chromium-at-rest axe scan (which runs with `prefers-color-scheme: light`) never saw it.

## Fix
- Define a `theme-dark:` Tailwind custom variant keyed off `[data-theme='dark']` (`frontend/src/index.css`, placed after all `@import`s).
- Convert the two `/regions` components (`RegionsLeaderboard`, `RegionGrid`) `dark:*` → `theme-dark:*`. Dark styling now tracks the manual toggle, never the OS.
- App-dark appearance is byte-identical (the `[data-theme='dark'] !important` overrides in `dark-mode.css` already win for text; bg/border/dot classes now fire on the toggle as intended).
- Scoped to the two region components (epic surface). The **systemic** migration of the other ~11 components off raw `dark:` is filed as **#715**.

## Verification (all four theme × OS quadrants, at rest AND hover)
- **RED→GREEN guard (CI):** `region-dark-variant-scope.test.ts` — a static vitest guard asserting the region components carry no raw prefers-scheme `dark:` and that `theme-dark` is defined. **This is the automated recurrence guard that runs in CI.**
- **Live legibility (WebKit + Chromium):** `e2e/regions-legibility.smoke.ts` + a `webkit` Playwright project assert every leaderboard cell clears WCAG AA against its rendered background in all four quadrants, at rest and on hover, in **both engines**. Closes the #685 Chromium-only blind spot. Run locally (staging-data preview): **8/8 pass**. Note: Playwright smokes are a **manual / preview-channel** tool — no CI workflow invokes them — so the CI guard is the static test above.
- Full frontend suite: **2529/2529 pass**, zero regressions.

## Acceptance criteria
- [x] Root cause identified (mechanism mismatch, not Safari render / dimming / regression) with a falsifying test.
- [x] All region rows legible at rest + hover, Safari + Chrome, light + dark, WCAG AA.
- [x] Verification runs in WebKit (Playwright `webkit` project).
- [x] Guard test added (static CI guard + WebKit/Chromium smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)