### PR TITLE
chore(deploy): remove the unused hosting:staging deploy step (#708)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,18 +94,10 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
 
-      - name: Build and deploy staging
-        run: |
-          npm run build:frontend
-          npm install -g firebase-tools
-          firebase deploy --only hosting:staging --project ${{ secrets.GCP_PROJECT_ID }}
-        env:
-          VITE_APP_VERSION: v${{ steps.pkg.outputs.version }}
-          VITE_CDN_BASE_URL: https://storage.googleapis.com/toast-stats-data-staging
-
       - name: Build and deploy production
         run: |
           npm run build:frontend
+          npm install -g firebase-tools
           firebase deploy --only hosting:production --project ${{ secrets.GCP_PROJECT_ID }}
         env:
           VITE_APP_VERSION: v${{ steps.pkg.outputs.version }}


### PR DESCRIPTION
## Summary

Removes the **"Build and deploy staging"** step from `deploy.yml`. It ran `firebase deploy --only hosting:staging` on every push to `main`, deploying to a retired/unused Firebase staging *site* — pure waste on every merge.

## Why it's safe

- The step has no `id` and no outputs — **nothing downstream reads it**. The "Build and deploy production" step rebuilds the frontend independently.
- **PR preview channels are unaffected**: `pr-preview.yml` uses `firebase hosting:channel:deploy --only "staging"`, which creates *ephemeral channels* under the staging site. That does **not** depend on the `firebase deploy --only hosting:staging` *deploy* step being removed here.
- `data-pipeline.yml`'s "staging" refers to the GCS bucket `toast-stats-data-staging` — a data concept, unrelated to Firebase hosting.
- The staging *site/target* remains in `firebase.json` and `.firebaserc` (preview channels still need it to exist).

`npm install -g firebase-tools` was moved into the production step, since the removed staging step was previously the one installing it.

## Acceptance criteria

- [x] `hosting:staging` deploy step removed from `deploy.yml`.
- [x] PR preview channels still deploy and comment (unaffected — they use channel deploy, not this step).
- [x] Production deploy step unchanged in behaviour (still builds + deploys `hosting:production`; firebase-tools install preserved).

## Verification note

This is a **CD-trigger / workflow-config change**. Per epic #709's verification caveat, a PR preview channel cannot exercise a deploy-trigger change. `pr-preview.yml` is path-filtered to `frontend/**`, `packages/{shared-contracts,analytics-core}/**`, and firebase config — this PR touches none of those, so **no preview is deployed and there is no live surface to drive**. Verification rests on: `npm run lint:yaml` green (no deploy.yml findings) + CI green + the static safety analysis above. Actual prod-deploy behaviour is operator-attended post-merge per the epic note.

Part of epic #709.