### PR TITLE
refactor(rankings): consolidate duplicated Borda logic into analytics-core shared helpers (#306)

### DIFF
--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -225,4 +225,12 @@ export {
   type OfficerAwardResult,
   type OfficerAwardStandings,
   calculateDistinguishedPercent,
+  calculateCategoryRanking,
+  calculateAggregateRankings,
+  type CategoryRanking,
+  type AggregateRanking,
+  type CategoryRankingLogger,
+  parseDateFlexible,
+  getProgramYearStartDate,
+  parseCharterDateFromStatusField,
 } from './rankings/index.js'

--- a/packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts
+++ b/packages/analytics-core/src/rankings/BordaCountRankingCalculator.ts
@@ -19,6 +19,15 @@ import type {
 
 import { getConfirmedDistinguishedLevel } from '../analytics/ClubEligibilityUtils.js'
 import { calculateDistinguishedPercent } from './distinguishedPercent.js'
+import {
+  calculateCategoryRanking,
+  calculateAggregateRankings,
+  type AggregateRanking,
+} from './bordaCount.js'
+import {
+  getProgramYearStartDate,
+  parseCharterDateFromStatusField,
+} from './programYearDates.js'
 
 /**
  * Logger interface for ranking calculator.
@@ -39,74 +48,6 @@ const noopLogger: RankingLogger = {
   warn: () => {},
   error: () => {},
   debug: () => {},
-}
-
-/**
- * Return the start-of-program-year date (July 1) preceding the given
- * snapshot date, or null if the snapshot date is unparseable (#336).
- *
- * Toastmasters program years run July 1 → June 30.
- */
-function getProgramYearStartDate(snapshotDate: string): Date | null {
-  const parsed = parseDateFlexible(snapshotDate)
-  if (!parsed) return null
-  const year = parsed.getUTCFullYear()
-  const month = parsed.getUTCMonth() + 1 // 1-indexed
-  const pyStartYear = month >= 7 ? year : year - 1
-  return new Date(Date.UTC(pyStartYear, 6, 1)) // July 1 UTC
-}
-
-/**
- * Parse a date string in ISO (YYYY-MM-DD), US 4-digit (M/D/YYYY), or US
- * 2-digit (M/D/YY) format and return a UTC-normalized Date. Two-digit years
- * are interpreted as 20YY — Toastmasters' district-performance CSVs use this
- * for charter/suspend dates. Returns null on failure.
- */
-function parseDateFlexible(value: string): Date | null {
-  const trimmed = value.trim()
-  if (!trimmed) return null
-
-  // ISO format: YYYY-MM-DD (optionally with time)
-  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/)
-  if (isoMatch) {
-    const y = Number(isoMatch[1])
-    const m = Number(isoMatch[2])
-    const d = Number(isoMatch[3])
-    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
-      return new Date(Date.UTC(y, m - 1, d))
-    }
-  }
-
-  // US format: M/D/YY or M/D/YYYY (2-digit year → 20YY)
-  const usMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})$/)
-  if (usMatch) {
-    const m = Number(usMatch[1])
-    const d = Number(usMatch[2])
-    const yRaw = Number(usMatch[3])
-    const y = usMatch[3]!.length === 2 ? 2000 + yRaw : yRaw
-    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
-      return new Date(Date.UTC(y, m - 1, d))
-    }
-  }
-
-  return null
-}
-
-/**
- * Extract a charter date from a `Charter Date/Suspend Date` field value (#336).
- *
- * Toastmasters district-performance.csv encodes club status changes as a
- * single string with a prefix and date: `Charter MM/DD/YY` for newly
- * chartered clubs, `Susp MM/DD/YY` for suspensions. Returns null if the
- * field is empty, prefixed `Susp`, or unparseable.
- */
-function parseCharterDateFromStatusField(value: unknown): Date | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  if (trimmed === '') return null
-  const match = trimmed.match(/^Charter\s+(.+)$/i)
-  if (!match) return null
-  return parseDateFlexible(match[1]!)
 }
 
 /**
@@ -324,27 +265,6 @@ interface RankingMetrics {
 }
 
 /**
- * Category ranking result
- */
-interface CategoryRanking {
-  districtId: string
-  rank: number
-  bordaPoints: number
-  value: number
-}
-
-/**
- * Aggregate ranking result
- */
-interface AggregateRanking {
-  districtId: string
-  clubsRank: number
-  paymentsRank: number
-  distinguishedRank: number
-  aggregateScore: number
-}
-
-/**
  * Configuration options for BordaCountRankingCalculator.
  */
 export interface BordaCountRankingCalculatorConfig {
@@ -402,20 +322,23 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
       })
 
       // Step 2: Calculate category rankings
