### PR TITLE
ci: skip PR preview deploy for Dependabot PRs (#733)

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -45,7 +45,12 @@ jobs:
     # Skip PRs from forks — WIF tokens are not issued to fork branches,
     # and we don't want to leak credentials to untrusted code anyway.
     # Fork contributors fall back to local-checkout for visual review.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Also skip Dependabot: its branches are intra-repo (so the fork guard
+    # passes) but its runs get no access to the Actions secret store, so the
+    # GCP auth step would fail. Dependency bumps have no UI to preview (#733).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Closes #733

## Problem

All open Dependabot PRs (#691, #693, #721) show a red ✗ on the **Deploy preview channel** check while every other check passes. The job fails at the GCP auth step:

```
google-github-actions/auth failed: must specify exactly one of
"workload_identity_provider" or "credentials_json"!
By default, secrets are not passed to workflows triggered from forks, including Dependabot.
```

## Root cause

`pr-preview.yml` authenticates to GCP via `secrets.GCP_WORKLOAD_IDENTITY_PROVIDER` / `secrets.GCP_SERVICE_ACCOUNT`. Dependabot-triggered `pull_request` runs get a read-only token and **no access to the regular Actions secret store**, so those secrets resolve to empty strings and auth aborts. The existing fork guard (`head.repo.full_name == github.repository`) doesn't catch it: Dependabot branches are intra-repo, so the guard passes.

## Fix

Add `&& github.actor != 'dependabot[bot]'` to the job-level `if:` guard. The preview job is skipped for Dependabot PRs — no spurious red ✗, and no deploy credentials are exposed to Dependabot. Dependency bumps have no UI to preview.

## Verification

- `if:` expression parses to the expected combined condition (validated with js-yaml).
- `npm run lint:yaml` passes (warnings only, all pre-existing in other files).
- Pre-commit hook (typecheck + lint + yaml lint) passed with 0 errors.
- Behavioural confirmation: once merged, re-running the failing check on #691/#693/#721 should report the preview job as skipped rather than failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)