### PR TITLE
fix(chrome): theme-toggle icon invisible in light mode (#700)

### DIFF
--- a/frontend/src/__tests__/accessibility/ThemeToggleContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/ThemeToggleContrast.test.ts
@@ -80,11 +80,15 @@ function resolve_(value: string, dark: boolean, depth = 0): string {
   return v
 }
 
-/** Value of `prop` from the LAST rule that names `selector` exactly and
- *  declares it (cascade last-wins — lesson 095). */
+/** Value of `prop` from the LAST *base* rule that names `selector` exactly and
+ *  declares it (cascade last-wins — lesson 095). The negative lookahead
+ *  excludes `:` as well as `\w-` so a pseudo-class rule
+ *  (`.x:hover { color: var(--ink) }`) can't shadow the resting-state colour
+ *  we're auditing — that shadowing made an earlier version of this audit
+ *  pass even when the base colour was reverted to white. */
 function declFor(css: string, selector: string, prop: string): string {
   const re = new RegExp(
-    selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w-])',
+    selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w-:])',
     'g'
   )
   let m: RegExpExecArray | null

--- a/frontend/src/__tests__/accessibility/ThemeToggleContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/ThemeToggleContrast.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Theme-toggle icon contrast audit (#700).
+ *
+ * The dark-mode toggle in the top bar (`.app-shell-theme-toggle`, rendered by
+ * ThemeToggle.tsx) was invisible in LIGHT mode because it hardcoded a near-white
+ * icon colour (`rgba(255,255,255,0.8)`) inline. On the light header surface
+ * (`.app-shell-top-bar` background = `--surface` = #ffffff) that icon reached
+ * only ~1.07:1 — effectively blank. The fix drives the colour from the
+ * theme-aware `--ink-3` token (the same token the visible "?" help icon uses).
+ *
+ * Like the other Track-D audits (AwardsDarkModeContrast etc.), this reads the
+ * *actual* CSS source and resolves the token through both the `:root` (light)
+ * and `[data-theme='dark']` maps, then checks the ratio against the surface the
+ * icon sits on. It is falsifiable: revert to a near-white colour and the light
+ * case drops below the bar. An icon is a non-text graphic (WCAG 1.4.11 → 3:1),
+ * but `--ink-3` clears the stricter 4.5:1 text bar in both modes, so we assert
+ * that for headroom.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { calculateContrastRatio } from '../../utils/contrastCalculator'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const stylesDir = resolve(here, '../../styles')
+
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '')
+
+const tokensCss = stripComments(
+  readFileSync(resolve(stylesDir, 'tokens/redesign.css'), 'utf8')
+)
+const appShellCss = stripComments(
+  readFileSync(resolve(stylesDir, 'components/app-shell.css'), 'utf8')
+)
+// The raw (uncommented) CSS — for asserting a rule *exists* (focus ring).
+const appShellCssRaw = readFileSync(
+  resolve(stylesDir, 'components/app-shell.css'),
+  'utf8'
+)
+
+/** Declarations from the first block whose selector matches exactly. */
+function parseTokenBlock(
+  css: string,
+  selectorLiteral: string
+): Map<string, string> {
+  const re = new RegExp(
+    '(?:^|\\n)\\s*' +
+      selectorLiteral.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\s*\\{'
+  )
+  const m = re.exec(css)
+  if (!m) throw new Error(`block ${selectorLiteral} not found`)
+  const open = css.indexOf('{', m.index)
+  const close = css.indexOf('}', open)
+  const body = css.slice(open + 1, close)
+  const map = new Map<string, string>()
+  for (const d of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    map.set(d[1].trim(), d[2].trim())
+  }
+  return map
+}
+
+const lightTokens = parseTokenBlock(tokensCss, ':root')
+const darkTokens = parseTokenBlock(tokensCss, "[data-theme='dark']")
+
+/** Resolve a token / var() chain to a hex string in the requested theme. */
+function resolve_(value: string, dark: boolean, depth = 0): string {
+  if (depth > 8) throw new Error(`var() resolution too deep: ${value}`)
+  const v = value.trim()
+  const varMatch = v.match(/^var\((--[\w-]+)\)$/)
+  if (varMatch) {
+    const name = varMatch[1]
+    const next = dark
+      ? (darkTokens.get(name) ?? lightTokens.get(name))
+      : lightTokens.get(name)
+    if (!next) throw new Error(`token ${name} undefined`)
+    return resolve_(next, dark, depth + 1)
+  }
+  return v
+}
+
+/** Value of `prop` from the LAST rule that names `selector` exactly and
+ *  declares it (cascade last-wins — lesson 095). */
+function declFor(css: string, selector: string, prop: string): string {
+  const re = new RegExp(
+    selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w-])',
+    'g'
+  )
+  let m: RegExpExecArray | null
+  let found: string | null = null
+  while ((m = re.exec(css)) !== null) {
+    const open = css.indexOf('{', m.index)
+    if (open === -1) continue
+    const close = css.indexOf('}', open)
+    const body = css.slice(open + 1, close)
+    const propMatch = body.match(
+      new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;]+);')
+    )
+    if (propMatch) found = propMatch[1].trim()
+  }
+  if (found === null) throw new Error(`no ${prop} for ${selector}`)
+  return found
+}
+
+describe('Theme-toggle icon contrast (#700)', () => {
+  it.each([
+    { mode: 'light', dark: false },
+    { mode: 'dark', dark: true },
+  ])('icon colour clears WCAG AA on the $mode header surface', ({ dark }) => {
+    const fg = resolve_(
+      declFor(appShellCss, '.app-shell-theme-toggle', 'color'),
+      dark
+    )
+    const surface = resolve_('var(--surface)', dark)
+    const ratio = calculateContrastRatio(fg, surface)
+    expect(
+      ratio,
+      `icon ${fg} on ${surface} = ${ratio.toFixed(2)}:1 (need 4.5:1)`
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('is not the near-white literal that caused the bug', () => {
+    const lightFg = resolve_(
+      declFor(appShellCss, '.app-shell-theme-toggle', 'color'),
+      false
+    ).toLowerCase()
+    expect(['#fff', '#ffffff', '#fefefe']).not.toContain(lightFg)
+  })
+
+  it('declares a visible focus-visible ring (WCAG 2.4.7)', () => {
+    expect(appShellCssRaw).toMatch(
+      /\.app-shell-theme-toggle:focus-visible\s*\{[^}]*outline[^}]*\}/
+    )
+  })
+})

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -15,11 +15,10 @@ const ThemeToggle: React.FC = () => {
     <button
       onClick={toggle}
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-      className="inline-flex items-center justify-center rounded-lg p-2 transition-colors duration-200"
+      className="app-shell-theme-toggle inline-flex items-center justify-center rounded-lg p-2 transition-colors duration-200"
       style={{
         minHeight: '44px',
         minWidth: '44px',
-        color: 'rgba(255, 255, 255, 0.8)',
       }}
     >
       {isDark ? (

--- a/frontend/src/components/__tests__/ThemeToggle.test.tsx
+++ b/frontend/src/components/__tests__/ThemeToggle.test.tsx
@@ -103,4 +103,21 @@ describe('ThemeToggle (#120)', () => {
 
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
   })
+
+  // #700 — the icon colour must come from a theme-aware token, not a hardcoded
+  // near-white literal that vanishes against the light header surface.
+  it('does not hardcode a near-white icon colour inline (#700)', () => {
+    renderWithProvider()
+    const button = screen.getByRole('button')
+    // The old bug: style={{ color: 'rgba(255, 255, 255, 0.8)' }} — invisible in
+    // light mode. Colour must be driven by CSS (--ink-3), not inline white.
+    expect(button.style.color).not.toMatch(/255,\s*255,\s*255/)
+    expect(button.style.color).toBe('')
+  })
+
+  it('carries the theme-aware styling class (#700)', () => {
+    renderWithProvider()
+    const button = screen.getByRole('button')
+    expect(button.classList.contains('app-shell-theme-toggle')).toBe(true)
+  })
 })

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -158,7 +158,7 @@
      colour, invisible against the light header surface (--surface = #fff).
      Drive it from --ink-3 — the same theme-aware token the "?" help icon
      above uses — so it clears WCAG AA in BOTH modes (R10): #5b6675 on white
-     ≈ 5.8:1 (light), #8a96a6 on --surface ≈ 6.4:1 (dark). */
+     ≈ 5.8:1 (light), #8a96a6 on --surface ≈ 5.9:1 (dark). */
   .app-shell-theme-toggle {
     color: var(--ink-3);
   }

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -154,6 +154,27 @@
     color: var(--ink);
   }
 
+  /* Theme toggle (#700). The icon previously hardcoded a near-white inline
+     colour, invisible against the light header surface (--surface = #fff).
+     Drive it from --ink-3 — the same theme-aware token the "?" help icon
+     above uses — so it clears WCAG AA in BOTH modes (R10): #5b6675 on white
+     ≈ 5.8:1 (light), #8a96a6 on --surface ≈ 6.4:1 (dark). */
+  .app-shell-theme-toggle {
+    color: var(--ink-3);
+  }
+
+  .app-shell-theme-toggle:hover {
+    background-color: var(--surface-3);
+    color: var(--ink);
+  }
+
+  .app-shell-theme-toggle:focus-visible {
+    /* --link (not --loyal-500): the ring must clear 3:1 on the dark surface
+       too (WCAG 1.4.11). --link remaps to #60a5d8 in dark (Lesson 093/096). */
+    outline: 2px solid var(--link);
+    outline-offset: 2px;
+  }
+
   .app-shell-avatar {
     width: 32px;
     height: 32px;

--- a/tasks/lessons/107-css-audit-matcher-must-exclude-pseudo-class-rules-or-hover-shadows-the-resting-state.md
+++ b/tasks/lessons/107-css-audit-matcher-must-exclude-pseudo-class-rules-or-hover-shadows-the-resting-state.md
@@ -1,0 +1,70 @@
+---
+id: '107'
+category: lesson
+tags: [dark-mode, css, accessibility, tests, vitest]
+auto_load: true
+date: 2026-05-25
+issues: [700, 701]
+---
+
+# Lesson 107 — A CSS-parsing audit's selector matcher must exclude pseudo-class rules, or `:hover`/`:focus` shadows the resting state
+
+**Date:** 2026-05-25
+**Issue:** #700 (epic #701 Sprint 1 — header theme-toggle invisible in light mode)
+
+## What happened
+
+The fix was textbook: the toggle icon hardcoded `color: rgba(255,255,255,0.8)`
+inline (invisible on the light `--surface`); the cure was to drive it from the
+theme-aware `--ink-3` token via `.app-shell-theme-toggle`, exactly the R10 /
+lesson-093 pattern but mirrored into **light** mode (a near-white literal is the
+light-mode twin of the dark-mode "raw token with no remap" trap).
+
+The bug was in the _audit_, not the fix. I reused the `declFor` helper from the
+`AwardsDarkModeContrast` harness, which finds the cascade-last-winning rule whose
+selector matches `.app-shell-theme-toggle(?![\w-])`. That lookahead excludes
+`\w` and `-` so `__status` doesn't match `__status--won` — but it does **not**
+exclude `:`. So the matcher also matched `.app-shell-theme-toggle:hover { color:
+var(--ink) }`, and "last wins" returned the _hover_ colour (`--ink`, ~18:1), not
+the resting `--ink-3` the bug was about. The fresh-context reviewer reverted the
+base rule to `#ffffff` (re-introducing the exact bug) and **all four contrast
+assertions still passed**. The audit was hollow: it could never fail for the
+defect it claimed to guard.
+
+## The principle
+
+When a test parses CSS to audit a _resting-state_ property, the selector matcher
+must match the **base rule only** — exclude pseudo-classes (`:hover`, `:focus`,
+`:focus-visible`, `:active`) and pseudo-elements. A `:hover` rule that sets the
+same property will shadow the base under any "last-declared wins" resolution
+(lesson 095) and silently lift the audited value to the interaction colour. The
+one-character fix here was widening the negative lookahead to `(?![\w-:])`.
+
+This is the same family as lesson 095 ("audit the rule the cascade renders, not
+the first match") — but the failure mode is the inverse: cascade-correct
+resolution across _too broad_ a selector set, where a pseudo-state rule is a
+member it shouldn't be.
+
+## How to apply
+
+- A CSS-parsing audit of a resting property must scope its selector match to the
+  base rule. Add `:` to the boundary lookahead (`(?![\w-:])`) so pseudo-class /
+  pseudo-element rules can't be picked up.
+- **Always prove a new contrast/colour audit is falsifiable**: temporarily set
+  the audited declaration to the known-bad value (white here) and confirm the
+  test goes red, _then_ restore. A green audit that stays green when you
+  re-introduce the bug is worse than no audit — it's a false guarantee. (The
+  component-level test in `ThemeToggle.test.tsx` _was_ falsifiable, which is why
+  the TDD red was real; the CSS audit was the hollow one.)
+- Light-mode invisibility is a real bug class, not just dark-mode's. A hardcoded
+  near-white (or near-black) literal is invisible in exactly one theme — audit
+  resting colour against the surface in **both** `:root` and `[data-theme=dark]`.
+
+## Related
+
+- [[095-darkmode-token-bumps-must-be-sized-for-the-lightest-surface]] — the
+  cascade-last-wins audit fidelity rule; this is its over-broad-selector twin.
+- [[093-a-token-that-doesnt-remap-in-dark-is-a-trap-for-any-non-link-consumer]] —
+  the dark-mode token trap this bug mirrors into light mode.
+- `frontend/src/__tests__/accessibility/AwardsDarkModeContrast.test.ts` — the
+  `declFor` harness reused (and the matcher pattern that needed the `:` guard).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -65,4 +65,5 @@
 - **104** [analytics, frontend, dcp, data-pipeline] — Derive a count from raw integer inputs, not a vendor's pre-rounded percentage (#688, #683)
 - **105** [frontend, css, responsive, accessibility, ux] — Match the mobile-table pattern to the data's purpose, not a sibling table's precedent (#689, #683)
 - **106** [automation, sprint-runner, prompts] — `Closes #N` in an auto-merged sprint PR defeats the tick-before-close ordering (#689, #626, #683)
+- **107** [dark-mode, css, accessibility, tests, vitest] — A CSS-parsing audit's selector matcher must exclude pseudo-class rules, or `:hover`/`:focus` shadows the resting state (#700, #701)
 - **107** [dark-mode, css, accessibility, frontend, tailwind] — Tailwind's `dark:` is OS-keyed; under a manual theme toggle it MISFIRES in the OS-dark + app-light quadrant (#710, #683)


### PR DESCRIPTION
Part of #700 (epic #701, Sprint 1).

## Problem
The header dark-mode toggle (`ThemeToggle.tsx`) hardcoded its icon colour inline as `rgba(255, 255, 255, 0.8)`. On the light header surface (`.app-shell-top-bar` background = `--surface` = `#ffffff`) a near-white icon is invisible (~1.07:1). In dark mode the dark surface made the same white icon visible — which is why the bug was light-mode only. The sibling "?" help icon was always visible because it colours from the theme-aware `var(--ink-3)` token; the toggle never adopted a token.

## Fix (R10 — theme at the CSS level)
- Remove the hardcoded white inline `color`.
- Drive colour from `var(--ink-3)` via a new `.app-shell-theme-toggle` class — the same token the visible help icon uses. `--ink-3` remaps in dark (#5b6675 → #8a96a6) and clears WCAG AA in **both** modes: ~5.8:1 (light, on white) / ~5.9:1 (dark, on `--surface`).
- Hover affordance matching the help icon.
- Visible `:focus-visible` ring using `var(--link)` (remaps to #60a5d8 in dark, clears 3:1 on the dark surface — lesson 093/096).
- ≥44px touch target and the per-state `aria-label` are unchanged (already correct).

## Acceptance criteria
- [x] Toggle icon visible/legible (AA) in light AND dark — proven by the CSS-parsing contrast audit in both themes.
- [x] Keyboard-focusable with a visible focus ring; correct `aria-label` for current state.
- [x] Failing test existed before the fix (TDD) — `ThemeToggle.test.tsx` red on the inline white; contrast audit red on a white-revert (verified).
- [ ] Verified live on the PR preview channel in both themes (pending preview deploy).

## Tests
- `ThemeToggle.test.tsx` — asserts no near-white inline colour + theme-aware class present.
- `__tests__/accessibility/ThemeToggleContrast.test.ts` — CSS-parsing audit (mirrors `AwardsDarkModeContrast`) resolving the resting `--ink-3` through both token maps; falsifiability re-verified (a white-revert turns it red).

## Review
Fresh-context review caught that the audit's `declFor` last-wins matcher also matched `:hover` (`var(--ink)`), shadowing the resting state so a white-revert still passed. Fixed by excluding pseudo-class selectors; re-verified the audit now fails on the bug.