### PR TITLE
feat(cd): release-gated production deploy (ADR-004) (#707)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,11 @@
 # Production Deployment Workflow
-# Deploys frontend to Firebase Hosting
-# on every merge to main, after CI passes.
+# Deploys frontend to Firebase Hosting on a release-please release
+# (ADR-004). Production deploys are release-gated, not merge-gated:
+# release-please.yml calls this workflow when a release PR is merged
+# (releases_created == 'true'). workflow_dispatch is the manual/hotfix path.
+#
+# Full CI runs on PRs and on the release PR (a PR to main), so there is no
+# redundant per-merge CI re-run here.
 #
 # Prerequisites:
 #   1. Run scripts/setup-wif.sh (one-time)
@@ -9,18 +14,10 @@
 name: Deploy
 
 on:
-  push:
-    branches: [main]
-    # Don't rebuild + redeploy prod when a merge touches only non-code
-    # artifacts (lessons, docs, markdown, ignore/license) — the deployed
-    # site would be byte-identical. workflow_dispatch still allows a
-    # manual deploy from any state.
-    paths-ignore:
-      - '**/*.md'
-      - 'tasks/**'
-      - 'docs/**'
-      - '.gitignore'
-      - 'LICENSE'
+  # Invoked by release-please.yml when a release is published. Secrets are
+  # passed via `secrets: inherit` from the caller.
+  workflow_call:
+  # Manual / emergency hotfix deploy from any state.
   workflow_dispatch:
 
 # Prevent concurrent deployments
@@ -33,28 +30,24 @@ env:
   REGION: 'northamerica-northeast1'
   GCS_BUCKET: 'toast-stats-data-ca'
 
+# Least privilege for the deploy job. The redundant CI gate job (which
+# needed packages / pull-requests / security-events) was removed in
+# ADR-004, so those scopes are gone. When called from release-please.yml
+# these are capped by that workflow's permissions; they apply directly on
+# a workflow_dispatch run.
 permissions:
-  contents: write # Required to push version tags
-  id-token: write # Required for Workload Identity Federation
-  packages: write # Required by CI workflow
-  pull-requests: write # Required by CI workflow
-  security-events: write # Required by CI workflow
+  contents: write # version tags / git metadata
+  id-token: write # Workload Identity Federation (GCP auth)
 
 jobs:
   # ──────────────────────────────────────────────
-  # Gate: CI must pass before deployment
-  # ──────────────────────────────────────────────
-  ci:
-    name: CI Quality Gates
-    uses: ./.github/workflows/ci.yml
-
-  # ──────────────────────────────────────────────
   # Deploy Frontend to Firebase Hosting
   # ──────────────────────────────────────────────
+  # No CI gate job here: CI already ran on the PR and again on the
+  # release PR (the integration gate). See ADR-004.
   deploy-frontend:
     name: Deploy Frontend
     runs-on: ubuntu-latest
-    needs: [ci]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,16 +5,40 @@ on:
     branches:
       - main
 
+# Superset of permissions needed by release-please AND the reusable deploy
+# workflow it calls (deploy.yml needs id-token for Workload Identity). A
+# called workflow's GITHUB_TOKEN permissions are capped by the caller, so
+# the deploy-relevant scopes must be granted here.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write # release-please tags + deploy version tags
+  pull-requests: write # release-please PR
+  id-token: write # WIF auth in deploy.yml
+  packages: write # required by deploy chain
+  security-events: write # required by deploy chain
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      # Aggregate boolean: 'true' when ANY component was released by this
+      # run. Fires exactly once per release-PR merge regardless of how many
+      # components released — collapses the multi-component tag fan-out and
+      # still covers package-only changes that alter the deployed bundle.
+      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Gate production deploy on a release-please release (ADR-004), not on
+  # every merge to main. The release PR gets full CI for free (it is a PR
+  # to main) — that is the integration gate; this fires only on its merge.
+  deploy:
+    name: Deploy on release
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit

--- a/docs/architecture-decisions/004-release-gated-production-deploy.md
+++ b/docs/architecture-decisions/004-release-gated-production-deploy.md
@@ -1,0 +1,144 @@
+# ADR-004: Release-gated production deploys
+
+**Status**: Accepted
+**Date**: 2026-05-25
+**Issue**: #707 (epic #709, meta-epic #606)
+
+## Context
+
+Today `deploy.yml` triggers on **every** `push` to `main` (with a `paths-ignore`
+for docs/lessons/markdown). On each qualifying merge it:
+
+1. Re-runs the full `ci.yml` suite as a gate (`jobs.ci: uses: ./.github/workflows/ci.yml`), then
+2. Deploys the frontend to Firebase Hosting **production**.
+
+Two problems follow from this:
+
+- **Redundant CI.** `ci.yml` already ran on the PR before merge. Re-running the
+  full suite on every push to main duplicates that work for no new signal in the
+  common case (no other PR merged in between).
+- **Unintentional production churn.** The autonomous sprint runner merges sprint
+  PRs to `main` rapidly. Each merge ships straight to prod. Production deploys are
+  therefore incidental side-effects of merging, not intentional, versioned,
+  batched events. There is no changelog boundary, no human "ship it" gate, and
+  DORA "deploy" signals are noisy (every merge is a "deploy").
+
+The prerequisites for fixing this are now in place:
+
+- **`release-please.yml` already exists** and maintains a release PR on every push
+  to main (`googleapis/release-please-action@v5`, `release-please-config.json`).
+  The versioning/changelog machinery is live but its release event is not yet
+  wired to a deploy.
+- **#706 moved per-sprint verification to the PR preview channel** (ADR-supersedes
+  the "verify on prod" assumption). Verification no longer depends on prod, so
+  prod can be release-gated **without stalling the autonomy loop**.
+
+## Decision
+
+Gate production deploys on **release-please releases**, not on merges to main.
+
+### Target event → workflow mapping
+
+| Event                                           | Runs                                                                                                               |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| PR → main                                       | `ci.yml` (per-change validation) + PR Preview + Lighthouse                                                         |
+| Merge → main                                    | `release-please` only — updates the release PR. **No deploy, no full re-run.**                                     |
+| Release-please **release PR** (a PR to main)    | `ci.yml` runs automatically → full suite on the **integrated/batched** main state. This _is_ the integration gate. |
+| Release PR **merged** (release published / tag) | **Deploy** → build + `firebase deploy ... hosting:production`                                                      |
+
+The release PR getting full CI for free is the linchpin: integration testing
+moves to the release boundary, so dropping the per-merge re-run loses nothing.
+
+### Concrete workflow changes
+
+1. **Trigger on the aggregate `releases_created` output — not `release: published`.**
+   `deploy.yml` becomes `on: [workflow_call, workflow_dispatch]` (no `push`).
+   `release-please.yml` exposes the action's `releases_created` output and adds a
+   `deploy` job gated `if: needs.release-please.outputs.releases_created == 'true'`
+   that calls `deploy.yml` via `uses:` with `secrets: inherit`.
+
+   **Why not `release: published`?** This is a _grouped multi-component_ monorepo
+   (`include-component-in-tag: true`, `separate-pull-requests: false`, 5 packages).
+   One release-PR merge publishes _several_ GitHub Releases/tags (`frontend-v…`,
+   `analytics-core-v…`, `toast-stats-v…`). `release: published` would fire **once
+   per component** → 2–5 concurrent prod deploys.
+
+   **Why not the per-component `frontend--release_created` output?** The deployed
+   artifact bundles `analytics-core` + `shared-contracts`. A sprint touching only
+   `packages/analytics-core/` releases that package but **not** `frontend`, so a
+   frontend-only gate would never deploy a real bundle change. The **aggregate**
+   `releases_created` fires exactly once per release-PR merge regardless of which
+   components released — collapsing the fan-out _and_ closing the package-only gap.
+   A docs/CLI-only release redeploys a byte-identical bundle (cheap no-op).
+
+2. **Drop the redundant gate.** Remove the `ci` job inside `deploy.yml` that
+   re-ran `ci.yml` on every push to main. CI now runs on the PR and on the
+   release PR.
+3. **Keep `workflow_dispatch`.** Manual deploy from any state stays — the hotfix /
+   emergency path.
+4. **Caller permissions.** Because a called workflow's `GITHUB_TOKEN` permissions
+   are capped by the caller, `release-please.yml` must grant the superset deploy
+   needs (notably `id-token: write` for WIF). `deploy.yml` is trimmed to least
+   privilege (`contents` + `id-token`).
+5. **Release-please already owns the frontend version.** `.release-please-manifest.json`
+   tracks all five components incl. `frontend: 2.13.0`, and `release-please-config.json`
+   lists the `frontend` package — no config change required.
+
+### Relationship to ADR-002
+
+ADR-002 governs the **staging → production data** promotion (GCS buckets, diff-based
+gate) — it is about _data_ reaching prod. This ADR governs the **frontend code**
+deploy _cadence/trigger_. They are orthogonal: ADR-002's staging gate still
+protects data; ADR-004 only changes _when_ frontend code deploys (release vs every
+merge). Note any overlap where `deploy.yml` currently couples both.
+
+## Consequences
+
+### Easier
+
+- Production deploys are intentional, versioned, and batched — tied to a release
+  with a changelog and a tag.
+- CI cycles saved: no full-suite re-run on every merge to main.
+- A natural human/approval gate (merging the release PR) sits in front of prod.
+- DORA "deploy frequency" / "lead time" key off real releases — more accurate.
+- Hotfix path preserved via `workflow_dispatch`.
+
+### Harder / risks
+
+- **Prod lags main** between releases. The autonomous runner merges sprints to
+  main continuously; users see them only when the release PR is merged. This is
+  the desired human gate but must be documented so it is not mistaken for a
+  stalled deploy.
+- **Direct pushes to main would skip CI** under the new model. Mitigation:
+  the repo is PR-only today (branch protection). Confirm and keep it that way;
+  a direct push to main would otherwise reach the release PR un-validated.
+- **Release-please config must be correct** — a misconfigured manifest could
+  produce empty/no releases and silently stop all prod deploys. Add a smoke check
+  / alert that a release was produced when expected.
+- **Verification caveat (operator-attended):** a PR preview channel cannot
+  exercise a deploy-_trigger_ change. The runner's preview-based verification does
+  **not** fully cover this ADR's impl — an operator must confirm actual deploy
+  behavior after merge (watch the first post-release deploy fire, and confirm a
+  plain merge no longer deploys).
+
+## Alternatives Considered
+
+1. **Status quo — deploy on every merge to main.** Rejected: redundant CI and
+   unintentional, unversioned prod churn (the motivating problem).
+2. **Manual promotion gate on every merge** (e.g. environment approval).
+   Rejected: adds friction to every change; the release PR already provides the
+   batched gate.
+3. **Tag-push trigger without release-please** (`on: push: tags`). Workable but
+   discards the changelog/version automation release-please already provides.
+   Rejected in favor of the existing tooling.
+4. **Keep the per-merge `ci.yml` re-run "just in case."** Rejected: the release
+   PR is itself a PR to main and runs full CI on the integrated state, so the
+   per-merge re-run is pure duplication.
+
+## Acceptance (mirrors #707)
+
+- [x] This ADR accepted (status Accepted; operator-approved 2026-05-25), `needs-product-review` cleared on merge.
+- [ ] Prod deploys only on a release-please release.
+- [ ] Full CI runs on PRs and on the release PR; no redundant per-merge re-run.
+- [ ] `workflow_dispatch` manual deploy retained.
+- [ ] README ADR index updated to list 002, 003, 004.

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -19,9 +19,12 @@ Each ADR follows this template:
 
 ## Index
 
