### PR TITLE
feat(clubs-table): re-skin controls row — search, segmented filter, quick chips (epic #665 Sprint 4)

### DIFF
--- a/frontend/src/__tests__/accessibility/ClubsControlsDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/ClubsControlsDarkModeContrast.test.ts
@@ -236,4 +236,19 @@ describe('Clubs controls dark-mode contrast (#670)', () => {
     const bg = resolveVar('var(--loyal-500)', 'dark')
     expect(calculateContrastRatio('#ffffff', bg)).toBeGreaterThanOrEqual(AA)
   })
+
+  // Validation error band text on --surface-2, both themes (review #670):
+  // --red-600 was 4.42:1 in dark; --red-500 remaps lighter and clears AA.
+  it('filter error band text clears AA on --surface-2 both themes', () => {
+    const fgToken = ruleProp(appShellCss, '.clubs-filter-error', 'color')
+    for (const theme of ['light', 'dark'] as const) {
+      const fg = resolveVar(fgToken, theme)
+      const bg = resolveVar('var(--surface-2)', theme)
+      const ratio = calculateContrastRatio(fg, bg)
+      expect(
+        ratio,
+        `error ${fg} on --surface-2 ${bg} (${theme}) = ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(AA)
+    }
+  })
 })

--- a/frontend/src/__tests__/accessibility/ClubsControlsDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/ClubsControlsDarkModeContrast.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Clubs-table controls-row dark-mode contrast audit (#670, epic #665 Sprint 4).
+ *
+ * The controls row (segmented status filter, quick-filter chips, and the
+ * column-filter popover) was authored on redesign tokens back in #361/#470 but
+ * was never part of the Track-D dark sweep (#574 covered Awards/Region/Club/
+ * Methodology/History/Landing, not the clubs table). Sprint 4 re-skins the
+ * active/hover states to the handoff pattern — `--loyal-500` text on `--loyal-50`,
+ * hover `--surface-3` — which is exactly the navy-on-navy trap lessons 093/096
+ * warn about: `--loyal-500` (#004165) has NO dark remap, so used as foreground
+ * on the dark `--loyal-50` pill (#112432) it lands at ~1.5:1.
+ *
+ * The fix (R10, lesson 093): use the semantic `--link` token for text — it
+ * equals `--loyal-500` in light (zero light-mode change) but remaps to a
+ * dark-safe `#60a5d8`. The maroon "Clear" chip (`--maroon-500`, also no remap)
+ * gets a scoped `[data-theme='dark']` override (lesson 096, value #e8879a).
+ *
+ * Like the Awards/Region/Club audits this reads the *real* CSS (jest-axe can't
+ * compute contrast in jsdom — no layout) and resolves each foreground through
+ * the `[data-theme='dark']` cascade. It is falsifiable: before the fix the
+ * segmented-active and chip-clear assertions fail (raw `--loyal-500`/`--maroon-500`
+ * on dark). Lives in `__tests__/accessibility/` → integration project (lesson 090).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { calculateContrastRatio } from '../../utils/contrastCalculator'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const stylesDir = resolve(here, '../../styles')
+
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '')
+const read = (p: string) =>
+  stripComments(readFileSync(resolve(stylesDir, p), 'utf8'))
+
+const redesignCss = read('tokens/redesign.css')
+const darkModeCss = read('dark-mode.css')
+const appShellCss = read('components/app-shell.css')
+
+/** Parse `--name: value;` declarations from the first rule whose selector
+ *  matches `selectorLiteral` exactly. Anchored to a real rule start so a
+ *  comment mentioning the selector can't poison the match (lesson 093). */
+function parseTokenBlock(css: string, selectorLiteral: string) {
+  const re = new RegExp(
+    '(?:^|\\n)\\s*' +
+      selectorLiteral.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\s*\\{'
+  )
+  const m = re.exec(css)
+  if (!m) return new Map<string, string>()
+  const open = css.indexOf('{', m.index)
+  const close = css.indexOf('}', open)
+  const map = new Map<string, string>()
+  for (const d of css
+    .slice(open + 1, close)
+    .matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g))
+    map.set(d[1].trim(), d[2].trim())
+  return map
+}
+
+const lightTokens = parseTokenBlock(redesignCss, ':root')
+const darkTokens = new Map([
+  ...parseTokenBlock(redesignCss, "[data-theme='dark']"),
+  ...parseTokenBlock(darkModeCss, "[data-theme='dark']"),
+])
+
+/** Resolve a `var(--x)` chain to a literal hex, in the requested theme. */
+function resolveVar(value: string, theme: 'light' | 'dark', depth = 0): string {
+  if (depth > 8) throw new Error(`var() too deep: ${value}`)
+  const v = value.trim()
+  const m = v.match(/^var\((--[\w-]+)\)$/)
+  if (!m) return v
+  const map = theme === 'dark' ? darkTokens : lightTokens
+  const next =
+    theme === 'dark' ? (map.get(m[1]) ?? lightTokens.get(m[1])) : map.get(m[1])
+  if (!next) throw new Error(`token ${m[1]} undefined in ${theme}`)
+  return resolveVar(next, theme, depth + 1)
+}
+
+/** Value of `prop` from a flat (non-nested) CSS rule whose selector matches
+ *  `selectorLiteral` exactly. Anchored to the rule start so `--active` doesn't
+ *  match `--active .descendant`. Throws if the rule or prop is missing — the
+ *  audit must fail loudly if the surface it guards was renamed away. */
+function ruleProp(css: string, selectorLiteral: string, prop: string): string {
+  const re = new RegExp(
+    '(?:^|\\n)\\s*' +
+      selectorLiteral.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\s*\\{'
+  )
+  const m = re.exec(css)
+  if (!m) throw new Error(`rule ${selectorLiteral} not found`)
+  const open = css.indexOf('{', m.index)
+  const close = css.indexOf('}', open)
+  const body = css.slice(open + 1, close)
+  const pm = body.match(
+    new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;!]+)')
+  )
+  if (!pm) throw new Error(`prop ${prop} not in rule ${selectorLiteral}`)
+  return pm[1].trim()
+}
+
+/** Value of `prop` from the cascade-winning `[data-theme='dark'] <selector>`
+ *  rule in dark-mode.css (last wins, lesson 095). Null if none. */
+function darkOverride(selector: string, prop: string): string | null {
+  const re = new RegExp(
+    "\\[data-theme='dark'\\]\\s*" +
+      selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '(?![\\w-])[^{}]*\\{',
+    'g'
+  )
+  let winner: string | null = null
+  for (const m of darkModeCss.matchAll(re)) {
+    const open = darkModeCss.indexOf('{', m.index)
+    const close = darkModeCss.indexOf('}', open)
+    const pm = darkModeCss
+      .slice(open + 1, close)
+      .match(new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;!]+)'))
+    if (pm) winner = pm[1].trim()
+  }
+  return winner
+}
+
+const AA = 4.5
+
+/**
+ * Each row: a foreground/background pair drawn from the *real* controls CSS,
+ * with the spec-mandated token it must reference. `bg` is either the same rule
+ * (active button bg) or the surface the element sits on. We assert (1) the rule
+ * uses the dark-safe token (spec alignment — fails today for the raw-token
+ * surfaces), and (2) the resolved colour clears AA in dark AND light.
+ */
+interface Surface {
+  name: string
+  /** selector + prop yielding the foreground token */
+  fg: [string, string]
+  /** the foreground token we expect (spec/dark-safety) */
+  expectFgToken: string
+  /** the background: a token literal (resolved both themes) */
+  bgToken: string
+  /** dark-mode override selector/prop for the fg, if it's a raw non-remapping
+   *  token that needs a scoped `[data-theme='dark']` rule instead of `--link`. */
+  darkFg?: [string, string]
+}
+
+const SURFACES: Surface[] = [
+  {
+    name: 'segmented active label',
+    fg: ['.clubs-status-segmented__btn--active', 'color'],
+    expectFgToken: 'var(--link)',
+    bgToken: 'var(--loyal-50)',
+  },
+  {
+    name: 'segmented active count badge',
+    fg: [
+      '.clubs-status-segmented__btn--active .clubs-status-segmented__count',
+      'color',
+    ],
+    expectFgToken: 'var(--link)',
+    bgToken: 'var(--surface)',
+  },
+  {
+    name: 'quick-filter chip active label',
+    fg: ['.clubs-quick-filter-chip--active', 'color'],
+    expectFgToken: 'var(--link)',
+    bgToken: 'var(--loyal-50)',
+  },
+  {
+    name: 'quick-filter chip hover label',
+    fg: ['.clubs-quick-filter-chip:hover', 'color'],
+    expectFgToken: 'var(--link)',
+    bgToken: 'var(--surface-3)',
+  },
+  {
+    name: 'filter popover operator/sort active',
+    fg: ['.clubs-filter-btn--active', 'color'],
+    expectFgToken: 'var(--link)',
+    bgToken: 'var(--loyal-50)',
+  },
+]
+
+describe('Clubs controls dark-mode contrast (#670)', () => {
+  it.each(SURFACES)(
+    '$name uses the dark-safe token and clears AA both themes',
+    ({ fg, expectFgToken, bgToken }) => {
+      const fgToken = ruleProp(appShellCss, fg[0], fg[1])
+      expect(fgToken, `${fg[0]} { ${fg[1]} } should be ${expectFgToken}`).toBe(
+        expectFgToken
+      )
+      for (const theme of ['light', 'dark'] as const) {
+        const fgHex = resolveVar(fgToken, theme)
+        const bgHex = resolveVar(bgToken, theme)
+        const ratio = calculateContrastRatio(fgHex, bgHex)
+        expect(
+          ratio,
+          `${fg[0]} ${fgHex} on ${bgToken} ${bgHex} (${theme}) = ${ratio.toFixed(2)}:1`
+        ).toBeGreaterThanOrEqual(AA)
+      }
+    }
+  )
+
+  // The maroon "Clear" chip keeps `--maroon-500` in light (brand danger colour)
+  // but that token has no dark remap (#7b1828 → ~2:1 on the dark surface), so it
+  // needs a scoped `[data-theme='dark']` override (lesson 096, #e8879a). It sits
+  // on the chip's base `--surface` background.
+  it('quick-filter Clear chip clears AA in both themes (light token + dark override)', () => {
+    const lightFg = resolveVar(
+      ruleProp(appShellCss, '.clubs-quick-filter-chip__clear', 'color'),
+      'light'
+    )
+    const lightBg = resolveVar(
+      ruleProp(appShellCss, '.clubs-quick-filter-chip', 'background-color'),
+      'light'
+    )
+    expect(
+      calculateContrastRatio(lightFg, lightBg),
+      `clear chip light ${lightFg} on ${lightBg}`
+    ).toBeGreaterThanOrEqual(AA)
+
+    const darkFgRaw = darkOverride('.clubs-quick-filter-chip__clear', 'color')
+    expect(
+      darkFgRaw,
+      'clear chip needs a [data-theme="dark"] color override (maroon-500 has no remap)'
+    ).not.toBeNull()
+    const darkFg = resolveVar(darkFgRaw as string, 'dark')
+    const darkBg = resolveVar('var(--surface)', 'dark')
+    expect(
+      calculateContrastRatio(darkFg, darkBg),
+      `clear chip dark ${darkFg} on ${darkBg}`
+    ).toBeGreaterThanOrEqual(AA)
+  })
+
+  // The solid "Apply" button (primary action) is white on the brand navy
+  // --loyal-500, which is fixed in both themes — assert it stays AA.
+  it('filter Apply button (white on --loyal-500) clears AA', () => {
+    const bg = resolveVar('var(--loyal-500)', 'dark')
+    expect(calculateContrastRatio('#ffffff', bg)).toBeGreaterThanOrEqual(AA)
+  })
+})

--- a/frontend/src/components/ColumnHeader.tsx
+++ b/frontend/src/components/ColumnHeader.tsx
@@ -327,7 +327,7 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
                     className={`px-3 py-1 text-sm rounded border focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue transition-all duration-200 clubs-filter-btn${
                       currentSort.field === field &&
                       currentSort.direction === 'asc'
-                        ? '--active'
+                        ? ' clubs-filter-btn--active'
                         : ''
                     }`}
                     tabIndex={0}
@@ -359,7 +359,7 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
                     className={`px-3 py-1 text-sm rounded border focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue transition-all duration-200 clubs-filter-btn${
                       currentSort.field === field &&
                       currentSort.direction === 'desc'
-                        ? '--active'
+                        ? ' clubs-filter-btn--active'
                         : ''
                     }`}
                     tabIndex={0}

--- a/frontend/src/components/ColumnHeader.tsx
+++ b/frontend/src/components/ColumnHeader.tsx
@@ -292,18 +292,20 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
         )}
       </button>
 
-      {/* Dropdown/Popover — the filter control surface. Its legacy gray
-          chrome is intentionally deferred to the controls re-skin (Sprint 4
-          #670); the resting header chrome (button + caret above) is the
-          #668 scope. The clubs-table re-skin guard only renders the resting
-          state, so these closed-popover gray classes are out of its frame. */}
+      {/* Dropdown/Popover — the filter control surface, re-skinned to redesign
+          tokens in Sprint 4 (#670). Token-driven (.clubs-filter-*) so dark mode
+          works via [data-theme='dark'] remaps (R10) — no legacy gray, no baked
+          opacity-variants (lesson 073). The active accent matches the
+          segmented/chip controls (--link on --loyal-50). */}
       {isDropdownOpen && (sortable || filterable) && (
-        <div className="absolute top-full left-0 z-50 mt-1 w-80 bg-white border border-gray-200 rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-200">
+        <div className="absolute top-full left-0 z-50 mt-1 w-80 clubs-filter-popover shadow-lg hover:shadow-xl transition-shadow duration-200">
           <div className="p-4 space-y-4">
             {/* Sort Options */}
             {sortable && (
               <div className="space-y-2">
-                <h4 className="text-sm font-medium text-gray-900">Sort</h4>
+                <h4 className="text-sm font-medium clubs-filter-heading">
+                  Sort
+                </h4>
                 <div className="flex gap-2">
                   <button
                     onClick={() => {
@@ -322,11 +324,11 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
                         e.currentTarget.click()
                       }
                     }}
-                    className={`px-3 py-1 text-sm rounded border focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue transition-all duration-200 ${
+                    className={`px-3 py-1 text-sm rounded border focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue transition-all duration-200 clubs-filter-btn${
                       currentSort.field === field &&
                       currentSort.direction === 'asc'
-                        ? 'bg-tm-loyal-blue-20 text-tm-loyal-blue border-tm-loyal-blue hover:bg-tm-loyal-blue-30'
-                        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 hover:border-gray-400 hover:shadow-xs'
+                        ? '--active'
+                        : ''
                     }`}
                     tabIndex={0}
                     aria-label={`Sort ${label} ascending (A to Z)`}
@@ -354,11 +356,11 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
                         e.currentTarget.click()
                       }
                     }}
-                    className={`px-3 py-1 text-sm rounded border focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue transition-all duration-200 ${
+                    className={`px-3 py-1 text-sm rounded border focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue transition-all duration-200 clubs-filter-btn${
                       currentSort.field === field &&
                       currentSort.direction === 'desc'
-                        ? 'bg-tm-loyal-blue-20 text-tm-loyal-blue border-tm-loyal-blue hover:bg-tm-loyal-blue-30'
-                        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 hover:border-gray-400 hover:shadow-xs'
+                        ? '--active'
+                        : ''
                     }`}
                     tabIndex={0}
                     aria-label={`Sort ${label} descending (Z to A)`}
@@ -372,7 +374,9 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
             {/* Filter Options */}
             {filterable && (
               <div className="space-y-2">
-                <h4 className="text-sm font-medium text-gray-900">Filter</h4>
+                <h4 className="text-sm font-medium clubs-filter-heading">
+                  Filter
+                </h4>
                 {renderFilterComponent()}
                 <div className="flex gap-2 pt-2">
                   <button
@@ -383,7 +387,7 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
                         e.currentTarget.click()
                       }
                     }}
-                    className="px-3 py-1 text-sm bg-tm-loyal-blue text-tm-white rounded hover:bg-tm-loyal-blue-90 hover:shadow-md focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue transition-all duration-200"
+                    className="px-3 py-1 text-sm rounded border clubs-filter-btn--primary hover:shadow-md focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue transition-all duration-200"
                     tabIndex={0}
                     aria-label={`Apply ${label} filter`}
                   >
@@ -397,7 +401,7 @@ export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
                         e.currentTarget.click()
                       }
                     }}
-                    className="px-3 py-1 text-sm bg-gray-100 text-gray-700 rounded hover:bg-gray-200 hover:text-gray-900 hover:shadow-xs focus:outline-hidden focus:ring-2 focus:ring-gray-500 transition-all duration-200"
+                    className="px-3 py-1 text-sm rounded border clubs-filter-btn--ghost hover:shadow-xs focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue transition-all duration-200"
                     tabIndex={0}
                     aria-label={`Clear ${label} filter`}
                   >

--- a/frontend/src/components/__tests__/ColumnHeader.reskin.test.tsx
+++ b/frontend/src/components/__tests__/ColumnHeader.reskin.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Re-skin guard for the clubs column-filter popover (#670, epic #665 Sprint 4).
+ *
+ * The #668 chrome re-skin (Sprint 2) deliberately left the *open* column-filter
+ * popover on legacy gray Tailwind — its guard (ClubsTable.reskin.test.tsx) only
+ * renders the resting header, so the closed popover's gray was out of frame. A
+ * breadcrumb in app-shell.css / ColumnHeader.tsx parks it for "the controls
+ * re-skin (Sprint 4 #670)". This guard opens each popover variant (text /
+ * numeric / categorical) and fails if any rendered element still carries a
+ * legacy `*-gray-*` utility OR a baked opacity-variant brand utility
+ * (`bg-tm-loyal-blue-NN`) — the latter is the lesson-073 dark trap (it inlines a
+ * light-mode rgba at build time and never re-resolves under [data-theme=dark]).
+ *
+ * JSDOM can't compute contrast (lesson 075) but it CAN prove which classes ship
+ * — which is exactly what a "no legacy chrome left" criterion is about. The
+ * resolved dark contrast of the new token-driven classes is guarded separately
+ * by ClubsControlsDarkModeContrast.test.ts.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { ColumnHeader } from '../ColumnHeader'
+import { SortField, ColumnFilter } from '../filters/types'
+
+const baseProps = {
+  field: 'name' as SortField,
+  label: 'Club Name',
+  sortable: true,
+  filterable: true,
+  currentSort: { field: null as SortField | null, direction: 'asc' as const },
+  currentFilter: null as ColumnFilter | null,
+  onSort: () => {},
+  onFilter: () => {},
+  options: ['Active', 'Suspended'] as string[],
+}
+
+// Matches Tailwind gray utilities incl. state-variant prefixes
+// (`hover:bg-gray-100`, `group-hover:text-gray-700`), but NOT brand tokens like
+// `tm-cool-gray-20` (those have a non-enumerated prefix before `-gray-`).
+const GRAY_CLASS =
+  /(?:^|[\s:])(?:text|bg|border|divide|from|to|ring|fill|stroke)-gray-\d/
+
+// Baked opacity-variant brand utilities — lesson 073: they inline a light-mode
+// rgba and never remap in dark. The re-skin replaces these with token classes.
+const OPACITY_VARIANT = /(?:^|[\s:])(?:bg|text|border)-tm-[a-z-]+-\d{2}\b/
+
+function offenders(container: HTMLElement): string[] {
+  const out: string[] = []
+  container.querySelectorAll<HTMLElement>('*').forEach(el => {
+    const cls = el.getAttribute('class')
+    if (cls && (GRAY_CLASS.test(cls) || OPACITY_VARIANT.test(cls)))
+      out.push(cls)
+  })
+  return out
+}
+
+const VARIANTS: ReadonlyArray<{
+  name: string
+  filterType: ColumnFilter['type']
+}> = [
+  { name: 'text (search)', filterType: 'text' },
+  { name: 'numeric', filterType: 'numeric' },
+  { name: 'categorical', filterType: 'categorical' },
+]
+
+describe('Clubs column-filter popover re-skin (#670)', () => {
+  afterEach(cleanup)
+
+  it.each(VARIANTS)(
+    'open $name popover carries zero legacy gray / opacity-variant classes',
+    ({ filterType }) => {
+      const { container } = render(
+        <ColumnHeader {...baseProps} filterType={filterType} />
+      )
+      fireEvent.click(screen.getByRole('button', { expanded: false }))
+      // popover is open
+      expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument()
+      expect(offenders(container)).toEqual([])
+    }
+  )
+})

--- a/frontend/src/components/__tests__/FocusIndicators.test.tsx
+++ b/frontend/src/components/__tests__/FocusIndicators.test.tsx
@@ -172,7 +172,8 @@ describe('Focus Indicators', () => {
       const inputClasses = textInput?.className || ''
       expect(inputClasses).toContain('focus:outline-hidden')
       expect(inputClasses).toContain('focus:ring-2')
-      expect(inputClasses).toContain('focus:ring-blue-500')
+      // #670: themed ring token (has a dark-mode override, unlike blue-500).
+      expect(inputClasses).toContain('focus:ring-tm-loyal-blue')
     })
 
     it('should have focus indicators on operator buttons', () => {
@@ -195,7 +196,8 @@ describe('Focus Indicators', () => {
         const buttonClasses = button.className
         expect(buttonClasses).toContain('focus:outline-hidden')
         expect(buttonClasses).toContain('focus:ring-2')
-        expect(buttonClasses).toContain('focus:ring-blue-500')
+        // #670: themed ring token (has a dark-mode override, unlike blue-500).
+        expect(buttonClasses).toContain('focus:ring-tm-loyal-blue')
       })
     })
 
@@ -244,7 +246,8 @@ describe('Focus Indicators', () => {
         const inputClasses = input.className
         expect(inputClasses).toContain('focus:outline-hidden')
         expect(inputClasses).toContain('focus:ring-2')
-        expect(inputClasses).toContain('focus:ring-blue-500')
+        // #670: themed ring token (has a dark-mode override, unlike blue-500).
+        expect(inputClasses).toContain('focus:ring-tm-loyal-blue')
       })
     })
 

--- a/frontend/src/components/filters/CategoricalFilter.tsx
+++ b/frontend/src/components/filters/CategoricalFilter.tsx
@@ -78,17 +78,19 @@ export const CategoricalFilter: React.FC<CategoricalFilterProps> = ({
 
   return (
     <div
-      className={`p-4 bg-white border border-gray-200 rounded-lg shadow-lg min-w-64 max-w-80 ${className}`}
+      className={`p-4 clubs-filter-popover shadow-lg min-w-64 max-w-80 ${className}`}
     >
       <div className="space-y-3">
         {/* Header */}
         <div className="flex items-center justify-between">
-          <span className="text-sm font-medium text-gray-700">{label}</span>
+          <span className="text-sm font-medium clubs-filter-heading">
+            {label}
+          </span>
           {hasSelection && (
             <button
               type="button"
               onClick={handleClear}
-              className="text-xs text-tm-loyal-blue hover:text-tm-loyal-blue hover:underline font-medium focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue rounded transition-all duration-200"
+              className="text-xs clubs-filter-link font-medium focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue rounded transition-all duration-200"
               tabIndex={0}
               aria-label="Clear categorical filter"
             >
@@ -99,7 +101,7 @@ export const CategoricalFilter: React.FC<CategoricalFilterProps> = ({
 
         {/* Select All/None (only for multiple mode) */}
         {multiple && options.length > 1 && (
-          <div className="pb-2 border-b border-gray-100">
+          <div className="pb-2 border-b clubs-filter-divider">
             <div
               role="checkbox"
               aria-checked={allSelected}
@@ -111,15 +113,15 @@ export const CategoricalFilter: React.FC<CategoricalFilterProps> = ({
                   handleSelectAll()
                 }
               }}
-              className="flex items-center gap-2 cursor-pointer text-sm text-tm-loyal-blue hover:underline font-medium focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue rounded px-1 py-1"
+              className="flex items-center gap-2 cursor-pointer text-sm clubs-filter-link hover:underline font-medium focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue rounded px-1 py-1"
             >
               <div
-                className={`w-4 h-4 min-w-[16px] min-h-[16px] border-2 rounded-xs flex items-center justify-center flex-shrink-0 transition-colors duration-200 ${
+                className={`w-4 h-4 min-w-[16px] min-h-[16px] border-2 rounded-xs flex items-center justify-center flex-shrink-0 transition-colors duration-200 clubs-filter-checkbox${
                   allSelected
-                    ? 'bg-tm-loyal-blue border-tm-loyal-blue'
+                    ? '--checked'
                     : localSelected.length > 0
-                      ? 'bg-blue-100 border-tm-loyal-blue'
-                      : 'bg-white border-gray-300'
+                      ? '--partial'
+                      : ''
                 }`}
               >
                 {allSelected && (
@@ -138,7 +140,7 @@ export const CategoricalFilter: React.FC<CategoricalFilterProps> = ({
                   </svg>
                 )}
                 {localSelected.length > 0 && !allSelected && (
-                  <div className="w-2 h-2 bg-tm-loyal-blue rounded-xs" />
+                  <div className="w-2 h-2 clubs-filter-checkbox__pip rounded-xs" />
                 )}
               </div>
               <span>{allSelected ? 'Deselect All' : 'Select All'}</span>
@@ -163,13 +165,11 @@ export const CategoricalFilter: React.FC<CategoricalFilterProps> = ({
                     handleToggle(option)
                   }
                 }}
-                className="flex items-center gap-3 cursor-pointer hover:bg-gray-50 rounded px-2 py-2 transition-colors duration-200 focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue focus:ring-inset"
+                className="flex items-center gap-3 cursor-pointer clubs-filter-option rounded px-2 py-2 transition-colors duration-200 focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue focus:ring-inset"
               >
                 <div
-                  className={`w-4 h-4 min-w-[16px] min-h-[16px] border-2 rounded-xs flex items-center justify-center flex-shrink-0 transition-colors duration-200 ${
-                    isSelected
-                      ? 'bg-tm-loyal-blue border-tm-loyal-blue'
-                      : 'bg-white border-gray-300 hover:border-gray-400'
+                  className={`w-4 h-4 min-w-[16px] min-h-[16px] border-2 rounded-xs flex items-center justify-center flex-shrink-0 transition-colors duration-200 clubs-filter-checkbox${
+                    isSelected ? '--checked' : ''
                   }`}
                 >
                   {isSelected && (
@@ -188,9 +188,7 @@ export const CategoricalFilter: React.FC<CategoricalFilterProps> = ({
                     </svg>
                   )}
                 </div>
-                <span className="text-sm text-gray-700 select-none">
-                  {option}
-                </span>
+                <span className="text-sm select-none">{option}</span>
               </div>
             )
           })}
@@ -198,12 +196,12 @@ export const CategoricalFilter: React.FC<CategoricalFilterProps> = ({
 
         {/* Selection Summary */}
         {hasSelection && (
-          <div className="text-xs text-gray-500 bg-gray-50 rounded px-2 py-1 border-t border-gray-100">
+          <div className="text-xs clubs-filter-meta rounded px-2 py-1 border-t clubs-filter-divider">
             {localSelected.length === 1
               ? `1 ${label.toLowerCase()} selected`
               : `${localSelected.length} ${label.toLowerCase()}s selected`}
             {localSelected.length <= 3 && (
-              <div className="mt-1 text-gray-600">
+              <div className="mt-1 clubs-filter-note">
                 {localSelected.join(', ')}
               </div>
             )}

--- a/frontend/src/components/filters/CategoricalFilter.tsx
+++ b/frontend/src/components/filters/CategoricalFilter.tsx
@@ -118,9 +118,9 @@ export const CategoricalFilter: React.FC<CategoricalFilterProps> = ({
               <div
                 className={`w-4 h-4 min-w-[16px] min-h-[16px] border-2 rounded-xs flex items-center justify-center flex-shrink-0 transition-colors duration-200 clubs-filter-checkbox${
                   allSelected
-                    ? '--checked'
+                    ? ' clubs-filter-checkbox--checked'
                     : localSelected.length > 0
-                      ? '--partial'
+                      ? ' clubs-filter-checkbox--partial'
                       : ''
                 }`}
               >
@@ -169,7 +169,7 @@ export const CategoricalFilter: React.FC<CategoricalFilterProps> = ({
               >
                 <div
                   className={`w-4 h-4 min-w-[16px] min-h-[16px] border-2 rounded-xs flex items-center justify-center flex-shrink-0 transition-colors duration-200 clubs-filter-checkbox${
-                    isSelected ? '--checked' : ''
+                    isSelected ? ' clubs-filter-checkbox--checked' : ''
                   }`}
                 >
                   {isSelected && (

--- a/frontend/src/components/filters/NumericFilter.tsx
+++ b/frontend/src/components/filters/NumericFilter.tsx
@@ -129,7 +129,7 @@ export const NumericFilter: React.FC<NumericFilterProps> = ({
               placeholder="Min"
               min={min}
               max={max}
-              className="w-full px-3 py-2 text-sm rounded clubs-filter-input focus:outline-hidden transition-colors duration-200"
+              className="w-full px-3 py-2 text-sm rounded clubs-filter-input focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue focus:border-transparent transition-colors duration-200"
               tabIndex={0}
               aria-label={`Minimum ${label.toLowerCase()} value`}
             />
@@ -145,7 +145,7 @@ export const NumericFilter: React.FC<NumericFilterProps> = ({
               placeholder="Max"
               min={min}
               max={max}
-              className="w-full px-3 py-2 text-sm rounded clubs-filter-input focus:outline-hidden transition-colors duration-200"
+              className="w-full px-3 py-2 text-sm rounded clubs-filter-input focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue focus:border-transparent transition-colors duration-200"
               tabIndex={0}
               aria-label={`Maximum ${label.toLowerCase()} value`}
             />

--- a/frontend/src/components/filters/NumericFilter.tsx
+++ b/frontend/src/components/filters/NumericFilter.tsx
@@ -96,20 +96,18 @@ export const NumericFilter: React.FC<NumericFilterProps> = ({
   const hasValue = localMin !== '' || localMax !== ''
 
   return (
-    <div
-      className={`p-4 bg-white border border-gray-200 rounded-lg shadow-lg min-w-64 ${className}`}
-    >
+    <div className={`p-4 clubs-filter-popover shadow-lg min-w-64 ${className}`}>
       <div className="space-y-3">
         {/* Header */}
         <div className="flex items-center justify-between">
-          <span className="text-sm font-medium text-gray-700">
+          <span className="text-sm font-medium clubs-filter-heading">
             {label} Range
           </span>
           {hasValue && (
             <button
               type="button"
               onClick={handleClear}
-              className="text-xs text-tm-loyal-blue hover:text-tm-loyal-blue hover:underline font-medium focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue rounded transition-all duration-200"
+              className="text-xs clubs-filter-link font-medium focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue rounded transition-all duration-200"
               tabIndex={0}
               aria-label="Clear numeric filter"
             >
@@ -121,7 +119,9 @@ export const NumericFilter: React.FC<NumericFilterProps> = ({
         {/* Range Inputs */}
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="block text-xs text-gray-500 mb-1">Minimum</label>
+            <label className="block text-xs clubs-filter-label mb-1">
+              Minimum
+            </label>
             <input
               type="number"
               value={localMin}
@@ -129,13 +129,15 @@ export const NumericFilter: React.FC<NumericFilterProps> = ({
               placeholder="Min"
               min={min}
               max={max}
-              className="w-full px-3 py-2 text-sm text-gray-900 bg-white border border-gray-300 rounded hover:border-gray-400 focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-500 transition-colors duration-200"
+              className="w-full px-3 py-2 text-sm rounded clubs-filter-input focus:outline-hidden transition-colors duration-200"
               tabIndex={0}
               aria-label={`Minimum ${label.toLowerCase()} value`}
             />
           </div>
           <div>
-            <label className="block text-xs text-gray-500 mb-1">Maximum</label>
+            <label className="block text-xs clubs-filter-label mb-1">
+              Maximum
+            </label>
             <input
               type="number"
               value={localMax}
@@ -143,7 +145,7 @@ export const NumericFilter: React.FC<NumericFilterProps> = ({
               placeholder="Max"
               min={min}
               max={max}
-              className="w-full px-3 py-2 text-sm text-gray-900 bg-white border border-gray-300 rounded hover:border-gray-400 focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-500 transition-colors duration-200"
+              className="w-full px-3 py-2 text-sm rounded clubs-filter-input focus:outline-hidden transition-colors duration-200"
               tabIndex={0}
               aria-label={`Maximum ${label.toLowerCase()} value`}
             />
@@ -152,14 +154,14 @@ export const NumericFilter: React.FC<NumericFilterProps> = ({
 
         {/* Error Message */}
         {error && (
-          <div className="text-xs text-red-600 bg-red-50 border border-red-200 rounded px-2 py-1">
+          <div className="text-xs clubs-filter-error rounded px-2 py-1">
             {error}
           </div>
         )}
 
         {/* Range Display */}
         {hasValue && !error && (
-          <div className="text-xs text-gray-500 bg-gray-50 rounded px-2 py-1">
+          <div className="text-xs clubs-filter-meta rounded px-2 py-1">
             {localMin !== '' && localMax !== ''
               ? `${localMin} - ${localMax}`
               : localMin !== ''
@@ -170,7 +172,7 @@ export const NumericFilter: React.FC<NumericFilterProps> = ({
 
         {/* Bounds Info */}
         {(min !== undefined || max !== undefined) && (
-          <div className="text-xs text-gray-600 pt-2 border-t border-gray-100">
+          <div className="text-xs clubs-filter-note pt-2 border-t clubs-filter-divider">
             {min !== undefined && max !== undefined
               ? `Valid range: ${min} - ${max}`
               : min !== undefined

--- a/frontend/src/components/filters/TextFilter.tsx
+++ b/frontend/src/components/filters/TextFilter.tsx
@@ -118,7 +118,7 @@ export const TextFilter: React.FC<TextFilterProps> = ({
             value={localValue}
             onChange={e => handleInputChange(e.target.value)}
             placeholder={placeholder}
-            className="w-full px-3 py-2 text-sm rounded clubs-filter-input focus:outline-hidden transition-colors duration-200"
+            className="w-full px-3 py-2 text-sm rounded clubs-filter-input focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue focus:border-transparent transition-colors duration-200"
             autoFocus
             tabIndex={0}
             aria-label={`Filter text input. Current operator: ${operator}`}

--- a/frontend/src/components/filters/TextFilter.tsx
+++ b/frontend/src/components/filters/TextFilter.tsx
@@ -69,9 +69,7 @@ export const TextFilter: React.FC<TextFilterProps> = ({
   }
 
   return (
-    <div
-      className={`p-4 bg-white border border-gray-200 rounded-lg shadow-lg min-w-64 ${className}`}
-    >
+    <div className={`p-4 clubs-filter-popover shadow-lg min-w-64 ${className}`}>
       <div className="space-y-3">
         {/* Filter Type Selection */}
         <div className="flex gap-2">
@@ -84,10 +82,8 @@ export const TextFilter: React.FC<TextFilterProps> = ({
                 e.currentTarget.click()
               }
             }}
-            className={`px-3 py-1 text-xs font-medium rounded transition-all duration-200 focus:outline-hidden focus:ring-2 focus:ring-blue-500 ${
-              operator === 'contains'
-                ? 'bg-blue-100 text-tm-loyal-blue border border-blue-300 hover:bg-blue-200'
-                : 'bg-gray-100 text-gray-600 border border-gray-300 hover:bg-gray-200 hover:border-gray-400'
+            className={`px-3 py-1 text-xs font-medium rounded border transition-all duration-200 focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue clubs-filter-btn${
+              operator === 'contains' ? ' clubs-filter-btn--active' : ''
             }`}
             tabIndex={0}
             aria-label="Filter by contains"
@@ -104,10 +100,8 @@ export const TextFilter: React.FC<TextFilterProps> = ({
                 e.currentTarget.click()
               }
             }}
-            className={`px-3 py-1 text-xs font-medium rounded transition-all duration-200 focus:outline-hidden focus:ring-2 focus:ring-blue-500 ${
-              operator === 'startsWith'
-                ? 'bg-blue-100 text-tm-loyal-blue border border-blue-300 hover:bg-blue-200'
-                : 'bg-gray-100 text-gray-600 border border-gray-300 hover:bg-gray-200 hover:border-gray-400'
+            className={`px-3 py-1 text-xs font-medium rounded border transition-all duration-200 focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue clubs-filter-btn${
+              operator === 'startsWith' ? ' clubs-filter-btn--active' : ''
             }`}
             tabIndex={0}
             aria-label="Filter by starts with"
@@ -124,7 +118,7 @@ export const TextFilter: React.FC<TextFilterProps> = ({
             value={localValue}
             onChange={e => handleInputChange(e.target.value)}
             placeholder={placeholder}
-            className="w-full px-3 py-2 text-sm text-gray-900 bg-white border border-gray-300 rounded hover:border-gray-400 focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-500 transition-colors duration-200"
+            className="w-full px-3 py-2 text-sm rounded clubs-filter-input focus:outline-hidden transition-colors duration-200"
             autoFocus
             tabIndex={0}
             aria-label={`Filter text input. Current operator: ${operator}`}
@@ -133,7 +127,7 @@ export const TextFilter: React.FC<TextFilterProps> = ({
             <button
               type="button"
               onClick={handleClear}
-              className="absolute right-2 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 focus:outline-hidden focus:ring-2 focus:ring-blue-500 rounded p-1 transition-all duration-200"
+              className="absolute right-2 top-1/2 transform -translate-y-1/2 clubs-filter-x focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue rounded p-1 transition-all duration-200"
               aria-label="Clear filter"
               tabIndex={0}
             >
@@ -155,14 +149,14 @@ export const TextFilter: React.FC<TextFilterProps> = ({
         </div>
 
         {/* Actions */}
-        <div className="flex justify-between items-center pt-2 border-t border-gray-100">
-          <span className="text-xs text-gray-500">
+        <div className="flex justify-between items-center pt-2 border-t clubs-filter-divider">
+          <span className="text-xs clubs-filter-note">
             {operator === 'contains' ? 'Contains text' : 'Starts with text'}
           </span>
           <button
             type="button"
             onClick={handleClear}
-            className="text-xs text-tm-loyal-blue hover:text-tm-loyal-blue hover:underline font-medium focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue rounded transition-all duration-200"
+            className="text-xs clubs-filter-link font-medium focus:outline-hidden focus:ring-2 focus:ring-tm-loyal-blue rounded transition-all duration-200"
             tabIndex={0}
             aria-label="Clear text filter"
           >

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -1968,10 +1968,13 @@
     background-color: var(--surface-3);
   }
 
+  /* Active = --link text on --loyal-50 per handoff (#670). --link equals
+     --loyal-500 in light (byte-identical to the old look) but remaps to a
+     dark-safe #60a5d8 — never raw --loyal-500, the navy-on-navy dark trap
+     (lessons 093/096). */
   .clubs-status-segmented__btn--active {
-    background-color: var(--surface);
-    color: var(--loyal-500);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    background-color: var(--loyal-50);
+    color: var(--link);
   }
 
   .clubs-status-segmented__count {
@@ -1991,8 +1994,8 @@
   }
 
   .clubs-status-segmented__btn--active .clubs-status-segmented__count {
-    background-color: var(--loyal-50);
-    color: var(--loyal-500);
+    background-color: var(--surface);
+    color: var(--link);
   }
 
   /* Clubs tab quick-filter chip strip (#24 follow-up). Sits above the
@@ -2031,28 +2034,29 @@
   }
 
   .clubs-quick-filter-chip:hover {
+    background-color: var(--surface-3);
     border-color: var(--loyal-200);
-    color: var(--loyal-500);
+    color: var(--link);
   }
 
+  /* Active chip matches the segmented control: --link text on --loyal-50,
+     not a solid --loyal-500 fill — keeps the accent dark-safe (#670). */
   .clubs-quick-filter-chip--active {
-    background-color: var(--loyal-500);
-    border-color: var(--loyal-500);
-    color: #ffffff;
+    background-color: var(--loyal-50);
+    border-color: var(--loyal-200);
+    color: var(--link);
   }
 
   .clubs-quick-filter-chip--active:hover {
-    background-color: var(--loyal-600);
-    border-color: var(--loyal-600);
-    color: #ffffff;
+    background-color: var(--loyal-100);
+    border-color: var(--loyal-200);
+    color: var(--link);
   }
 
+  /* Star stays gold in both rest and active states (the active fill is now
+     a light tint, so a white star would vanish). */
   .clubs-quick-filter-chip__star {
     color: var(--yellow-600);
-  }
-
-  .clubs-quick-filter-chip--active .clubs-quick-filter-chip__star {
-    color: #ffffff;
   }
 
   .clubs-quick-filter-chip__clear {
@@ -2064,6 +2068,168 @@
     background-color: rgba(123, 24, 40, 0.06);
     border-color: var(--maroon-500);
     color: var(--maroon-500);
+  }
+
+  /* ── Clubs column-filter popover re-skin (#670, epic #665 Sprint 4) ──
+     The open filter popover (ColumnHeader dropdown + Text/Numeric/Categorical
+     filters) was the last legacy-gray surface on the clubs table; #668 parked
+     it here. Token-driven so dark mode works via the [data-theme='dark']
+     remaps (R10, lessons 093/096) — no baked opacity-variants (lesson 073).
+     The active accent matches the segmented/chip controls: --link text on
+     --loyal-50, never raw --loyal-500 (the navy-on-navy dark trap). */
+  .clubs-filter-popover {
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-lg);
+  }
+
+  .clubs-filter-heading {
+    color: var(--ink);
+  }
+
+  /* Hairline separators inside the popover (was border-gray-100). */
+  .clubs-filter-divider {
+    border-color: var(--line);
+  }
+
+  /* Small field labels (Minimum/Maximum) and caption/summary text. */
+  .clubs-filter-label,
+  .clubs-filter-note {
+    color: var(--ink-3);
+  }
+
+  .clubs-filter-meta {
+    color: var(--ink-3);
+    background-color: var(--surface-2);
+  }
+
+  /* Sort A-Z / Z-A + operator toggles. Layout (padding, radius, focus ring)
+     stays on Tailwind in the JSX; these classes own only the themed colours. */
+  .clubs-filter-btn {
+    background-color: var(--surface);
+    border-color: var(--line);
+    color: var(--ink-2);
+  }
+
+  .clubs-filter-btn:hover {
+    background-color: var(--surface-3);
+    border-color: var(--loyal-200);
+    color: var(--ink);
+  }
+
+  .clubs-filter-btn--active {
+    background-color: var(--loyal-50);
+    border-color: var(--loyal-200);
+    color: var(--link);
+  }
+
+  .clubs-filter-btn--active:hover {
+    background-color: var(--loyal-100);
+    border-color: var(--loyal-200);
+    color: var(--link);
+  }
+
+  /* Apply — primary. White on the brand navy --loyal-500, fixed both themes. */
+  .clubs-filter-btn--primary {
+    background-color: var(--loyal-500);
+    border-color: var(--loyal-500);
+    color: #ffffff;
+  }
+
+  .clubs-filter-btn--primary:hover {
+    background-color: var(--loyal-600);
+    border-color: var(--loyal-600);
+  }
+
+  /* Clear (popover footer) — neutral ghost. */
+  .clubs-filter-btn--ghost {
+    background-color: var(--surface-2);
+    border-color: var(--line);
+    color: var(--ink-2);
+  }
+
+  .clubs-filter-btn--ghost:hover {
+    background-color: var(--surface-3);
+    color: var(--ink);
+  }
+
+  .clubs-filter-input {
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    color: var(--ink);
+  }
+
+  .clubs-filter-input::placeholder {
+    color: var(--ink-4);
+  }
+
+  .clubs-filter-input:hover {
+    border-color: var(--loyal-200);
+  }
+
+  .clubs-filter-input:focus {
+    outline: none;
+    border-color: var(--link);
+    box-shadow: 0 0 0 2px var(--loyal-200);
+  }
+
+  /* Text "Clear" / "Clear Filter" / "Select All" links. */
+  .clubs-filter-link {
+    color: var(--link);
+  }
+
+  .clubs-filter-link:hover {
+    text-decoration: underline;
+  }
+
+  /* Categorical option rows. */
+  .clubs-filter-option {
+    color: var(--ink-2);
+  }
+
+  .clubs-filter-option:hover {
+    background-color: var(--surface-3);
+  }
+
+  /* Checkbox box: unchecked / checked / partial (select-all indeterminate). */
+  .clubs-filter-checkbox {
+    background-color: var(--surface);
+    border-color: var(--line);
+  }
+
+  .clubs-filter-checkbox:hover {
+    border-color: var(--loyal-200);
+  }
+
+  .clubs-filter-checkbox--checked {
+    background-color: var(--loyal-500);
+    border-color: var(--loyal-500);
+  }
+
+  .clubs-filter-checkbox--partial {
+    background-color: var(--loyal-50);
+    border-color: var(--loyal-200);
+  }
+
+  .clubs-filter-checkbox__pip {
+    background-color: var(--link);
+  }
+
+  /* Input clear (×) button. */
+  .clubs-filter-x {
+    color: var(--ink-4);
+  }
+
+  .clubs-filter-x:hover {
+    color: var(--ink);
+    background-color: var(--surface-3);
+  }
+
+  /* Validation error band (numeric out-of-range). --red-600 remaps in dark. */
+  .clubs-filter-error {
+    color: var(--red-600);
+    background-color: var(--surface-2);
+    border: 1px solid var(--line);
   }
 
   /* Awards Race 3-card contender summary (#357). Sits between the

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -2167,11 +2167,10 @@
     border-color: var(--loyal-200);
   }
 
-  .clubs-filter-input:focus {
-    outline: none;
-    border-color: var(--link);
-    box-shadow: 0 0 0 2px var(--loyal-200);
-  }
+  /* Focus ring is the themed Tailwind `focus:ring-2 focus:ring-tm-loyal-blue`
+     in the JSX (matches the popover buttons; --tm-loyal-blue has a dark
+     override, unlike the old blue-500). No CSS :focus ring here, or it would
+     double up. */
 
   /* Text "Clear" / "Clear Filter" / "Select All" links. */
   .clubs-filter-link {

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -2197,7 +2197,12 @@
     border-color: var(--line);
   }
 
-  .clubs-filter-checkbox:hover {
+  /* Hover affordance is for the unchecked box only (the checked/partial
+     boxes carry their own --loyal-500/--loyal-200 borders); scoping avoids
+     the base :hover (higher pseudo-class specificity) lightening them. */
+  .clubs-filter-checkbox:not(.clubs-filter-checkbox--checked):not(
+      .clubs-filter-checkbox--partial
+    ):hover {
     border-color: var(--loyal-200);
   }
 
@@ -2225,9 +2230,11 @@
     background-color: var(--surface-3);
   }
 
-  /* Validation error band (numeric out-of-range). --red-600 remaps in dark. */
+  /* Validation error band (numeric out-of-range). --red-500 remaps lighter in
+     dark (#f87171) so the text clears AA on --surface-2 in both themes;
+     --red-600 was 4.42:1 in dark, just under (review #670). */
   .clubs-filter-error {
-    color: var(--red-600);
+    color: var(--red-500);
     background-color: var(--surface-2);
     border: 1px solid var(--line);
   }

--- a/frontend/src/styles/dark-mode.css
+++ b/frontend/src/styles/dark-mode.css
@@ -849,6 +849,24 @@
     border-color: rgba(232, 135, 154, 0.35) !important;
 }
 
+/* ─── Clubs quick-filter "Clear all" chip (#670, epic #665 Sprint 4) ───
+   The chip text/border uses the brand --maroon-500 (#7b1828), which has NO
+   dark remap — on the dark --surface it lands at ~2:1. Scoped override to the
+   dark maroon #e8879a the theme already uses for --tm-true-maroon (lesson 096):
+   light mode is byte-identical, dark passes AA. The segmented / quick-chip /
+   filter-popover active states need no override here — they were re-skinned to
+   the --link token, which remaps itself (R10, lesson 093). */
+[data-theme='dark'] .clubs-quick-filter-chip__clear {
+    color: #e8879a;
+    border-color: rgba(232, 135, 154, 0.3);
+}
+
+[data-theme='dark'] .clubs-quick-filter-chip__clear:hover {
+    background-color: rgba(232, 135, 154, 0.1);
+    border-color: #e8879a;
+    color: #e8879a;
+}
+
 /* ─── Transition for Theme Switch ─── */
 
 html[data-theme] body {


### PR DESCRIPTION
Part of epic #665. Implements sub-issue #670 (Sprint 4).

## What
Re-skins the clubs-table controls — the segmented status filter, quick-filter chips, and the column-filter popover (ColumnHeader dropdown + Text/Numeric/Categorical filters) — to the redesign handoff tokens, light **and** dark.

These controls were authored on redesign tokens back in #361, but the **active/hover states** used raw `--loyal-500` and the **column-filter popover** was still legacy gray (the #668 chrome re-skin parked it here on purpose). The clubs table was never part of the Track-D dark sweep (#574), so this also closes its dark-mode contrast gaps.

## Changes
- **Segmented + chip active states** → `--link` text on `--loyal-50`, hover `--surface-3` (per epic spec). `--link` equals `--loyal-500` in light (byte-identical look) but remaps to a dark-safe `#60a5d8`, so the tinted active state is AA in dark instead of navy-on-navy (lessons 093/096, R10).
- **Column-filter popover** fully tokenised via a `.clubs-filter-*` class set — zero `*-gray-*`, zero baked `bg-tm-loyal-blue-NN` opacity variants (lesson 073). Operator/sort active states match the segmented accent. Focus ring unified to the themed `focus:ring-tm-loyal-blue` (has a dark override, unlike the old `blue-500`).
- **Maroon "Clear all" chip** gets a scoped `[data-theme='dark']` override to `#e8879a` (`--maroon-500` has no dark remap; lesson 096). Light mode unchanged.
- **Error band** moved `--red-600` → `--red-500` (the former was 4.42:1 in dark, just under AA).

## Acceptance criteria
- [x] Segmented + chips + search (filter popover) match handoff styling in light/dark — guarded by a CSS-parsing contrast audit (`ClubsControlsDarkModeContrast.test.ts`) resolving each foreground through the dark cascade and asserting AA.
- [x] Keyboard + ARIA tablist semantics preserved (role=tab/aria-selected, checkbox roles, focus rings, keydown handlers untouched).
- [x] Controls stay visible while scrolling rows — the #667 capped-height inner-scroll model keeps the controls band above the scroll region (verified on preview).

## Tests
- RED→GREEN: `ClubsControlsDarkModeContrast.test.ts` (8 assertions, dark+light AA) and `ColumnHeader.reskin.test.tsx` (opens each popover variant, fails on any gray / opacity-variant survivor — the #668 guard only rendered the resting header).
- Full frontend suite green: **2561 passed / 185 files**. Typecheck, lint (0 errors), format:check all clean.

## Notes
- Scope decision: re-skinned **all three** filter popovers (Text/Numeric/Categorical) — they are clubs-exclusive (only `ColumnHeader` consumes them, only `ClubsTable` consumes `ColumnHeader`), so re-skinning all three avoids the half-gray popover the epic's Lesson-092 guardrail forbids; no blast radius outside the clubs table.
- Fresh-context review applied (checkbox base+modifier robustness, error-band AA). Accepted nit: the decorative ★ on the active "Close to Distinguished" chip is faint on the light tint (1.73:1) — it's `aria-hidden` and redundant with its text label, so not an a11y blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)