### PR TITLE
feat(dx): path-aware pre-commit/pre-push hooks — skip docs/lessons-only (#720)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,36 @@
+#!/usr/bin/env sh
+# Path-aware pre-commit gate (#720).
+#
+# Mirrors the CI/Deploy `paths-ignore` set from #704 (**/*.md, tasks/**,
+# docs/**, .gitignore, LICENSE): when EVERY staged file is non-code, skip the
+# expensive typecheck + lint. This is NOT a --no-verify bypass — the hook is
+# correctly determining there is nothing code-relevant to verify, exactly as
+# CI already skips the same changes. CI remains the gate of record.
+#
+# ALL-not-ANY: a mixed code+docs commit runs the full gate. The classifier is
+# scripts/lib/changedFilesGate.ts (unit-tested), invoked via the CLI bridge so
+# there is no parallel bash reimplementation to drift.
+#
+# POSIX sh only: husky runs this with `sh -e`, so no bashisms ([[ ]], $'\n',
+# pipefail). Pipeline exit status is the last command's (the classifier's),
+# which is exactly the signal we branch on.
+set -eu
+
+# Always format staged files (prettier on markdown, etc.).
 npx lint-staged
+
+staged=$(git diff --cached --name-only)
+
+if [ -n "$staged" ] &&
+  printf '%s\n' "$staged" | npx tsx scripts/changed-files-gate.ts is-docs-only; then
+  echo "pre-commit: docs/lessons-only commit — skipping typecheck + lint (CI is the gate of record)."
+  # Still lint YAML if a docs/ YAML file changed (lint:yaml covers .github/ + docs/).
+  if printf '%s\n' "$staged" | npx tsx scripts/changed-files-gate.ts needs-yaml-lint; then
+    npm run lint:yaml
+  fi
+  exit 0
+fi
+
 npm run typecheck
 npm run lint
 npm run lint:yaml

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
-# Pre-push gate restored 2026-05-23 (#482).
+#!/usr/bin/env sh
+# Pre-push gate restored 2026-05-23 (#482); made path-aware 2026-05-25 (#720).
 #
 # Runs the fast `unit` vitest project only. The full suite was removed in
 # May (exit 0) because the page-mount / journey / axe tests saturated worker
@@ -8,7 +9,62 @@
 # #482 split vitest into first-class `unit` and `integration` projects. The
 # `unit` project runs well under the 30s pre-push budget (~18-20s on a 10-core
 # Mac) with zero variance across 10 runs — fast and reliable enough to gate
-# every push. The heavy `integration` project still
-# runs in CI (which runs both projects with --coverage), so nothing is lost
-# as the gate of record; this is purely a fast inner-loop signal.
-npm run test:unit --workspace=frontend
+# every push. The heavy `integration` project still runs in CI (which runs both
+# projects with --coverage), so nothing is lost as the gate of record; this is
+# purely a fast inner-loop signal.
+#
+# Path-aware (#720): mirrors the CI/Deploy `paths-ignore` set from #704
+# (**/*.md, tasks/**, docs/**, .gitignore, LICENSE). When EVERY file in the
+# push range is non-code, skip `test:unit`. This is NOT a --no-verify bypass —
+# there is genuinely nothing code-relevant to test, exactly as CI now skips the
+# same pushes. CI remains the gate of record. ALL-not-ANY: a mixed code+docs
+# push runs the gate. Ambiguous ranges (new branch / no remote ref / deletion /
+# empty stdin) default to RUNNING the gate, never to skipping.
+#
+# POSIX sh only: husky runs this with `sh -e`, so no bashisms ([[ ]], +=,
+# pipefail). The classifier is scripts/lib/changedFilesGate.ts (unit-tested),
+# invoked via the CLI bridge so there is no parallel bash reimplementation.
+set -eu
+
+ZERO='0000000000000000000000000000000000000000'
+
+run_gate() {
+  exec npm run test:unit --workspace=frontend
+}
+
+# git feeds pre-push one line per ref on stdin:
+#   <local ref> <local sha> <remote ref> <remote sha>
+changed=''
+saw_ref=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -z "$local_ref" ] && continue
+  saw_ref=1
+
+  # Deletion of a remote ref (local sha all-zeros): nothing to push for it.
+  [ "$local_sha" = "$ZERO" ] && continue
+
+  # New branch on the remote (remote sha all-zeros): no base to diff against →
+  # ambiguous, fall back to running the gate.
+  [ "$remote_sha" = "$ZERO" ] && run_gate
+
+  # Files changed in the range being pushed. If the diff can't be computed
+  # (e.g. remote sha not present locally), fall back to running the gate.
+  if ! files=$(git diff --name-only "$remote_sha" "$local_sha" 2>/dev/null); then
+    run_gate
+  fi
+  changed="$changed$files
+"
+done
+
+# No refs on stdin, or every ref was a deletion → nothing to test, but default
+# to running the gate (safe default; the no-op test run is cheap).
+if [ "$saw_ref" -eq 0 ] || [ -z "$(printf '%s' "$changed" | tr -d '[:space:]')" ]; then
+  run_gate
+fi
+
+if printf '%s' "$changed" | npx tsx scripts/changed-files-gate.ts is-docs-only; then
+  echo "pre-push: docs/lessons-only push — skipping test:unit (CI is the gate of record)."
+  exit 0
+fi
+
+run_gate

