### PR TITLE
ci: auto-reap pr-<N> Firebase preview channel on PR close (#741)

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,86 @@
+# Reap the per-PR Firebase Hosting preview channel when a PR closes (#741).
+#
+# pr-preview.yml creates a `pr-<N>` channel on the `staging-toast-stats` site
+# for every PR push. The staging site has a ~50 preview-channel quota; channels
+# were only reclaimed by their 7-day TTL, so merged/closed PRs accumulated
+# faster than they expired and new deploys failed with HTTP 429
+# "channel quota reached". This workflow deletes the channel on PR close so the
+# quota frees immediately instead of waiting on the TTL.
+#
+# Deliberately NOT part of pr-preview.yml: that workflow has a `paths:` filter,
+# and a `closed` event would not reliably pass it. This one has no `paths:`
+# filter so it fires for every closed PR.
+#
+# Re-uses the same Workload Identity Federation credentials as deploy.yml /
+# pr-preview.yml — no extra IAM setup.
+
+name: PR Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+# A PR number is unique, so two closes can't race; no concurrency group needed.
+
+permissions:
+  contents: read
+  id-token: write # Required for Workload Identity Federation
+
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  cleanup:
+    name: Delete preview channel
+    runs-on: ubuntu-latest
+    # Same guards as pr-preview.yml's deploy job. Forks never get a WIF token;
+    # Dependabot gets no secret access — and neither ever had a preview channel
+    # (their deploy job is skipped), so there is nothing to reap. Running the
+    # GCP auth step for them would only fail.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
+
+    steps:
+      # No checkout: channel:delete needs only the explicit --site/--project,
+      # not .firebaserc/firebase.json — and skipping it avoids running any
+      # closed-PR code here.
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Delete preview channel
+        run: |
+          set -o pipefail
+          npm install -g firebase-tools
+          CHANNEL_ID="pr-${{ github.event.pull_request.number }}"
+
+          # An already-absent channel (TTL-expired, or never created because the
+          # preview job was skipped for a non-frontend PR) returns HTTP 404 and
+          # exits non-zero. That is a successful no-op for our purpose, so we
+          # tolerate ONLY the 404 — any other failure (auth, network, quota)
+          # still fails the job so it surfaces.
+          if firebase hosting:channel:delete "$CHANNEL_ID" \
+              --site staging-toast-stats \
+              --project "${{ secrets.GCP_PROJECT_ID }}" \
+              --force 2> /tmp/del-err.log; then
+            echo "Deleted preview channel $CHANNEL_ID"
+          elif grep -qiE 'HTTP Error: 404|Not Found' /tmp/del-err.log; then
+            echo "::notice::Channel $CHANNEL_ID already absent (expired or never created) — no-op"
+          else
+            echo "::group::firebase stderr"
+            cat /tmp/del-err.log || true
+            echo "::endgroup::"
+            echo "::error::channel:delete failed for $CHANNEL_ID"
+            exit 1
+          fi

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -4,8 +4,9 @@
 # Firebase Hosting preview channel under the `staging` site. Posts (or
 # updates) a sticky PR comment with the live URL.
 #
-# Channels auto-expire after 7 days; closed/merged PRs are cleaned up
-# by Firebase TTL, not by an explicit teardown step.
+# Channels auto-expire after 7 days. Closed/merged PRs are also reaped
+# explicitly on close by pr-preview-cleanup.yml (#741), so the staging
+# site's ~50-channel quota frees immediately rather than waiting on TTL.
 #
 # Re-uses the same Workload Identity Federation credentials that
 # .github/workflows/deploy.yml uses for production deploys, so no
@@ -147,8 +148,8 @@ jobs:
 
             _Channel expires: ${{ steps.deploy.outputs.expires }}_
 
-            Updated on every push to this PR. Closed PRs are cleaned
-            up automatically when the channel TTL elapses.
+            Updated on every push to this PR. The channel is removed
+            automatically when this PR closes.
 
       # Lightweight cross-engine smoke against the freshly-deployed preview
       # (#713). #685 verified contrast in Chromium-at-rest only and missed a


### PR DESCRIPTION
Closes #741

## Problem

`pr-preview.yml` creates a `pr-<N>` Firebase Hosting channel on the `staging-toast-stats` site for every PR push. The site has a **~50 preview-channel quota**, and channels were only reclaimed by their 7-day TTL — so merged/closed PRs accumulated faster than they expired, the quota filled, and new preview deploys failed with `HTTP 429 "channel quota reached"`.

## Fix

New workflow `pr-preview-cleanup.yml`, triggered on `pull_request: closed`, deletes the PR's channel:

```
firebase hosting:channel:delete pr-<N> --site staging-toast-stats --project <id> --force
```

The quota now frees immediately on close instead of waiting on TTL.

## Design notes
- **Separate workflow, not a job in `pr-preview.yml`** — that workflow has a `paths:` filter a `closed` event wouldn't reliably pass. This one has no `paths:` filter so it fires for every close.
- **Same fork + Dependabot guards** — neither ever has a channel to reap (their deploy job is skipped), and running GCP auth for them would only fail.
- **404 tolerated, real errors not.** An absent channel (TTL-expired, or never created for a non-frontend PR) returns HTTP 404 / exit 1. The step tolerates *only* a 404/"Not Found" as a no-op; auth/network/quota failures still fail the job.
- **No checkout** — `channel:delete` needs only `--site`/`--project`, and skipping checkout avoids running any closed-PR code.
- Also corrects the now-stale "cleaned up by TTL" claims in `pr-preview.yml`'s header comment and sticky-comment text.

## Verification
- YAML parses (js-yaml); `if:` and `on:` resolve as intended.
- `npm run lint:yaml` clean (no findings on the new file).
- **Core command verified against the live site:** `firebase hosting:channel:list` confirms `staging-toast-stats` is the correct site; `channel:delete` on a non-existent channel returns `HTTP Error: 404 … Not Found` / exit 1 — exactly the case the 404-tolerant branch handles.
- Pre-commit hook (typecheck + lint + yaml lint): 0 errors.

End-to-end behaviour (the `closed`-triggered run actually deleting a real channel) can only be confirmed once this is on `main` and a PR closes — same caveat as any workflow-trigger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)