### PR TITLE
feat(district): secondary route-nav primitive (epic #674, Sprint 4) (#678)

### DIFF
--- a/frontend/src/__tests__/accessibility/DistrictDetailPage.axe.test.tsx
+++ b/frontend/src/__tests__/accessibility/DistrictDetailPage.axe.test.tsx
@@ -20,7 +20,7 @@
 // full WCAG rule set on the dark DOM tree, not just the light one.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, cleanup } from '@testing-library/react'
+import { render, cleanup, screen } from '@testing-library/react'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -173,5 +173,22 @@ describe('DistrictDetailPage — axe-core scan in light and dark mode (#564 Phas
     const { container } = renderPage()
     const results = await axe(container)
     expect(results).toHaveNoViolations()
+  })
+})
+
+// Reuses the routed hub mount (renderPage at /district/57) to prove the
+// hub wires the lateral subnav with Overview active (#678, ADR-005 §3).
+describe('DistrictDetailPage — section subnav wiring (#678)', () => {
+  afterEach(() => cleanup())
+
+  it('renders the subnav with Overview marked active on the hub', () => {
+    renderPage()
+    const subnav = screen.getByRole('navigation', { name: 'District sections' })
+    expect(subnav).toBeInTheDocument()
+    const overview = screen.getByRole('link', {
+      name: 'Overview',
+      current: 'page',
+    })
+    expect(overview).toHaveAttribute('href', '/district/57')
   })
 })