--- a/scripts/changed-files-gate.ts
+++ b/scripts/changed-files-gate.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env tsx
+/**
+ * CLI bridge for the path-aware husky hooks (#720).
+ *
+ * Reads a newline-separated list of repo-relative changed-file paths from
+ * stdin and answers one yes/no question via exit code, so the bash hooks stay
+ * thin and the classification has a single tested source of truth
+ * (scripts/lib/changedFilesGate.ts) rather than a parallel bash reimplementation.
+ *
+ *   is-docs-only    exit 0 if every changed file is non-code (safe to skip the
+ *                   local gate), else exit 1.
+ *   needs-yaml-lint exit 0 if any changed file is YAML under .github/ or docs/
+ *                   (lint:yaml covers it), else exit 1.
+ *
+ * Empty / ambiguous input → exit 1 for both (default to running the gate).
+ */
+
+import { isDocsOnly, needsYamlLint } from './lib/changedFilesGate.js'
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer)
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+async function main(): Promise<void> {
+  const mode = process.argv[2]
+  if (mode !== 'is-docs-only' && mode !== 'needs-yaml-lint') {
+    console.error(
+      `usage: changed-files-gate.ts <is-docs-only|needs-yaml-lint>  (paths on stdin)`
+    )
+    process.exit(2)
+  }
+
+  const files = (await readStdin())
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0)
+
+  const answer =
+    mode === 'is-docs-only' ? isDocsOnly(files) : needsYamlLint(files)
+  process.exit(answer ? 0 : 1)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(2)
+})