-      const clubRankings = this.calculateCategoryRanking(
+      const clubRankings = calculateCategoryRanking(
         metrics,
         'clubGrowthPercent',
-        'clubs'
+        'clubs',
+        this.logger
       )
-      const paymentRankings = this.calculateCategoryRanking(
+      const paymentRankings = calculateCategoryRanking(
         metrics,
         'paymentGrowthPercent',
-        'payments'
+        'payments',
+        this.logger
       )
-      const distinguishedRankings = this.calculateCategoryRanking(
+      const distinguishedRankings = calculateCategoryRanking(
         metrics,
         'distinguishedPercent',
-        'distinguished'
+        'distinguished',
+        this.logger
       )
 
       this.logger.debug('Calculated category rankings', {
@@ -426,7 +349,7 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
       })
 
       // Step 3: Calculate aggregate rankings
-      const aggregateRankings = this.calculateAggregateRankings(
+      const aggregateRankings = calculateAggregateRankings(
         clubRankings,
         paymentRankings,
         distinguishedRankings
@@ -817,141 +740,6 @@ export class BordaCountRankingCalculator implements IRankingCalculator {
       if (chartered && chartered >= programYearStart) count++
     }
     return count
-  }
-
-  /**
-   * Calculate ranking for a single category
-   */
-  private calculateCategoryRanking(
-    metrics: RankingMetrics[],
-    valueField: keyof RankingMetrics,
-    category: string
-  ): CategoryRanking[] {
-    // When all districts have the same value (e.g., 0% Distinguished pre-April),
-    // the category provides no ranking differentiation. Award 0 Borda points
-    // to avoid inflating all scores equally (#198).
-    const uniqueValues = new Set(metrics.map(m => m[valueField] as number))
-    if (uniqueValues.size === 1) {
-      this.logger.debug(
-        'All districts tied in category — awarding 0 Borda points',
-        {
-          category,
-          totalDistricts: metrics.length,
-          tiedValue: [...uniqueValues][0],
-          operation: 'calculateCategoryRanking',
-        }
-      )
-      return metrics.map(m => ({
-        districtId: m.districtId,
-        rank: 1,
-        bordaPoints: 0,
-        value: m[valueField] as number,
-      }))
-    }
-
-    // Sort districts by value (highest first)
-    const sortedMetrics = [...metrics].sort((a, b) => {
-      const aValue = a[valueField] as number
-      const bValue = b[valueField] as number
-      return bValue - aValue
-    })
-
-    const rankings: CategoryRanking[] = []
-    let currentRank = 1
-
-    for (let i = 0; i < sortedMetrics.length; i++) {
-      const metric = sortedMetrics[i]
-      if (!metric) {
-        continue
-      }
-
-      const value = metric[valueField] as number
-
-      // Handle ties: if current value equals previous value, use same rank
-      if (i > 0) {
-        const previousMetric = sortedMetrics[i - 1]
-        if (previousMetric) {
-          const previousValue = previousMetric[valueField] as number
-          if (value !== previousValue) {
-            currentRank = i + 1
-          }
-        }
-      }
-
-      // Calculate Borda points: total districts - rank + 1
-      const bordaPoints = metrics.length - currentRank + 1
-
-      rankings.push({
-        districtId: metric.districtId,
-        rank: currentRank,
-        bordaPoints,
-        value,
-      })
-    }
-
-    this.logger.debug('Calculated category ranking', {
-      category,
-      totalDistricts: metrics.length,
-      uniqueRanks: new Set(rankings.map(r => r.rank)).size,
-      operation: 'calculateCategoryRanking',
-    })
-
-    return rankings
-  }
-
-  /**
-   * Calculate aggregate rankings by summing Borda points across categories
-   */
-  private calculateAggregateRankings(
-    clubRankings: CategoryRanking[],
-    paymentRankings: CategoryRanking[],
-    distinguishedRankings: CategoryRanking[]
-  ): AggregateRanking[] {
-    const aggregateMap = new Map<string, AggregateRanking>()
-
-    // Initialize aggregate rankings
-    for (const ranking of clubRankings) {
-      aggregateMap.set(ranking.districtId, {
-        districtId: ranking.districtId,
-        clubsRank: ranking.rank,
-        paymentsRank: 0,
-        distinguishedRank: 0,
-        aggregateScore: ranking.bordaPoints,
-      })
-    }
-
-    // Add payment rankings
-    for (const ranking of paymentRankings) {
-      const aggregate = aggregateMap.get(ranking.districtId)
-      if (aggregate) {
-        aggregate.paymentsRank = ranking.rank
-        aggregate.aggregateScore += ranking.bordaPoints
-      }
-    }
-
-    // Add distinguished rankings
-    for (const ranking of distinguishedRankings) {
-      const aggregate = aggregateMap.get(ranking.districtId)
-      if (aggregate) {
-        aggregate.distinguishedRank = ranking.rank
-        aggregate.aggregateScore += ranking.bordaPoints
-      }
-    }
-
-    // Sort by aggregate score (highest first)
-    const sortedAggregates = Array.from(aggregateMap.values()).sort(
-      (a, b) => b.aggregateScore - a.aggregateScore
-    )
-
-    this.logger.debug('Calculated aggregate rankings', {
-      totalDistricts: sortedAggregates.length,
-      highestScore: sortedAggregates[0]?.aggregateScore || 0,
-      lowestScore:
-        sortedAggregates[sortedAggregates.length - 1]?.aggregateScore || 0,
-      operation: 'calculateAggregateRankings',
-    })
-
-    return sortedAggregates
   }
 
   /**

--- a/packages/analytics-core/src/rankings/bordaCount.test.ts
+++ b/packages/analytics-core/src/rankings/bordaCount.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the shared Borda-count ranking primitives (#306).
+ *
+ * These pure functions are the single home for the category + aggregate
+ * Borda algorithm previously duplicated between
+ * `BordaCountRankingCalculator` (analytics-core) and `TransformService`
+ * (collector-cli). See tasks/lessons/061 + 076.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  calculateCategoryRanking,
+  calculateAggregateRankings,
+  type CategoryRanking,
+} from './bordaCount.js'
+
+interface Metric {
+  districtId: string
+  value: number
+}
+
+const m = (districtId: string, value: number): Metric => ({ districtId, value })
+
+describe('calculateCategoryRanking', () => {
+  it('awards Borda points = totalDistricts - rank + 1, highest value first', () => {
+    const metrics = [m('A', 30), m('B', 20), m('C', 10)]
+    const ranked = calculateCategoryRanking(metrics, 'value', 'test')
+
+    const byId = Object.fromEntries(ranked.map(r => [r.districtId, r]))
+    expect(byId.A).toMatchObject({ rank: 1, bordaPoints: 3, value: 30 })
+    expect(byId.B).toMatchObject({ rank: 2, bordaPoints: 2, value: 20 })
+    expect(byId.C).toMatchObject({ rank: 3, bordaPoints: 1, value: 10 })
+  })
+
+  it('gives tied districts the same rank and Borda points (standard competition)', () => {
+    const metrics = [m('A', 30), m('B', 30), m('C', 10)]
+    const ranked = calculateCategoryRanking(metrics, 'value', 'test')
+    const byId = Object.fromEntries(ranked.map(r => [r.districtId, r]))
+
+    // A and B tie at rank 1 (3 points each); C falls to rank 3 (1 point)
+    expect(byId.A).toMatchObject({ rank: 1, bordaPoints: 3 })
+    expect(byId.B).toMatchObject({ rank: 1, bordaPoints: 3 })
+    expect(byId.C).toMatchObject({ rank: 3, bordaPoints: 1 })
+  })
+
+  it('neutralizes a category where every district is tied — 0 points, rank 1 (#198)', () => {
+    const metrics = [m('A', 0), m('B', 0), m('C', 0)]
+    const ranked = calculateCategoryRanking(metrics, 'value', 'distinguished')
+
+    expect(ranked).toHaveLength(3)
+    for (const r of ranked) {
+      expect(r.rank).toBe(1)
+      expect(r.bordaPoints).toBe(0)
+    }
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(calculateCategoryRanking([] as Metric[], 'value', 'test')).toEqual(
+      []
+    )
+  })
+})
+
+describe('calculateAggregateRankings', () => {
+  it('sums Borda points across the three categories and sorts highest first', () => {
+    const club: CategoryRanking[] = [
+      { districtId: 'A', rank: 1, bordaPoints: 3, value: 30 },
+      { districtId: 'B', rank: 2, bordaPoints: 2, value: 20 },
+      { districtId: 'C', rank: 3, bordaPoints: 1, value: 10 },
+    ]
+    const payment: CategoryRanking[] = [
+      { districtId: 'A', rank: 3, bordaPoints: 1, value: 1 },
+      { districtId: 'B', rank: 1, bordaPoints: 3, value: 3 },
+      { districtId: 'C', rank: 2, bordaPoints: 2, value: 2 },
+    ]
+    const distinguished: CategoryRanking[] = [
+      { districtId: 'A', rank: 2, bordaPoints: 2, value: 50 },
+      { districtId: 'B', rank: 2, bordaPoints: 2, value: 50 },
+      { districtId: 'C', rank: 1, bordaPoints: 3, value: 60 },
+    ]
+
+    const agg = calculateAggregateRankings(club, payment, distinguished)
+
+    // A: 3+1+2=6, B: 2+3+2=7, C: 1+2+3=6 → sorted B(7), then A/C(6)
+    expect(agg[0]).toMatchObject({ districtId: 'B', aggregateScore: 7 })
+    const a = agg.find(r => r.districtId === 'A')!
+    expect(a).toMatchObject({
+      clubsRank: 1,
+      paymentsRank: 3,
+      distinguishedRank: 2,
+      aggregateScore: 6,
+    })
+  })
+})

--- a/packages/analytics-core/src/rankings/bordaCount.ts
+++ b/packages/analytics-core/src/rankings/bordaCount.ts
@@ -1,0 +1,177 @@
+/**
+ * Shared Borda-count ranking primitives (#306).
+ *
+ * The category-ranking and aggregate-ranking algorithms were independently
+ * implemented — byte-for-byte identical except for log strings — in both
+ * `BordaCountRankingCalculator` (analytics-core) and `TransformService`
+ * (collector-cli). Two copies of one formula is the drift surface lessons 61
+ * and 76 warn about. These pure functions are the single home; both call
+ * sites invoke them directly.
+ *
+ * @module @toastmasters/analytics-core/rankings
+ */
+
+/**
+ * Minimal debug-logger surface. Structurally compatible with the
+ * `RankingLogger` used by the calculator and the collector's logger; both
+ * pass through without coupling this module to either.
+ */
+export interface CategoryRankingLogger {
+  debug(message: string, context?: Record<string, unknown>): void
+}
+
+/**
+ * Result of ranking a single category.
+ */
+export interface CategoryRanking {
+  districtId: string
+  rank: number
+  bordaPoints: number
+  value: number
+}
+
+/**
+ * Aggregate ranking result — per-category ranks plus the summed Borda score.
+ */
+export interface AggregateRanking {
+  districtId: string
+  clubsRank: number
+  paymentsRank: number
+  distinguishedRank: number
+  aggregateScore: number
+}
+
+/**
+ * Calculate the Borda-count ranking for a single category.
+ *
+ * Scoring:
+ * - Districts are sorted by `valueField` (highest first).
+ * - Ties share a rank (standard competition ranking); the next distinct
+ *   value resumes at `index + 1`.
+ * - Borda points = `totalDistricts - rank + 1`.
+ * - Tie-neutralization (#198): if every district has the same value the
+ *   category cannot differentiate, so all districts get rank 1 and 0 points
+ *   to avoid inflating every aggregate score equally.
+ *
+ * Generic over the metric shape — the only requirement is a `districtId` and
+ * a numeric `valueField`.
+ */
+export function calculateCategoryRanking<T extends { districtId: string }>(
+  metrics: T[],
+  valueField: keyof T,
+  category: string,
+  logger?: CategoryRankingLogger
+): CategoryRanking[] {
+  // Tie-neutralization (#198): all values identical → no differentiation.
+  const uniqueValues = new Set(metrics.map(m => m[valueField] as number))
+  if (uniqueValues.size === 1) {
+    logger?.debug('All districts tied in category — awarding 0 Borda points', {
+      category,
+      totalDistricts: metrics.length,
+      tiedValue: [...uniqueValues][0],
+      operation: 'calculateCategoryRanking',
+    })
+    return metrics.map(m => ({
+      districtId: m.districtId,
+      rank: 1,
+      bordaPoints: 0,
+      value: m[valueField] as number,
+    }))
+  }
+
+  // Sort districts by value (highest first)
+  const sortedMetrics = [...metrics].sort((a, b) => {
+    const aValue = a[valueField] as number
+    const bValue = b[valueField] as number
+    return bValue - aValue
+  })
+
+  const rankings: CategoryRanking[] = []
+  let currentRank = 1
+
+  for (let i = 0; i < sortedMetrics.length; i++) {
+    const metric = sortedMetrics[i]
+    if (!metric) {
+      continue
+    }
+
+    const value = metric[valueField] as number
+
+    // Handle ties: if current value equals previous value, use same rank
+    if (i > 0) {
+      const previousMetric = sortedMetrics[i - 1]
+      if (previousMetric) {
+        const previousValue = previousMetric[valueField] as number
+        if (value !== previousValue) {
+          currentRank = i + 1
+        }
+      }
+    }
+
+    // Calculate Borda points: total districts - rank + 1
+    const bordaPoints = metrics.length - currentRank + 1
+
+    rankings.push({
+      districtId: metric.districtId,
+      rank: currentRank,
+      bordaPoints,
+      value,
+    })
+  }
+
+  logger?.debug('Calculated category ranking', {
+    category,
+    totalDistricts: metrics.length,
+    uniqueRanks: new Set(rankings.map(r => r.rank)).size,
+    operation: 'calculateCategoryRanking',
+  })
+
+  return rankings
+}
+
+/**
+ * Sum Borda points across the three categories (club growth, payment growth,
+ * distinguished %) into an aggregate score, returning districts sorted by that
+ * score (highest first). Each district's per-category rank is preserved.
+ */
+export function calculateAggregateRankings(
+  clubRankings: CategoryRanking[],
+  paymentRankings: CategoryRanking[],
+  distinguishedRankings: CategoryRanking[]
+): AggregateRanking[] {
+  const aggregateMap = new Map<string, AggregateRanking>()
+
+  // Initialize aggregate rankings from club rankings
+  for (const ranking of clubRankings) {
+    aggregateMap.set(ranking.districtId, {
+      districtId: ranking.districtId,
+      clubsRank: ranking.rank,
+      paymentsRank: 0,
+      distinguishedRank: 0,
+      aggregateScore: ranking.bordaPoints,
+    })
+  }
+
+  // Add payment rankings
+  for (const ranking of paymentRankings) {
+    const aggregate = aggregateMap.get(ranking.districtId)
+    if (aggregate) {
+      aggregate.paymentsRank = ranking.rank
+      aggregate.aggregateScore += ranking.bordaPoints
+    }
+  }
+
+  // Add distinguished rankings
+  for (const ranking of distinguishedRankings) {
+    const aggregate = aggregateMap.get(ranking.districtId)
+    if (aggregate) {
+      aggregate.distinguishedRank = ranking.rank
+      aggregate.aggregateScore += ranking.bordaPoints
+    }
+  }
+
+  // Sort by aggregate score (highest first)
+  return Array.from(aggregateMap.values()).sort(
+    (a, b) => b.aggregateScore - a.aggregateScore
+  )
+}

--- a/packages/analytics-core/src/rankings/index.ts
+++ b/packages/analytics-core/src/rankings/index.ts
@@ -58,3 +58,17 @@ export {
 } from './OfficerAwardsCalculator.js'
 
 export { calculateDistinguishedPercent } from './distinguishedPercent.js'
+
+export {
+  calculateCategoryRanking,
+  calculateAggregateRankings,
+  type CategoryRanking,
+  type AggregateRanking,
+  type CategoryRankingLogger,
+} from './bordaCount.js'
+
+export {
+  parseDateFlexible,
+  getProgramYearStartDate,
+  parseCharterDateFromStatusField,
+} from './programYearDates.js'

--- a/packages/analytics-core/src/rankings/programYearDates.test.ts
+++ b/packages/analytics-core/src/rankings/programYearDates.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for shared program-year date helpers (#306).
+ *
+ * Previously duplicated verbatim between BordaCountRankingCalculator
+ * (analytics-core) and TransformService (collector-cli).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  parseDateFlexible,
+  getProgramYearStartDate,
+  parseCharterDateFromStatusField,
+} from './programYearDates.js'
+
+describe('parseDateFlexible', () => {
+  it('parses ISO YYYY-MM-DD as UTC', () => {
+    expect(parseDateFlexible('2026-04-15')?.toISOString()).toBe(
+      '2026-04-15T00:00:00.000Z'
+    )
+  })
+
+  it('parses US M/D/YYYY', () => {
+    expect(parseDateFlexible('4/15/2026')?.toISOString()).toBe(
+      '2026-04-15T00:00:00.000Z'
+    )
+  })
+
+  it('parses US M/D/YY as 20YY', () => {
+    expect(parseDateFlexible('4/15/26')?.toISOString()).toBe(
+      '2026-04-15T00:00:00.000Z'
+    )
+  })
+
+  it('returns null for empty or unparseable input', () => {
+    expect(parseDateFlexible('')).toBeNull()
+    expect(parseDateFlexible('not a date')).toBeNull()
+  })
+})
+
+describe('getProgramYearStartDate', () => {
+  it('returns July 1 of the same calendar year for a date in/after July', () => {
+    expect(getProgramYearStartDate('2025-09-15')?.toISOString()).toBe(
+      '2025-07-01T00:00:00.000Z'
+    )
+  })
+
+  it('returns July 1 of the previous calendar year for a date before July', () => {
+    expect(getProgramYearStartDate('2026-04-15')?.toISOString()).toBe(
+      '2025-07-01T00:00:00.000Z'
+    )
+  })
+
+  it('returns null for an unparseable date', () => {
+    expect(getProgramYearStartDate('garbage')).toBeNull()
+  })
+})
+
+describe('parseCharterDateFromStatusField', () => {
+  it('extracts the date from a Charter entry', () => {
+    expect(
+      parseCharterDateFromStatusField('Charter 04/15/26')?.toISOString()
+    ).toBe('2026-04-15T00:00:00.000Z')
+  })
+
+  it('returns null for a Susp entry', () => {
+    expect(parseCharterDateFromStatusField('Susp 09/30/25')).toBeNull()
+  })
+
+  it('returns null for empty or non-string input', () => {
+    expect(parseCharterDateFromStatusField('')).toBeNull()
+    expect(parseCharterDateFromStatusField(null)).toBeNull()
+    expect(parseCharterDateFromStatusField(42)).toBeNull()
+  })
+})

--- a/packages/analytics-core/src/rankings/programYearDates.ts
+++ b/packages/analytics-core/src/rankings/programYearDates.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared program-year date helpers (#306).
+ *
+ * Toastmasters program years run July 1 → June 30. These flexible-format date
+ * parsers were duplicated verbatim between `BordaCountRankingCalculator`
+ * (analytics-core) and `TransformService` (collector-cli). This module is the
+ * single home; both import from here.
+ *
+ * @module @toastmasters/analytics-core/rankings
+ */
+
+/**
+ * Parse a date string in ISO (YYYY-MM-DD), US 4-digit (M/D/YYYY), or US
+ * 2-digit (M/D/YY) format and return a UTC-normalized Date. Two-digit years
+ * are interpreted as 20YY — Toastmasters' district-performance CSVs use this
+ * for charter/suspend dates. Returns null on failure.
+ */
+export function parseDateFlexible(value: string): Date | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  // ISO format: YYYY-MM-DD (optionally with time)
+  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (isoMatch) {
+    const y = Number(isoMatch[1])
+    const m = Number(isoMatch[2])
+    const d = Number(isoMatch[3])
+    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
+      return new Date(Date.UTC(y, m - 1, d))
+    }
+  }
+
+  // US format: M/D/YY or M/D/YYYY (2-digit year → 20YY)
+  const usMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})$/)
+  if (usMatch) {
+    const m = Number(usMatch[1])
+    const d = Number(usMatch[2])
+    const yRaw = Number(usMatch[3])
+    const y = usMatch[3]!.length === 2 ? 2000 + yRaw : yRaw
+    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
+      return new Date(Date.UTC(y, m - 1, d))
+    }
+  }
+
+  return null
+}
+
+/**
+ * Return the start-of-program-year date (July 1) preceding the given snapshot
+ * date, or null if the snapshot date is unparseable (#336).
+ */
+export function getProgramYearStartDate(snapshotDate: string): Date | null {
+  const parsed = parseDateFlexible(snapshotDate)
+  if (!parsed) return null
+  const year = parsed.getUTCFullYear()
+  const month = parsed.getUTCMonth() + 1 // 1-indexed
+  const pyStartYear = month >= 7 ? year : year - 1
+  return new Date(Date.UTC(pyStartYear, 6, 1)) // July 1 UTC
+}
+
+/**
+ * Extract a charter date from a `Charter Date/Suspend Date` field value (#336).
+ *
+ * Toastmasters district-performance.csv encodes club status changes as a
+ * single string with a prefix and date: `Charter MM/DD/YY` for newly chartered
+ * clubs, `Susp MM/DD/YY` for suspensions. Returns null if the field is empty,
+ * prefixed `Susp`, or unparseable.
+ */
+export function parseCharterDateFromStatusField(value: unknown): Date | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  const match = trimmed.match(/^Charter\s+(.+)$/i)
+  if (!match) return null
+  return parseDateFlexible(match[1]!)
+}

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -27,6 +27,10 @@ import {
   LeadershipExcellenceCalculator,
   OfficerAwardsCalculator,
   calculateDistinguishedPercent,
+  calculateCategoryRanking,
+  calculateAggregateRankings,
+  getProgramYearStartDate,
+  parseCharterDateFromStatusField,
   type Logger,
   type RawCSVData,
 } from '@toastmasters/analytics-core'
