### PR TITLE
fix(sprint-runner): --dry-run no longer mutates META_EPIC (#694)

### DIFF
--- a/scripts/sprint-runner.sh
+++ b/scripts/sprint-runner.sh
@@ -37,6 +37,9 @@
 #                         At least one of META_EPIC or EPIC must be set.
 #   STRICT_GATE=0|1       Require `sprint-verified` label on predecessor (default 0)
 #   SPRINT_RUNNER_LOG     Path to append-log; used for size-based rotation
+#   SPRINT_RUNNER_LOCK_DIR  Override the mkdir-lock path (default
+#                         /tmp/toast-stats-sprint.lock). Used by the regression
+#                         test so it can't collide with a live tick.
 #   WORKTREE_BASE         Parent dir for per-sprint git worktrees
 #                         (default: ~/sprint-worktrees). Each sprint gets
 #                         <WORKTREE_BASE>/sprint-<N>. Isolates the spawned
@@ -44,12 +47,13 @@
 #                         operator's primary checkout. See #625.
 #
 # Scheduling: this script is invoked by a launchd LaunchAgent — NOT crontab —
-# at minutes :02, :17, :32, :47 of every hour (15-min cadence). Plist lives at:
+# every 5 minutes (StartInterval 300). Plist lives at:
 #   ~/Library/LaunchAgents/red.taverns.toast-stats.sprint-runner.plist
 # Environment overrides (EPIC, STRICT_GATE, etc.) are set in that plist's
 # <key>EnvironmentVariables</key> dict. To apply changes:
-#   launchctl unload <plist> && launchctl load <plist>
-#   launchctl list | grep sprint-runner    # verify registered (PID '-' = idle, OK)
+#   launchctl bootout gui/$(id -u)/red.taverns.toast-stats.sprint-runner
+#   launchctl bootstrap gui/$(id -u) <plist>
+#   launchctl print gui/$(id -u)/red.taverns.toast-stats.sprint-runner  # verify run interval
 
 set -euo pipefail
 
@@ -58,7 +62,7 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 META_EPIC="${META_EPIC:-}"
 EPIC="${EPIC:-}"
 STRICT_GATE="${STRICT_GATE:-0}"
-LOCK_DIR="/tmp/toast-stats-sprint.lock"
+LOCK_DIR="${SPRINT_RUNNER_LOCK_DIR:-/tmp/toast-stats-sprint.lock}"
 BOOTSTRAP_PROMPT="$REPO_DIR/scripts/sprint-bootstrap.prompt"
 LOG_FILE="${SPRINT_RUNNER_LOG:-$HOME/.toast-stats-sprint-runner.log}"
 LOG_ROTATE_BYTES=$((1024 * 1024))
@@ -69,7 +73,11 @@ WORKTREE_BASE="${WORKTREE_BASE:-$HOME/sprint-worktrees}"
 EPIC_SOURCE=""
 META_PAUSED=0
 
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+# Append (not prepend) the standard dirs so launchd's minimal PATH can still
+# find gh/screen/git, while leaving any caller-supplied PATH entries ahead of
+# them. Prepending would shadow a test's mock bin dir and block operator
+# overrides; appending keeps the fallback without clobbering. (#694)
+export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 # === Mode parsing ===
 MODE=run
@@ -619,6 +627,13 @@ mode_run() {
     log "Epic #$EPIC has no unchecked sprints — complete."
     # Auto-advance ONLY when EPIC was resolved from META_EPIC (not pinned).
     if [[ "$EPIC_SOURCE" == "resolved via"* ]]; then
+      # --dry-run must not mutate the META_EPIC (#694): advance_meta_epic
+      # auto-ticks the epic line. Report the would-be tick and stop — without
+      # an actual tick the cascade would re-resolve the same epic and loop.
+      if [[ "$MODE" == "dry-run" ]]; then
+        log "DRY RUN — would auto-tick Epic #$EPIC in META_EPIC #$META_EPIC and advance to the next epic."
+        exit 0
+      fi
       if advance_meta_epic "$EPIC"; then
         continue  # cascade: re-resolve next epic in same tick (#627)
       fi

--- a/scripts/tests/sprint-runner-dry-run.test.sh
+++ b/scripts/tests/sprint-runner-dry-run.test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Regression test for #694: `sprint-runner.sh --dry-run` must NOT mutate the
+# META_EPIC.
+#
+# Background: the auto-advance/auto-tick branch in mode_run sat *before* the
+# dry-run guard, so `--dry-run` called advance_meta_epic() and checked off live
+# epics on roadmap #606 (it corrupted the real roadmap twice).
+#
+# Hermetic: mocks `gh` and `screen` on PATH, uses a temp lock dir + worktree
+# base, and asserts on whether `gh issue edit` (the only mutation) is invoked.
+#
+#   Case A: `--dry-run`  → MUST NOT call `gh issue edit`        (the bug)
+#   Case B: normal `run` → MUST     call `gh issue edit`        (advancement still works)
+#
+# Run directly: scripts/tests/sprint-runner-dry-run.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$SCRIPT_DIR/../sprint-runner.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+BIN="$TMP/bin"; mkdir -p "$BIN"
+EDIT_LOG="$TMP/gh-edit.log"
+
+# Mock gh: serve META_EPIC #900 with one unchecked epic (#901) whose body has
+# zero unchecked sprints → drives mode_run into the auto-advance branch.
+# Record any `gh issue edit` invocation (the mutation) to $EDIT_LOG.
+cat > "$BIN/gh" <<EOF
+#!/usr/bin/env bash
+sub="\$1"; verb="\$2"; num="\$3"
+if [[ "\$sub" == "issue" && "\$verb" == "edit" ]]; then
+  echo "EDIT \$*" >> "$EDIT_LOG"
+  exit 0
+fi
+if [[ "\$sub" == "issue" && "\$verb" == "view" ]]; then
+  field=""
+  args=("\$@")
+  for ((i=0; i<\${#args[@]}; i++)); do
+    [[ "\${args[i]}" == "--json" ]] && field="\${args[i+1]}"
+  done
+  case "\$num:\$field" in
+    900:labels) ;;                                       # no labels → not paused
+    900:body)   printf '%s' '- [ ] **Epic Test** — #901' ;;
+    901:body)   printf '%s' 'This epic has no sprint lines.' ;;
+    *) ;;
+  esac
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$BIN/gh"
+
+# Mock screen: report no active sessions (matches list_sprint_screens' grep).
+cat > "$BIN/screen" <<'EOF'
+#!/usr/bin/env bash
+echo "No Sockets found." >&2
+exit 1
+EOF
+chmod +x "$BIN/screen"
+
+export PATH="$BIN:$PATH"
+export META_EPIC=900
+export SPRINT_RUNNER_LOCK_DIR="$TMP/lock"
+export WORKTREE_BASE="$TMP/worktrees"
+unset EPIC || true
+
+fail=0
+
+# --- Case A: --dry-run must not mutate ---
+: > "$EDIT_LOG"
+"$RUNNER" --dry-run >"$TMP/dry.log" 2>&1 || true
+if [[ -s "$EDIT_LOG" ]]; then
+  echo "FAIL [A]: --dry-run mutated META_EPIC (gh issue edit called):"
+  sed 's/^/    /' "$EDIT_LOG"
+  fail=1
+else
+  echo "PASS [A]: --dry-run made no gh issue edit call"
+fi
+
+# --- Case B: normal run still advances (sanity: fix didn't disable auto-tick) ---
+: > "$EDIT_LOG"
+"$RUNNER" >"$TMP/run.log" 2>&1 || true
+if [[ -s "$EDIT_LOG" ]]; then
+  echo "PASS [B]: normal run auto-ticked (gh issue edit called)"
+else
+  echo "FAIL [B]: normal run did NOT auto-tick — advancement broke"
+  fail=1
+fi
+
+exit "$fail"


### PR DESCRIPTION
Closes #694

## Problem

`scripts/sprint-runner.sh --dry-run` is documented as "report what it would launch, no side effects" — but it **mutated the META_EPIC**. The auto-advance/auto-tick branch in `mode_run` ran *before* the dry-run guard, so a dry run called `advance_meta_epic()` and checked off live epics on roadmap #606. This corrupted the real roadmap twice (see #606 decision log, 2026-05-24).

## Fix

Guard the auto-advance branch: in dry-run mode it logs the would-be tick and exits without mutating. A no-op tick can't cascade anyway — without an actual `gh issue edit`, re-resolution loops on the same epic (which is exactly the 8x runaway the regression test caught).

## Testability changes (needed to prove the fix)

The runner had no test harness and two seams blocked hermetic testing:

- **`LOCK_DIR` now overridable** via `SPRINT_RUNNER_LOCK_DIR` — so the test can't collide with the live 5-min tick.
- **PATH now appends** the standard dirs instead of prepending. Prepending `/opt/homebrew/bin:…` shadowed any mock `gh`/`screen` (and blocked operator overrides). Appending keeps launchd's fallback while letting a caller-supplied PATH win. Verified the real `gh` still resolves via a live `--status` run.

## Test

Adds `scripts/tests/sprint-runner-dry-run.test.sh` — hermetic, mocks `gh` + `screen`:
- **Case A:** `--dry-run` must make **no** `gh issue edit` call.
- **Case B:** normal `run` **must** still auto-tick (advancement not broken).

```
RED  (before guard): FAIL [A] — 8 spurious gh issue edit calls; PASS [B]
GREEN (after guard):  PASS [A]; PASS [B]
```

## Verification

- `bash -n` syntax OK.
- Regression test GREEN (both cases).
- Live `--dry-run` against real #606: body SHA **byte-identical** before/after (`d18bcb5…` unchanged).
- Live `--status` against real #606 resolves correctly (PATH-append didn't break `gh`).
- Pre-commit hook (typecheck + lint + yaml lint): 0 errors.

Doc: corrected the scheduling comment to the current every-5-min `StartInterval` cadence + `bootout`/`bootstrap` reload commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)