### PR TITLE
docs(lessons): 107 — monitor output freshness, not the best-effort scheduler (#753)

### DIFF
--- a/tasks/lessons/107-monitor-the-output-freshness-not-the-best-effort-scheduler.md
+++ b/tasks/lessons/107-monitor-the-output-freshness-not-the-best-effort-scheduler.md
@@ -1,0 +1,73 @@
+---
+id: '107'
+category: principle
+tags: [ci, automation, data-pipeline, monitoring]
+auto_load: true
+date: 2026-05-26
+issues: [753, 757]
+---
+
+# Lesson 107 — Monitor the output's freshness, not the best-effort scheduler
+
+**Date:** 2026-05-26
+**Issue:** #753 (epic #757 Sprint 2)
+**Tags:** github-actions, schedule, monitoring, dead-mans-switch, data-pipeline
+
+## What happened
+
+The daily Data Pipeline runs on a GitHub Actions `schedule` cron. On
+2026-05-26 the scheduled run simply **didn't happen** — no run record, no
+failed job, nothing to alert on. The CDN kept serving the previous day's
+`v1/latest.json` and the only reason anyone noticed was a human spotting
+stale data by chance. GitHub `schedule` events are explicitly **best-effort**
+and can be dropped under load with no trace.
+
+## The trap
+
+The instinct is to monitor the _workflow_: "alert me when the daily run
+fails." But a dropped scheduled event produces **no run at all** — there is no
+failure to catch. Every workflow-centric alarm (a failing job, a `needs:`
+gate, an `if: failure()` notify step) is blind to the one failure mode that
+actually bit us: the run that never started.
+
+## The principle
+
+For anything that _must_ run on a best-effort schedule, monitor the
+**freshness of the output it produces**, not the success of the job that
+produces it. The pipeline already stamps every successful run with
+`generatedAt` in `v1/latest.json`; a tiny independent cron that fails loudly
+when that timestamp is older than ~26h is a **dead-man's-switch** — it fires
+precisely because nothing else did. The check reads a public artifact, so it
+needs no shared-infra credentials (cf. [[093-gcs-cors-has-no-subdomain-wildcard-so-dynamic-preview-hosts-need-star]]
+— the CDN is world-readable).
+
+Two independent levers, not one:
+
+- **Reduce the miss rate** — a backup cron a few hours after the primary
+  absorbs a dropped event (safe only because the daily flow is idempotent and
+  a concurrency group serializes overlaps).
+- **Detect the miss that slips through** — the freshness monitor. The backup
+  makes misses rarer; the monitor makes the remaining ones _loud_. Ship both;
+  neither subsumes the other.
+
+## How to apply
+
+- When adding a `schedule`-triggered workflow whose output matters, ask "what
+  proves it ran?" and monitor _that_ artifact's age — don't assume a missed
+  run will show up as a red run, because it won't.
+- Keep the freshness decision in a pure, unit-tested function (here
+  `scripts/lib/pipelineFreshness.ts`) and make the workflow thin glue. The
+  boundary cases — missing timestamp, unparseable timestamp, a non-numeric
+  threshold input that would make `age > NaN` always false and silently
+  disable the alarm — are exactly the ones a monitor must get right, and they
+  are trivial to unit-test and easy to fumble in inline YAML bash.
+- A monitor that can't read its own freshness signal (fetch failed, JSON
+  garbage, crash) must **alert**, not pass. Treat "can't tell" as stale.
+
+## Related
+
+- [[093-gcs-cors-has-no-subdomain-wildcard-so-dynamic-preview-hosts-need-star]]
+  — the artifact being monitored is public/world-readable, so the monitor
+  needs no credentials.
+- `docs/runbooks/data-pipeline-recovery.md` — the recovery runbook this lesson
+  backs (detection → manual re-run → safe queue-test).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -66,6 +66,7 @@
 - **105** [frontend, css, responsive, accessibility, ux] — Match the mobile-table pattern to the data's purpose, not a sibling table's precedent (#689, #683)
 - **106** [automation, sprint-runner, prompts] — `Closes #N` in an auto-merged sprint PR defeats the tick-before-close ordering (#689, #626, #683)
 - **107** [dark-mode, css, accessibility, tests, vitest] — A CSS-parsing audit's selector matcher must exclude pseudo-class rules, or `:hover`/`:focus` shadows the resting state (#700, #701)
+- **107** [ci, automation, data-pipeline, monitoring] — Monitor the output's freshness, not the best-effort scheduler (#753, #757)
 - **107** [process, frontend, router, tdd, sprint-runner] — Reserve a future seam with a tripwire test, not just a comment (#680, #678, #674)
 - **107** [dark-mode, css, accessibility, frontend, tailwind] — Tailwind's `dark:` is OS-keyed; under a manual theme toggle it MISFIRES in the OS-dark + app-light quadrant (#710, #683)
 - **108** [tests, playwright, css, frontend, accessibility] — Verify a sticky header by measuring the sticky cell, not the `<thead>` wrapper (#667, #665)


### PR DESCRIPTION
Captures the transferable insight from #753 Sprint 2 (epic #757): a dropped GitHub `schedule` event leaves no failed run, so monitor the output artifact's freshness as a dead-man's-switch rather than the workflow's success. Lessons-only — CI skips per #703.

Refs #753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)