### PR TITLE
test(clubs-table): a11y + verification pass (epic #665 Sprint 6) (#672)

### DIFF
--- a/frontend/src/__tests__/accessibility/ClubsTable.axe.test.tsx
+++ b/frontend/src/__tests__/accessibility/ClubsTable.axe.test.tsx
@@ -1,0 +1,150 @@
+// Axe scan of ClubsTable (#672, epic #665 Sprint 6 — the a11y + verification
+// pass). The clubs table is the last district surface to migrate to the
+// redesign chrome; sprints 1–5 rebuilt it (single sticky-header scroll, pill
+// column model, segmented/chip controls, 640px card collapse). This guards its
+// STRUCTURAL WCAG 2.1 AA rules — ARIA roles, accessible names, heading order,
+// and scrollable-region-focusable — across desktop + mobile and both themes,
+// and in the populated / no-data / loading states.
+//
+// Known JSDOM limitation (lesson 075): axe auto-disables `color-contrast`
+// under JSDOM (no layout engine), so a green scan here is NOT a contrast proof.
+// Contrast is owned by ClubsTableDarkModeContrast.test.ts (+ the controls audit)
+// and verified live in both engines on the PR preview.
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, cleanup, within } from '@testing-library/react'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import { ClubsTable } from '../../components/ClubsTable'
+import { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+// @ts-expect-error - jest-axe matcher types vs vitest expect
+expect.extend(toHaveNoViolations)
+
+const mockClub = (overrides: Partial<ClubTrend> = {}): ClubTrend => ({
+  clubId: 'club-1',
+  clubName: 'Test Club',
+  divisionId: 'div-1',
+  divisionName: 'Division A',
+  areaId: 'area-1',
+  areaName: 'Area 1',
+  distinguishedLevel: 'NotDistinguished',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: '2026-03-01T00:00:00.000Z', count: 20 }],
+  dcpGoalsTrend: [{ date: '2026-03-01T00:00:00.000Z', goalsAchieved: 5 }],
+  ...overrides,
+})
+
+// One club per status + tier so the pill branches all render.
+const CLUBS: ClubTrend[] = [
+  mockClub({
+    clubId: 'c1',
+    clubName: 'Alpha',
+    currentStatus: 'thriving',
+    distinguishedLevel: 'Distinguished',
+  }),
+  mockClub({
+    clubId: 'c2',
+    clubName: 'Beta',
+    currentStatus: 'vulnerable',
+    distinguishedLevel: 'Select',
+  }),
+  mockClub({
+    clubId: 'c3',
+    clubName: 'Gamma',
+    currentStatus: 'intervention-required',
+    distinguishedLevel: 'President',
+  }),
+]
+
+const mobileMatchMedia = () =>
+  vi.fn().mockImplementation((query: string) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+
+beforeEach(() => document.documentElement.removeAttribute('data-theme'))
+afterEach(() => {
+  document.documentElement.removeAttribute('data-theme')
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+describe('ClubsTable axe scan (#672)', () => {
+  it('desktop, populated — no structural a11y violations (light)', async () => {
+    const { container } = render(
+      <ClubsTable clubs={CLUBS} districtId="61" isLoading={false} />
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('desktop, populated — no structural a11y violations (dark)', async () => {
+    document.documentElement.setAttribute('data-theme', 'dark')
+    const { container } = render(
+      <ClubsTable clubs={CLUBS} districtId="61" isLoading={false} />
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('mobile card view — no structural a11y violations', async () => {
+    vi.stubGlobal('matchMedia', mobileMatchMedia())
+    const { container } = render(
+      <ClubsTable clubs={CLUBS} districtId="61" isLoading={false} />
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('no-data empty state — no structural a11y violations', async () => {
+    const { container } = render(
+      <ClubsTable clubs={[]} districtId="61" isLoading={false} />
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('loading state — no structural a11y violations', async () => {
+    const { container } = render(
+      <ClubsTable clubs={[]} districtId="61" isLoading={true} />
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  // WCAG 1.4.1 (Use of Color): status + tier are conveyed by a TEXT label, not
+  // colour alone. Assert every status/tier pill carries non-empty text — the
+  // CSS comments claim it, this proves it so a future "icon-only pill" refactor
+  // can't silently make status colour-only.
+  it('status and tier pills carry a text label (not colour alone)', () => {
+    const { container } = render(
+      <ClubsTable clubs={CLUBS} districtId="61" isLoading={false} />
+    )
+    const pills = container.querySelectorAll(
+      '[class*="clubs-status-pill--"], [class*="clubs-tier-pill--"]'
+    )
+    expect(pills.length).toBeGreaterThan(0)
+    pills.forEach(pill => {
+      expect(pill.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    })
+  })
+
+  // The keyboard-scrollable container must be a focusable, named region
+  // (WCAG 2.1.1 / axe scrollable-region-focusable). Assert the contract the
+  // axe scan relies on, independently of the engine.
+  it('scroll container is a focusable, labelled region', () => {
+    const { container } = render(
+      <ClubsTable clubs={CLUBS} districtId="61" isLoading={false} />
+    )
+    const region = container.querySelector('.clubs-table-scroll')
+    expect(region).not.toBeNull()
+    expect(region).toHaveAttribute('role', 'region')
+    expect(region).toHaveAttribute('tabindex', '0')
+    expect(region?.getAttribute('aria-label')?.length ?? 0).toBeGreaterThan(0)
+    // sanity: the table itself is inside the region
+    expect(within(region as HTMLElement).getByRole('table')).toBeTruthy()
+  })
+})

--- a/frontend/src/__tests__/accessibility/ClubsTableDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/ClubsTableDarkModeContrast.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Clubs-table column-model contrast audit (#672, epic #665 Sprint 6 — the
+ * a11y + verification pass).
+ *
+ * Sprint 4's audit (ClubsControlsDarkModeContrast) covered the controls row
+ * (segmented filter, chips, filter popover). This one covers the TABLE GRID
+ * combos introduced in Sprint 2/3 that no audit guards yet: the tier pills,
+ * the status (health) pills, the inline DCP bar, the sticky column header, and
+ * the muted cell/value text — in BOTH themes.
+ *
+ * Like its siblings it reads the *real* CSS instead of leaning on jest-axe,
+ * which auto-disables `color-contrast` under jsdom (no layout engine — lesson
+ * 075). It resolves each foreground through the `[data-theme='dark']` cascade
+ * (clubs pills/bar carry their dark overrides in app-shell.css, NOT
+ * dark-mode.css — so the override scan reads that file). Falsifiable: see the
+ * `__falsifiability__` block, which re-checks a deliberately-broken value goes
+ * red, proving the audit can fail for the defect it claims to guard (lesson
+ * 107 — a green audit that stays green when you re-introduce the bug is a false
+ * guarantee).
+ *
+ * The matcher scopes to RESTING-state rules: `ruleProp`/`darkOverride` anchor
+ * to the base selector and the override scan bounds with `(?![\w-:])`, so a
+ * `:hover`/`:focus` rule can't shadow the at-rest colour the audit is about
+ * (lesson 107). Lives in `__tests__/accessibility/` → integration project
+ * (lesson 090). Pure computation, so it's fast.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { calculateContrastRatio } from '../../utils/contrastCalculator'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const stylesDir = resolve(here, '../../styles')
+
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '')
+const read = (p: string) =>
+  stripComments(readFileSync(resolve(stylesDir, p), 'utf8'))
+
+const redesignCss = read('tokens/redesign.css')
+const darkModeCss = read('dark-mode.css')
+const appShellCss = read('components/app-shell.css')
+
+/** Parse `--name: value;` from the first rule matching `selectorLiteral`
+ *  exactly, anchored to a real rule start (lesson 093). */
+function parseTokenBlock(css: string, selectorLiteral: string) {
+  const re = new RegExp(
+    '(?:^|\\n)\\s*' +
+      selectorLiteral.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\s*\\{'
+  )
+  const m = re.exec(css)
+  if (!m) return new Map<string, string>()
+  const open = css.indexOf('{', m.index)
+  const close = css.indexOf('}', open)
+  const map = new Map<string, string>()
+  for (const d of css
+    .slice(open + 1, close)
+    .matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g))
+    map.set(d[1].trim(), d[2].trim())
+  return map
+}
+
+const lightTokens = parseTokenBlock(redesignCss, ':root')
+const darkTokens = new Map([
+  ...parseTokenBlock(redesignCss, "[data-theme='dark']"),
+  ...parseTokenBlock(darkModeCss, "[data-theme='dark']"),
+])
+
+/** Resolve a `var(--x)` chain to a literal hex, in the requested theme. */
+function resolveVar(value: string, theme: 'light' | 'dark', depth = 0): string {
+  if (depth > 8) throw new Error(`var() too deep: ${value}`)
+  const v = value.trim()
+  const m = v.match(/^var\((--[\w-]+)\)$/)
+  if (!m) return v
+  const map = theme === 'dark' ? darkTokens : lightTokens
+  const next =
+    theme === 'dark' ? (map.get(m[1]) ?? lightTokens.get(m[1])) : map.get(m[1])
+  if (!next) throw new Error(`token ${m[1]} undefined in ${theme}`)
+  return resolveVar(next, theme, depth + 1)
+}
+
+/** Value of `prop` from the base (resting) rule whose selector matches
+ *  `selectorLiteral` exactly. Anchored to the rule start; throws if missing so
+ *  a renamed surface fails loudly rather than silently passing. */
+function ruleProp(css: string, selectorLiteral: string, prop: string): string {
+  const re = new RegExp(
+    '(?:^|\\n)\\s*' +
+      selectorLiteral.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\s*\\{'
+  )
+  const m = re.exec(css)
+  if (!m) throw new Error(`rule ${selectorLiteral} not found`)
+  const open = css.indexOf('{', m.index)
+  const close = css.indexOf('}', open)
+  const body = css.slice(open + 1, close)
+  const pm = body.match(
+    new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;!]+)')
+  )
+  if (!pm) throw new Error(`prop ${prop} not in rule ${selectorLiteral}`)
+  return pm[1].trim()
+}
+
+/** Value of `prop` from the cascade-winning `[data-theme='dark'] <selector>`
+ *  rule in `css` (last-wins, lesson 095). The trailing `(?![\w-:])` keeps the
+ *  match to the base selector — a `:hover` override can't shadow the resting
+ *  value (lesson 107). Null if there is no dark override. */
+function darkOverride(
+  css: string,
+  selector: string,
+  prop: string
+): string | null {
+  const re = new RegExp(
+    "\\[data-theme='dark'\\]\\s*" +
+      selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '(?![\\w-:])[^{}]*\\{',
+    'g'
+  )
+  let winner: string | null = null
+  for (const m of css.matchAll(re)) {
+    const open = css.indexOf('{', m.index)
+    const close = css.indexOf('}', open)
+    const pm = css
+      .slice(open + 1, close)
+      .match(new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;!]+)'))
+    if (pm) winner = pm[1].trim()
+  }
+  return winner
+}
+
+/** The cascade-winning background-color for a clubs selector in `theme`,
+ *  honouring a `[data-theme='dark']` override in app-shell.css if present. */
+function bgFor(selector: string, theme: 'light' | 'dark'): string {
+  const base = ruleProp(appShellCss, selector, 'background-color')
+  if (theme === 'light') return resolveVar(base, 'light')
+  const override = darkOverride(appShellCss, selector, 'background-color')
+  return resolveVar(override ?? base, 'dark')
+}
+
+const AA = 4.5 // normal text
+const AA_GRAPHIC = 3.0 // non-text graphical objects / large text (WCAG 1.4.11 / 1.4.3)
+
+describe('Clubs-table column-model contrast (#672)', () => {
+  // ── Text on the table surfaces, both themes ──────────────────────────────
+  // Resting muted text (col header, cell-muted, dcp numeral, panel empty-state
+  // copy) is --ink-3; primary cell text is --ink. The sticky header sits on
+  // --surface-2; rows on --surface (hover --surface-3, audited separately).
+  const TEXT: ReadonlyArray<{
+    name: string
+    fg: [string, string]
+    bgToken: string
+  }> = [
+    {
+      name: 'sticky column header label (--ink-3 on --surface-2)',
+      fg: ['.clubs-col-header', 'color'],
+      bgToken: 'var(--surface-2)',
+    },
+    {
+      name: 'primary cell text (--ink on --surface)',
+      fg: ['#clubs-table td', 'color'],
+      bgToken: 'var(--surface)',
+    },
+    {
+      name: 'muted cell text (--ink-3 on --surface)',
+      fg: ['.clubs-cell-muted', 'color'],
+      bgToken: 'var(--surface)',
+    },
+    {
+      name: 'muted cell text on hovered row (--ink-3 on --surface-3)',
+      fg: ['.clubs-cell-muted', 'color'],
+      bgToken: 'var(--surface-3)',
+    },
+    {
+      name: 'DCP numeral (--ink-3 on --surface)',
+      fg: ['.clubs-dcp-cell__val', 'color'],
+      bgToken: 'var(--surface)',
+    },
+    {
+      name: 'panel muted / empty-state copy (--ink-3 on --surface)',
+      fg: ['.clubs-text-muted', 'color'],
+      bgToken: 'var(--surface)',
+    },
+  ]
+
+  it.each(TEXT)('$name clears AA in both themes', ({ fg, bgToken }) => {
+    const fgToken = ruleProp(appShellCss, fg[0], fg[1])
+    for (const theme of ['light', 'dark'] as const) {
+      const fgHex = resolveVar(fgToken, theme)
+      const bgHex = resolveVar(bgToken, theme)
+      const ratio = calculateContrastRatio(fgHex, bgHex)
+      expect(
+        ratio,
+        `${fg[0]} ${fgHex} on ${bgToken} ${bgHex} (${theme}) = ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(AA)
+    }
+  })
+
+  // ── Tier pills: white text on a solid fill, both themes ──────────────────
+  // Distinguished pins to the light-mode green in dark (the dark --green-600
+  // #22c55e fails white text — lesson 095); the others carry no dark remap.
+  const TIER_PILLS = [
+    '.clubs-tier-pill--smedley',
+    '.clubs-tier-pill--presidents',
+    '.clubs-tier-pill--select',
+    '.clubs-tier-pill--distinguished',
+  ] as const
+
+  it('tier pills carry white text', () => {
+    expect(ruleProp(appShellCss, '.clubs-tier-pill', 'color')).toBe('#fff')
+  })
+
+  it.each(TIER_PILLS)(
+    '%s: white text clears AA on its fill both themes',
+    sel => {
+      for (const theme of ['light', 'dark'] as const) {
+        const bg = bgFor(sel, theme)
+        const ratio = calculateContrastRatio('#ffffff', bg)
+        expect(
+          ratio,
+          `${sel} #ffffff on ${bg} (${theme}) = ${ratio.toFixed(2)}:1`
+        ).toBeGreaterThanOrEqual(AA)
+      }
+    }
+  )
+
+  // Projected/provisional: dark text on a yellow stripe. Yellow tokens have no
+  // dark remap, so worst case is the darker stripe band (--yellow-600) in
+  // either theme.
+  it('projected tier pill: dark text clears AA on the darker stripe band', () => {
+    const fg = resolveVar(
+      ruleProp(appShellCss, '.clubs-tier-pill--projected', 'color'),
+      'light'
+    )
+    const darkerBand = resolveVar('var(--yellow-600)', 'light')
+    const ratio = calculateContrastRatio(fg, darkerBand)
+    expect(
+      ratio,
+      `projected ${fg} on --yellow-600 ${darkerBand} = ${ratio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(AA)
+  })
+
+  // ── Status (health) pills: soft tint + saturated text, theme-invariant ───
+  // Literal hex pairs (matching the mobile ClubCard so the datum reads
+  // identically). No dark override by design, so the pair is self-contained.
+  const STATUS_PILLS = [
+    '.clubs-status-pill--thriving',
+    '.clubs-status-pill--vulnerable',
+    '.clubs-status-pill--intervention',
+  ] as const
+
+  it.each(STATUS_PILLS)('%s: text clears AA on its tint', sel => {
+    const fg = ruleProp(appShellCss, sel, 'color')
+    const bg = ruleProp(appShellCss, sel, 'background-color')
+    const ratio = calculateContrastRatio(fg, bg)
+    expect(
+      ratio,
+      `${sel} ${fg} on ${bg} = ${ratio.toFixed(2)}:1`
+    ).toBeGreaterThanOrEqual(AA)
+  })
+
+  // ── DCP inline bar: fill vs track is a graphical 3:1 (not text) ──────────
+  it('DCP bar fill is visible against its track (graphical 3:1) both themes', () => {
+    for (const theme of ['light', 'dark'] as const) {
+      const fill = bgFor('.clubs-dcp-bar__fill', theme)
+      const track = bgFor('.clubs-dcp-bar', theme)
+      const ratio = calculateContrastRatio(fill, track)
+      expect(
+        ratio,
+        `DCP fill ${fill} on track ${track} (${theme}) = ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(AA_GRAPHIC)
+    }
+  })
+
+  // ── Sort-direction caret: a graphical state indicator (3:1) ──────────────
+  it('column-header sort caret clears graphical 3:1 on the sticky header both themes', () => {
+    const fgToken = ruleProp(appShellCss, '.clubs-col-header__arrow', 'color')
+    for (const theme of ['light', 'dark'] as const) {
+      const fg = resolveVar(fgToken, theme)
+      const bg = resolveVar('var(--surface-2)', theme)
+      const ratio = calculateContrastRatio(fg, bg)
+      expect(
+        ratio,
+        `caret ${fg} on --surface-2 ${bg} (${theme}) = ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(AA_GRAPHIC)
+    }
+  })
+
+  // ── Falsifiability proof (lesson 107) ────────────────────────────────────
+  // The audit above is only trustworthy if it CAN go red. Re-run the core
+  // check with a known-bad foreground (white text on the dark --green-600
+  // #22c55e the distinguished pill deliberately avoids) and confirm it fails
+  // AA — proving the assertions aren't hollow.
+  it('__falsifiability__ a known-bad combo is caught', () => {
+    const badGreen = resolveVar('var(--green-600)', 'dark') // #22c55e
+    const ratio = calculateContrastRatio('#ffffff', badGreen)
+    expect(ratio, `white on ${badGreen} should fail AA`).toBeLessThan(AA)
+  })
+})

--- a/frontend/src/__tests__/css-migration/redesign-tokens.test.ts
+++ b/frontend/src/__tests__/css-migration/redesign-tokens.test.ts
@@ -66,7 +66,11 @@ describe('Redesign token system (#353)', () => {
       expect(block).toMatch(/--ink:\s*#0f1720/i)
       expect(block).toMatch(/--ink-2:\s*#344052/i)
       expect(block).toMatch(/--ink-3:\s*#5b6675/i)
-      expect(block).toMatch(/--ink-4:\s*#8b94a3/i)
+      // #672: darkened #8b94a3 → #828b9a so the graphical-tier muted token
+      // (sort carets, pips, axis labels) clears the 3:1 floor on the off-white
+      // --surface-2/3 it lands on (was 2.93:1 on --surface-2). Light-side
+      // analog of the dark #610 bump below; monotonic-safe in light mode.
+      expect(block).toMatch(/--ink-4:\s*#828b9a/i)
       expect(block).toMatch(/--link:\s*var\(--loyal-500\)/i)
     })
 

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -9,7 +9,6 @@ import {
   getClubHealthStatusLabel,
   getClubHealthStatusPillModifier,
 } from '../utils/clubHealthStatus'
-import { EmptyState } from './ErrorDisplay'
 import { useColumnFilters } from '../hooks/useColumnFilters'
 import { ColumnHeader } from './ColumnHeader'
 import { SortField, SortDirection, COLUMN_CONFIGS } from './filters/types'
@@ -651,13 +650,32 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
       {/* Loading State */}
       {isLoading && <LoadingSkeleton variant="table" count={5} />}
 
-      {/* No Results */}
+      {/* No Results — no data at all. Token-driven inline markup mirroring
+          the filter-empty state below (#672), so the clubs table is gray-free
+          in every state it renders. Distinct copy from the filter-empty case:
+          this is "nothing cached yet", not "your filters excluded everything". */}
       {!isLoading && sortedClubs.length === 0 && clubs.length === 0 && (
-        <EmptyState
-          title="No Clubs Found"
-          message="No club data is available for this district. This may be because no data has been cached yet."
-          icon="data"
-        />
+        <div className="p-12 text-center" role="status">
+          <svg
+            className="w-16 h-16 clubs-text-muted mx-auto mb-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
+            />
+          </svg>
+          <p className="clubs-text-muted font-medium">No Clubs Found</p>
+          <p className="clubs-text-muted text-sm mt-1 max-w-lg mx-auto">
+            No club data is available for this district. This may be because no
+            data has been cached yet.
+          </p>
+        </div>
       )}
 
       {/* No Search Results */}

--- a/frontend/src/components/__tests__/ClubsTable.reskin.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.reskin.test.tsx
@@ -118,4 +118,24 @@ describe('ClubsTable re-skin (#668) — no legacy gray chrome', () => {
     // The mobile card list is re-skinned in Sprint 5 (#671) — no exclusion.
     expect(grayClassesIn(container)).toEqual([])
   })
+
+  // Sprint 6 (#672): the populated renders above never mount the no-data
+  // empty state, so its chrome fell outside the original guard's render
+  // boundary (lesson 109 — the render boundary is the scope boundary). It
+  // was still delegating to the shared <EmptyState>, which ships legacy
+  // gray. The clubs-table re-skin owns its OWN no-data state; re-skin it
+  // to redesign tokens so the table is gray-free in every state it renders.
+  it('renders the no-data empty state with zero `*-gray-*` utility classes', () => {
+    const { container } = render(
+      <ClubsTable clubs={[]} districtId="61" isLoading={false} />
+    )
+    expect(grayClassesIn(container)).toEqual([])
+  })
+
+  // The loading state delegates to the shared <LoadingSkeleton variant=table>
+  // (~25 consumers, dark-safe via dark-mode.css remaps). Re-skinning that
+  // shared primitive is a cross-cutting migration, out of scope for the
+  // clubs a11y pass (UX ruling, #672) — so the loading branch is
+  // deliberately NOT asserted here, the same way the closed filter popover
+  // (Sprint 4 surface) sits outside the desktop render above.
 })

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -2864,7 +2864,10 @@
      confirmed" state, HANDOFF §256). Yellow tokens have no dark remap, so
      dark text on the stripe stays legible in both themes. */
   .clubs-tier-pill--projected {
-    color: #5a4a14;
+    /* #672: darkened #5a4a14 → #534213 so the dark text clears AA (4.5:1) on
+       the DARKER stripe band (--yellow-600 #c9b748) too — the worst case as
+       text crosses the 6px stripe (was 4.27:1 on that band). */
+    color: #534213;
     background-image: repeating-linear-gradient(
       45deg,
       var(--yellow-500) 0,

--- a/frontend/src/styles/tokens/redesign.css
+++ b/frontend/src/styles/tokens/redesign.css
@@ -36,7 +36,13 @@
   --ink: #0f1720;
   --ink-2: #344052;
   --ink-3: #5b6675;
-  --ink-4: #8b94a3;
+  /* #672: darkened from #8b94a3 (2.93:1 on --surface-2, below the 3:1 graphical
+     floor for the sort caret + other --ink-4 carets/pips/axis labels that land
+     on the off-white panel surfaces). #828b9a clears 3:1 on every light surface
+     (#fff 3.44, --surface-2 3.29, --surface-3 ~3.2) while staying perceptibly
+     lighter than --ink-3. Light-side analog of the dark #610 bump (lesson 095);
+     monotonic-safe (only raises contrast in light mode). */
+  --ink-4: #828b9a;
   --link: var(--loyal-500);
 
   --serif: 'Montserrat', system-ui, sans-serif;

--- a/frontend/src/styles/tokens/redesign.css
+++ b/frontend/src/styles/tokens/redesign.css
@@ -39,7 +39,7 @@
   /* #672: darkened from #8b94a3 (2.93:1 on --surface-2, below the 3:1 graphical
      floor for the sort caret + other --ink-4 carets/pips/axis labels that land
      on the off-white panel surfaces). #828b9a clears 3:1 on every light surface
-     (#fff 3.44, --surface-2 3.29, --surface-3 ~3.2) while staying perceptibly
+     (#fff 3.44, --surface-2 3.29, --surface-3 3.09) while staying perceptibly
      lighter than --ink-3. Light-side analog of the dark #610 bump (lesson 095);
      monotonic-safe (only raises contrast in light mode). */
   --ink-4: #828b9a;

--- a/tasks/lessons/112-the-verification-sprint-contrast-guard-earns-its-keep-on-the-marginals.md
+++ b/tasks/lessons/112-the-verification-sprint-contrast-guard-earns-its-keep-on-the-marginals.md
@@ -1,0 +1,89 @@
+---
+id: '112'
+category: lesson
+tags: [accessibility, css, dark-mode, tests, frontend]
+auto_load: true
+date: 2026-05-26
+issues: [672, 665]
+---
+
+# Lesson 112 — A "verification pass" contrast guard earns its keep on the marginals the eye and hand-math miss
+
+**Date:** 2026-05-26
+**Issue:** #672 (epic #665 Sprint 6 — clubs-table a11y + verification pass)
+
+## What happened
+
+Five careful re-skin sprints (#667–#671) built the clubs table on redesign
+tokens, each with dark-mode contrast in mind. By Sprint 6 — the "a11y +
+verification pass" — the expectation was that the new contrast guard would be
+pure ceremony: render the audit, watch it pass, ship. Hand-math on the obvious
+combos (tier-pill white-on-fill, `--ink-3` muted text on the surfaces) all
+cleared AA with comfortable margins (5–10:1), reinforcing the "this is just a
+guard" framing.
+
+The CSS-parsing audit (modelled on the #608→#670 harness — resolve each token
+through the `[data-theme]` map, assert the ratio) caught **two** genuinely
+sub-threshold values that the five prior sprints, the eye, and back-of-envelope
+math had all missed:
+
+1. **A graphical-tier muted token on an off-white surface.** The sort caret is
+   `var(--ink-4)`. On pure white `--ink-4` (#8b94a3) is 3.06:1 — just over the
+   3:1 non-text floor. But the caret lives in the sticky header, which is
+   `--surface-2` (#f9fafb, _off_-white), where it drops to **2.93:1**. The 0.13
+   the surface isn't white costs the compliance.
+2. **Text over the darker band of a striped fill.** The "projected" tier pill
+   is dark text on a 45° `repeating-linear-gradient` of `--yellow-500`/`-600`.
+   Against the _lighter_ band it's fine; against the **darker** band
+   (`--yellow-600` #c9b748) the text was **4.27:1** — below AA. Auditing a
+   striped/gradient bg against its single fill colour would have missed it;
+   the worst band is the binding one.
+
+## The principles
+
+- **A contrast guard added "just to verify" is worth writing precisely because
+  the marginals don't announce themselves.** The failures aren't the headline
+  combos (those get hand-checked during the re-skin); they're the
+  near-threshold ones a human rounds to "fine." Size the audit to catch 0.1-off
+  cases, and include every surface a token actually lands on — not just the
+  canonical one.
+- **Marginal contrast failures cluster in two predictable places.** (a) A
+  _graphical-tier_ muted token (carets, pips, axis labels — designed to sit
+  near the 3:1 floor) on a _non-white_ near-surface; the surface being slightly
+  off-white is enough to push it under. (b) _Text over a multi-band / striped /
+  gradient_ background — audit the **darkest** band the text crosses, not the
+  average or the lightest.
+- **The light-side analog of a dark-mode token fix is a separate, real gap.**
+  `--ink-4` was lightened in dark mode back in #610 (lesson 095) for exactly
+  this "muted token below the floor on the lighter surface" reason. The **light**
+  `--ink-4` never got the mirror treatment and quietly sat at 2.93:1 on
+  `--surface-2`. Fixing one theme's muted token does not fix the other's — they
+  are independent values with independent surfaces. When you bump a muted token
+  for dark, check whether the light value has the same disease.
+
+## How to apply
+
+- When you add a contrast audit expecting it to pass, treat a green run as
+  _unproven_ until you've (a) included every background a token lands on
+  (sticky header `--surface-2`, hovered row `--surface-3`, not just the resting
+  `--surface`), and (b) proven it falsifiable by injecting a known-bad value
+  (lesson 107). The audit that "just passes" on the canonical surface is the one
+  that misses the off-white one.
+- For a striped/gradient fill, assert text contrast against the **darkest** band.
+- Fix a sub-floor _graphical_ muted token at the **token** level (global, R10)
+  when it's monotonic-safe (strictly darker in light mode → contrast only
+  rises), not with a component-scoped override — every caret/pip/axis-label
+  consumer benefits and none can regress. Lock the new value with the audit and
+  the token-pin test, and mirror lesson 095's "sized for the surface it lands
+  on" note in the comment.
+
+## Related
+
+- [[095-darkmode-token-bumps-must-be-sized-for-the-lightest-surface]] — the
+  dark-side instance of the same `--ink-4` muted-token-below-the-floor fix;
+  this is its light-side mirror, plus the off-white-surface and striped-band
+  marginals.
+- [[075-axe-core-jsdom-and-the-allowlist-pattern]] — why the static CSS-parsing
+  audit exists at all (JSDOM axe can't compute contrast).
+- [[107-css-audit-matcher-must-exclude-pseudo-class-rules-or-hover-shadows-the-resting-state]]
+  — prove the audit is falsifiable; scope it to the resting state.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -71,3 +71,4 @@
 - **109** [frontend, css, tests, scope, dark-mode] — A render-time class guard scopes to the resting state; let that be the deferral boundary, but don't mistake it for a contrast audit (#668, #665)
 - **110** [tests, e2e, css, frontend, verification] — jsdom `textContent` ignores CSS `text-transform`; a live `innerText` assertion doesn't (#669, #665)
 - **111** [css, accessibility, frontend, tests, playwright, dark-mode] — A native `<select>` ignores `min-height` in WebKit; the 44px touch target needs `appearance:none` (#671, #665)
+- **112** [accessibility, css, dark-mode, tests, frontend] — A "verification pass" contrast guard earns its keep on the marginals the eye and hand-math miss (#672, #665)


### PR DESCRIPTION
## Sprint 6 (#672) — Clubs-table accessibility + verification pass

Final sprint of epic #665 (clubs-table redesign). Part of #672.

After five re-skin sprints (#667–#671), the clubs table was already on redesign tokens with carefully-handled dark mode. This sprint **verifies** that with standing guards and fixes the marginals those guards surfaced.

### What shipped
- **No-data empty state re-skinned** off the shared `<EmptyState>` (legacy `text-gray-*`) onto token-driven inline markup mirroring the sibling filter-empty state. Copy + `role=status` preserved verbatim. The shared `<LoadingSkeleton>` is intentionally left (dark-safe, ~25 consumers — out of scope for a clubs a11y pass; UX ruling).
- **`ClubsTableDarkModeContrast.test.ts`** — new CSS-parsing contrast guard (both themes) for the table-grid combos no audit covered yet: tier pills, status pills, DCP bar, sticky column header, muted cell/value text. Resting-state matcher (lesson 107); includes a `__falsifiability__` proof.
- **`ClubsTable.axe.test.tsx`** — structural axe scan across populated / no-data / loading × desktop / mobile × light / dark. Folds in two WCAG checks: every status/tier pill carries a text label (1.4.1, not colour-alone), and the scroll region is a focusable labelled region (2.1.1).
- **Two genuine sub-AA fixes** the audit caught (RED→GREEN):
  - Projected tier pill text `#5a4a14 → #534213` — was 4.27:1 on the darker stripe band (`--yellow-600`). Scoped to the one pill.
  - Sort caret `--ink-4` was 2.93:1 on the off-white sticky header (`--surface-2`), below the 3:1 graphical floor. Root cause is the **global light `--ink-4`** token (a graphical-tier muted token: carets/pips/axis labels). Bumped `#8b94a3 → #828b9a` — the light-side analog of the dark `#610` bump (lesson 095); monotonic-safe (strictly darker → contrast only rises in light mode).

### Scope note for the reviewer
The `--ink-4` light change is a **global token** touching ~15 consumers app-wide. It is the root-cause fix (R10, manifesto: fix at source) and monotonic-safe in light mode (dark `--ink-4` is a separate value, untouched). Flagged here per the fresh-context review.

### Verification
- 2594 frontend tests pass; 256 accessibility + css-migration tests pass; typecheck, lint, `format:check`, `build:frontend` all clean.
- `/simplify` (high) + fresh-context `/review` both clean (APPROVE-WITH-NITS; nits addressed/flagged). Reviewer empirically confirmed the contrast audit goes red on the known-bad values (not hollow).
- Dual-engine (Chromium + WebKit) Playwright preview smoke + screenshots to follow on this PR's preview channel (the "live verification" gate).

### Lessons
- Lesson 112 — a "verification pass" contrast guard earns its keep on the marginals the eye and hand-math miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
