### PR TITLE
chore(district): breakpoint reconciliation + dark-mode panel audit (epic #674 Sprint 8)

### DIFF
--- a/frontend/src/__tests__/css-migration/district-breakpoints.test.ts
+++ b/frontend/src/__tests__/css-migration/district-breakpoints.test.ts
@@ -1,0 +1,53 @@
+// District-surface breakpoint reconciliation guard (#682, epic #674 Sprint 8)
+//
+// The redesign HANDOFF (docs/design/club-redesign-2026-05/HANDOFF.md §126/§234)
+// defines ONE responsive system for the district pages:
+//   - 2-col content grids collapse to 1-col under 980px
+//   - tables collapse to cards under 640px (owned by ClubsTable useIsMobile(640))
+//
+// Before this sprint the district surface mixed 768 / 1024 for its 2-col grids
+// and KPI strip. This guard pins every 2-col content grid and the KPI strip's
+// desktop threshold to 980px so the system can't drift back. It reads the real
+// source (CSS + the two TSX call sites), so it's falsifiable and fast — no
+// layout engine needed (jsdom can't compute media queries; cf. Lesson 66).
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const SRC = resolve(__dirname, '../..')
+const read = (p: string) => readFileSync(resolve(SRC, p), 'utf-8')
+
+const narrativeCss = read('styles/components/district-narrative.css')
+const districtOverview = read('components/DistrictOverview.tsx')
+const topGrowthClubs = read('components/TopGrowthClubs.tsx')
+
+describe('District breakpoint reconciliation (#682)', () => {
+  describe('district-narrative.css KPI strip', () => {
+    it('uses 980px as the desktop threshold, not 1024px or 768px', () => {
+      expect(narrativeCss).toContain('min-width: 980px')
+      expect(narrativeCss).not.toContain('min-width: 1024px')
+      expect(narrativeCss).not.toContain('min-width: 768px')
+    })
+
+    it('keeps the 640px 2-col intermediate step (#681)', () => {
+      // The 4-card strip steps 1 → 2 (640) → 4 (980); the 640 intermediate
+      // avoids four tall stacked cards on tablet and is intentionally kept.
+      expect(narrativeCss).toContain('min-width: 640px')
+    })
+  })
+
+  describe('DistrictOverview composition grid', () => {
+    it('collapses the 2-col content grid at 980px, not Tailwind lg (1024)', () => {
+      expect(districtOverview).toContain('min-[980px]:grid-cols-2')
+      expect(districtOverview).not.toContain('lg:grid-cols-2')
+    })
+  })
+
+  describe('TopGrowthClubs Achievement Highlights grid', () => {
+    it('collapses the 2-col stat grid at 980px, not Tailwind md (768)', () => {
+      expect(topGrowthClubs).toContain('min-[980px]:grid-cols-2')
+      expect(topGrowthClubs).not.toContain('md:grid-cols-2')
+    })
+  })
+})

--- a/frontend/src/__tests__/css-migration/district-panel-surfaces.test.ts
+++ b/frontend/src/__tests__/css-migration/district-panel-surfaces.test.ts
@@ -1,0 +1,54 @@
+// District analytics panel-surface guard (#682, epic #674 Sprint 8)
+//
+// The district pages theme dark mode via the manual `[data-theme='dark']`
+// toggle, NOT `prefers-color-scheme`. Tailwind `dark:` variants are therefore
+// INERT here (the project registers `@custom-variant theme-dark`, not `dark`;
+// Lessons 73 / 95). A panel styled with `bg-white dark:bg-gray-800` renders
+// `bg-white` in dark — which the dark-mode.css override routes to
+// `--surface-card` (#1A1722), a LIGHTER surface than the neighbour
+// `.redesign-panel`'s `--surface` (#111922). Result: the Education Levels and
+// Achievement Highlights panels read lighter than their neighbours in dark.
+//
+// Fix: drive both panels from the token-driven `.redesign-panel` primitive
+// (matches every neighbour), and give the nested stat cards a `--surface-2`
+// arbitrary-value background that re-resolves live under the dark toggle
+// (Lesson 093). This guard pins that so the legacy patterns can't return.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const SRC = resolve(__dirname, '../..')
+const read = (p: string) => readFileSync(resolve(SRC, p), 'utf-8')
+
+const educationCard = read('components/EducationLevelsCard.tsx')
+const topGrowthClubs = read('components/TopGrowthClubs.tsx')
+
+describe('District panel dark-mode surfaces (#682)', () => {
+  describe('EducationLevelsCard', () => {
+    it('is a token-driven redesign-panel, not a bg-white card', () => {
+      expect(educationCard).toContain('redesign-panel')
+      expect(educationCard).not.toContain('bg-white')
+    })
+
+    it('drops the inert dark: panel utilities', () => {
+      // `dark:bg-gray-800` / `dark:border-gray-700` never fire under the
+      // manual toggle — they are dead selectors, not a dark-mode fix.
+      expect(educationCard).not.toContain('dark:bg-gray-800')
+      expect(educationCard).not.toContain('dark:border-gray-700')
+    })
+  })
+
+  describe('TopGrowthClubs Achievement Highlights', () => {
+    it('uses a token-driven panel surface, not a light-baked gradient', () => {
+      expect(topGrowthClubs).not.toContain(
+        'from-tm-loyal-blue-10 to-tm-cool-gray-20'
+      )
+    })
+
+    it('nests the stat cards on a re-resolving --surface-2 token, not bg-white', () => {
+      expect(topGrowthClubs).toContain('bg-[var(--surface-2)]')
+      expect(topGrowthClubs).not.toContain('bg-white')
+    })
+  })
+})

--- a/frontend/src/components/DistrictOverview.tsx
+++ b/frontend/src/components/DistrictOverview.tsx
@@ -97,7 +97,7 @@ export const DistrictOverview: React.FC<DistrictOverviewProps> = ({
 
       {/* Distinguished Composition stack-bar + Payment Composition donut */}
       {!isLoading && !error && analytics && analytics.allClubs.length > 0 && (
-        <div className="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="mt-4 grid grid-cols-1 min-[980px]:grid-cols-2 gap-4">
           <DistinguishedCompositionBar
             smedley={analytics.distinguishedClubs.smedley}
             presidents={analytics.distinguishedClubs.presidents}

--- a/frontend/src/components/EducationLevelsCard.tsx
+++ b/frontend/src/components/EducationLevelsCard.tsx
@@ -57,13 +57,11 @@ export const EducationLevelsCard: React.FC<EducationLevelsCardProps> = ({
   if (isLoading) {
     return (
       <section
-        className="bg-white rounded-lg p-4 border border-gray-200 dark:bg-gray-800 dark:border-gray-700"
+        className="redesign-panel"
         aria-busy="true"
         aria-label="Loading education levels rollup"
       >
-        <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">
-          Education Levels
-        </p>
+        <p className="text-sm font-semibold text-gray-700">Education Levels</p>
         <p className="text-xs text-gray-500 mt-2">Loading…</p>
       </section>
     )
@@ -78,22 +76,22 @@ export const EducationLevelsCard: React.FC<EducationLevelsCardProps> = ({
 
   return (
     <section
-      className="bg-white rounded-lg p-4 border border-gray-200 dark:bg-gray-800 dark:border-gray-700"
+      className="redesign-panel"
       aria-labelledby="education-levels-card-title"
       aria-label="education levels"
     >
       <header className="mb-3">
         <h3
           id="education-levels-card-title"
-          className="flex items-center gap-1 text-sm font-semibold text-gray-800 dark:text-gray-100"
+          className="flex items-center gap-1 text-sm font-semibold text-gray-800"
         >
           Education Levels
           <Tooltip content="Total education awards earned this program year, summed across all clubs. Source: clubPerformance.csv columns Level 1s, Level 2s, Level 3s, and the bundled Level 4 / Path Completion / DTM column. TI does not publish per-Pathway breakdowns in the district dashboard.">
             <InfoIcon />
           </Tooltip>
         </h3>
-        <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
-          <strong className="text-gray-900 dark:text-gray-50">
+        <p className="text-xs text-gray-600 mt-1">
+          <strong className="text-gray-900">
             {totals.total.toLocaleString()}
           </strong>{' '}
           total awards · {totals.contributingClubs}/{totals.totalClubs} clubs
@@ -110,22 +108,22 @@ export const EducationLevelsCard: React.FC<EducationLevelsCardProps> = ({
               key={spec.key}
               className="grid grid-cols-[6.5rem_1fr_5rem] items-center gap-2 text-xs"
             >
-              <span className="flex items-center gap-1 text-gray-700 dark:text-gray-200">
+              <span className="flex items-center gap-1 text-gray-700">
                 {spec.label}
                 <Tooltip content={spec.description}>
                   <InfoIcon />
                 </Tooltip>
               </span>
               <span
-                className="h-2 rounded-full bg-tm-loyal-blue/80 dark:bg-tm-loyal-blue/60"
+                className="h-2 rounded-full bg-tm-loyal-blue/80"
                 aria-hidden="true"
                 style={{ width: `${pct}%` }}
               />
-              <span className="text-right text-gray-700 dark:text-gray-200">
-                <strong className="text-gray-900 dark:text-gray-50">
+              <span className="text-right text-gray-700">
+                <strong className="text-gray-900">
                   {count.toLocaleString()}
                 </strong>{' '}
-                <span className="text-gray-500 dark:text-gray-400">{pct}%</span>
+                <span className="text-gray-500">{pct}%</span>
               </span>
             </li>
           )

--- a/frontend/src/components/TopGrowthClubs.tsx
+++ b/frontend/src/components/TopGrowthClubs.tsx
@@ -292,13 +292,18 @@ export const TopGrowthClubs: React.FC<TopGrowthClubsProps> = ({
         </div>
       )}
 
-      {/* Achievement Summary */}
-      <div className="bg-gradient-to-r from-tm-loyal-blue-10 to-tm-cool-gray-20 rounded-lg shadow-md p-6">
+      {/* Achievement Summary. #682: token-driven redesign-panel (was a
+          light-baked loyal-blue→cool-gray gradient that read lighter than the
+          neighbouring panels in dark mode). The nested stat cards sit on
+          --surface-2 (an arbitrary-value var that re-resolves live under the
+          [data-theme='dark'] toggle, Lesson 093) so they stay distinct from
+          the panel surface in both themes. */}
+      <div className="redesign-panel">
         <h3 className="text-lg font-semibold text-gray-900 mb-3 font-tm-headline">
           Achievement Highlights
         </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="bg-white rounded-lg p-4">
+        <div className="grid grid-cols-1 min-[980px]:grid-cols-2 gap-4">
+          <div className="bg-[var(--surface-2)] border border-[var(--line)] rounded-lg p-4">
             <div className="flex items-center gap-2 mb-2">
               <svg
                 className="w-5 h-5 text-green-600"
@@ -324,7 +329,7 @@ export const TopGrowthClubs: React.FC<TopGrowthClubsProps> = ({
           </div>
 
           {topDCPClubs && topDCPClubs.length > 0 && (
-            <div className="bg-white rounded-lg p-4">
+            <div className="bg-[var(--surface-2)] border border-[var(--line)] rounded-lg p-4">
               <div className="flex items-center gap-2 mb-2">
                 <svg
                   className="w-5 h-5 text-tm-loyal-blue"

--- a/frontend/src/styles/__tests__/districtNarrative.test.ts
+++ b/frontend/src/styles/__tests__/districtNarrative.test.ts
@@ -39,9 +39,12 @@ describe('district-narrative.css (#572)', () => {
     expect(css).toMatch(/\.district-kpi-strip\s*\{[^}]*top:\s*56px/)
   })
 
-  it('hides the strip toggle chevron at tablet+', () => {
+  it('hides the strip toggle chevron at the 980px desktop threshold (#682)', () => {
+    // #682 reconciled the strip's desktop threshold from 768 to the handoff's
+    // 980px 2-col-collapse point so the whole district surface shares one
+    // breakpoint system. Below 980 the collapse chevron is available.
     expect(css).toMatch(
-      /@media\s*\(min-width:\s*768px\)[\s\S]*\.district-kpi-strip__toggle[\s\S]*?display:\s*none/
+      /@media\s*\(min-width:\s*980px\)[\s\S]*\.district-kpi-strip__toggle[\s\S]*?display:\s*none/
     )
   })
 

--- a/frontend/src/styles/components/district-narrative.css
+++ b/frontend/src/styles/components/district-narrative.css
@@ -56,15 +56,19 @@
     gap: 12px;
   }
 
-  /* 4 cards (#681): 1-col → 2-col (640) → 4-col (1024). A 3-col rule would
-     orphan the 4th card on a second row; 2×2 then 4-across reads cleanly. */
+  /* 4 cards (#681): 1-col → 2-col (640) → 4-col (980). A 3-col rule would
+     orphan the 4th card on a second row; 2×2 then 4-across reads cleanly.
+     #682: the 4-col threshold is the handoff's 980px 2-col-collapse point
+     (HANDOFF §234), reconciled from the original 1024 so the whole district
+     surface shares one breakpoint system. The 640 intermediate stays — four
+     stacked cards on tablet would be needlessly tall. */
   @media (min-width: 640px) {
     .district-kpi-strip__cards {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
-  @media (min-width: 1024px) {
+  @media (min-width: 980px) {
     .district-kpi-strip__cards {
       grid-template-columns: repeat(4, minmax(0, 1fr));
     }
@@ -137,8 +141,10 @@
     outline-offset: 2px;
   }
 
-  /* Desktop / tablet: chevron is hidden — strip is always expanded. */
-  @media (min-width: 768px) {
+  /* Desktop: chevron is hidden — strip is always expanded at the 980px
+     full-layout threshold (#682, matching the 4-col step). Below 980 the
+     collapse chevron is available. */
+  @media (min-width: 980px) {
     .district-kpi-strip__toggle {
       display: none;
     }

--- a/tasks/lessons/107-bg-white-routes-to-a-lighter-dark-scale-than-redesign-panel-neighbours.md
+++ b/tasks/lessons/107-bg-white-routes-to-a-lighter-dark-scale-than-redesign-panel-neighbours.md
@@ -1,0 +1,71 @@
+---
+id: '107'
+category: lesson
+tags: [dark-mode, css, frontend, responsive]
+auto_load: true
+date: 2026-05-26
+issues: [682, 674]
+---
+
+# Lesson 107 — `bg-white` themes to a LIGHTER dark scale than its `.redesign-panel` neighbours
+
+**Date:** 2026-05-26
+**Issue:** #682 (epic #674 Sprint 8 — district page breakpoints + dark panels)
+
+## What happened
+
+Two district analytics panels (Education Levels, Achievement Highlights) "read
+lighter than their neighbours" in dark mode. Neither was _unthemed_ in the
+usual sense — `dark-mode.css` does have a `[data-theme='dark'] .bg-white`
+override. The bug was subtler: there are **two parallel dark-surface token
+systems** in this app, and `bg-white` routes to the lighter one.
+
+- `.redesign-panel` (the neighbour primitive) → `var(--surface)` = **#111922**.
+- `bg-white` → (via the dark-mode.css override) `var(--surface-card)` =
+  **#1A1722** — a visibly lighter surface from the older `--surface-primary/
+  secondary/card` scale.
+
+So a panel built from `bg-white … border-gray-200` themes correctly but lands
+on a different, lighter surface than every panel built from `.redesign-panel`.
+Side by side, it looks like a half-fixed dark mode. (Compounding it: the
+`dark:bg-gray-800` the author also wrote is **inert** under the manual
+`[data-theme='dark']` toggle — Lessons 73/95 — so it contributes nothing.)
+
+## The principle
+
+When a codebase has more than one surface-token scale, "is it themed?" is the
+wrong question — ask **"does it land on the SAME surface token as its
+neighbours?"** Converge new panels on the shared primitive (`.redesign-panel`
+→ `--surface`) rather than on whatever a legacy utility (`bg-white`) happens to
+map to. A panel can be fully dark-mode-aware and still look broken because it
+sits one scale lighter than everything around it.
+
+For a nested card that must stay distinct from its panel surface, use an
+**arbitrary-value var** (`bg-[var(--surface-2)]`, `border border-[var(--line)]`)
+— it re-resolves live under the manual toggle (Lesson 093), so it adapts in
+both themes with zero `dark-mode.css` entries. Add the border: in LIGHT mode
+`--surface-2` (#f9fafb) on `--surface` (#fff) is near-imperceptible by fill
+alone; the border is what carries the nesting cue there.
+
+## How to apply
+
+- Auditing a "reads lighter/darker than neighbours" dark-mode report: compare
+  the offending element's resolved `background-color` against a neighbour's,
+  not against "is it dark at all." A live equality assertion (`panel.bg ===
+  neighbour.bg`) in a Playwright smoke catches this where a jsdom or single-
+  element axe check can't.
+- Prefer the shared panel class over re-deriving chrome from raw utilities.
+  `.redesign-panel` carries surface + line + radius + shadow + ink as one
+  token bundle; reaching past it to `bg-white border-gray-200` re-opens this
+  trap and the Lesson-73 inert-`dark:` trap at once.
+
+## Related
+
+- [[092-fixed-background-elements-need-literal-colors-not-theme-tokens]] — the
+  inverse: a fixed bg with theme-token text. Here it's a theme-token bg on the
+  wrong scale.
+- [[093-a-token-that-doesnt-remap-in-dark-is-a-trap-for-any-non-link-consumer]]
+  — use the semantic/re-resolving token; `bg-[var(--surface-2)]` is that move.
+- [[073-opacity-variant-utilities-need-explicit-dark-mode-overrides]] /
+  [[095-darkmode-token-bumps-must-be-sized-for-the-lightest-surface]] — why the
+  `dark:` utilities on these panels were inert dead weight.

--- a/tasks/lessons/116-bg-white-routes-to-a-lighter-dark-scale-than-redesign-panel-neighbours.md
+++ b/tasks/lessons/116-bg-white-routes-to-a-lighter-dark-scale-than-redesign-panel-neighbours.md
@@ -1,5 +1,5 @@
 ---
-id: '107'
+id: '116'
 category: lesson
 tags: [dark-mode, css, frontend, responsive]
 auto_load: true
@@ -7,7 +7,7 @@ date: 2026-05-26
 issues: [682, 674]
 ---
 
-# Lesson 107 — `bg-white` themes to a LIGHTER dark scale than its `.redesign-panel` neighbours
+# Lesson 116 — `bg-white` themes to a LIGHTER dark scale than its `.redesign-panel` neighbours
 
 **Date:** 2026-05-26
 **Issue:** #682 (epic #674 Sprint 8 — district page breakpoints + dark panels)
@@ -23,7 +23,7 @@ systems** in this app, and `bg-white` routes to the lighter one.
 - `.redesign-panel` (the neighbour primitive) → `var(--surface)` = **#111922**.
 - `bg-white` → (via the dark-mode.css override) `var(--surface-card)` =
   **#1A1722** — a visibly lighter surface from the older `--surface-primary/
-  secondary/card` scale.
+secondary/card` scale.
 
 So a panel built from `bg-white … border-gray-200` themes correctly but lands
 on a different, lighter surface than every panel built from `.redesign-panel`.
@@ -52,7 +52,7 @@ alone; the border is what carries the nesting cue there.
 - Auditing a "reads lighter/darker than neighbours" dark-mode report: compare
   the offending element's resolved `background-color` against a neighbour's,
   not against "is it dark at all." A live equality assertion (`panel.bg ===
-  neighbour.bg`) in a Playwright smoke catches this where a jsdom or single-
+neighbour.bg`) in a Playwright smoke catches this where a jsdom or single-
   element axe check can't.
 - Prefer the shared panel class over re-deriving chrome from raw utilities.
   `.redesign-panel` carries surface + line + radius + shadow + ink as one

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -68,6 +68,7 @@
 - **107** [dark-mode, css, accessibility, tests, vitest] — A CSS-parsing audit's selector matcher must exclude pseudo-class rules, or `:hover`/`:focus` shadows the resting state (#700, #701)
 - **107** [process, frontend, router, tdd, sprint-runner] — Reserve a future seam with a tripwire test, not just a comment (#680, #678, #674)
 - **107** [dark-mode, css, accessibility, frontend, tailwind] — Tailwind's `dark:` is OS-keyed; under a manual theme toggle it MISFIRES in the OS-dark + app-light quadrant (#710, #683)
+- **107** [dark-mode, css, frontend, responsive] — `bg-white` themes to a LIGHTER dark scale than its `.redesign-panel` neighbours (#682, #674)
 - **108** [tests, playwright, css, frontend, accessibility] — Verify a sticky header by measuring the sticky cell, not the `<thead>` wrapper (#667, #665)
 - **109** [frontend, css, tests, scope, dark-mode] — A render-time class guard scopes to the resting state; let that be the deferral boundary, but don't mistake it for a contrast audit (#668, #665)
 - **110** [tests, e2e, css, frontend, verification] — jsdom `textContent` ignores CSS `text-transform`; a live `innerText` assertion doesn't (#669, #665)

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -68,7 +68,6 @@
 - **107** [dark-mode, css, accessibility, tests, vitest] — A CSS-parsing audit's selector matcher must exclude pseudo-class rules, or `:hover`/`:focus` shadows the resting state (#700, #701)
 - **107** [process, frontend, router, tdd, sprint-runner] — Reserve a future seam with a tripwire test, not just a comment (#680, #678, #674)
 - **107** [dark-mode, css, accessibility, frontend, tailwind] — Tailwind's `dark:` is OS-keyed; under a manual theme toggle it MISFIRES in the OS-dark + app-light quadrant (#710, #683)
-- **107** [dark-mode, css, frontend, responsive] — `bg-white` themes to a LIGHTER dark scale than its `.redesign-panel` neighbours (#682, #674)
 - **108** [tests, playwright, css, frontend, accessibility] — Verify a sticky header by measuring the sticky cell, not the `<thead>` wrapper (#667, #665)
 - **109** [frontend, css, tests, scope, dark-mode] — A render-time class guard scopes to the resting state; let that be the deferral boundary, but don't mistake it for a contrast audit (#668, #665)
 - **110** [tests, e2e, css, frontend, verification] — jsdom `textContent` ignores CSS `text-transform`; a live `innerText` assertion doesn't (#669, #665)
@@ -77,3 +76,4 @@
 - **113** [frontend, react, charts, performance, cls] — An IntersectionObserver visibility gate on already-code-split content is invisible to every non-scroll context (#675, #674)
 - **114** [dark-mode, css, accessibility, frontend] — A raw non-remapping token that "passes" in a sibling component may be leaning on that sibling's background fill (#678, #674)
 - **115** [frontend, analytics, data-pipeline, dcp, verification] — A field's name (and comment) can lie about whether it's populated in _your_ surface (#681, #674)
+- **116** [dark-mode, css, frontend, responsive] — `bg-white` themes to a LIGHTER dark scale than its `.redesign-panel` neighbours (#682, #674)

--- a/tasks/sprint-682-plan.md
+++ b/tasks/sprint-682-plan.md
@@ -1,0 +1,52 @@
+# Sprint 8 (#682) — breakpoint reconciliation + dark-mode panel audit
+
+Epic #674, final sprint. Branch `sprint-682-breakpoints-darkmode` off `origin/main`.
+
+## Handoff spec (source of truth)
+
+`docs/design/club-redesign-2026-05/HANDOFF.md` §126/§234:
+
+- **2-col grids collapse at 980px**
+- **Tables → cards at 640px** (already done: ClubsTable `useIsMobile(640)`)
+
+## A. Breakpoint reconciliation (criterion 1)
+
+Genuine 2-col content grids on the district surface not yet on 980:
+
+| #   | File:line                                                  | Now                     | →                         |
+| --- | ---------------------------------------------------------- | ----------------------- | ------------------------- |
+| 1   | `DistrictOverview.tsx:100` composition bar + payment donut | `lg:grid-cols-2` (1024) | `min-[980px]:grid-cols-2` |
+| 2   | `TopGrowthClubs.tsx:301` Achievement Highlights inner grid | `md:grid-cols-2` (768)  | `min-[980px]:grid-cols-2` |
+| 3   | `district-narrative.css:67` KPI strip 4-col                | `1024px`                | `980px`                   |
+| 4   | `district-narrative.css:141` KPI toggle hide               | `768px`                 | `980px`                   |
+
+Rationale #3/#4: reconcile the KPI strip's desktop threshold to the single 980 system (audit line 55 flagged "640/768 for KPI"). Keep #681's 640 → 2-col intermediate (avoids 4 tall stacked cards on tablet).
+
+Tailwind v4 supports `min-[980px]:` arbitrary variants; verify build emits it (fall back to a CSS media-query class if not).
+
+## B. Dark-mode panel audit (criterion 2)
+
+Root cause: two dark-surface token systems. Neighbor panels use `.redesign-panel` → `--surface` (#111922 dark). The two flagged panels route through the legacy `bg-white` → `--surface-card` (#1A1722, **lighter**) or a light-baked gradient tint. Their `dark:` utilities are **inert** under the manual `[data-theme='dark']` toggle (Lessons 73/95; `@custom-variant theme-dark`, no `dark` variant).
+
+| Panel                                          | Now                                                                       | Fix                                                                                                                                                           |
+| ---------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EducationLevelsCard` outer (loading + normal) | `bg-white … border-gray-200 dark:bg-gray-800 dark:border-gray-700`        | `redesign-panel`; drop dead `dark:` utils (base `text-gray-*` already remap in dark-mode.css)                                                                 |
+| Achievement Highlights container               | `bg-gradient-to-r from-tm-loyal-blue-10 to-tm-cool-gray-20 shadow-md p-6` | `redesign-panel`                                                                                                                                              |
+| Achievement Highlights inner stat cards (×2)   | `bg-white rounded-lg p-4`                                                 | `bg-[var(--surface-2)] border border-[var(--line)] rounded-lg p-4` — arbitrary-value vars re-resolve live in dark (Lesson 093), no dark-mode.css entry needed |
+
+`--surface-2` (#161f2a dark / #f9fafb light) keeps the nested stat cards distinct from the panel `--surface` in BOTH modes.
+
+## TDD
+
+- **Red:** `__tests__/css-migration/district-breakpoints.test.ts` — parse `district-narrative.css` asserting 980 (not 1024/768) for the two rules; grep `DistrictOverview.tsx` / `TopGrowthClubs.tsx` for `min-[980px]:grid-cols-2` and absence of `lg:grid-cols-2`/`md:grid-cols-2` on those grids.
+- **Red:** `__tests__/css-migration/district-panel-surfaces.test.ts` — assert `EducationLevelsCard.tsx` + Achievement Highlights container use `redesign-panel` and contain no `bg-white`/gradient/`dark:bg-gray-800`; inner stat cards use `bg-[var(--surface-2)]`.
+- **Green:** apply edits. **Verify:** full suite, no regressions.
+
+## Verification (criterion 3)
+
+PR preview channel. Playwright smoke in chromium + webkit at 375/640/980/1280 + dark on `/district/61/analytics` and `/district/61` (Overview). Screenshots → /tmp, surfaced to operator. Lessons entry filed.
+
+## Notes
+
+- No `Closes #682` in PR body (Lesson 106). Close manually, last, after epic tick.
+- This is the LAST sprint of #674 → close epic after (step 5 of runner protocol).


### PR DESCRIPTION
Part of epic #674 (final sprint, #682). **P2.**

## What

Two reconciliations on the district detail surface, both pinned by new guard tests.

### A. Breakpoints → the handoff system (HANDOFF §126/§234: 2-col grids collapse at **980px**, tables→cards at **640px**)

| Surface | Was | Now |
|---|---|---|
| DistrictOverview composition bar + payment donut | `lg:grid-cols-2` (1024) | `min-[980px]:grid-cols-2` |
| TopGrowthClubs Achievement Highlights stat grid | `md:grid-cols-2` (768) | `min-[980px]:grid-cols-2` |
| KPI strip 4-col threshold | `1024px` | `980px` |
| KPI strip toggle-hide | `768px` | `980px` |

640px → 2-col KPI intermediate kept (#681) — four stacked cards on tablet would be needlessly tall. Tables→cards is already 640 (`ClubsTable useIsMobile(640)`). Verified the build emits `@media (width>=980px)` for the Tailwind v4 arbitrary variant.

### B. Dark-mode panel audit (no unthemed panels; R10)

Root cause: `EducationLevelsCard` and the Achievement Highlights band routed through the legacy `bg-white` → `--surface-card` (#1A1722) / a light-baked gradient, both **lighter** than the neighbouring `.redesign-panel` (`--surface` #111922). Their `dark:` utilities were inert under the manual `[data-theme='dark']` toggle (Lessons 73/93/95).

- Both panels → token-driven `.redesign-panel`.
- Nested Achievement Highlights stat cards → `bg-[var(--surface-2)] border border-[var(--line)]` (arbitrary-value vars re-resolve live in dark; the border keeps them distinct from the panel surface in light, where the bg delta alone is near-imperceptible).
- Dropped the dead `dark:` utilities; base `text-gray-*` already remap via `dark-mode.css`.

## Tests

- New: `css-migration/district-breakpoints.test.ts`, `css-migration/district-panel-surfaces.test.ts` (source/CSS-parsing guards — jsdom can't compute media queries, cf. Lesson 66).
- Updated `districtNarrative.test.ts` toggle assertion 768→980 (spec change, not assertion-pinning).
- Full suite: **2654 passed**. Fresh-context review: APPROVE.

## Verification

Playwright chromium + webkit at 375/640/980/1280 + dark on the PR preview channel — evidence to follow on #682.