--- a/frontend/src/__tests__/accessibility/DistrictSubnavDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/DistrictSubnavDarkModeContrast.test.ts
@@ -1,0 +1,137 @@
+/**
+ * District subnav dark-mode contrast audit (#678, epic #674 Sprint 4).
+ *
+ * The lateral section nav (`DistrictSubnav`) sits on the `.app-shell__main`
+ * surface (`--surface`) with a transparent background, so its active-link text,
+ * active bottom-border, and focus outline are read directly against `--surface`
+ * in both themes. The navy accent `--loyal-500` (#004165) has NO dark remap
+ * (lessons 093/096) — used as a foreground on the dark `--surface` (#111922) it
+ * lands at ~1.6:1, failing AA. The dark-safe token is `--link` (== `--loyal-500`
+ * in light, remaps to #60a5d8 in dark; R10, lesson 093).
+ *
+ * Like the sibling Awards/Region/Clubs audits this reads the *real* CSS (jest-axe
+ * can't compute contrast in jsdom — no layout) and resolves each token through
+ * the `[data-theme='dark']` cascade. Falsifiable: before the fix the active and
+ * focus assertions fail (raw `--loyal-500` on dark `--surface`). Lives in
+ * `__tests__/accessibility/` → integration project (lesson 090).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { calculateContrastRatio } from '../../utils/contrastCalculator'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const stylesDir = resolve(here, '../../styles')
+
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '')
+const read = (p: string) =>
+  stripComments(readFileSync(resolve(stylesDir, p), 'utf8'))
+
+const redesignCss = read('tokens/redesign.css')
+const subnavCss = read('components/district-subnav.css')
+
+/** Parse `--name: value;` declarations from the first rule whose selector
+ *  matches `selectorLiteral` exactly (anchored to a real rule start). */
+function parseTokenBlock(css: string, selectorLiteral: string) {
+  const re = new RegExp(
+    '(?:^|\\n)\\s*' +
+      selectorLiteral.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\s*\\{'
+  )
+  const m = re.exec(css)
+  if (!m) return new Map<string, string>()
+  const open = css.indexOf('{', m.index)
+  const close = css.indexOf('}', open)
+  const map = new Map<string, string>()
+  for (const d of css
+    .slice(open + 1, close)
+    .matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g))
+    map.set(d[1].trim(), d[2].trim())
+  return map
+}
+
+const lightTokens = parseTokenBlock(redesignCss, ':root')
+const darkTokens = parseTokenBlock(redesignCss, "[data-theme='dark']")
+
+/** Resolve a `var(--x)` chain to a literal hex, in the requested theme. */
+function resolveVar(value: string, theme: 'light' | 'dark', depth = 0): string {
+  if (depth > 8) throw new Error(`var() too deep: ${value}`)
+  const v = value.trim()
+  const m = v.match(/^var\((--[\w-]+)\)$/)
+  if (!m) return v
+  const map = theme === 'dark' ? darkTokens : lightTokens
+  const next =
+    theme === 'dark' ? (map.get(m[1]) ?? lightTokens.get(m[1])) : map.get(m[1])
+  if (!next) throw new Error(`token ${m[1]} undefined in ${theme}`)
+  return resolveVar(next, theme, depth + 1)
+}
+
+/** The raw `var(--x)` token a prop references in a flat subnav rule. */
+function ruleProp(selectorLiteral: string, prop: string): string {
+  const re = new RegExp(
+    '(?:^|\\n)\\s*' +
+      selectorLiteral.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\s*\\{'
+  )
+  const m = re.exec(subnavCss)
+  if (!m) throw new Error(`rule ${selectorLiteral} not found`)
+  const open = subnavCss.indexOf('{', m.index)
+  const close = subnavCss.indexOf('}', open)
+  const pm = subnavCss
+    .slice(open + 1, close)
+    .match(new RegExp('(?:^|[;{\\s])' + prop + '\\s*:\\s*([^;!]+)'))
+  if (!pm) throw new Error(`prop ${prop} not in rule ${selectorLiteral}`)
+  return pm[1].trim()
+}
+
+const AA_TEXT = 4.5
+const AA_NONTEXT = 3.0 // WCAG 1.4.11 (focus indicator / UI component)
+
+describe('DistrictSubnav dark-mode contrast (#678)', () => {
+  const surface = {
+    light: resolveVar('var(--surface)', 'light'),
+    dark: resolveVar('var(--surface)', 'dark'),
+  }
+
+  it('active-link text clears AA against --surface in light AND dark', () => {
+    const token = ruleProp(
+      ".district-subnav__link[aria-current='page']",
+      'color'
+    )
+    for (const theme of ['light', 'dark'] as const) {
+      const fg = resolveVar(token, theme)
+      const ratio = calculateContrastRatio(fg, surface[theme])
+      expect(
+        ratio,
+        `${theme}: ${token}→${fg} on ${surface[theme]}`
+      ).toBeGreaterThanOrEqual(AA_TEXT)
+    }
+  })
+
+  it('active bottom-border clears the 3:1 non-text threshold in light AND dark', () => {
+    const token = ruleProp(
+      ".district-subnav__link[aria-current='page']",
+      'border-bottom-color'
+    )
+    for (const theme of ['light', 'dark'] as const) {
+      const fg = resolveVar(token, theme)
+      const ratio = calculateContrastRatio(fg, surface[theme])
+      expect(ratio, `${theme}: ${token}→${fg}`).toBeGreaterThanOrEqual(
+        AA_NONTEXT
+      )
+    }
+  })
+
+  it('focus outline clears the 3:1 non-text threshold in light AND dark', () => {
+    const token = ruleProp('.district-subnav__link:focus-visible', 'outline')
+    const colorToken = token.match(/var\(--[\w-]+\)/)?.[0] ?? token
+    for (const theme of ['light', 'dark'] as const) {
+      const fg = resolveVar(colorToken, theme)
+      const ratio = calculateContrastRatio(fg, surface[theme])
+      expect(ratio, `${theme}: ${colorToken}→${fg}`).toBeGreaterThanOrEqual(
+        AA_NONTEXT
+      )
+    }
+  })
+})

--- a/frontend/src/components/DistrictSubnav.tsx
+++ b/frontend/src/components/DistrictSubnav.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { NavLink } from 'react-router-dom'
+
+/* #678 (epic #674 Sprint 4) — District secondary route-nav primitive.
+
+   ADR-005 decision 3: a NEW lateral section-nav, deliberately DISTINCT from
+   `SubpageBreadcrumb` (#577 / Lesson 085). They are different affordances with
+   different ARIA contracts and must not be conflated:
+     - Breadcrumb = vertical hierarchy ("where am I": District 61 › Clubs),
+       `nav[aria-label="Breadcrumb"]`, aria-current on the LAST crumb,
+       landing-opt-OUT.
+     - Subnav    = lateral view-switching ("jump to a sibling view"),
+       `nav[aria-label="District sections"]`, aria-current on the ACTIVE route,
+       landing-opt-IN (renders on the hub AND every flat sub-page).
+
+   The leaf ClubDetailPage is NOT a sibling section view — it keeps its full
+   breadcrumb trail and does NOT get the subnav.
+
+   Mobile: a horizontally-scrollable link ROW at all widths (ADR §3 / handoff
+   §126), NOT a <select> — keeping the sibling views visible preserves the
+   "every item is a visible route" intent. The links are natively focusable, so
+   keyboard users tab through them (the focused link scrolls into view); the
+   scroll container needs no role="region" (cf. Lesson 105, which applies to
+   non-focusable table scrolls). */
+
+export interface DistrictSection {
+  /** Visible label. */
+  label: string
+  /** Path segment appended after /district/:id. '' = the Overview hub. */
+  segment: string
+}
+
+/* The canonical, ordered section list. ADR-005 §2 + the epic's AC1 require
+   every item to be a REAL route — a destination-less nav item is the exact
+   tab-like fiction the no-tabs decision rejects. `/trends` and `/analytics`
+   are created in Sprint 6 (#680); they join this array THEN, not before. This
+   const is the single extension point. */
+export const DISTRICT_SECTIONS: readonly DistrictSection[] = [
+  { label: 'Overview', segment: '' },
+  { label: 'Clubs', segment: 'clubs' },
+  { label: 'Divisions', segment: 'divisions' },
+  { label: 'Rankings', segment: 'rankings' },
+]
+
+interface DistrictSubnavProps {
+  districtId: string
+}
+
+export const DistrictSubnav: React.FC<DistrictSubnavProps> = ({
+  districtId,
+}) => {
+  return (
+    <nav
+      aria-label="District sections"
+      className="district-subnav"
+      data-testid="district-subnav"
+    >
+      <ul className="district-subnav__list">
+        {DISTRICT_SECTIONS.map(({ label, segment }) => {
+          const to = segment
+            ? `/district/${districtId}/${segment}`
+            : `/district/${districtId}`
+          return (
+            <li key={label} className="district-subnav__item">
+              <NavLink
+                to={to}
+                // `end` so Overview is active ONLY at the exact hub URL, not on
+                // every /district/:id/* sub-route (NavLink prefix-matches).
+                end={segment === ''}
+                className="district-subnav__link"
+              >
+                {label}
+              </NavLink>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}
+
+export default DistrictSubnav

--- a/frontend/src/components/__tests__/DistrictSubnav.test.tsx
+++ b/frontend/src/components/__tests__/DistrictSubnav.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import { DistrictSubnav, DISTRICT_SECTIONS } from '../DistrictSubnav'
+
+expect.extend(toHaveNoViolations)
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <DistrictSubnav districtId="61" />
+    </MemoryRouter>
+  )
+
+describe('DistrictSubnav (#678, ADR-005 §3)', () => {
+  it('renders a nav labelled "District sections" — distinct from the breadcrumb', () => {
+    renderAt('/district/61')
+    expect(
+      screen.getByRole('navigation', { name: 'District sections' })
+    ).toBeInTheDocument()
+    // It is NOT the breadcrumb affordance.
+    expect(
+      screen.queryByRole('navigation', { name: 'Breadcrumb' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders one link per live section with the right hrefs', () => {
+    renderAt('/district/61')
+    const expected: Record<string, string> = {
+      Overview: '/district/61',
+      Clubs: '/district/61/clubs',
+      Divisions: '/district/61/divisions',
+      Rankings: '/district/61/rankings',
+    }
+    for (const [label, href] of Object.entries(expected)) {
+      expect(screen.getByRole('link', { name: label })).toHaveAttribute(
+        'href',
+        href
+      )
+    }
+  })
+
+  it('does not list Trends or Analytics yet — their routes land in #680', () => {
+    renderAt('/district/61')
+    expect(screen.queryByRole('link', { name: 'Trends' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Analytics' })).toBeNull()
+    // The canonical list is the single extension point for #680.
+    expect(DISTRICT_SECTIONS.map(s => s.label)).toEqual([
+      'Overview',
+      'Clubs',
+      'Divisions',
+      'Rankings',
+    ])
+  })
+
+  it('marks the active route with aria-current="page" (Clubs)', () => {
+    renderAt('/district/61/clubs')
+    expect(screen.getByRole('link', { name: 'Clubs' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+    expect(screen.getByRole('link', { name: 'Divisions' })).not.toHaveAttribute(
+      'aria-current'
+    )
+  })
+
+  it('marks Overview active only at the exact hub, not on sub-routes (end match)', () => {
+    renderAt('/district/61')
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+  })
+
+  it('does NOT mark Overview active when on a sub-route', () => {
+    renderAt('/district/61/divisions')
+    expect(screen.getByRole('link', { name: 'Overview' })).not.toHaveAttribute(
+      'aria-current'
+    )
+    expect(screen.getByRole('link', { name: 'Divisions' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+  })
+
+  it('has no axe violations', async () => {
+    const { container } = renderAt('/district/61/clubs')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,6 +42,7 @@
 @import './styles/components/alerts.css';
 @import './styles/components/app-shell.css';
 @import './styles/components/district-narrative.css';
+@import './styles/components/district-subnav.css';
 @import './styles/responsive.css';
 @import './styles/dark-mode.css';
 @import './styles/print.css';

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -17,6 +17,7 @@ import {
 } from '../utils/programYear'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
 import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
+import { DistrictSubnav } from '../components/DistrictSubnav'
 import { ClubsTable } from '../components/ClubsTable'
 import { ProspectiveClubsPanel } from '../components/ProspectiveClubsPanel'
 import ErrorBoundary from '../components/ErrorBoundary'
@@ -289,6 +290,8 @@ const DistrictClubsPage: React.FC = () => {
           <SubpageBreadcrumb
             crumbs={[{ label: districtName, to: `/district/${districtId}` }]}
           />
+
+          <DistrictSubnav districtId={districtId} />
 
           <div className="space-y-4 sm:space-y-6">
             {isLoading && allClubs.length === 0 ? (

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -9,6 +9,7 @@ import {
 import { redirectLegacyDistrictTab } from '../utils/legacyTabRedirect'
 import { useDistricts } from '../hooks/useDistricts'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
+import { DistrictSubnav } from '../components/DistrictSubnav'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
 import { useAggregatedAnalytics } from '../hooks/useAggregatedAnalytics'
 import { useDistrictStatistics } from '../hooks/useMembershipData'
@@ -479,6 +480,10 @@ const DistrictDetailPageInner: React.FC = () => {
               }
             />
           )}
+
+          {/* Lateral section nav (#678, ADR-005 §3). Landing-opt-IN — renders
+              on the hub and every flat sub-page (unlike the breadcrumb). */}
+          {districtId && <DistrictSubnav districtId={districtId} />}
 
           {/* Global Error State */}
           {overviewError && (

--- a/frontend/src/pages/DistrictDivisionsPage.tsx
+++ b/frontend/src/pages/DistrictDivisionsPage.tsx
@@ -13,6 +13,7 @@ import {
 import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
 import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
+import { DistrictSubnav } from '../components/DistrictSubnav'
 import { DivisionPerformanceCards } from '../components/DivisionPerformanceCards'
 import DistinguishedProgramCriteriaExplainer from '../components/DistinguishedProgramCriteriaExplainer'
 import { DivisionAreaRecognitionPanel } from '../components/DivisionAreaRecognitionPanel'
@@ -132,6 +133,8 @@ const DistrictDivisionsPage: React.FC = () => {
           <SubpageBreadcrumb
             crumbs={[{ label: districtName, to: `/district/${districtId}` }]}
           />
+
+          <DistrictSubnav districtId={districtId} />
 
           <div className="space-y-4 sm:space-y-6">
             {districtStatistics ? (

--- a/frontend/src/pages/DistrictRankingsPage.tsx
+++ b/frontend/src/pages/DistrictRankingsPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '../utils/programYear'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
 import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
+import { DistrictSubnav } from '../components/DistrictSubnav'
 import GlobalRankingsTab from '../components/GlobalRankingsTab'
 import ErrorBoundary from '../components/ErrorBoundary'
 
@@ -121,6 +122,8 @@ const DistrictRankingsPage: React.FC = () => {
           <SubpageBreadcrumb
             crumbs={[{ label: districtName, to: `/district/${districtId}` }]}
           />
+
+          <DistrictSubnav districtId={districtId} />
 
           <div className="space-y-4 sm:space-y-6">
             <GlobalRankingsTab

--- a/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
@@ -240,6 +240,17 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('renders the District section subnav with Clubs active (#678)', async () => {
+    renderAt('/district/61/clubs')
+    await screen.findByText(/alpha toastmasters/i)
+
+    const subnav = screen.getByRole('navigation', { name: 'District sections' })
+    expect(within(subnav).getByRole('link', { name: 'Clubs' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+  })
+
   it('round-trips the current filter into club navigation state (#577)', async () => {
     const user = userEvent.setup()
     const { router } = renderAt('/district/61/clubs?status=vulnerable')

--- a/frontend/src/pages/__tests__/DistrictDivisionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDivisionsPage.test.tsx
@@ -169,6 +169,18 @@ describe('DistrictDivisionsPage (#571 — Phase 3)', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders the District section subnav with Divisions active (#678)', async () => {
+    renderAt('/district/61/divisions')
+    await screen.findByTestId('division-performance-cards')
+
+    expect(
+      screen.getByRole('navigation', { name: 'District sections' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Divisions', current: 'page' })
+    ).toBeInTheDocument()
+  })
+
   it('shows a back-to-district breadcrumb, not the old back button (#577)', async () => {
     renderAt('/district/61/divisions')
     await screen.findByTestId('division-performance-cards')

--- a/frontend/src/pages/__tests__/DistrictRankingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictRankingsPage.test.tsx
@@ -158,6 +158,18 @@ describe('DistrictRankingsPage (#571 — Phase 3)', () => {
     expect(await screen.findByTestId('global-rankings-tab')).toBeInTheDocument()
   })
 
+  it('renders the District section subnav with Rankings active (#678)', async () => {
+    renderAt('/district/61/rankings')
+    await screen.findByTestId('global-rankings-tab')
+
+    expect(
+      screen.getByRole('navigation', { name: 'District sections' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Rankings', current: 'page' })
+    ).toBeInTheDocument()
+  })
+
   it('shows a back-to-district breadcrumb, not the old back button (#577)', async () => {
     renderAt('/district/61/rankings')
     await screen.findByTestId('global-rankings-tab')

--- a/frontend/src/styles/components/district-subnav.css
+++ b/frontend/src/styles/components/district-subnav.css
@@ -1,8 +1,14 @@
 /* #678 (epic #674 Sprint 4) — District secondary route-nav (ADR-005 §3).
-   Mirrors the app-shell primary-nav convention (redesign tokens, dark-aware
-   via [data-theme='dark'] remaps; active state keyed off NavLink's
-   aria-current="page"). Active is signalled by BOTH colour AND a bottom rule
-   (never colour alone — WCAG 1.4.1). */
+   Mirrors the app-shell primary-nav convention (redesign tokens; active state
+   keyed off NavLink's aria-current="page"). Active is signalled by BOTH colour
+   AND a bottom rule (never colour alone — WCAG 1.4.1).
+
+   The accent is `--link`, NOT `--loyal-500`: this subnav has a transparent
+   background, so its active text/border and focus ring are read directly
+   against the dark `--surface`. `--loyal-500` (#004165) has no dark remap and
+   lands at ~1.6:1 there; `--link` equals `--loyal-500` in light but remaps to a
+   dark-safe #60a5d8 (R10, lessons 093/096). The app-shell nav can use raw
+   `--loyal-500` only because it pairs it with a `--loyal-50` background fill. */
 
 @layer components {
   .district-subnav {
@@ -47,18 +53,18 @@
   }
 
   .district-subnav__link:hover {
-    color: var(--loyal-500);
+    color: var(--link);
     text-decoration: none;
   }
 
   .district-subnav__link[aria-current='page'] {
-    color: var(--loyal-500);
-    border-bottom-color: var(--loyal-500);
+    color: var(--link);
+    border-bottom-color: var(--link);
     font-weight: 600;
   }
 
   .district-subnav__link:focus-visible {
-    outline: 2px solid var(--loyal-500);
+    outline: 2px solid var(--link);
     outline-offset: -2px;
     border-radius: var(--rds-radius-sm);
   }

--- a/frontend/src/styles/components/district-subnav.css
+++ b/frontend/src/styles/components/district-subnav.css
@@ -1,0 +1,65 @@
+/* #678 (epic #674 Sprint 4) — District secondary route-nav (ADR-005 §3).
+   Mirrors the app-shell primary-nav convention (redesign tokens, dark-aware
+   via [data-theme='dark'] remaps; active state keyed off NavLink's
+   aria-current="page"). Active is signalled by BOTH colour AND a bottom rule
+   (never colour alone — WCAG 1.4.1). */
+
+@layer components {
+  .district-subnav {
+    margin-bottom: 1rem;
+    border-bottom: 1px solid var(--surface-3);
+    /* Horizontal-scroll link row at all widths (ADR §3 — not a <select>). */
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+  }
+
+  .district-subnav__list {
+    display: flex;
+    gap: 2px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    /* Keep items on one row so the container scrolls instead of wrapping. */
+    min-width: max-content;
+  }
+
+  .district-subnav__item {
+    margin: 0;
+  }
+
+  .district-subnav__link {
+    display: flex;
+    align-items: center;
+    /* WCAG 2.5.5 touch target. */
+    min-height: 44px;
+    padding: 0 14px;
+    white-space: nowrap;
+    text-decoration: none;
+    color: var(--ink-2);
+    font-family: var(--sans);
+    font-weight: 500;
+    font-size: 14px;
+    border-bottom: 2px solid transparent;
+    transition:
+      color 150ms ease,
+      border-color 150ms ease;
+  }
+
+  .district-subnav__link:hover {
+    color: var(--loyal-500);
+    text-decoration: none;
+  }
+
+  .district-subnav__link[aria-current='page'] {
+    color: var(--loyal-500);
+    border-bottom-color: var(--loyal-500);
+    font-weight: 600;
+  }
+
+  .district-subnav__link:focus-visible {
+    outline: 2px solid var(--loyal-500);
+    outline-offset: -2px;
+    border-radius: var(--rds-radius-sm);
+  }
+}

--- a/tasks/lessons/114-a-raw-token-that-passes-in-a-sibling-may-rely-on-that-siblings-background-fill.md
+++ b/tasks/lessons/114-a-raw-token-that-passes-in-a-sibling-may-rely-on-that-siblings-background-fill.md
@@ -1,0 +1,66 @@
+---
+id: '114'
+category: lesson
+tags: [dark-mode, css, accessibility, frontend]
+auto_load: true
+date: 2026-05-26
+issues: [678, 674]
+---
+
+# Lesson 114 — A raw non-remapping token that "passes" in a sibling component may be leaning on that sibling's background fill
+
+**Date:** 2026-05-26
+**Issue:** #678 (epic #674 Sprint 4 — DistrictSubnav route-nav primitive)
+**Tags:** dark-mode, css, accessibility, react-router, brand-tokens
+
+## What happened
+
+The new `DistrictSubnav` copied its active-state styling from the app-shell
+primary nav, which uses `--loyal-500` for the active link's text and a `--loyal-50`
+**background fill** (`app-shell.css` `.app-shell-nav__link[aria-current='page']`).
+The subnav kept the `--loyal-500` text/border but dropped the background fill (it
+sits on a transparent strip over `.app-shell__main`'s `--surface`).
+
+`--loyal-500` (#004165) has **no dark remap** (lessons 093/096). On the app-shell
+nav that is invisible because the active link is painted on the light-in-both-themes
+`--loyal-50` pill — the contrast lived in the fill, not the token. Strip the fill
+and the same `--loyal-500` lands directly on the dark `--surface` (#111922) at
+**~1.6:1** — failing AA for the active text, the active bottom-border, and the
+focus ring. Fresh-context review caught it before push; the light-only axe tests
+would have shipped it green (jest-axe can't compute contrast — lesson 075).
+
+## The principle
+
+**"This token passes in component X" is not evidence it is safe to reuse — X's
+contrast may be coming from a background it pairs the token with, not from the
+token itself.** A raw non-remapping brand token is only as safe as the surface
+it's painted on. When you lift an active/hover pattern off a sibling, you inherit
+the token but _not necessarily the background that made it legible_. Re-derive
+the foreground/background pair for your actual surface, in both themes.
+
+The fix is the standard one (R10, lesson 093): use the semantic `--link` token —
+it equals `--loyal-500` in light (zero light-mode change) and remaps to a
+dark-safe `#60a5d8`. Use it for any accent foreground that sits on a themed
+surface without its own opaque fill.
+
+## How to apply
+
+- Copying an `[aria-current]` / `:hover` / active style from another component?
+  List its declarations and ask which ones are load-bearing for contrast. A
+  `background-color` on the active rule is a tell: the text token is probably not
+  dark-safe on its own.
+- Foreground accent on a transparent / `--surface`-backed element → reach for
+  `--link` (or a `[data-theme='dark']` override, lesson 096), never raw
+  `--loyal-500` / `--maroon-500`.
+- Guard it with a contrast test that resolves the **real CSS token** through the
+  `[data-theme='dark']` cascade against the **actual** background (see
+  `DistrictSubnavDarkModeContrast.test.ts`) — not a light-only axe scan.
+
+## Related
+
+- [[093-a-token-that-doesnt-remap-in-dark-is-a-trap-for-every-consumer-that-isnt-link]]
+  — the parent rule; this lesson is the "but it works over there" corollary.
+- [[096-the-catch-all-dark-mode-sweep-is-where-the-brand-token-traps-hide]]
+- [[075-axe-core-in-jsdom-doesnt-catch-contrast-pair-it-with-a-static-allowlist]]
+  — why the light-only axe test missed it.
+- `frontend/src/styles/components/district-subnav.css` — the fix in situ.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -73,3 +73,4 @@
 - **111** [css, accessibility, frontend, tests, playwright, dark-mode] — A native `<select>` ignores `min-height` in WebKit; the 44px touch target needs `appearance:none` (#671, #665)
 - **112** [accessibility, css, dark-mode, tests, frontend] — A "verification pass" contrast guard earns its keep on the marginals the eye and hand-math miss (#672, #665)
 - **113** [frontend, react, charts, performance, cls] — An IntersectionObserver visibility gate on already-code-split content is invisible to every non-scroll context (#675, #674)
+- **114** [dark-mode, css, accessibility, frontend] — A raw non-remapping token that "passes" in a sibling component may be leaning on that sibling's background fill (#678, #674)

--- a/tasks/plan-678-district-subnav.md
+++ b/tasks/plan-678-district-subnav.md
@@ -1,0 +1,42 @@
+# Sprint 4 (#678) — Secondary route-nav primitive
+
+Epic #674. Implements ADR-005 decision 3. Branch: `feat/678-secondary-route-nav` (from origin/main, R19).
+
+## Decision: ship 4 live routes now, not 6
+
+ADR-005 §2 + AC1 ("every item navigates to a real route") forbid a destination-less
+nav item — that is the exact "tab-like fiction" the no-tabs decision rejects. `/trends`
+and `/analytics` routes are created in Sprint 6 (#680). So `DISTRICT_SECTIONS` lists the
+4 routes that exist today (Overview · Clubs · Divisions · Rankings); #680 inserts Trends +
+Analytics when it lands the routes. No `--soon` placeholder (also destination-less).
+
+## Component
+
+`frontend/src/components/DistrictSubnav.tsx` — NEW, distinct from `SubpageBreadcrumb`.
+
+- `nav[aria-label="District sections"] > ul` of React-Router `<NavLink>`s (ADR §3 ARIA contract).
+- `NavLink` auto-sets `aria-current="page"`; `end` on Overview so it's active only at exact hub.
+- Module const `DISTRICT_SECTIONS` drives the list (one place for #680 to extend).
+- CSS `frontend/src/styles/components/district-subnav.css` (redesign tokens, dark-aware like app-shell):
+  active = `--loyal-500` text + 2px bottom-border (not colour alone, WCAG 1.4.1);
+  `min-height:44px` touch target; horizontal scroll via `overflow-x:auto` + `min-width:max-content`;
+  `:focus-visible` outline.
+
+## Placement
+
+- Hub `DistrictDetailPage`: after `<DistrictDetailHeader>`, before KPI strip.
+- `DistrictClubsPage` / `DistrictDivisionsPage` / `DistrictRankingsPage`: after `<SubpageBreadcrumb>`.
+- Leaf `ClubDetailPage`: NO subnav (ADR §3 — it is a leaf, keeps its full breadcrumb).
+
+## TDD
+
+1. Red — `DistrictSubnav.test.tsx`: nav label, 4 hrefs, active aria-current per route, Overview `end`, axe clean.
+2. Green — component + CSS.
+3. Wire into 4 pages; add one `nav[aria-label="District sections"]` smoke assertion per page test.
+4. Verify — full suite; /simplify; review; Playwright on preview (chromium+webkit) at 375/768/1280 light+dark.
+
+## Lessons in play
+
+058 (focus visibility on nav), 085 (breadcrumb vs subnav distinct affordances), 105 (non-trap
+scroll — links are focusable so no role=region needed), 106 (no `Closes #N`; close manually last).
+</content>


### PR DESCRIPTION
Part of epic #674. Implements **ADR-005 decision 3**. (No closing keyword — sub-issue is closed manually after the epic checkbox is ticked, per Lesson 106.)

## What

A new **`DistrictSubnav`** lateral section-nav, mounted on the district hub and the 3 flat sub-pages (Clubs / Divisions / Rankings). The leaf `ClubDetailPage` is untouched (it keeps its breadcrumb trail).

- `nav[aria-label="District sections"]` of React-Router `<NavLink>`s — **deliberately distinct** from `SubpageBreadcrumb` (different ARIA contract per ADR-005 §3: subnav = lateral switching, `aria-current` on the active route; breadcrumb = hierarchy, `aria-current` on the last crumb).
- `NavLink` auto-emits `aria-current="page"`; `end` on Overview so it's active only at the exact hub.
- Horizontal-scroll link **row** at all widths (ADR §3 — **not** a `<select>`). Links are natively focusable, so the scroll container needs no `role=region` (Lesson 105 applies to non-focusable table scrolls).
- 44px touch targets; active signalled by **colour + bottom-border** (not colour alone, WCAG 1.4.1); `:focus-visible` ring.

## Scope decision: 4 routes now, not 6

ADR-005 §2 + AC1 forbid a destination-less nav item (the exact tab-fiction the no-tabs decision rejects). `/trends` and `/analytics` routes don't exist until Sprint 6 (#680), so `DISTRICT_SECTIONS` ships the **4 live routes** (Overview · Clubs · Divisions · Rankings). #680 inserts the other two when it lands the routes — `DISTRICT_SECTIONS` is the single extension point.

## Dark-mode fix (caught by fresh-context review pre-push)

First pass used `--loyal-500` for active/focus — but it has **no dark remap** and lands at ~1.6:1 on the subnav's transparent background against dark `--surface`. Swapped to `--link` (== `--loyal-500` in light, remaps to #60a5d8 in dark; R10, lessons 093/096) and added a falsifiable `DistrictSubnavDarkModeContrast` guard that resolves the real CSS tokens through the `[data-theme=dark]` cascade.

## Tests

- `DistrictSubnav.test.tsx` — nav label, 4 hrefs, per-route `aria-current`, Overview `end`, no-Trends/Analytics, axe.
- Wiring assertions on each page test (hub Overview-active reuses the axe test's routed mount).
- `DistrictSubnavDarkModeContrast.test.ts` — active text ≥ 4.5:1, border + focus ≥ 3:1, light **and** dark.
- Full suite green (2620 tests).

## Acceptance criteria
- [x] Every item navigates to a real route; back button + deep links work (real `<Link>`s; 4 existing routes).
- [x] Active route visually (colour + border) + programmatically (`aria-current`) indicated.
- [x] Usable 375/768/1280, light + dark; ≥44px targets — verified on preview (screenshots in evidence comment).
- [x] Keyboard + screen-reader nav (focusable links, `:focus-visible` ring, labelled nav landmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)