### PR TITLE
fix(dark-mode): migrate remaining components off prefers-scheme `dark:` to the theme toggle (#715)

### DIFF
--- a/frontend/src/__tests__/css-migration/region-dark-variant-scope.test.ts
+++ b/frontend/src/__tests__/css-migration/region-dark-variant-scope.test.ts
@@ -19,11 +19,15 @@ import { join, relative, resolve } from 'path'
 
 const FRONTEND_SRC = resolve(__dirname, '../..')
 
-// Match a Tailwind `dark:` variant token (incl. stacked like
-// `dark:hover:`), but NOT our toggle-scoped `theme-dark:`. A `dark:`
-// token is bounded on the left by start/whitespace/quote and is not
-// preceded by `theme-` (the `[\w-]` lookbehind excludes `theme-dark:`).
-const RAW_DARK_VARIANT = /(?<![\w-])dark:/g
+// Match any Tailwind variant token that compiles to
+// @media(prefers-color-scheme:dark): bare `dark:`, stacked `dark:hover:`,
+// AND the `group-dark:` / `peer-dark:` parent-state forms. The only
+// sanctioned form is our toggle-scoped `theme-dark:`, so flag every
+// `dark:` whose word-boundary start is NOT preceded by `theme-`.
+// `\b` avoids matching inside an unrelated identifier; the lookbehind
+// keeps `theme-dark:` (and stacks like `theme-dark:hover:`) clean while
+// still catching `group-dark:` / `peer-dark:`.
+const RAW_DARK_VARIANT = /(?<!theme-)\bdark:/g
 
 // Recursive .tsx/.jsx walker, skipping tests so a guard-fixture string
 // can't trip this assertion (mirrors unmitigated-color-utilities.test.ts).

--- a/frontend/src/__tests__/css-migration/region-dark-variant-scope.test.ts
+++ b/frontend/src/__tests__/css-migration/region-dark-variant-scope.test.ts
@@ -14,34 +14,56 @@
 // This guard fails if a region component reintroduces a raw `dark:` utility.
 
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { join, relative, resolve } from 'path'
 
 const FRONTEND_SRC = resolve(__dirname, '../..')
-
-// The two components that render the /regions page surface (#710 scope).
-const REGION_COMPONENTS = [
-  'components/RegionsLeaderboard.tsx',
-  'components/RegionGrid.tsx',
-]
 
 // Match a Tailwind `dark:` variant token (incl. stacked like
 // `dark:hover:`), but NOT our toggle-scoped `theme-dark:`. A `dark:`
 // token is bounded on the left by start/whitespace/quote and is not
-// preceded by `theme-`.
+// preceded by `theme-` (the `[\w-]` lookbehind excludes `theme-dark:`).
 const RAW_DARK_VARIANT = /(?<![\w-])dark:/g
 
-describe('region components scope dark styling to [data-theme], not the OS', () => {
-  it.each(REGION_COMPONENTS)(
-    '%s uses no raw prefers-color-scheme `dark:` utilities',
-    file => {
-      const src = readFileSync(resolve(FRONTEND_SRC, file), 'utf-8')
+// Recursive .tsx/.jsx walker, skipping tests so a guard-fixture string
+// can't trip this assertion (mirrors unmitigated-color-utilities.test.ts).
+function collectComponentFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue
+      out.push(...collectComponentFiles(full))
+    } else if (/\.(tsx|jsx)$/.test(entry) && !/\.test\.|\.spec\./.test(entry)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+// Repo-wide guard (#715): the migration off raw `dark:` covers the WHOLE
+// component tree, not just the two #710 region components. A raw `dark:`
+// utility fires via @media(prefers-color-scheme:dark) and misfires when the
+// OS prefers dark but the app shows light mode — light text on a light
+// surface. Every dark style must scope to the manual `[data-theme='dark']`
+// toggle via the `theme-dark:` custom variant instead.
+describe('no component uses raw prefers-color-scheme `dark:` utilities (#715)', () => {
+  const files = collectComponentFiles(FRONTEND_SRC)
+
+  it('finds component files to scan', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it.each(files.map(f => relative(FRONTEND_SRC, f)))(
+    '%s uses `theme-dark:`, never raw `dark:`',
+    rel => {
+      const src = readFileSync(resolve(FRONTEND_SRC, rel), 'utf-8')
       const matches = src.match(RAW_DARK_VARIANT) ?? []
       expect(
         matches.length,
-        `${file} contains ${matches.length} raw \`dark:\` utility(ies). ` +
+        `${rel} contains ${matches.length} raw \`dark:\` utility(ies). ` +
           'These fire via @media(prefers-color-scheme:dark) and misfire when ' +
-          'the OS is dark but the app shows light mode (#710). Use the ' +
+          'the OS is dark but the app shows light mode (#710/#715). Use the ' +
           'toggle-scoped `theme-dark:` variant instead.'
       ).toBe(0)
     }

--- a/frontend/src/components/ClubAnniversaryBadge.tsx
+++ b/frontend/src/components/ClubAnniversaryBadge.tsx
@@ -41,8 +41,8 @@ export const ClubAnniversaryBadge: React.FC<ClubAnniversaryBadgeProps> = ({
         className={
           'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold ' +
           (isMilestone
-            ? 'bg-yellow-100 text-yellow-900 ring-1 ring-yellow-400 dark:bg-yellow-900/40 dark:text-yellow-100 dark:ring-yellow-500'
-            : 'bg-blue-50 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100')
+            ? 'bg-yellow-100 text-yellow-900 ring-1 ring-yellow-400 theme-dark:bg-yellow-900/40 theme-dark:text-yellow-100 theme-dark:ring-yellow-500'
+            : 'bg-blue-50 text-blue-900 theme-dark:bg-blue-900/40 theme-dark:text-blue-100')
         }
       >
         🎉 {copy}
@@ -59,7 +59,7 @@ export const ClubAnniversaryBadge: React.FC<ClubAnniversaryBadgeProps> = ({
       <span
         data-milestone="true"
         title={charterDateLabel}
-        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-900 ring-1 ring-yellow-400 dark:bg-yellow-900/40 dark:text-yellow-100 dark:ring-yellow-500"
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-900 ring-1 ring-yellow-400 theme-dark:bg-yellow-900/40 theme-dark:text-yellow-100 theme-dark:ring-yellow-500"
       >
         🥇 {years} Years
         {charterDateLabel && (
@@ -74,7 +74,7 @@ export const ClubAnniversaryBadge: React.FC<ClubAnniversaryBadgeProps> = ({
     <span
       data-milestone="false"
       title={charterDateLabel}
-      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs text-gray-600 bg-gray-100 dark:bg-gray-700 dark:text-gray-300"
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs text-gray-600 bg-gray-100 theme-dark:bg-gray-700 theme-dark:text-gray-300"
     >
       {years} years
       {charterDateLabel && (

--- a/frontend/src/components/DataControlsBar.tsx
+++ b/frontend/src/components/DataControlsBar.tsx
@@ -16,7 +16,7 @@ export interface DataControlsBarProps {
 }
 
 const CHIP_BASE =
-  'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border bg-white border-gray-200 text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-200'
+  'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border bg-white border-gray-200 text-gray-700 theme-dark:bg-gray-800 theme-dark:border-gray-700 theme-dark:text-gray-200'
 
 const FreshnessPill: React.FC<{ date: string }> = ({ date }) => (
   <div
@@ -49,7 +49,7 @@ const ChipSelect: React.FC<{
   return (
     <label
       data-testid={testId}
-      className={`${CHIP_BASE} relative cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 focus-within:ring-2 focus-within:ring-tm-loyal-blue focus-within:ring-offset-1`}
+      className={`${CHIP_BASE} relative cursor-pointer hover:bg-gray-50 theme-dark:hover:bg-gray-700 focus-within:ring-2 focus-within:ring-tm-loyal-blue focus-within:ring-offset-1`}
     >
       <span>{display}</span>
       <span aria-hidden="true" className="text-gray-400">

--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -113,17 +113,19 @@ const GapTile: React.FC<GapTileSpec> = ({
   const closed = gap === 0
   const showConcrete = !closed && concreteCount != null && concreteCount > 0
   return (
-    <div className="rounded-md border border-gray-200 dark:border-gray-700 px-3 py-2">
+    <div className="rounded-md border border-gray-200 theme-dark:border-gray-700 px-3 py-2">
       <div
         data-testid="gap-tile-label"
-        className="text-[11px] uppercase tracking-wide text-gray-600 dark:text-gray-400 font-tm-body"
+        className="text-[11px] uppercase tracking-wide text-gray-600 theme-dark:text-gray-400 font-tm-body"
       >
         {label}
       </div>
       <div
         data-testid="gap-tile-value"
         className={`mt-0.5 text-base font-semibold tabular-nums ${
-          closed ? 'text-tm-loyal-blue' : 'text-gray-900 dark:text-gray-100'
+          closed
+            ? 'text-tm-loyal-blue'
+            : 'text-gray-900 theme-dark:text-gray-100'
         }`}
       >
         {closed ? '✓' : `+${gap.toFixed(1)}%`}
@@ -131,7 +133,7 @@ const GapTile: React.FC<GapTileSpec> = ({
       {showConcrete && (
         <div
           data-testid="gap-tile-units"
-          className="mt-0.5 text-[11px] text-gray-600 dark:text-gray-400 font-tm-body tabular-nums"
+          className="mt-0.5 text-[11px] text-gray-600 theme-dark:text-gray-400 font-tm-body tabular-nums"
         >
           ~{concreteCount} {concreteCount === 1 ? unitSingular : unitPlural}
         </div>

--- a/frontend/src/components/LongestServingClubsLeaderboard.tsx
+++ b/frontend/src/components/LongestServingClubsLeaderboard.tsx
@@ -89,7 +89,7 @@ export const LongestServingClubsLeaderboard: React.FC<
         <h3 id="longest-serving-heading" className="redesign-panel__header">
           Longest-serving clubs
         </h3>
-        <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+        <p className="text-xs text-gray-500 theme-dark:text-gray-400 font-tm-body">
           No charter data yet for this district.
         </p>
       </section>
@@ -111,11 +111,11 @@ export const LongestServingClubsLeaderboard: React.FC<
         >
           Longest-serving clubs
         </h3>
-        <span className="text-[11px] uppercase tracking-wider text-gray-600 dark:text-gray-400 font-tm-body">
+        <span className="text-[11px] uppercase tracking-wider text-gray-600 theme-dark:text-gray-400 font-tm-body">
           Top {rows.length}
         </span>
       </div>
-      <ol className="divide-y divide-gray-100 dark:divide-gray-800 -mx-1">
+      <ol className="divide-y divide-gray-100 theme-dark:divide-gray-800 -mx-1">
         {rows.map((row, i) => (
           <li
             key={row.club.clubId}
@@ -131,10 +131,10 @@ export const LongestServingClubsLeaderboard: React.FC<
             >
               {row.club.clubName}
             </Link>
-            <span className="shrink-0 tabular-nums text-xs font-semibold text-gray-700 dark:text-gray-200">
+            <span className="shrink-0 tabular-nums text-xs font-semibold text-gray-700 theme-dark:text-gray-200">
               {row.years}y
             </span>
-            <span className="shrink-0 tabular-nums text-[11px] text-gray-600 dark:text-gray-400">
+            <span className="shrink-0 tabular-nums text-[11px] text-gray-600 theme-dark:text-gray-400">
               {row.charterLabel}
             </span>
           </li>

--- a/frontend/src/components/MilestonesCallout.tsx
+++ b/frontend/src/components/MilestonesCallout.tsx
@@ -193,7 +193,7 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
           Milestones · PY {pyLabel}
         </h3>
         {nextUpcoming ? (
-          <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+          <p className="text-xs text-gray-500 theme-dark:text-gray-400 font-tm-body">
             None this PY — next is{' '}
             <Link
               to={clubHref(nextUpcoming.club.clubId)}
@@ -202,13 +202,13 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
               {nextUpcoming.club.clubName}
             </Link>{' '}
             at{' '}
-            <strong className="font-semibold text-gray-700 dark:text-gray-200">
+            <strong className="font-semibold text-gray-700 theme-dark:text-gray-200">
               {nextUpcoming.milestoneYears}y
             </strong>{' '}
             in {formatShortDate(nextUpcoming.anniversaryDate)}.
           </p>
         ) : (
-          <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+          <p className="text-xs text-gray-500 theme-dark:text-gray-400 font-tm-body">
             None this PY.
           </p>
         )}
@@ -222,11 +222,11 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
         <h3 id="milestones-heading" className="redesign-panel__header !mb-0">
           Milestones · PY {pyLabel}
         </h3>
-        <span className="text-[11px] uppercase tracking-wider text-gray-600 dark:text-gray-400 font-tm-body">
+        <span className="text-[11px] uppercase tracking-wider text-gray-600 theme-dark:text-gray-400 font-tm-body">
           {totalCount} club{totalCount === 1 ? '' : 's'}
         </span>
       </div>
-      <ul className="divide-y divide-gray-100 dark:divide-gray-800 -mx-1">
+      <ul className="divide-y divide-gray-100 theme-dark:divide-gray-800 -mx-1">
         {groups.map(group => (
           <li
             key={group.years}
@@ -249,7 +249,7 @@ export const MilestonesCallout: React.FC<MilestonesCalloutProps> = ({
                   >
                     {entry.club.clubName}
                   </Link>
-                  <span className="text-[11px] text-gray-600 dark:text-gray-400 tabular-nums">
+                  <span className="text-[11px] text-gray-600 theme-dark:text-gray-400 tabular-nums">
                     {formatShortDate(entry.anniversaryDate)}
                   </span>
                   {i < group.entries.length - 1 && (

--- a/frontend/src/components/NotableDatesSection.tsx
+++ b/frontend/src/components/NotableDatesSection.tsx
@@ -63,7 +63,7 @@ export const NotableDatesSection: React.FC<NotableDatesSectionProps> = ({
         className="redesign-panel py-2"
         aria-label="No upcoming anniversaries or milestones"
       >
-        <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+        <p className="text-xs text-gray-500 theme-dark:text-gray-400 font-tm-body">
           <span aria-hidden="true" className="mr-1">
             ○
           </span>

--- a/frontend/src/components/ProspectiveClubsPanel.tsx
+++ b/frontend/src/components/ProspectiveClubsPanel.tsx
@@ -38,17 +38,17 @@ export const ProspectiveClubsPanel: React.FC<ProspectiveClubsPanelProps> = ({
         >
           Prospective clubs ({clubs.length})
         </h3>
-        <span className="text-[11px] uppercase tracking-wider text-gray-600 dark:text-gray-400 font-tm-body">
+        <span className="text-[11px] uppercase tracking-wider text-gray-600 theme-dark:text-gray-400 font-tm-body">
           FAC registry
         </span>
       </div>
-      <p className="text-xs text-gray-600 dark:text-gray-400 font-tm-body mb-2">
+      <p className="text-xs text-gray-600 theme-dark:text-gray-400 font-tm-body mb-2">
         In TI&rsquo;s public Find-A-Club registry but not yet in this
         district&rsquo;s performance reports — typically ATO (Application To
         Organize) clubs or fresh charters. Excluded from rankings and
         distinguished counts.
       </p>
-      <ul className="divide-y divide-gray-100 dark:divide-gray-800 -mx-1">
+      <ul className="divide-y divide-gray-100 theme-dark:divide-gray-800 -mx-1">
         {clubs.map(club => {
           const location = formatLocation(club)
           return (
@@ -57,11 +57,11 @@ export const ProspectiveClubsPanel: React.FC<ProspectiveClubsPanelProps> = ({
               className="flex items-center gap-2 px-2 py-1.5 text-sm font-tm-body"
               data-testid="prospective-club-row"
             >
-              <span className="flex-1 min-w-0 truncate font-semibold text-gray-800 dark:text-gray-100">
+              <span className="flex-1 min-w-0 truncate font-semibold text-gray-800 theme-dark:text-gray-100">
                 {club.clubName}
               </span>
               {location && (
-                <span className="hidden sm:inline text-xs text-gray-500 dark:text-gray-400 truncate max-w-[12rem]">
+                <span className="hidden sm:inline text-xs text-gray-500 theme-dark:text-gray-400 truncate max-w-[12rem]">
                   {location}
                 </span>
               )}

--- a/frontend/src/components/SubpageBreadcrumb.tsx
+++ b/frontend/src/components/SubpageBreadcrumb.tsx
@@ -52,7 +52,7 @@ export const SubpageBreadcrumb: React.FC<SubpageBreadcrumbProps> = ({
                 </Link>
               ) : (
                 <span
-                  className="font-medium text-gray-900 dark:text-gray-100"
+                  className="font-medium text-gray-900 theme-dark:text-gray-100"
                   aria-current="page"
                 >
                   {crumb.label}

--- a/frontend/src/components/UpcomingAnniversariesPanel.tsx
+++ b/frontend/src/components/UpcomingAnniversariesPanel.tsx
@@ -98,9 +98,9 @@ export const UpcomingAnniversariesPanel: React.FC<
           Upcoming anniversaries
         </h3>
         {nextBeyondWindow ? (
-          <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+          <p className="text-xs text-gray-500 theme-dark:text-gray-400 font-tm-body">
             All quiet — next in{' '}
-            <strong className="font-semibold text-gray-700 dark:text-gray-200">
+            <strong className="font-semibold text-gray-700 theme-dark:text-gray-200">
               {nextBeyondWindow.anniversary.daysUntilNext}d
             </strong>{' '}
             at{' '}
@@ -112,7 +112,7 @@ export const UpcomingAnniversariesPanel: React.FC<
             </Link>
           </p>
         ) : (
-          <p className="text-xs text-gray-500 dark:text-gray-400 font-tm-body">
+          <p className="text-xs text-gray-500 theme-dark:text-gray-400 font-tm-body">
             All quiet — no charter dates available.
           </p>
         )}
@@ -135,11 +135,11 @@ export const UpcomingAnniversariesPanel: React.FC<
         >
           Upcoming anniversaries
         </h3>
-        <span className="text-[11px] uppercase tracking-wider text-gray-600 dark:text-gray-400 font-tm-body">
+        <span className="text-[11px] uppercase tracking-wider text-gray-600 theme-dark:text-gray-400 font-tm-body">
           Next {UPCOMING_WINDOW_DAYS}d · {upcoming.length}
         </span>
       </div>
-      <ul className="divide-y divide-gray-100 dark:divide-gray-800 -mx-1">
+      <ul className="divide-y divide-gray-100 theme-dark:divide-gray-800 -mx-1">
         {visible.map(row => {
           const { club, anniversary } = row
           // Milestone for this row = milestone on the UPCOMING year count.
@@ -170,7 +170,7 @@ export const UpcomingAnniversariesPanel: React.FC<
                   'w-10 shrink-0 text-right tabular-nums text-xs font-semibold ' +
                   (anniversary.daysUntilNext <= 7
                     ? 'text-tm-true-maroon'
-                    : 'text-gray-700 dark:text-gray-300')
+                    : 'text-gray-700 theme-dark:text-gray-300')
                 }
               >
                 {dayCopy}
@@ -181,7 +181,7 @@ export const UpcomingAnniversariesPanel: React.FC<
               >
                 {club.clubName}
               </Link>
-              <span className="hidden sm:inline text-xs text-gray-500 dark:text-gray-400 truncate max-w-[8rem]">
+              <span className="hidden sm:inline text-xs text-gray-500 theme-dark:text-gray-400 truncate max-w-[8rem]">
                 {club.areaName}
               </span>
               <span
@@ -189,7 +189,7 @@ export const UpcomingAnniversariesPanel: React.FC<
                   'shrink-0 tabular-nums text-xs font-semibold ' +
                   (isUpcomingMilestone
                     ? 'text-tm-true-maroon'
-                    : 'text-gray-600 dark:text-gray-300')
+                    : 'text-gray-600 theme-dark:text-gray-300')
                 }
               >
                 {ord}

--- a/frontend/src/pages/RegionsPage.tsx
+++ b/frontend/src/pages/RegionsPage.tsx
@@ -110,7 +110,7 @@ const RegionsPage: React.FC = () => {
       <section className="my-8" aria-labelledby="regions-grid-heading">
         <h2
           id="regions-grid-heading"
-          className="text-lg font-tm-headline text-gray-900 dark:text-gray-50 mb-3"
+          className="text-lg font-tm-headline text-gray-900 theme-dark:text-gray-50 mb-3"
         >
           Region cards
         </h2>
@@ -118,7 +118,7 @@ const RegionsPage: React.FC = () => {
       </section>
 
       {dnarCount > 0 && (
-        <p className="text-xs text-gray-500 dark:text-gray-400 mt-6 italic">
+        <p className="text-xs text-gray-500 theme-dark:text-gray-400 mt-6 italic">
           {dnarCount} district{dnarCount === 1 ? '' : 's'} not yet assigned to a
           region — not shown above.
         </p>

--- a/tasks/lessons/107-reskoping-dark-to-theme-dark-is-a-no-op-in-app-dark-when-base-overrides-exist.md
+++ b/tasks/lessons/107-reskoping-dark-to-theme-dark-is-a-no-op-in-app-dark-when-base-overrides-exist.md
@@ -1,0 +1,80 @@
+---
+id: '107'
+category: lesson
+tags: [dark-mode, css, tailwind, accessibility, verification, frontend]
+auto_load: true
+date: 2026-05-26
+issues: [715, 710, 564]
+---
+
+# Lesson 107 — Re-scoping `dark:` → `theme-dark:` is a no-op in app-dark when the base class already has a `dark-mode.css` override
+
+**Date:** 2026-05-26
+**Issue:** #715 (migrate remaining components off raw `dark:` — epic #756 Sprint 3)
+
+## What happened
+
+#710 introduced a `theme-dark:` custom variant (keyed off the manual
+`[data-theme='dark']` toggle, not `@media(prefers-color-scheme:dark)`) and
+converted the two region components. #715 swept the remaining 10 components +
+RegionsPage with a mechanical `dark:` → `theme-dark:` substitution.
+
+The reflex worry was Track D all over again (lessons 094/095/096): would
+flipping the variant flip app-DARK rendering and reopen a contrast audit? It did
+**not** — and the reason is worth keeping.
+
+## Why the sweep was safe by construction
+
+Every converted pair's **light-side base class** (`text-gray-500`, `bg-white`,
+`bg-yellow-100`, `text-yellow-900`, …) already carries a `[data-theme='dark']`
+override in `dark-mode.css` (most are `!important`; even without, `[attr]
+.class` = (0,2,0) beats the `theme-dark:` utility's `&:where(...)` = (0,1,0)).
+So in **app-dark mode the base override still wins the cascade** — the
+`theme-dark:` utility is dominated and inert. App-dark rendering is therefore
+**byte-identical** before and after the migration.
+
+The raw `dark:` utility was only ever _visibly_ active in one quadrant:
+**app-light + OS-dark**, where it fired off the OS media query and painted light
+text on the light surface (#710, Amy's Safari bug). Converting it to
+`theme-dark:` makes that quadrant go inert → clean light base. So the migration's
+_only_ behavioural change is removing the misfire.
+
+**The takeaway:** a raw-`dark:`→`theme-dark:` re-scope is fundamentally different
+from a Track-D dark-mode _fix_. Track D edited `dark-mode.css` to change what
+app-dark renders; #715 changed nothing app-dark renders. Verify it as **"no
+app-dark regression + bug-quadrant now legible,"** not as a contrast redesign.
+If a converted element has _no_ base override, that's the exception to check —
+there the `theme-dark:` utility becomes the only app-dark styling and you must
+confirm it's AA. (#715 had none; all base classes were already covered.)
+
+## The verification selector that maps exactly to the diff
+
+`document.querySelectorAll('[class*="theme-dark"]')` selects **precisely** the
+elements this migration touched, on whatever page is loaded — the class
+attribute literally contains the `theme-dark:` token. A Playwright smoke that
+sweeps those elements for own-text contrast across all four {app theme} × {OS
+pref} quadrants, in **both** engines (Chromium `smoke` + WebKit, per #710), is a
+faithful, low-maintenance guard: it follows the diff instead of hard-coding
+per-component selectors. Run it before the unit guard goes in so RED is real.
+
+## How to apply
+
+- Before treating a `dark:`→`theme-dark:` sweep as risky, check whether the
+  paired base class has a `dark-mode.css` override. If it does, app-dark is
+  unchanged and the only thing to verify is the OS-misfire quadrant
+  (app-light/OS-dark) — in WebKit especially (#710).
+- Use `[class*="theme-dark"]` as the live-verification selector; it tracks the
+  migration set automatically.
+- The repo-wide reintroduction guard must flag every prefers-scheme form, not
+  just bare `dark:` — `group-dark:` / `peer-dark:` compile the same way. Match
+  `(?<!theme-)\bdark:`, not `(?<![\w-])dark:`.
+
+## Related
+
+- [[094-darkmode-utilities-fail-by-asymmetry-text-and-bg-must-remap-together]] —
+  Track D _changed_ app-dark rendering; #715 deliberately does not. Same file,
+  opposite blast radius.
+- [[095-darkmode-token-bumps-must-be-sized-for-the-lightest-surface]] — the
+  ClubAnniversaryBadge base overrides this lesson relies on were added by #610.
+- [[073-opacity-variant-utilities-need-explicit-dark-mode-overrides]] — why raw
+  `dark:` is inert under the manual toggle in the first place.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -69,6 +69,7 @@
 - **107** [frontend, react, cls, performance] — A deferred async-insert CLS source reactivates the moment its data gets populated (#750, #488, #683)
 - **107** [css, responsive, frontend, mobile] — A horizontal-overflow fix has two layers: collapse the wide child AND shrink the container's own fixed gutters (#735, #756)
 - **107** [ci, automation, data-pipeline, monitoring] — Monitor the output's freshness, not the best-effort scheduler (#753, #757)
+- **107** [dark-mode, css, tailwind, accessibility, verification, frontend] — Re-scoping `dark:` → `theme-dark:` is a no-op in app-dark when the base class already has a `dark-mode.css` override (#715, #710, #564)
 - **107** [process, frontend, router, tdd, sprint-runner] — Reserve a future seam with a tripwire test, not just a comment (#680, #678, #674)
 - **107** [dark-mode, css, accessibility, frontend, tailwind] — Tailwind's `dark:` is OS-keyed; under a manual theme toggle it MISFIRES in the OS-dark + app-light quadrant (#710, #683)
 - **108** [tests, playwright, css, frontend, accessibility] — Verify a sticky header by measuring the sticky cell, not the `<thead>` wrapper (#667, #665)


### PR DESCRIPTION
## What

Migrate the 10 remaining components + `RegionsPage` off raw Tailwind `dark:`
utilities to the toggle-scoped `theme-dark:` custom variant (#710's mechanism),
and generalize the #710 region guard into a repo-wide reintroduction guard.

Part of #715 (epic #756, Sprint 3).

## Why

This app's dark mode is a **manual `[data-theme='dark']` toggle**, but raw
`dark:` compiles to `@media (prefers-color-scheme: dark)`. When a user's OS
prefers dark while the app shows light, every `dark:` utility misfires —
painting light text on a light surface (#710, Amy's Safari leaderboard bug).
`theme-dark:` keys off the manual toggle, so dark styling tracks the app theme,
never the OS.

## How it stays safe in app-dark mode

Every converted pair's light-side base class (`text-gray-*`, `bg-white`,
`bg-yellow-100`, …) already has a `[data-theme='dark']` override in
`dark-mode.css` that wins the cascade over the `theme-dark:` utility. So
**app-dark rendering is unchanged**; the only behavioural change is removing the
app-light/OS-dark misfire. Verified across all four {app theme} × {OS pref}
quadrants in Chromium **and** WebKit on the preview channel (evidence on #715).

## Commits

1. `test` — repo-wide guard (RED): scans every `.tsx`/`.jsx` for raw `dark:`.
2. `fix` — convert `dark:` → `theme-dark:` in 10 components + RegionsPage (GREEN).
3. `refactor` — guard also catches `group-dark:` / `peer-dark:` (review nit).

## Acceptance criteria

- [x] No component renders light-on-light (or vice-versa) in any of the four quadrants.
- [x] A guard prevents reintroduction (repo-wide `region-dark-variant-scope.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