--- a/scripts/lib/__tests__/changedFilesGate.test.ts
+++ b/scripts/lib/__tests__/changedFilesGate.test.ts
@@ -1,0 +1,85 @@
+// Unit tests for scripts/lib/changedFilesGate.ts
+//
+// The husky pre-commit / pre-push hooks use this pure classifier to decide
+// whether a set of changed files is "docs/lessons-only" — in which case the
+// expensive typecheck/lint/test gate can be skipped (CI remains the gate of
+// record). The classifier mirrors the CI/Deploy `paths-ignore` glob set from
+// #704: `**/*.md`, `tasks/**`, `docs/**`, `.gitignore`, `LICENSE`.
+//
+// RED phase (#720): these tests are written before the implementation exists.
+
+import { describe, it, expect } from 'vitest'
+import { isNonCodeFile, isDocsOnly, needsYamlLint } from '../changedFilesGate'
+
+describe('isNonCodeFile', () => {
+  it('treats any .md file as non-code (mirrors **/*.md)', () => {
+    expect(isNonCodeFile('README.md')).toBe(true)
+    expect(isNonCodeFile('tasks/lessons/106-foo.md')).toBe(true)
+    expect(isNonCodeFile('frontend/src/components/Card.md')).toBe(true)
+  })
+
+  it('treats tasks/** and docs/** as non-code', () => {
+    expect(isNonCodeFile('tasks/rules.md')).toBe(true)
+    expect(isNonCodeFile('tasks/lessons/INDEX.md')).toBe(true)
+    expect(isNonCodeFile('docs/ci-cd-flow.md')).toBe(true)
+    expect(isNonCodeFile('docs/strategy/decisions/0004.md')).toBe(true)
+  })
+
+  it('treats the .gitignore and LICENSE literals as non-code', () => {
+    expect(isNonCodeFile('.gitignore')).toBe(true)
+    expect(isNonCodeFile('LICENSE')).toBe(true)
+  })
+
+  it('treats source / config / workflow files as code', () => {
+    expect(isNonCodeFile('frontend/src/App.tsx')).toBe(false)
+    expect(isNonCodeFile('packages/analytics-core/src/index.ts')).toBe(false)
+    expect(isNonCodeFile('package.json')).toBe(false)
+    expect(isNonCodeFile('.husky/pre-push')).toBe(false)
+    // .github/ is NOT in the paths-ignore set → code
+    expect(isNonCodeFile('.github/workflows/ci.yml')).toBe(false)
+    // a nested .gitignore is not the root literal → code
+    expect(isNonCodeFile('frontend/.gitignore')).toBe(false)
+    // a docs-named file outside docs/ is code unless it ends in .md
+    expect(isNonCodeFile('docsHelper.ts')).toBe(false)
+  })
+})
+
+describe('isDocsOnly (ALL-not-ANY, mirrors paths-ignore)', () => {
+  it('is true when every changed file is non-code', () => {
+    expect(
+      isDocsOnly([
+        'tasks/lessons/107-foo.md',
+        'docs/ci-cd-flow.md',
+        'README.md',
+      ])
+    ).toBe(true)
+  })
+
+  it('is false when any changed file is code (mixed change runs the gate)', () => {
+    expect(
+      isDocsOnly(['tasks/lessons/107-foo.md', 'frontend/src/App.tsx'])
+    ).toBe(false)
+  })
+
+  it('is false for an empty set (ambiguous → run the gate)', () => {
+    expect(isDocsOnly([])).toBe(false)
+  })
+})
+
+describe('needsYamlLint', () => {
+  it('is true when a docs/ yaml file changed', () => {
+    expect(needsYamlLint(['docs/some-config.yml'])).toBe(true)
+    expect(needsYamlLint(['docs/nested/thing.yaml'])).toBe(true)
+  })
+
+  it('is true when a .github/ yaml file changed', () => {
+    expect(needsYamlLint(['.github/workflows/ci.yml'])).toBe(true)
+  })
+
+  it('is false when no .github/ or docs/ yaml changed', () => {
+    expect(needsYamlLint(['tasks/lessons/107-foo.md'])).toBe(false)
+    expect(needsYamlLint(['frontend/src/config.yml'])).toBe(false)
+    expect(needsYamlLint(['docs/ci-cd-flow.md'])).toBe(false)
+    expect(needsYamlLint([])).toBe(false)
+  })
+})

--- a/scripts/lib/changedFilesGate.ts
+++ b/scripts/lib/changedFilesGate.ts
@@ -1,0 +1,61 @@
+/**
+ * Changed-files gate — pure classification logic (#720).
+ *
+ * The husky pre-commit / pre-push hooks use this to decide whether a set of
+ * changed files is "docs/lessons-only". When it is, the expensive
+ * typecheck/lint/test gate can be skipped locally — CI remains the gate of
+ * record. This is NOT a `--no-verify` bypass: the hook is correctly
+ * determining there is nothing code-relevant to verify.
+ *
+ * The non-code set mirrors the CI/Deploy `paths-ignore` globs introduced in
+ * #704 (see .github/workflows/ci.yml, deploy.yml):
+ *   - any Markdown file at any depth
+ *   - everything under tasks/
+ *   - everything under docs/
+ *   - the root .gitignore
+ *   - the root LICENSE
+ *
+ * All functions are pure (no git / fs I/O) so they can be unit-tested.
+ */
+
+/**
+ * True if a single repo-relative path is a "non-code" file per the #704
+ * paths-ignore set. ALL-not-ANY semantics live in {@link isDocsOnly}.
+ */
+export function isNonCodeFile(path: string): boolean {
+  // `**/*.md` — any Markdown file, any depth.
+  if (path.endsWith('.md')) return true
+  // Root literals (a nested `frontend/.gitignore` is NOT the root one).
+  if (path === '.gitignore' || path === 'LICENSE') return true
+  // `tasks/**` and `docs/**` — anything under these trees.
+  if (path.startsWith('tasks/')) return true
+  if (path.startsWith('docs/')) return true
+  return false
+}
+
+/**
+ * True only when EVERY changed file is non-code — the same ALL-not-ANY
+ * semantics as a GitHub `paths-ignore` filter. A mixed code+docs change runs
+ * the full gate.
+ *
+ * An empty set returns false: an ambiguous/empty change defaults to running
+ * the gate (safe default), never to skipping it.
+ */
+export function isDocsOnly(files: string[]): boolean {
+  if (files.length === 0) return false
+  return files.every(isNonCodeFile)
+}
+
+/**
+ * True if any changed file is a YAML file that `npm run lint:yaml` covers.
+ * `lint:yaml` runs `yamllint` over `.github/` and `docs/`, so only YAML under
+ * those trees is relevant. Used by the docs-only pre-commit branch to still
+ * lint a `docs/*.yml` change after skipping typecheck/lint.
+ */
+export function needsYamlLint(files: string[]): boolean {
+  return files.some(
+    f =>
+      (f.startsWith('.github/') || f.startsWith('docs/')) &&
+      (f.endsWith('.yml') || f.endsWith('.yaml'))
+  )
+}