-| ADR                             | Title                             | Status   | Date     |
-| ------------------------------- | --------------------------------- | -------- | -------- |
-| [001](001-cdn-only-frontend.md) | CDN-only frontend (no API server) | Accepted | Jan 2026 |
+| ADR                                                | Title                                     | Status   | Date     |
+| -------------------------------------------------- | ----------------------------------------- | -------- | -------- |
+| [001](001-cdn-only-frontend.md)                    | CDN-only frontend (no API server)         | Accepted | Jan 2026 |
+| [002](002-staging-environment.md)                  | Staging environment and deployment flow   | Accepted | Apr 2026 |
+| [003](003-staging-bucket-cors-preview-channels.md) | Staging bucket CORS for Firebase previews | Accepted | May 2026 |
+| [004](004-release-gated-production-deploy.md)      | Release-gated production deploys          | Accepted | May 2026 |
 
 ## When to Write an ADR
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -25,6 +25,17 @@ export default defineConfig({
     // Set aggressive timeout limits for fast test execution
     testTimeout: 5000, // 5 seconds max per test
     hookTimeout: 5000, // 5 seconds max for setup/teardown hooks
+    // Cap local worker forks at 3. The default (one fork per core) saturates
+    // a busy dev machine — when something else is eating CPU (a background OS
+    // update/reindex, a persistent VM like Rancher Desktop, another build),
+    // forks starve each other and fast tests blow the 5s timeout, failing the
+    // pre-push gate for reasons unrelated to the code (worker-saturation
+    // flakiness, #473 / Lesson 53). A 50% cap still left ~4 timeouts on a
+    // heavily-contended machine; a fixed 3 forks gives each enough headroom
+    // to finish in time. CI runners are small and not oversubscribed, so they
+    // keep the default for full throughput.
+    // eslint-disable-next-line no-undef
+    maxWorkers: process.env.CI ? undefined : 3,
     exclude: baseExclude,
     coverage: {
       exclude: [...baseExclude],

--- a/scripts/lib/__tests__/releaseGatedDeploy.test.ts
+++ b/scripts/lib/__tests__/releaseGatedDeploy.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Contract test for ADR-004: release-gated production deploys (#707).
+ *
+ * Production deploys must fire on a release-please *release*, not on every
+ * merge to main, and the redundant per-merge full-CI re-run must be gone.
+ * These assertions are dependency-free (no YAML parser available at root):
+ * we strip full-line comments and check the structural contract as text.
+ */
+
+const WORKFLOWS = join(__dirname, '..', '..', '..', '.github', 'workflows')
+
+function readWorkflow(name: string): string {
+  return readFileSync(join(WORKFLOWS, name), 'utf8')
+}
+
+/** Lines with all full-line `#` comments removed (keeps inline content). */
+function stripComments(yaml: string): string[] {
+  return yaml.split('\n').filter(line => !/^\s*#/.test(line))
+}
+
+/**
+ * Return the top-level `on:` trigger keys (one indent level under `on:`).
+ * Stops at the next top-level (column-0) key.
+ */
+function topLevelTriggers(yaml: string): string[] {
+  const lines = stripComments(yaml)
+  const onIdx = lines.findIndex(l => /^on:\s*$/.test(l))
+  expect(onIdx, 'workflow must have a block-style `on:`').toBeGreaterThan(-1)
+  const triggers: string[] = []
+  for (let i = onIdx + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.trim() === '') continue
+    if (/^\S/.test(line)) break // next top-level key
+    const m = line.match(/^\s{2}([A-Za-z_]+):/)
+    if (m) triggers.push(m[1])
+  }
+  return triggers
+}
+
+describe('ADR-004: release-gated production deploy', () => {
+  describe('deploy.yml', () => {
+    const deploy = readWorkflow('deploy.yml')
+
+    it('does NOT trigger on push to main (deploys are release-gated)', () => {
+      expect(topLevelTriggers(deploy)).not.toContain('push')
+    })
+
+    it('is callable by release-please (workflow_call)', () => {
+      expect(topLevelTriggers(deploy)).toContain('workflow_call')
+    })
+
+    it('retains workflow_dispatch for manual/hotfix deploys', () => {
+      expect(topLevelTriggers(deploy)).toContain('workflow_dispatch')
+    })
+
+    it('drops the redundant per-merge full-CI re-run job', () => {
+      const lines = stripComments(deploy)
+      // No top-level `ci:` job, and deploy-frontend no longer needs it.
+      expect(lines.some(l => /^\s{2}ci:\s*$/.test(l))).toBe(false)
+      expect(deploy).not.toMatch(/needs:\s*\[?\s*ci\b/)
+    })
+  })
+
+  describe('release-please.yml', () => {
+    const rp = readWorkflow('release-please.yml')
+
+    it('exposes the aggregate releases_created output', () => {
+      expect(rp).toMatch(/releases_created/)
+    })
+
+    it('has a deploy job gated on releases_created (not per-component)', () => {
+      expect(rp).toMatch(/^\s{2}deploy:\s*$/m)
+      expect(rp).toMatch(/if:\s*.*releases_created\s*==\s*'true'/)
+    })
+
+    it('deploys by calling the reusable deploy workflow', () => {
+      expect(rp).toMatch(/uses:\s*\.\/\.github\/workflows\/deploy\.yml/)
+    })
+  })
+})


### PR DESCRIPTION
Closes #707 (epic #709 Sprint 2, meta-epic #606).

## What & why
Moves production from **deploy-on-every-merge** to **deploy-on-release** (release-please). Per-merge full-CI + deploy redundancy goes away; prod deploys become intentional, versioned, batched. Design recorded in **ADR-004** (Accepted, operator-approved).

## Changes
- **`deploy.yml`** — `on: push:[main]` → `on: [workflow_call, workflow_dispatch]`; dropped the redundant per-merge `ci.yml` re-run job; trimmed permissions to least privilege (`contents` + `id-token`).
- **`release-please.yml`** — exposes the aggregate `releases_created` output and adds a `deploy` job gated `if: ...releases_created == 'true'` that calls `deploy.yml` via `secrets: inherit`. Top-level permissions widened to the superset deploy needs (a called workflow's token is capped by the caller).
- **ADR-004** + README ADR index (002–004).
- **Contract test** (`scripts/lib/__tests__/releaseGatedDeploy.test.ts`) — asserts deploy is no longer push-triggered, the CI re-run job is gone, and release-please gates deploy on `releases_created`.
- **`frontend/vitest.config.ts`** — caps local vitest at 3 forks (CI unchanged). Unrelated to the CD change but required to get the pre-push gate to pass reliably on a contended machine; see commit body (#473 / Lesson 53).

## Key design decision (why aggregate `releases_created`, not `release: published`)
This is a grouped multi-component monorepo (`include-component-in-tag: true`, 5 packages). One release-PR merge publishes several tags, so `release: published` would fire **2–5 concurrent deploys**. A per-component `frontend--release_created` gate would miss package-only changes that still alter the bundled frontend. The **aggregate** output fires exactly once per release-PR merge — collapsing the fan-out and covering bundle changes. Full rationale in ADR-004.

## Verification
- Contract test green (7/7); full scripts suite green (86/86); frontend `unit` green (2014/2014, 0 timeouts).
- **CD-trigger changes can't be exercised on a PR preview** (per epic #709's verification caveat). Verification is code-proof (contract test + reviewable workflow logic). **Operator must confirm actual deploy behavior post-merge**: (1) a plain merge to main no longer deploys, (2) the first release-please release publish triggers a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)