### PR TITLE
feat(monitor): alert + backup cron when the daily pipeline silently misses a run (#753)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,9 @@ jobs:
       - name: Run frontend tests
         run: npm run test --workspace=frontend -- --coverage
 
+      - name: Run scripts/lib tests
+        run: npm run test:scripts
+
   # Build Applications
   build:
     name: Build Applications

--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -17,8 +17,13 @@ name: Data Pipeline
 
 on:
   schedule:
-    # Run daily at 10:00 UTC (5 AM EST / 6 AM EDT)
+    # Primary daily run at 08:00 UTC (4 AM EST / 5 AM EDT).
     - cron: '0 8 * * *'
+    # Backup run at 11:00 UTC to absorb dropped scheduled events (#753).
+    # The daily flow is idempotent (same snapshot date is re-scraped and
+    # re-uploaded) and the `data-pipeline` concurrency group already
+    # serializes runs, so a backup that overlaps a slow primary is safe.
+    - cron: '0 11 * * *'
   workflow_dispatch:
     inputs:
       mode:

--- a/.github/workflows/pipeline-freshness-monitor.yml
+++ b/.github/workflows/pipeline-freshness-monitor.yml
@@ -1,0 +1,99 @@
+# Pipeline Freshness Monitor (#753)
+#
+# The daily Data Pipeline (data-pipeline.yml) is driven by a best-effort
+# `schedule` event that GitHub can silently drop — when it does, nothing
+# fails, the CDN just keeps serving a stale v1/latest.json and no one is
+# told. This monitor closes that gap: it runs a few hours after the primary
+# + backup daily crons, checks how old the published manifest is, and opens
+# a `pipeline-stale` issue (and fails the run) when the snapshot is missed.
+#
+# Decision logic is unit-tested in scripts/lib/__tests__/pipelineFreshness.test.ts;
+# this workflow is the scheduler + alerter around scripts/check-pipeline-freshness.ts.
+
+name: Pipeline Freshness Monitor
+
+on:
+  schedule:
+    # Primary daily pipeline runs at 08:00 UTC, backup at 11:00 UTC.
+    # Check at 14:00 UTC so both have had a chance to land.
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+    inputs:
+      threshold_hours:
+        description: 'Staleness threshold in hours (default 26)'
+        required: false
+        type: string
+      manifest_url:
+        description: 'Manifest URL to check (default: production CDN)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: pipeline-freshness-monitor
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check v1/latest.json freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check manifest freshness
+        id: freshness
+        env:
+          THRESHOLD_HOURS: ${{ inputs.threshold_hours }}
+          MANIFEST_URL: ${{ inputs.manifest_url }}
+        run: npx tsx scripts/check-pipeline-freshness.ts
+
+      - name: Ensure pipeline-stale label exists
+        if: steps.freshness.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create pipeline-stale \
+            --color B60205 \
+            --description "Daily data pipeline missed a scheduled run" \
+            2>/dev/null || echo "Label already exists"
+
+      - name: Open or update alert issue
+        if: steps.freshness.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Deduplicate: one open alert at a time. Comment on the existing
+          # issue rather than spamming a new one each daily check.
+          EXISTING=$(gh issue list --label pipeline-stale --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${EXISTING}" ]; then
+            echo "Existing open alert #${EXISTING} — adding a comment."
+            gh issue comment "${EXISTING}" \
+              --body-file "${{ steps.freshness.outputs.body_file }}"
+          else
+            echo "No open alert — creating one."
+            gh issue create \
+              --title "${{ steps.freshness.outputs.title }}" \
+              --label pipeline-stale \
+              --body-file "${{ steps.freshness.outputs.body_file }}"
+          fi
+
+      - name: Fail the run when stale
+        if: steps.freshness.outputs.stale == 'true'
+        run: |
+          echo "::error::Daily data pipeline manifest is stale — a pipeline-stale issue has been filed."
+          exit 1

--- a/docs/runbooks/data-pipeline-recovery.md
+++ b/docs/runbooks/data-pipeline-recovery.md
@@ -1,0 +1,86 @@
+# Runbook — Daily Data Pipeline Recovery (#753)
+
+When the daily snapshot doesn't land, the CDN keeps serving the last
+`v1/latest.json` and nothing fails on its own. This runbook covers detecting
+that, recovering, and the guardrails that now catch it automatically.
+
+## How a missed run is detected
+
+- **Freshness monitor** (`.github/workflows/pipeline-freshness-monitor.yml`)
+  runs daily at **14:00 UTC** — after the primary (08:00) and backup (11:00)
+  pipeline crons. It fetches the production manifest
+  `https://storage.googleapis.com/toast-stats-data-ca/v1/latest.json`,
+  compares its `generatedAt` against a **26h** threshold, and on staleness:
+  1. opens (or comments on) a `pipeline-stale` GitHub issue with the age,
+     last snapshot date, and the recovery command, and
+  2. **fails the monitor run** so GitHub's own notifications fire too.
+
+  The decision logic is pure and unit-tested in
+  `scripts/lib/pipelineFreshness.ts` (run via `scripts/check-pipeline-freshness.ts`).
+
+- **Manual check** any time:
+
+  ```bash
+  curl -s https://storage.googleapis.com/toast-stats-data-ca/v1/latest.json | jq .
+  # or run the exact monitor logic locally:
+  npx tsx scripts/check-pipeline-freshness.ts
+  ```
+
+  `generatedAt` is refreshed on every successful daily run. If it is more than
+  ~26h old, a run was missed.
+
+## Manual recovery
+
+Re-run the daily pipeline from the CLI (writes to staging, then promotes to
+production):
+
+```bash
+gh workflow run data-pipeline.yml -f mode=daily
+```
+
+Watch it:
+
+```bash
+gh run list --workflow=data-pipeline.yml --limit 3
+gh run watch <run-id>
+```
+
+When it finishes, confirm the manifest advanced:
+
+```bash
+curl -s https://storage.googleapis.com/toast-stats-data-ca/v1/latest.json | jq .generatedAt
+```
+
+Then close the `pipeline-stale` issue.
+
+## Confirming a dispatch queues (without writing prod data)
+
+A `daily` dispatch writes to production. To verify only that
+`workflow_dispatch` queues — e.g. when debugging a "Failed to queue workflow
+run" error from GitHub's queuing layer — use the safe no-op: `prune` mode with
+`dry_run=true` skips all delete/promote steps.
+
+```bash
+gh workflow run data-pipeline.yml -f mode=prune -f dry_run=true
+gh run list --workflow=data-pipeline.yml --limit 1   # confirm it queued
+```
+
+## Why runs go missing
+
+`schedule` events are **best-effort** — GitHub can drop them under load with
+no failure record (observed 2026-05-26). Causes seen / ruled out during the
+#753 investigation:
+
+- **GitHub queuing-layer degradation** — the dropped run plus a concurrent
+  `Failed to queue workflow run. Please try again.` on manual dispatch, while
+  other workflows ran fine. GitHub's own remedy is "try again."
+- **Not** the >10-input `workflow_dispatch` cap (the pipeline has 7 inputs).
+- **Not** a recent workflow-file change (file unchanged since 2026-05-12).
+- **Not** billing / a repo-wide Actions outage (other workflows ran).
+
+## Guardrails now in place
+
+| Guardrail                      | Where                            | Purpose                                                                                                   |
+| ------------------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Backup cron `0 11 * * *`       | `data-pipeline.yml`              | Absorbs a dropped 08:00 scheduled event. Idempotent; serialized by the `data-pipeline` concurrency group. |
+| Freshness monitor `0 14 * * *` | `pipeline-freshness-monitor.yml` | Alerts loudly (issue + red run) when the manifest is still stale after both crons.                        |

--- a/scripts/check-pipeline-freshness.ts
+++ b/scripts/check-pipeline-freshness.ts
@@ -24,12 +24,14 @@ import {
   parseManifest,
   evaluateFreshness,
   buildAlertIssueBody,
-  STALE_THRESHOLD_HOURS,
+  resolveThresholdHours,
   type FreshnessResult,
 } from './lib/pipelineFreshness.js'
 
 const DEFAULT_MANIFEST_URL =
   'https://storage.googleapis.com/toast-stats-data-ca/v1/latest.json'
+
+const BODY_FILE = '/tmp/pipeline-freshness-body.md'
 
 function log(msg: string): void {
   process.stderr.write(`${msg}\n`)
@@ -40,11 +42,35 @@ function emitOutput(key: string, value: string): void {
   if (out) appendFileSync(out, `${key}=${value}\n`)
 }
 
+/**
+ * Emit the stale/fresh decision for the workflow. When stale, ALWAYS write
+ * the alert body and emit `body_file` so the issue-create step never runs
+ * with an empty `--body-file` — including the crash path.
+ */
+function emitDecision(
+  result: FreshnessResult,
+  manifestUrl: string,
+  now: Date
+): void {
+  emitOutput('stale', String(result.stale))
+  emitOutput(
+    'title',
+    result.stale
+      ? `🚨 Daily data pipeline stale — ${result.latestSnapshotDate ?? 'no snapshot date'}`
+      : 'pipeline fresh'
+  )
+  if (result.stale) {
+    writeFileSync(BODY_FILE, buildAlertIssueBody(result, { manifestUrl, now }))
+    emitOutput('body_file', BODY_FILE)
+    log('Manifest is STALE — alert body written.')
+  } else {
+    log('Manifest is fresh — no alert.')
+  }
+}
+
 async function main(): Promise<void> {
   const manifestUrl = process.env.MANIFEST_URL || DEFAULT_MANIFEST_URL
-  const thresholdHours = process.env.THRESHOLD_HOURS
-    ? Number(process.env.THRESHOLD_HOURS)
-    : STALE_THRESHOLD_HOURS
+  const thresholdHours = resolveThresholdHours(process.env.THRESHOLD_HOURS)
   const now = new Date()
 
   log(`Checking pipeline freshness: ${manifestUrl}`)
@@ -78,30 +104,26 @@ async function main(): Promise<void> {
   }
 
   log(`Result: ${result.reason}`)
-
-  emitOutput('stale', String(result.stale))
-  emitOutput(
-    'title',
-    result.stale
-      ? `🚨 Daily data pipeline stale — ${result.latestSnapshotDate ?? 'no snapshot date'}`
-      : 'pipeline fresh'
-  )
-
-  if (result.stale) {
-    const body = buildAlertIssueBody(result, { manifestUrl, now })
-    const bodyFile = '/tmp/pipeline-freshness-body.md'
-    writeFileSync(bodyFile, body)
-    emitOutput('body_file', bodyFile)
-    log('Manifest is STALE — alert body written.')
-  } else {
-    log('Manifest is fresh — no alert.')
-  }
+  emitDecision(result, manifestUrl, now)
 }
 
 main().catch(err => {
-  log(`Unexpected error: ${err instanceof Error ? err.stack : String(err)}`)
-  // Surface as stale so the monitor still alerts rather than passing silently.
-  emitOutput('stale', 'true')
-  emitOutput('title', '🚨 Pipeline freshness monitor crashed')
+  const message =
+    err instanceof Error ? (err.stack ?? err.message) : String(err)
+  log(`Unexpected error: ${message}`)
+  // Surface as stale — with a real body — so the monitor still alerts rather
+  // than passing silently, and the issue-create step always has a body file.
+  emitDecision(
+    {
+      stale: true,
+      reason: `pipeline freshness monitor crashed: ${message}`,
+      ageHours: null,
+      generatedAt: null,
+      latestSnapshotDate: null,
+      thresholdHours: resolveThresholdHours(process.env.THRESHOLD_HOURS),
+    },
+    process.env.MANIFEST_URL || DEFAULT_MANIFEST_URL,
+    new Date()
+  )
   process.exit(0)
 })

--- a/scripts/check-pipeline-freshness.ts
+++ b/scripts/check-pipeline-freshness.ts
@@ -1,0 +1,107 @@
+/**
+ * Pipeline Freshness Check — Runner (#753)
+ *
+ * Thin glue around the pure functions in ./lib/pipelineFreshness.js:
+ *   1. fetch the published v1/latest.json (production CDN by default),
+ *   2. evaluate its freshness against a threshold,
+ *   3. emit a stale/fresh decision + alert body for the monitor workflow.
+ *
+ * No decision logic lives here — that is unit-tested in
+ * scripts/lib/__tests__/pipelineFreshness.test.ts. All logging goes to
+ * stderr (R4); stdout/$GITHUB_OUTPUT carry only the structured decision.
+ *
+ * Env:
+ *   MANIFEST_URL    — manifest to check (default: production CDN bucket)
+ *   THRESHOLD_HOURS — staleness threshold in hours (default: 26)
+ *
+ * The process always exits 0; the workflow decides whether to open an
+ * issue (and to mark the run red) based on the `stale` output. This keeps
+ * the issue-create step reachable even when the manifest is stale.
+ */
+
+import { appendFileSync, writeFileSync } from 'node:fs'
+import {
+  parseManifest,
+  evaluateFreshness,
+  buildAlertIssueBody,
+  STALE_THRESHOLD_HOURS,
+  type FreshnessResult,
+} from './lib/pipelineFreshness.js'
+
+const DEFAULT_MANIFEST_URL =
+  'https://storage.googleapis.com/toast-stats-data-ca/v1/latest.json'
+
+function log(msg: string): void {
+  process.stderr.write(`${msg}\n`)
+}
+
+function emitOutput(key: string, value: string): void {
+  const out = process.env.GITHUB_OUTPUT
+  if (out) appendFileSync(out, `${key}=${value}\n`)
+}
+
+async function main(): Promise<void> {
+  const manifestUrl = process.env.MANIFEST_URL || DEFAULT_MANIFEST_URL
+  const thresholdHours = process.env.THRESHOLD_HOURS
+    ? Number(process.env.THRESHOLD_HOURS)
+    : STALE_THRESHOLD_HOURS
+  const now = new Date()
+
+  log(`Checking pipeline freshness: ${manifestUrl}`)
+  log(`Threshold: ${thresholdHours}h | Now: ${now.toISOString()}`)
+
+  let result: FreshnessResult
+
+  try {
+    const res = await fetch(manifestUrl, {
+      signal: AbortSignal.timeout(20_000),
+    })
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`)
+    }
+    const manifest = parseManifest(await res.text())
+    result = evaluateFreshness(manifest, now, thresholdHours)
+  } catch (err) {
+    // A fetch/parse failure is itself an alert condition — the CDN is
+    // unreachable or serving garbage, which is exactly the silent outage
+    // the monitor exists to catch.
+    const message = err instanceof Error ? err.message : String(err)
+    log(`Failed to fetch/parse manifest: ${message}`)
+    result = {
+      stale: true,
+      reason: `could not fetch or parse the manifest: ${message}`,
+      ageHours: null,
+      generatedAt: null,
+      latestSnapshotDate: null,
+      thresholdHours,
+    }
+  }
+
+  log(`Result: ${result.reason}`)
+
+  emitOutput('stale', String(result.stale))
+  emitOutput(
+    'title',
+    result.stale
+      ? `🚨 Daily data pipeline stale — ${result.latestSnapshotDate ?? 'no snapshot date'}`
+      : 'pipeline fresh'
+  )
+
+  if (result.stale) {
+    const body = buildAlertIssueBody(result, { manifestUrl, now })
+    const bodyFile = '/tmp/pipeline-freshness-body.md'
+    writeFileSync(bodyFile, body)
+    emitOutput('body_file', bodyFile)
+    log('Manifest is STALE — alert body written.')
+  } else {
+    log('Manifest is fresh — no alert.')
+  }
+}
+
+main().catch(err => {
+  log(`Unexpected error: ${err instanceof Error ? err.stack : String(err)}`)
+  // Surface as stale so the monitor still alerts rather than passing silently.
+  emitOutput('stale', 'true')
+  emitOutput('title', '🚨 Pipeline freshness monitor crashed')
+  process.exit(0)
+})

--- a/scripts/lib/__tests__/pipelineFreshness.test.ts
+++ b/scripts/lib/__tests__/pipelineFreshness.test.ts
@@ -12,6 +12,7 @@ import {
   parseManifest,
   evaluateFreshness,
   buildAlertIssueBody,
+  resolveThresholdHours,
   STALE_THRESHOLD_HOURS,
   type LatestManifest,
 } from '../pipelineFreshness'
@@ -94,6 +95,28 @@ describe('evaluateFreshness', () => {
     }
     expect(evaluateFreshness(manifest, NOW, 4).stale).toBe(true)
     expect(evaluateFreshness(manifest, NOW, 8).stale).toBe(false)
+  })
+})
+
+// ── resolveThresholdHours ──────────────────────────────────────────────────
+
+describe('resolveThresholdHours', () => {
+  it('uses the default when the value is undefined or empty', () => {
+    expect(resolveThresholdHours(undefined)).toBe(STALE_THRESHOLD_HOURS)
+    expect(resolveThresholdHours('')).toBe(STALE_THRESHOLD_HOURS)
+  })
+
+  it('parses a valid positive number', () => {
+    expect(resolveThresholdHours('12')).toBe(12)
+    expect(resolveThresholdHours('4.5')).toBe(4.5)
+  })
+
+  it('falls back to the default for non-numeric or non-positive input', () => {
+    // A typo'd manual threshold must NOT silently disable the alert by
+    // making `ageHours > NaN` always false.
+    expect(resolveThresholdHours('abc')).toBe(STALE_THRESHOLD_HOURS)
+    expect(resolveThresholdHours('0')).toBe(STALE_THRESHOLD_HOURS)
+    expect(resolveThresholdHours('-5')).toBe(STALE_THRESHOLD_HOURS)
   })
 })
 

--- a/scripts/lib/__tests__/pipelineFreshness.test.ts
+++ b/scripts/lib/__tests__/pipelineFreshness.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for scripts/lib/pipelineFreshness.ts (#753)
+ *
+ * The daily Data Pipeline writes v1/latest.json with a `generatedAt`
+ * timestamp on every successful run. When a scheduled run is silently
+ * dropped by GitHub, generatedAt stops advancing — these pure functions
+ * decide whether the manifest is stale enough to alert on.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  parseManifest,
+  evaluateFreshness,
+  buildAlertIssueBody,
+  STALE_THRESHOLD_HOURS,
+  type LatestManifest,
+} from '../pipelineFreshness'
+
+// Reference "now": 2026-05-26T14:00:00Z (when the monitor cron fires)
+const NOW = new Date('2026-05-26T14:00:00Z')
+
+// ── parseManifest ────────────────────────────────────────────────────────
+
+describe('parseManifest', () => {
+  it('parses a well-formed manifest', () => {
+    const raw = JSON.stringify({
+      _format: { version: '1.0.0', type: 'manifest' },
+      latestSnapshotDate: '2026-05-25',
+      generatedAt: '2026-05-26T08:01:00.000Z',
+    })
+    const m = parseManifest(raw)
+    expect(m.latestSnapshotDate).toBe('2026-05-25')
+    expect(m.generatedAt).toBe('2026-05-26T08:01:00.000Z')
+  })
+
+  it('throws on invalid JSON rather than returning a partial object', () => {
+    expect(() => parseManifest('not json')).toThrow()
+  })
+})
+
+// ── evaluateFreshness ──────────────────────────────────────────────────────
+
+describe('evaluateFreshness', () => {
+  it('is fresh when generatedAt is within the threshold (ran today)', () => {
+    const manifest: LatestManifest = {
+      latestSnapshotDate: '2026-05-25',
+      generatedAt: '2026-05-26T08:01:00.000Z', // 6h ago
+    }
+    const r = evaluateFreshness(manifest, NOW)
+    expect(r.stale).toBe(false)
+    expect(r.ageHours).toBeCloseTo(6, 1)
+    expect(r.thresholdHours).toBe(STALE_THRESHOLD_HOURS)
+  })
+
+  it('is fresh at exactly the threshold boundary (not strictly older)', () => {
+    // 26h before NOW
+    const manifest: LatestManifest = {
+      generatedAt: '2026-05-25T12:00:00.000Z',
+    }
+    const r = evaluateFreshness(manifest, NOW, 26)
+    expect(r.ageHours).toBeCloseTo(26, 5)
+    expect(r.stale).toBe(false)
+  })
+
+  it('is stale when generatedAt is older than the threshold (missed run)', () => {
+    // matches the real 2026-05-26 incident: last good run was 05-25 ~11:57Z
+    const manifest: LatestManifest = {
+      latestSnapshotDate: '2026-05-24',
+      generatedAt: '2026-05-25T11:57:32.518Z', // ~26.04h ago
+    }
+    const r = evaluateFreshness(manifest, NOW)
+    expect(r.stale).toBe(true)
+    expect(r.ageHours).toBeGreaterThan(26)
+    expect(r.reason).toMatch(/stale/i)
+  })
+
+  it('is stale when generatedAt is missing entirely', () => {
+    const r = evaluateFreshness({ latestSnapshotDate: '2026-05-25' }, NOW)
+    expect(r.stale).toBe(true)
+    expect(r.ageHours).toBeNull()
+    expect(r.reason).toMatch(/missing/i)
+  })
+
+  it('is stale when generatedAt is unparseable', () => {
+    const r = evaluateFreshness({ generatedAt: 'yesterday-ish' }, NOW)
+    expect(r.stale).toBe(true)
+    expect(r.ageHours).toBeNull()
+    expect(r.reason).toMatch(/unparseable|invalid/i)
+  })
+
+  it('honours a custom threshold', () => {
+    const manifest: LatestManifest = {
+      generatedAt: '2026-05-26T08:00:00.000Z', // 6h ago
+    }
+    expect(evaluateFreshness(manifest, NOW, 4).stale).toBe(true)
+    expect(evaluateFreshness(manifest, NOW, 8).stale).toBe(false)
+  })
+})
+
+// ── buildAlertIssueBody ────────────────────────────────────────────────────
+
+describe('buildAlertIssueBody', () => {
+  it('includes the age, last snapshot date, and the manual recovery command', () => {
+    const result = evaluateFreshness(
+      {
+        latestSnapshotDate: '2026-05-24',
+        generatedAt: '2026-05-25T11:57:32.518Z',
+      },
+      NOW
+    )
+    const body = buildAlertIssueBody(result, {
+      manifestUrl:
+        'https://storage.googleapis.com/toast-stats-data-ca/v1/latest.json',
+      now: NOW,
+    })
+    expect(body).toContain('2026-05-24') // last snapshot date
+    expect(body).toContain('gh workflow run data-pipeline.yml -f mode=daily')
+    expect(body).toMatch(/26\.0\d?\s*h|26\.0/) // approximate age surfaced
+    expect(body).toContain('toast-stats-data-ca/v1/latest.json')
+  })
+
+  it('handles the missing-generatedAt case without crashing', () => {
+    const result = evaluateFreshness({}, NOW)
+    const body = buildAlertIssueBody(result, {
+      manifestUrl: 'https://example.com/latest.json',
+      now: NOW,
+    })
+    expect(body).toMatch(/missing/i)
+    expect(body).toContain('gh workflow run data-pipeline.yml -f mode=daily')
+  })
+})

--- a/scripts/lib/pipelineFreshness.ts
+++ b/scripts/lib/pipelineFreshness.ts
@@ -47,6 +47,21 @@ export const STALE_THRESHOLD_HOURS = 26
 
 const MS_PER_HOUR = 1000 * 60 * 60
 
+/**
+ * Resolve a threshold from an env/dispatch value, defaulting on anything
+ * unusable. A non-numeric or non-positive value (e.g. a typo'd manual
+ * dispatch input) must NOT silently disable the monitor — `ageHours > NaN`
+ * is always false, which would make every run look fresh.
+ */
+export function resolveThresholdHours(
+  raw: string | undefined,
+  fallback: number = STALE_THRESHOLD_HOURS
+): number {
+  if (!raw) return fallback
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
 /** Parse the manifest body, throwing on invalid JSON. */
 export function parseManifest(raw: string): LatestManifest {
   const parsed = JSON.parse(raw) as unknown

--- a/scripts/lib/pipelineFreshness.ts
+++ b/scripts/lib/pipelineFreshness.ts
@@ -1,0 +1,156 @@
+/**
+ * Pipeline Freshness Evaluation — Pure Functions (#753)
+ *
+ * The daily Data Pipeline (`.github/workflows/data-pipeline.yml`) writes
+ * `v1/latest.json` with a `generatedAt` ISO timestamp on every successful
+ * run, then promotes it to the production CDN bucket. When GitHub silently
+ * drops a scheduled run (observed 2026-05-26), nothing fails — the CDN just
+ * keeps serving the last manifest and `generatedAt` stops advancing.
+ *
+ * These pure functions decide, given a fetched manifest and the current
+ * time, whether the snapshot is stale enough to alert on. No network or
+ * GCS I/O lives here so the decision logic is unit-testable; the monitor
+ * workflow supplies the fetched body and `new Date()`.
+ */
+
+/** Minimum shape of v1/latest.json we depend on. */
+export interface LatestManifest {
+  /** Snapshot date the manifest points at, e.g. "2026-05-25". */
+  latestSnapshotDate?: string
+  /** ISO-8601 timestamp of when this manifest was generated. */
+  generatedAt?: string
+  _format?: { version?: string; type?: string }
+}
+
+export interface FreshnessResult {
+  /** True when the manifest is older than the threshold (or unreadable). */
+  stale: boolean
+  /** Human-readable reason, suitable for the alert title/body. */
+  reason: string
+  /** Age of the manifest in hours, or null when generatedAt is unusable. */
+  ageHours: number | null
+  /** The raw generatedAt string we evaluated (or null when absent). */
+  generatedAt: string | null
+  /** The snapshot date the manifest points at (or null when absent). */
+  latestSnapshotDate: string | null
+  /** The threshold used for the decision. */
+  thresholdHours: number
+}
+
+/**
+ * Default staleness threshold. The primary cron fires at 08:00 UTC with a
+ * backup a few hours later; a healthy manifest is at most ~hours old when the
+ * monitor runs. 26h cleanly separates "ran today" (< ~12h) from "missed
+ * today" (> 24h) while tolerating the spread between primary and backup runs.
+ */
+export const STALE_THRESHOLD_HOURS = 26
+
+const MS_PER_HOUR = 1000 * 60 * 60
+
+/** Parse the manifest body, throwing on invalid JSON. */
+export function parseManifest(raw: string): LatestManifest {
+  const parsed = JSON.parse(raw) as unknown
+  if (parsed === null || typeof parsed !== 'object') {
+    throw new Error('manifest is not a JSON object')
+  }
+  return parsed as LatestManifest
+}
+
+/**
+ * Decide whether a manifest is stale relative to `now`.
+ * A missing or unparseable `generatedAt` is treated as stale — the monitor
+ * should shout, not silently pass, when the freshness signal is unreadable.
+ */
+export function evaluateFreshness(
+  manifest: LatestManifest,
+  now: Date,
+  thresholdHours: number = STALE_THRESHOLD_HOURS
+): FreshnessResult {
+  const latestSnapshotDate = manifest.latestSnapshotDate ?? null
+  const base = { thresholdHours, latestSnapshotDate }
+
+  if (!manifest.generatedAt) {
+    return {
+      ...base,
+      stale: true,
+      reason: 'manifest is missing a `generatedAt` timestamp',
+      ageHours: null,
+      generatedAt: null,
+    }
+  }
+
+  const generatedMs = Date.parse(manifest.generatedAt)
+  if (Number.isNaN(generatedMs)) {
+    return {
+      ...base,
+      stale: true,
+      reason: `manifest has an invalid/unparseable \`generatedAt\`: ${manifest.generatedAt}`,
+      ageHours: null,
+      generatedAt: manifest.generatedAt,
+    }
+  }
+
+  const ageHours = (now.getTime() - generatedMs) / MS_PER_HOUR
+  const stale = ageHours > thresholdHours
+  return {
+    ...base,
+    stale,
+    generatedAt: manifest.generatedAt,
+    ageHours,
+    reason: stale
+      ? `manifest is stale: ${ageHours.toFixed(1)}h old (> ${thresholdHours}h threshold)`
+      : `manifest is fresh: ${ageHours.toFixed(1)}h old (<= ${thresholdHours}h threshold)`,
+  }
+}
+
+export interface AlertBodyOptions {
+  /** Public URL the manifest was fetched from. */
+  manifestUrl: string
+  /** Evaluation time, surfaced in the alert for context. */
+  now: Date
+}
+
+/** Build the markdown body for the freshness alert issue. */
+export function buildAlertIssueBody(
+  result: FreshnessResult,
+  opts: AlertBodyOptions
+): string {
+  const ageLine =
+    result.ageHours === null
+      ? '**Manifest age:** unknown (generatedAt missing or unparseable)'
+      : `**Manifest age:** ${result.ageHours.toFixed(1)}h (threshold ${result.thresholdHours}h)`
+
+  return [
+    '## 🚨 Daily data pipeline may have missed a run',
+    '',
+    `The freshness monitor checked \`${opts.manifestUrl}\` at ${opts.now.toISOString()} and found the published snapshot stale.`,
+    '',
+    `- ${ageLine}`,
+    `- **Reason:** ${result.reason}`,
+    `- **Last snapshot date:** ${result.latestSnapshotDate ?? 'unknown'}`,
+    `- **generatedAt:** ${result.generatedAt ?? 'missing'}`,
+    '',
+    '### Likely cause',
+    '',
+    'GitHub silently dropped the scheduled `Data Pipeline` run (`schedule` events are best-effort and can be dropped with no failure record), or the run failed before promoting `v1/latest.json` to production.',
+    '',
+    '### Manual recovery',
+    '',
+    'Re-run the daily pipeline from the CLI:',
+    '',
+    '```bash',
+    'gh workflow run data-pipeline.yml -f mode=daily',
+    '```',
+    '',
+    'To confirm dispatch queues without writing prod data, use the safe no-op:',
+    '',
+    '```bash',
+    'gh workflow run data-pipeline.yml -f mode=prune -f dry_run=true',
+    '```',
+    '',
+    'See `docs/runbooks/data-pipeline-recovery.md` for the full runbook.',
+    '',
+    '---',
+    '_Filed automatically by `.github/workflows/pipeline-freshness-monitor.yml` (#753)._',
+  ].join('\n')
+}


### PR DESCRIPTION
## Summary

Closes the silent-failure gap behind #753: when GitHub drops a scheduled `Data Pipeline` run, nothing fails — the CDN keeps serving a stale `v1/latest.json` and no one is told (observed 2026-05-26). This sprint adds detection, a backup, and a runbook.

Refs #753 (epic #757, Sprint 2). _Manual close after verification — no auto-close keyword, per Lesson 106._

## What shipped

**AC1 — loud freshness monitor** (`.github/workflows/pipeline-freshness-monitor.yml`)
- Daily at **14:00 UTC** (after the 08:00 primary + 11:00 backup), fetches the prod manifest, and when `generatedAt` is older than **26h** it opens (or comments on, deduped by the `pipeline-stale` label) a GitHub issue **and fails the run** — two loud signals.
- Decision logic is pure + unit-tested in `scripts/lib/pipelineFreshness.ts`; the workflow is thin glue around `scripts/check-pipeline-freshness.ts`.

**AC3 — backup cron** (`data-pipeline.yml`): added `0 11 * * *`. The daily flow is idempotent and the `data-pipeline` concurrency group serializes runs, so an overlap with a slow primary is safe.

**AC2 — recovery runbook** (`docs/runbooks/data-pipeline-recovery.md`): documents `gh workflow run data-pipeline.yml -f mode=daily` and the **safe queue-test** (`-f mode=prune -f dry_run=true`, which skips all delete/promote steps).

**Bonus**: `ci.yml` now runs `npm run test:scripts` — the `scripts/lib` suite (incl. these tests) was previously ungated and could rot (cf. Lesson 054).

## Verification
- 13 new pure-function tests; full suite green (scripts 106, frontend 735, analytics-core 803, shared-contracts 134 + collector-cli).
- Runner executed **live** against prod `v1/latest.json` — correctly reports the real 26.5h-stale manifest (the #753 incident) with the right alert body + recovery command.
- Fresh-context review applied: crash path now always writes an issue body; non-numeric `THRESHOLD_HOURS` falls back to 26h instead of silently disabling the alert.

## Notes
- No `frontend/**` or package src touched → no PR preview channel (path-filtered). Verification is code-proof + live runner output.
- "Confirm it queues" (AC2) is documented as the safe `prune` dry-run; firing a real dispatch is operator-gated (prod-adjacent + classifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