### PR DESCRIPTION
Part of epic #709 (Sprint 4). Addresses #720.

## What

Makes the local husky hooks **path-aware**, mirroring the CI/Deploy `paths-ignore` globs from #704 (`**/*.md`, `tasks/**`, `docs/**`, `.gitignore`, `LICENSE`). Since #704, CI already skips docs/lessons-only PRs — so a docs-only change was doing *more* work locally than in CI. The sprint runner writes a lesson file most sprints, so docs-touching commits/pushes are frequent.

- **pre-commit:** when every staged file is non-code, skip `typecheck` + `lint`. `lint-staged` still runs (markdown gets prettier'd); `lint:yaml` still runs if a `docs/` (or `.github/`) YAML file changed.
- **pre-push:** reads the push range from stdin; when every changed file in the range is non-code, skip `test:unit`.

## Design

Single tested source of truth — no parallel bash glob reimplementation to drift:

- `scripts/lib/changedFilesGate.ts` — pure classifier (`isNonCodeFile` / `isDocsOnly` / `needsYamlLint`), unit-tested (10 cases).
- `scripts/changed-files-gate.ts` — thin CLI bridge (reads paths on stdin, answers via exit code), matching the `relevant-lessons.sh` → `relevantLessons.ts` precedent.
- Hooks are **POSIX sh** (husky invokes them with `sh -e`, so no bashisms / `pipefail`).

## Hard constraints honored

- **ALL-not-ANY:** skip only when *every* changed/staged file is non-code. A mixed code+docs change runs the full gate.
- **Not a `--no-verify` bypass:** the hook is correctly determining there is nothing code-relevant to verify; CI remains the gate of record. Documented in a comment in each hook.
- **Ambiguous push ranges** (new branch / no remote ref / deletion / empty stdin) default to **running** the gate, never skipping.

## Acceptance criteria

- [x] Docs/lessons-only commit skips typecheck/lint (still formats md); docs/lessons-only push skips `test:unit`.
- [x] A commit/push touching any code runs the full gate (mixed included).
- [x] Ambiguous push range (new branch, no upstream) defaults to running the gate.
- [x] No `--no-verify` involved in the design; behavior documented in a comment in each hook.

## Evidence

Behavioral tests run against `sh -e` (mimicking husky) with a stubbed `npm` to observe the gate decision:

| Hook | Scenario | Result |
|---|---|---|
| pre-push | docs-only range (`tasks/**` only) | **skips** test:unit ✓ |
| pre-push | code range (`scripts/**`) | runs gate ✓ |
| pre-push | new branch (remote sha all-zeros) | runs gate ✓ |
| pre-push | empty stdin | runs gate ✓ |
| pre-push | deletion (local sha all-zeros) | runs gate ✓ |
| pre-commit | docs-only staged | skips typecheck+lint, no yaml ✓ |
| pre-commit | `docs/*.yml` staged | skips typecheck+lint, **runs** lint:yaml ✓ |
| pre-commit | code staged | runs typecheck+lint+yaml ✓ |

Suites: `test:scripts` 96/96, frontend `test:unit` 2017/2017. The pre-push gate itself ran on this very push (dogfood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
