### PR TITLE
feat(clubs-table): re-skin table chrome to redesign tokens (epic #665, Sprint 2)

### DIFF
--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -174,7 +174,9 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
       case 'vulnerable':
         return 'bg-yellow-50 hover:bg-yellow-100'
       default:
-        return 'bg-white hover:bg-gray-50'
+        // Default (non-status) row — token-driven surface + hover (#668).
+        // Status rows above keep their semantic red/yellow bg (Sprint 3 #669).
+        return 'clubs-table-row'
     }
   }
 
@@ -319,11 +321,9 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   return (
     <div className="redesign-panel">
       {/* Header with Export and Results Count */}
-      <div className="p-6 border-b border-gray-200">
+      <div className="p-6 clubs-panel-header">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-xl font-bold text-gray-900 font-tm-headline">
-            All Clubs
-          </h3>
+          <h3 className="text-xl font-bold clubs-panel-title">All Clubs</h3>
           <ExportButton
             onExport={() =>
               exportClubPerformance(
@@ -350,7 +350,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
         </div>
 
         {/* Results Count and Quick Filters */}
-        <div className="flex flex-wrap items-center gap-4 text-sm text-gray-600">
+        <div className="flex flex-wrap items-center gap-4 text-sm clubs-text-muted">
           <div>
             {sortedClubs.length === clubs.length ? (
               <>Total: {clubs.length} clubs</>
@@ -652,7 +652,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
       {!isLoading && sortedClubs.length === 0 && clubs.length > 0 && (
         <div className="p-12 text-center">
           <svg
-            className="w-16 h-16 text-gray-400 mx-auto mb-4"
+            className="w-16 h-16 clubs-text-muted mx-auto mb-4"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -664,10 +664,10 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
               d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
             />
           </svg>
-          <p className="text-gray-600 font-medium">
+          <p className="clubs-text-muted font-medium">
             No clubs match your filters
           </p>
-          <p className="text-gray-500 text-sm mt-1">
+          <p className="clubs-text-muted text-sm mt-1">
             Try adjusting your column filters
           </p>
         </div>
@@ -680,7 +680,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
           <div className="flex items-center gap-2 mb-3">
             <label
               htmlFor="mobile-sort"
-              className="text-xs text-gray-500 font-medium"
+              className="text-xs clubs-text-muted font-medium"
             >
               Sort by:
             </label>
@@ -696,7 +696,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                   setSortDirection('asc')
                 }
               }}
-              className="text-xs border border-gray-300 rounded-md px-2 py-1 text-gray-700 bg-white"
+              className="text-xs clubs-mobile-select rounded-md px-2 py-1"
               aria-label="Sort clubs"
             >
               {COLUMN_CONFIGS.filter(c => c.sortable).map(config => (
@@ -710,7 +710,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
               onClick={() =>
                 setSortDirection(d => (d === 'asc' ? 'desc' : 'asc'))
               }
-              className="text-xs text-gray-500 hover:text-gray-700 px-1"
+              className="text-xs clubs-sort-dir px-1"
               aria-label={`Sort direction: ${sortDirection === 'asc' ? 'ascending' : 'descending'}`}
             >
               {sortDirection === 'asc' ? '↑' : '↓'}
@@ -740,8 +740,8 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
           aria-label="All clubs table"
           tabIndex={0}
         >
-          <table className="w-full table-auto">
-            <thead className="clubs-table-sticky-head bg-gray-50 border-b border-gray-200">
+          <table id="clubs-table" className="w-full table-auto">
+            <thead className="clubs-table-sticky-head">
               <tr>
                 {COLUMN_CONFIGS.map(config => (
                   <th key={config.field} className="p-0">
@@ -766,7 +766,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                 ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200">
+            <tbody>
               {sortedClubs.map(club => (
                 <tr
                   key={club.clubId}
@@ -774,29 +774,27 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                   className={`${getRowColor(club.currentStatus)} cursor-pointer transition-colors`}
                 >
                   <td className="px-2 py-3 whitespace-nowrap">
-                    <div className="font-medium text-gray-900 text-sm">
-                      {club.clubName}
-                    </div>
+                    <div className="font-medium text-sm">{club.clubName}</div>
                   </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm text-gray-600 text-center">
+                  <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center">
                     {club.divisionName}
                   </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm text-gray-600 text-center">
+                  <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center">
                     {club.areaName}
                   </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center text-gray-900">
+                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
                     {club.latestMembership}
                   </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center text-gray-900">
+                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
                     {club.latestDcpGoals}
                   </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center text-gray-900 font-medium">
+                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center font-medium">
                     {club.membersNeeded > 0 ? (
                       <span className="text-tm-true-maroon">
                         {club.membersNeeded}
                       </span>
                     ) : (
-                      <span className="text-gray-400">—</span>
+                      <span className="clubs-cell-muted">—</span>
                     )}
                   </td>
                   <td className="px-2 py-3 whitespace-nowrap text-center">
@@ -814,7 +812,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                         {isProvisionallyDistinguished(club) ? '*' : ''}
                       </span>
                     ) : (
-                      <span className="text-sm text-gray-400">—</span>
+                      <span className="text-sm clubs-cell-muted">—</span>
                     )}
                   </td>
                   <td className="px-2 py-3 whitespace-nowrap text-center">
@@ -826,9 +824,9 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                   </td>
                   <td className="px-2 py-3 whitespace-nowrap text-sm text-center">
                     {club.clubStatus ? (
-                      <span className="text-gray-900">{club.clubStatus}</span>
+                      <span>{club.clubStatus}</span>
                     ) : (
-                      <span className="text-gray-400">—</span>
+                      <span className="clubs-cell-muted">—</span>
                     )}
                   </td>
                   <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
@@ -836,14 +834,14 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                       <span
                         className={
                           club.octoberRenewals === 0
-                            ? 'text-gray-500'
-                            : 'text-gray-900'
+                            ? 'clubs-cell-muted'
+                            : undefined
                         }
                       >
                         {club.octoberRenewals}
                       </span>
                     ) : (
-                      <span className="text-gray-500">—</span>
+                      <span className="clubs-cell-muted">—</span>
                     )}
                   </td>
                   <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
@@ -851,38 +849,34 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                       <span
                         className={
                           club.aprilRenewals === 0
-                            ? 'text-gray-500'
-                            : 'text-gray-900'
+                            ? 'clubs-cell-muted'
+                            : undefined
                         }
                       >
                         {club.aprilRenewals}
                       </span>
                     ) : (
-                      <span className="text-gray-500">—</span>
+                      <span className="clubs-cell-muted">—</span>
                     )}
                   </td>
                   <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
                     {club.newMembers !== undefined ? (
                       <span
                         className={
-                          club.newMembers === 0
-                            ? 'text-gray-500'
-                            : 'text-gray-900'
+                          club.newMembers === 0 ? 'clubs-cell-muted' : undefined
                         }
                       >
                         {club.newMembers}
                       </span>
                     ) : (
-                      <span className="text-gray-500">—</span>
+                      <span className="clubs-cell-muted">—</span>
                     )}
                   </td>
                   <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
                     {club.yearsChartered !== null ? (
-                      <span className="text-gray-900">
-                        {club.yearsChartered}
-                      </span>
+                      <span>{club.yearsChartered}</span>
                     ) : (
-                      <span className="text-gray-500">—</span>
+                      <span className="clubs-cell-muted">—</span>
                     )}
                   </td>
                 </tr>

--- a/frontend/src/components/ColumnHeader.tsx
+++ b/frontend/src/components/ColumnHeader.tsx
@@ -267,7 +267,7 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
         ref={buttonRef}
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
         onKeyDown={handleKeyDown}
-        className="group flex items-center gap-1 px-2 py-2 text-left text-[9px] font-medium text-gray-700 uppercase tracking-wider hover:bg-gray-100 hover:text-gray-900 hover:shadow-xs focus:bg-gray-100 focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue focus:ring-inset transition-all duration-200 w-full cursor-pointer"
+        className="clubs-col-header group flex items-center gap-1 px-2 py-2 text-left text-[9px] font-medium uppercase tracking-wider hover:shadow-xs focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue focus:ring-inset transition-all duration-200 w-full cursor-pointer"
         tabIndex={0}
         aria-expanded={isDropdownOpen}
         aria-haspopup="true"
@@ -276,7 +276,7 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
         <span className="flex-1">{label}</span>
         {(sortable || filterable) && (
           <svg
-            className={`w-2.5 h-2.5 transition-all duration-200 ${isDropdownOpen ? 'rotate-180' : ''} ${hasActiveState() ? 'text-tm-loyal-blue' : 'text-gray-400 group-hover:text-gray-700'}`}
+            className={`w-2.5 h-2.5 transition-all duration-200 ${isDropdownOpen ? 'rotate-180' : ''} ${hasActiveState() ? 'text-tm-loyal-blue' : 'clubs-col-header__arrow'}`}
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"

--- a/frontend/src/components/ColumnHeader.tsx
+++ b/frontend/src/components/ColumnHeader.tsx
@@ -292,7 +292,11 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
         )}
       </button>
 
-      {/* Dropdown/Popover */}
+      {/* Dropdown/Popover — the filter control surface. Its legacy gray
+          chrome is intentionally deferred to the controls re-skin (Sprint 4
+          #670); the resting header chrome (button + caret above) is the
+          #668 scope. The clubs-table re-skin guard only renders the resting
+          state, so these closed-popover gray classes are out of its frame. */}
       {isDropdownOpen && (sortable || filterable) && (
         <div className="absolute top-full left-0 z-50 mt-1 w-80 bg-white border border-gray-200 rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-200">
           <div className="p-4 space-y-4">

--- a/frontend/src/components/__tests__/ClubsTable.reskin.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.reskin.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Re-skin guard for ClubsTable chrome (#668, epic #665 Sprint 2).
+ *
+ * Acceptance criterion #1: "Zero legacy `*-gray-*` classes left on the table."
+ * The clubs-table chrome (panel header, table header, rows, mobile sort
+ * controls, empty states) must be driven by redesign tokens
+ * (`--surface`/`--surface-2`/`--surface-3`/`--line`/`--ink`/`--ink-3`) via the
+ * CSS layer, not by legacy gray Tailwind utilities that rely on the
+ * dark-mode.css override layer (R10, lessons 093/096).
+ *
+ * This is a falsifiable DOM check: it renders the real component (desktop AND
+ * mobile branches) and fails if any rendered element carries a `*-gray-N`
+ * class. JSDOM can't compute contrast (lesson 075), but it CAN prove which
+ * classes ship — which is exactly what this criterion is about.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { ClubsTable } from '../ClubsTable'
+import { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+const createMockClub = (overrides: Partial<ClubTrend> = {}): ClubTrend => ({
+  clubId: 'club-1',
+  clubName: 'Test Club',
+  divisionId: 'div-1',
+  divisionName: 'Division A',
+  areaId: 'area-1',
+  areaName: 'Area 1',
+  distinguishedLevel: 'NotDistinguished',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: new Date().toISOString(), count: 20 }],
+  dcpGoalsTrend: [{ date: new Date().toISOString(), goalsAchieved: 5 }],
+  ...overrides,
+})
+
+// Fixtures that exercise every cell branch where a legacy gray utility lived:
+// status variety (row backgrounds), a distinguished pill, zero renewals
+// (muted values), and missing clubStatus / yearsChartered (em-dash placeholders).
+const CLUBS: ClubTrend[] = [
+  createMockClub({
+    clubId: 'c1',
+    clubName: 'Alpha',
+    currentStatus: 'thriving',
+    distinguishedLevel: 'Distinguished',
+    octoberRenewals: 12,
+    aprilRenewals: 10,
+    newMembers: 5,
+    clubStatus: 'Active',
+    yearsChartered: 8,
+  }),
+  createMockClub({
+    clubId: 'c2',
+    clubName: 'Beta',
+    currentStatus: 'vulnerable',
+    octoberRenewals: 0,
+    aprilRenewals: 0,
+    newMembers: 0,
+  }),
+  createMockClub({
+    clubId: 'c3',
+    clubName: 'Gamma',
+    currentStatus: 'intervention-required',
+  }),
+]
+
+// Matches Tailwind gray utilities including state-variant prefixes
+// (`hover:bg-gray-100`, `group-hover:text-gray-700`) via the `:` boundary,
+// but NOT brand tokens like `tm-cool-gray-20` (Sprint 3 #669 tier pills) —
+// those have a non-enumerated prefix before `-gray-`.
+const GRAY_CLASS =
+  /(?:^|[\s:])(?:text|bg|border|divide|from|to|ring|fill|stroke)-gray-\d/
+
+// `excludeSelector` skips elements inside a matching subtree. The mobile view
+// embeds <ClubCard>, whose own re-skin is Sprint 5 (#671) — out of scope here,
+// so the mobile assertion excludes the card list (`.space-y-3`) and only covers
+// ClubsTable's own sort-control chrome.
+function grayClassesIn(
+  container: HTMLElement,
+  excludeSelector?: string
+): string[] {
+  const offenders: string[] = []
+  container.querySelectorAll<HTMLElement>('*').forEach(el => {
+    if (excludeSelector && el.closest(excludeSelector)) return
+    const cls = el.getAttribute('class')
+    if (cls && GRAY_CLASS.test(cls)) {
+      offenders.push(cls)
+    }
+  })
+  return offenders
+}
+
+describe('ClubsTable re-skin (#668) — no legacy gray chrome', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the desktop table with zero `*-gray-*` utility classes', () => {
+    const { container } = render(
+      <ClubsTable clubs={CLUBS} districtId="61" isLoading={false} />
+    )
+    expect(grayClassesIn(container)).toEqual([])
+  })
+
+  it('renders the mobile view with zero `*-gray-*` utility classes', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+    )
+    const { container } = render(
+      <ClubsTable clubs={CLUBS} districtId="61" isLoading={false} />
+    )
+    // Exclude the ClubCard list (`.space-y-3`) — its re-skin is Sprint 5 (#671).
+    expect(grayClassesIn(container, '.space-y-3')).toEqual([])
+  })
+})

--- a/frontend/src/components/__tests__/ColumnHeader.test.tsx
+++ b/frontend/src/components/__tests__/ColumnHeader.test.tsx
@@ -219,14 +219,16 @@ describe('ColumnHeader', () => {
       expect(filterIcon).toBeInTheDocument()
     })
 
-    it('displays gray filter icon when no filter is active', () => {
+    it('displays muted filter icon when no filter is active', () => {
       render(<ColumnHeader {...defaultProps} currentFilter={null} />)
 
       const headerButton = screen.getByRole('button')
 
-      // Check for gray filter indicator (inactive state)
+      // Inactive caret uses the token-driven muted class (#668 re-skin —
+      // was text-gray-400; colour now resolves via .clubs-col-header__arrow
+      // in app-shell.css so dark mode remaps for free).
       const filterIcon = headerButton.querySelector(
-        'svg[class*="text-gray-400"]'
+        'svg[class*="clubs-col-header__arrow"]'
       )
       expect(filterIcon).toBeInTheDocument()
     })
@@ -321,9 +323,10 @@ describe('ColumnHeader', () => {
       const headerButton = screen.getByRole('button')
       const buttonClasses = headerButton.className
 
-      // Verify hover classes are present
-      expect(buttonClasses).toMatch(/hover:bg-gray-100/)
-      expect(buttonClasses).toMatch(/hover:text-gray-900/)
+      // Hover bg/text feedback now lives in .clubs-col-header (#668 re-skin —
+      // was hover:bg-gray-100 / hover:text-gray-900; the CSS rule swaps to
+      // --surface-3 / --ink so dark mode remaps for free, R10).
+      expect(buttonClasses).toMatch(/clubs-col-header/)
       expect(buttonClasses).toMatch(/hover:shadow-xs/)
 
       // Verify cursor-pointer for interactivity
@@ -344,13 +347,15 @@ describe('ColumnHeader', () => {
 
       expect(icons.length).toBeGreaterThan(0)
 
-      // At least one icon should have group-hover classes
+      // At least one icon carries the re-skinned caret class (#668 — its
+      // group-hover colour shift now lives in .clubs-col-header__arrow CSS;
+      // was group-hover:text-gray-700) or the inline transition.
       const hasHoverIcon = Array.from(icons).some(icon => {
         const iconClasses =
           icon.className.baseVal || icon.getAttribute('class') || ''
         return (
-          iconClasses.includes('group-hover:text-gray-700') ||
-          iconClasses.includes('transition-colors')
+          iconClasses.includes('clubs-col-header__arrow') ||
+          iconClasses.includes('transition-all')
         )
       })
       expect(hasHoverIcon).toBe(true)

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -2526,7 +2526,6 @@
      under border-collapse) with an opaque themed background so scrolling
      rows don't bleed through (lesson 092 — the bg must be a token, not a
      literal, or dark mode shows a light cell). --surface-2 per the scope. */
-  #clubs-table thead th,
   .clubs-table-sticky-head th {
     position: sticky;
     top: 0;

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -2489,23 +2489,116 @@
      removed; the full sorted+filtered set renders in one capped-height
      container so the header stays in view while the body scrolls. The
      container is keyboard-operable (role/tabindex/aria-label on the element)
-     per WCAG 2.1.1. Re-skin to redesign tokens lands in Sprint 2 (#668);
-     the legacy gray header chrome stays for now. */
+     per WCAG 2.1.1. */
   .clubs-table-scroll {
     max-height: 70vh;
     overflow-y: auto;
   }
 
+  /* ── Clubs table chrome re-skin (#668, epic #665 Sprint 2) ──
+     Replaces the legacy gray Tailwind utilities (text-gray-*, bg-gray-50,
+     border-gray-200, divide-gray-200, font-tm-headline) with redesign tokens.
+     Token-driven, so dark mode "just works" via the [data-theme='dark']
+     remaps in redesign.css — no component-level branches (R10, lessons
+     093/096). Status-colored rows + tier/status pills stay on their own
+     classes (Sprint 3 #669); the column-filter popover stays gray until the
+     controls re-skin (Sprint 4 #670). */
+
+  /* Panel header — title + results/filters band. The divider is the legacy
+     border-gray-200; → --line. The "All Clubs" title is Montserrat per
+     HANDOFF §215. */
+  .clubs-panel-header {
+    border-bottom: 1px solid var(--line);
+  }
+
+  .clubs-panel-title {
+    color: var(--ink);
+    font-family: var(--serif);
+  }
+
+  /* Muted text outside the table grid (results count, empty-state copy,
+     mobile sort label) — was text-gray-{400,500,600}. */
+  .clubs-text-muted {
+    color: var(--ink-3);
+  }
+
   /* Sticky header: pin the th cells (more robust than a sticky <thead>
-     under border-collapse) with an opaque background so scrolling rows
-     don't bleed through. bg-gray-50 (#f9fafb) is the current legacy
-     surface — Sprint 2 swaps it for a themed token; keeping a literal
-     here is deliberate until then so the header isn't transparent. */
+     under border-collapse) with an opaque themed background so scrolling
+     rows don't bleed through (lesson 092 — the bg must be a token, not a
+     literal, or dark mode shows a light cell). --surface-2 per the scope. */
+  #clubs-table thead th,
   .clubs-table-sticky-head th {
     position: sticky;
     top: 0;
     z-index: 1;
-    background-color: #f9fafb;
+    background-color: var(--surface-2);
+    border-bottom: 1px solid var(--line);
+  }
+
+  /* Column-header sort handle (ColumnHeader.tsx) resting chrome — was
+     text-gray-700 + hover:bg-gray-100 / hover:text-gray-900. */
+  .clubs-col-header {
+    color: var(--ink-3);
+  }
+
+  .clubs-col-header:hover,
+  .clubs-col-header:focus {
+    background-color: var(--surface-3);
+    color: var(--ink);
+  }
+
+  /* Sort-direction caret — was text-gray-400 group-hover:text-gray-700.
+     (The active-state accent stays --tm-loyal-blue in the component.) */
+  .clubs-col-header__arrow {
+    color: var(--ink-4);
+  }
+
+  .clubs-col-header:hover .clubs-col-header__arrow {
+    color: var(--ink-3);
+  }
+
+  /* Row rules replace divide-y divide-gray-200. Applies to every row
+     (default + status-colored) so the hairline is consistent. */
+  #clubs-table tbody tr {
+    border-bottom: 1px solid var(--line);
+  }
+
+  /* Default (non-status) row — was bg-white hover:bg-gray-50. Status rows
+     keep their own red/yellow bg classes (Sprint 3). Hover → --surface-3
+     per HANDOFF §122 ("table rows have a hover background swap"). */
+  .clubs-table-row {
+    background-color: var(--surface);
+  }
+
+  .clubs-table-row:hover {
+    background-color: var(--surface-3);
+  }
+
+  /* Primary cell text — was text-gray-900. */
+  #clubs-table td {
+    color: var(--ink);
+  }
+
+  /* De-emphasised cell text: division/area labels, zero values, and the "—"
+     placeholders — were text-gray-{400,500,600}. */
+  .clubs-cell-muted {
+    color: var(--ink-3);
+  }
+
+  /* Mobile sort controls (the dropdown + direction toggle above the card
+     list) — were border-gray-300 / text-gray-700 / bg-white / text-gray-500. */
+  .clubs-mobile-select {
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    color: var(--ink);
+  }
+
+  .clubs-sort-dir {
+    color: var(--ink-3);
+  }
+
+  .clubs-sort-dir:hover {
+    color: var(--ink);
   }
 
   /* History page year strip (#367) — chip row of archived years. */


### PR DESCRIPTION
Part of epic #665 (Clubs page redesign), Sprint 2 — #668.

## What
Re-skins the clubs-table **chrome** from legacy gray Tailwind to the redesign design tokens. No behavior change — same structure, same data, same interactions; only the color/typography layer moves to tokens that remap in dark mode at the CSS level (R10).

| Surface | Was | Now |
|---|---|---|
| Panel header divider | `border-gray-200` | `--line` |
| "All Clubs" title | `text-gray-900 font-tm-headline` | `--ink` + Montserrat (`--serif`, HANDOFF §215) |
| Table header (thead th) | `bg-gray-50 border-gray-200` | `--surface-2` + `--line` |
| Column-header sort handle | `text-gray-700 hover:bg-gray-100` | `.clubs-col-header` → `--ink-3`, hover `--surface-3`/`--ink` |
| Row dividers | `divide-gray-200` | `#clubs-table tbody tr` → `--line` |
| Default row + hover | `bg-white hover:bg-gray-50` | `.clubs-table-row` → `--surface`, hover `--surface-3` (HANDOFF §122) |
| Cell text / muted | `text-gray-900` / `text-gray-{400,500,600}` | `--ink` / `--ink-3` |
| Mobile sort controls | `border-gray-300 text-gray-700 bg-white` | tokenized `.clubs-mobile-select` / `.clubs-sort-dir` |

Styling moved into the `#clubs-table` CSS block in `app-shell.css`; the sticky-header literal `#f9fafb` is now `var(--surface-2)` (lesson 092 — a sticky cell bg must be a theme token).

## Dark mode
Handled entirely by the `[data-theme='dark']` token remaps already in `redesign.css` — no component branches, no OS-keyed `dark:` utilities (lesson 107). Tokens chosen are the semantic remapping ones (`--ink`, `--surface*`, `--line`), not raw palette tokens (lessons 093/096).

## Out of scope (deferred, by epic plan)
- Status/tier pills + red/yellow status-row backgrounds → Sprint 3 (#669)
- Column-filter **popover** internals → Sprint 4 (#670)
- ClubCard (mobile cards) → Sprint 5 (#671)

## Tests
- **RED→GREEN guard** `ClubsTable.reskin.test.tsx`: renders the real component (desktop + mobile) and asserts **zero `*-gray-*` classes** — encodes acceptance criterion #1, falsifiable in JSDOM.
- 3 `ColumnHeader` tests rewritten from gray-class assertions to the new token classes — a deliberate spec change (gray→token, identical visual behavior), not assertion pinning (R1).
- Full frontend suite green: **2539 passed**.
- Fresh-context review: APPROVE-WITH-NITS, no High/Medium findings.

Acceptance criteria #2 (light+dark match tokens) and #3 (responsive screenshots vs handoff) are verified on the PR preview channel — evidence to follow as a comment.