@@ -59,71 +63,6 @@ import {
   getPriorProgramYear,
 } from '../utils/CachePaths.js'
 import { DistrictAwardsHistoryStore } from './DistrictAwardsHistoryStore.js'
-
-/**
- * Parse a date string in ISO (YYYY-MM-DD), US 4-digit (M/D/YYYY), or US
- * 2-digit (M/D/YY) format and return a UTC-normalized Date. Returns null on
- * failure. Two-digit years are interpreted as 20YY — Toastmasters' district
- * performance CSVs use this for charter/suspend dates (#336).
- */
-function parseDateFlexible(value: string): Date | null {
-  const trimmed = value.trim()
-  if (!trimmed) return null
-
-  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/)
-  if (isoMatch) {
-    const y = Number(isoMatch[1])
-    const m = Number(isoMatch[2])
-    const d = Number(isoMatch[3])
-    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
-      return new Date(Date.UTC(y, m - 1, d))
-    }
-  }
-
-  const usMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})$/)
-  if (usMatch) {
-    const m = Number(usMatch[1])
-    const d = Number(usMatch[2])
-    const yRaw = Number(usMatch[3])
-    const y = usMatch[3]!.length === 2 ? 2000 + yRaw : yRaw
-    if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
-      return new Date(Date.UTC(y, m - 1, d))
-    }
-  }
-
-  return null
-}
-
-/**
- * Extract a charter date from a `Charter Date/Suspend Date` field value (#336).
- *
- * Toastmasters district-performance.csv encodes club status changes as a
- * single string with a prefix and date: `Charter MM/DD/YY` for newly
- * chartered clubs, `Susp MM/DD/YY` for suspensions. Returns null if the
- * field is empty, prefixed `Susp`, or unparseable.
- */
-function parseCharterDateFromStatusField(value: unknown): Date | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  if (trimmed === '') return null
-  const match = trimmed.match(/^Charter\s+(.+)$/i)
-  if (!match) return null
-  return parseDateFlexible(match[1]!)
-}
-
-/**
- * Return the start-of-program-year date (July 1) preceding the given
- * snapshot date, or null if unparseable. Toastmasters program years run
- * July 1 → June 30. (#336)
- */
-function getProgramYearStartDate(snapshotDate: string): Date | null {
-  const parsed = parseDateFlexible(snapshotDate)
-  if (!parsed) return null
-  const year = parsed.getUTCFullYear()
-  const month = parsed.getUTCMonth() + 1
-  const pyStartYear = month >= 7 ? year : year - 1
-  return new Date(Date.UTC(pyStartYear, 6, 1))
-}
 
 /**
  * Internal structure for ranking metrics extraction
@@ -162,27 +101,6 @@ interface RankingMetrics {
   octoberPayments: number
   latePayments: number
   charterPayments: number
-}
-
-/**
- * Category ranking result
- */
-interface CategoryRanking {
-  districtId: string
-  rank: number
-  bordaPoints: number
-  value: number
-}
-
-/**
- * Aggregate ranking result
- */
-interface AggregateRanking {
-  districtId: string
-  clubsRank: number
-  paymentsRank: number
-  distinguishedRank: number
-  aggregateScore: number
 }
 
 /**
@@ -822,127 +740,6 @@ export class TransformService {
   }
 
   /**
-   * Calculate ranking for a single category using Borda count
-   *
-   * Borda count scoring:
-   * - Ranks districts by value (highest first)
-   * - Handles ties by assigning the same rank
-   * - Borda points = total districts - rank + 1
-   */
-  private calculateCategoryRanking(
-    metrics: RankingMetrics[],
-    valueField: keyof RankingMetrics,
-    category: string
-  ): CategoryRanking[] {
-    // Tie-neutralization (#198): if all values are identical, award 0 points
-    const uniqueValues = new Set(metrics.map(m => m[valueField] as number))
-    if (uniqueValues.size === 1) {
-      this.logger.debug('All districts tied — neutralizing category', {
-        category,
-        totalDistricts: metrics.length,
-        value: [...uniqueValues][0],
-      })
-      return metrics.map(m => ({
-        districtId: m.districtId,
-        rank: 1,
-        bordaPoints: 0,
-        value: m[valueField] as number,
-      }))
-    }
-
-    // Sort districts by value (highest first)
-    const sortedMetrics = [...metrics].sort((a, b) => {
-      const aValue = a[valueField] as number
-      const bValue = b[valueField] as number
-      return bValue - aValue
-    })
-
-    const rankings: CategoryRanking[] = []
-    let currentRank = 1
-
-    for (let i = 0; i < sortedMetrics.length; i++) {
-      const metric = sortedMetrics[i]
-      if (!metric) continue
-
-      const value = metric[valueField] as number
-
-      // Handle ties: if current value equals previous value, use same rank
-      if (i > 0) {
-        const previousMetric = sortedMetrics[i - 1]
-        if (previousMetric) {
-          const previousValue = previousMetric[valueField] as number
-          if (value !== previousValue) {
-            currentRank = i + 1
-          }
-        }
-      }
-
-      // Calculate Borda points: total districts - rank + 1
-      const bordaPoints = metrics.length - currentRank + 1
-
-      rankings.push({
-        districtId: metric.districtId,
-        rank: currentRank,
-        bordaPoints,
-        value,
-      })
-    }
-
-    this.logger.debug('Calculated category ranking', {
-      category,
-      totalDistricts: metrics.length,
-      uniqueRanks: new Set(rankings.map(r => r.rank)).size,
-    })
-
-    return rankings
-  }
-
-  /**
-   * Calculate aggregate rankings by summing Borda points across categories
-   */
-  private calculateAggregateRankings(
-    clubRankings: CategoryRanking[],
-    paymentRankings: CategoryRanking[],
-    distinguishedRankings: CategoryRanking[]
-  ): AggregateRanking[] {
-    const aggregateMap = new Map<string, AggregateRanking>()
-
-    // Initialize aggregate rankings from club rankings
-    for (const ranking of clubRankings) {
-      aggregateMap.set(ranking.districtId, {
-        districtId: ranking.districtId,
-        clubsRank: ranking.rank,
-        paymentsRank: 0,
-        distinguishedRank: 0,
-        aggregateScore: ranking.bordaPoints,
-      })
-    }
-
-    // Add payment rankings
-    for (const ranking of paymentRankings) {
-      const aggregate = aggregateMap.get(ranking.districtId)
-      if (aggregate) {
-        aggregate.paymentsRank = ranking.rank
-        aggregate.aggregateScore += ranking.bordaPoints
-      }
-    }
-
-    // Add distinguished rankings
-    for (const ranking of distinguishedRankings) {
-      const aggregate = aggregateMap.get(ranking.districtId)
-      if (aggregate) {
-        aggregate.distinguishedRank = ranking.rank
-        aggregate.aggregateScore += ranking.bordaPoints
-      }
-    }
-
-    // Sort by aggregate score (highest first)
-    return Array.from(aggregateMap.values()).sort(
-      (a, b) => b.aggregateScore - a.aggregateScore
-    )
-  }
-
-  /**
    * Calculate all-districts rankings using Borda count algorithm
    *
    * Requirements:
@@ -1053,24 +850,27 @@ export class TransformService {
     })
 
     // Calculate category rankings
-    const clubRankings = this.calculateCategoryRanking(
+    const clubRankings = calculateCategoryRanking(
       metrics,
       'clubGrowthPercent',
-      'clubs'
+      'clubs',
+      this.logger
     )
-    const paymentRankings = this.calculateCategoryRanking(
+    const paymentRankings = calculateCategoryRanking(
       metrics,
       'paymentGrowthPercent',
-      'payments'
+      'payments',
+      this.logger
     )
-    const distinguishedRankings = this.calculateCategoryRanking(
+    const distinguishedRankings = calculateCategoryRanking(
       metrics,
       'distinguishedPercent',
-      'distinguished'
+      'distinguished',
+      this.logger
     )
 
     // Calculate aggregate rankings
-    const aggregateRankings = this.calculateAggregateRankings(
+    const aggregateRankings = calculateAggregateRankings(
       clubRankings,
       paymentRankings,
       distinguishedRankings

--- a/tasks/lessons/117-a-delegate-to-x-ticket-is-a-trap-when-the-two-impls-have-diverged-in-output.md
+++ b/tasks/lessons/117-a-delegate-to-x-ticket-is-a-trap-when-the-two-impls-have-diverged-in-output.md
@@ -1,0 +1,76 @@
+---
+id: '117'
+category: lesson
+tags: [monorepo, analytics, refactor, tdd, data-pipeline]
+auto_load: true
+date: 2026-05-26
+issues: [306, 757]
+---
+
+# Lesson 117 — A "delegate to X" refactor ticket is a trap when the two impls have diverged in output
+
+**Date:** 2026-05-26
+**Issue:** #306 (epic #757 Sprint 1)
+
+## What happened
+
+#306's title said `TransformService.calculateAllDistrictsRankings should
+delegate to BordaCountRankingCalculator` — the two classes had ~300 lines of
+duplicated ranking logic. The obvious reading is "make TransformService call
+the calculator." But the calculator's public entry points (`calculateRankings`
+
+- `buildRankingsData`) are **not** output-equivalent to what TransformService
+  produces:
+
+* **Metadata differs**: TransformService writes `schemaVersion:
+ANALYTICS_SCHEMA_VERSION` (`'1.0.0'`); the calculator hardcodes `'1.0'`.
+* **Confirmed-Distinguished gating differs**: TransformService computes the
+  pre-April confirmed count only when **all** districts report 0
+  (`metrics.every(m => m.distinguishedClubs === 0)`); the calculator gates
+  **per-district** (`if (metric.distinguishedClubs === 0)`). These produce
+  different snapshot values whenever some districts have 0 and some don't.
+* **Metric extraction reads different inputs**: TransformService parses
+  `AllDistrictsCSVRecord` + does per-district disk I/O + district-ID
+  validation; the calculator reads in-memory `RankingDistrictStatistics`.
+
+Full delegation would have silently changed the snapshot the CDN serves —
+exactly the kind of pipeline-output regression lesson 61 is about, in reverse.
+
+## The principle
+
+When a ticket says "delegate to / call X instead of duplicating," **audit
+output-equivalence of the two implementations before delegating.** Two methods
+with the same name and shape can have quietly diverged at the lines that matter
+(a denominator, a gating condition, a version string). Diff the actual
+behaviour, not the signatures.
+
+If they HAVE diverged, don't force delegation — that imports a behaviour change
+under the banner of a "pure refactor." Instead extract only the **proven
+byte-identical pure core** into the lower-level package (here:
+`calculateCategoryRanking`, `calculateAggregateRankings`, the program-year date
+parsers) and have both sites call it. The legitimately-different surrounding
+logic (metric extraction, metadata, conditional gating) stays where it is.
+This still kills the drift surface lessons 61/76 warn about, without changing
+output.
+
+## How to apply
+
+- Before a "delegate to X" refactor: for each field the two paths write, confirm
+  they compute it identically. `git show` both originals side by side; grep for
+  the field name (lesson 76's audit). Any divergence = a behaviour decision the
+  ticket didn't authorise.
+- Extract the intersection (the identical pure functions), not the union. A
+  partial extraction that preserves output beats a full delegation that changes
+  it.
+- The existing test suites on both sides are your equivalence proof: if the
+  extracted core is truly identical, both suites stay green untouched (here:
+  803 analytics-core + 735 collector-cli, zero assertion changes).
+
+## Related
+
+- [[076-shared-formula-helper-eliminates-the-two-copies-trap]] — extract a
+  pure helper, inline at the call site, no wrapper. This lesson adds: first
+  prove the two copies are actually identical; extract only what is.
+- [[061-fix-the-formula-everywhere-not-just-the-one-in-the-bug-report]] —
+  collector-cli writes the snapshot the CDN serves; a delegation that changes
+  its output ships the change to prod data, not just the library.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -77,3 +77,4 @@
 - **114** [dark-mode, css, accessibility, frontend] — A raw non-remapping token that "passes" in a sibling component may be leaning on that sibling's background fill (#678, #674)
 - **115** [frontend, analytics, data-pipeline, dcp, verification] — A field's name (and comment) can lie about whether it's populated in _your_ surface (#681, #674)
 - **116** [dark-mode, css, frontend, responsive] — `bg-white` themes to a LIGHTER dark scale than its `.redesign-panel` neighbours (#682, #674)
+- **117** [monorepo, analytics, refactor, tdd, data-pipeline] — A "delegate to X" refactor ticket is a trap when the two impls have diverged in output (#306, #757)


### PR DESCRIPTION
Part of #306. (No \`Closes\` keyword — sprint-runner ordering ticks the epic before closing the sub-issue; lesson 106.)

## What
The Borda-count ranking algorithm and the program-year date parsers were independently implemented — byte-for-byte identical except log strings — in both \`BordaCountRankingCalculator\` (analytics-core) and \`TransformService\` (collector-cli). This is the exact two-copies drift surface lessons 61 + 76 warn about. Consolidated the genuinely-identical, pure pieces into analytics-core; both consumers now call them directly (inlined, no wrapper — lesson 76).

### New shared modules (analytics-core)
- \`rankings/bordaCount.ts\` — \`calculateCategoryRanking<T>\`, \`calculateAggregateRankings\`, types \`CategoryRanking\`/\`AggregateRanking\`. Generic over metric shape.
- \`rankings/programYearDates.ts\` — \`parseDateFlexible\`, \`getProgramYearStartDate\`, \`parseCharterDateFromStatusField\`.
- Exported from \`rankings/index.ts\` + main barrel.

### Consumers (private copies deleted, shared imported)
- \`BordaCountRankingCalculator.ts\` — −250 lines.
- \`TransformService.ts\` — −228 lines.

## Why not full delegation (the issue title's literal ask)
Deliberately scoped to the pure pieces. Full delegation would **change snapshot output**:
- \`extractRankingMetrics\` reads different inputs (collector: \`AllDistrictsCSVRecord\` + per-district disk I/O + district-ID validation; calculator: in-memory \`RankingDistrictStatistics\`).
- Metadata differs (collector \`ANALYTICS_SCHEMA_VERSION='1.0.0'\` vs calculator hardcoded \`'1.0'\`).
- Confirmed-Distinguished gating differs (collector global \`every(===0)\` vs calculator per-district).

Zero behavior change is the invariant here.

## Tests / verification
- TDD: new failing specs first (\`bordaCount.test.ts\`, \`programYearDates.test.ts\`), then Green, then refactor both consumers.
- analytics-core: 803 pass. collector-cli: 735 pass. Both suites are the equivalence proof (no logger/metadata assertions broken).
- Fresh-context review (sprint \`/review\`): **APPROVE**, no High/Medium findings.
- Single definition each post-refactor; no dangling \`this.calculate*\` references.

## DoD note
Verification surface: this PR touches \`packages/{analytics-core,collector-cli}\`; \`pr-preview.yml\` is path-filtered to \`frontend/**\` + \`packages/{shared-contracts,analytics-core}/**\`, so a preview deploys but the change is **not exercised by any frontend code path** (no frontend module imports the changed symbols). Live verification is therefore code-proof via the unit suites — the snapshot-writing path (\`TransformService\`) only runs in the scheduled pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)