### PR TITLE
fix(sprint-runner): honor operator steering — read comments + gate needs-product-review (#767)

### DIFF
--- a/scripts/sprint-bootstrap.prompt
+++ b/scripts/sprint-bootstrap.prompt
@@ -19,7 +19,9 @@ Do these steps in order, and stop if any check fails:
    - If it is not CLOSED, STOP. Do not proceed; report to the operator via Remote Control and exit.
    - (No prod reachability gate: verification is done on the PR preview channel, not prod — see step 5.)
 
-3. **Re-read the epic** with `gh issue view {{EPIC}} --json body` and confirm Sprint {{SPRINT_N}} (#{{TARGET_ISSUE}}) is still the first unchecked sprint. If the epic has been edited (e.g. the operator manually advanced something), trust the epic over this prompt and re-pick the correct target.
+3. **Re-read the epic, then the target issue including its comments.**
+   - `gh issue view {{EPIC}} --json body` — confirm Sprint {{SPRINT_N}} (#{{TARGET_ISSUE}}) is still the first unchecked sprint. If the epic has been edited (e.g. the operator manually advanced something), trust the epic over this prompt and re-pick the correct target.
+   - `gh issue view {{TARGET_ISSUE}} --comments` — read the target's **body AND every comment**. `gh issue view` omits comments unless `--comments` is passed, so they were previously invisible to sessions (#767). Operator comments are **binding guidance**: they refine or override the body (scope, shape, constraints) and are newer intent, so where a comment conflicts with the body, **the comment wins**. If a comment asks for a decision, requests product review, or poses an unanswered question, **STOP** — do not proceed; surface it to the operator via Remote Control and exit.
 
 4. **Run the sprint skill** for the target: invoke `/sprint` with issue `#{{TARGET_ISSUE}}` as the input. Follow the sprint skill's full workflow (Red / Green / Refactor / Verify per CLAUDE.md), including filing the PR and watching CI.
 

--- a/scripts/sprint-runner.sh
+++ b/scripts/sprint-runner.sh
@@ -397,6 +397,16 @@ gc_worktrees() {
   git -C "$REPO_DIR" worktree prune 2>/dev/null || true
 }
 
+# True (0) if the issue carries the `needs-product-review` label — the runner
+# must not launch such a sprint autonomously (#767); the session can't make a
+# product call. Fail-open: a gh error yields "not flagged" and lets the normal
+# predecessor gate (which also queries gh) skip the tick instead.
+issue_needs_review() {
+  local issue="$1"
+  gh issue view "$issue" --json labels --jq '.labels[].name' 2>/dev/null \
+    | grep -qx 'needs-product-review'
+}
+
 # === Gate check ===
 # Echoes "PASS <desc>" or "FAIL <desc>". Non-fatal — caller decides.
 check_gate() {
@@ -645,6 +655,17 @@ mode_run() {
   fi
   local target_n target_issue
   read -r target_n target_issue <<<"$pair"
+
+  # --- Operator review gate (#767) ---
+  # A sprint flagged needs-product-review must NOT run autonomously — the
+  # session can't honor a product decision. Skip and notify; the operator
+  # removes the label (or hand-runs the sprint) to release it. Applies in
+  # dry-run too: report the skip rather than a would-be launch.
+  if issue_needs_review "$target_issue"; then
+    log "Sprint $target_n (#$target_issue) has needs-product-review — NOT launching. Remove the label (or hand-run) to release it."
+    notify "sprint-runner" "Sprint $target_n (#$target_issue) needs product review — skipped"
+    exit 0
+  fi
 
   # --- Gate check ---
   local prev_n=$((target_n - 1))

--- a/scripts/tests/sprint-runner-review-gate.test.sh
+++ b/scripts/tests/sprint-runner-review-gate.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Regression test for #767: the runner must NOT launch a sprint whose target
+# issue carries the `needs-product-review` label — it skips and notifies so the
+# operator decides. A normal target still launches.
+#
+# Hermetic: mocks `gh` and `screen` on PATH, runs in --dry-run so no worktree or
+# screen session is ever created, and asserts on the launch decision in the log.
+#   Case A: target HAS needs-product-review → "NOT launching", no "would launch"
+#   Case B: target WITHOUT the label        → "would launch"
+#
+# Run directly: scripts/tests/sprint-runner-review-gate.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$SCRIPT_DIR/../sprint-runner.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+BIN="$TMP/bin"; mkdir -p "$BIN"
+
+# Mock gh: META_EPIC #900 → epic #901 → one unchecked Sprint 1 (#902).
+# #902's labels depend on $MOCK_REVIEW so one mock serves both cases.
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+sub="$1"; verb="$2"; num="$3"
+[[ "$sub" == "issue" && "$verb" == "edit" ]] && exit 0
+if [[ "$sub" == "issue" && "$verb" == "view" ]]; then
+  field=""; args=("$@")
+  for ((i=0; i<${#args[@]}; i++)); do [[ "${args[i]}" == "--json" ]] && field="${args[i+1]}"; done
+  case "$num:$field" in
+    900:labels) ;;                                  # meta not paused
+    900:body)   printf '%s' '- [ ] **Epic Test** — #901' ;;
+    901:body)   printf '%s' '- [ ] **Sprint 1** — #902' ;;
+    902:labels) [[ "${MOCK_REVIEW:-0}" == "1" ]] && printf '%s\n' 'needs-product-review' ;;
+  esac
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$BIN/gh"
+
+cat > "$BIN/screen" <<'EOF'
+#!/usr/bin/env bash
+echo "No Sockets found." >&2
+exit 1
+EOF
+chmod +x "$BIN/screen"
+
+export PATH="$BIN:$PATH"
+export META_EPIC=900
+export SPRINT_RUNNER_LOCK_DIR="$TMP/lock"
+export WORKTREE_BASE="$TMP/worktrees"
+unset EPIC || true
+
+fail=0
+
+# --- Case A: needs-product-review target must be skipped ---
+MOCK_REVIEW=1 "$RUNNER" --dry-run >"$TMP/a.log" 2>&1 || true
+if grep -q 'needs-product-review — NOT launching' "$TMP/a.log" && ! grep -q 'would launch' "$TMP/a.log"; then
+  echo "PASS [A]: needs-product-review target was skipped, not launched"
+else
+  echo "FAIL [A]: expected skip, got:"; sed 's/^/    /' "$TMP/a.log"; fail=1
+fi
+
+# --- Case B: normal target still launches ---
+MOCK_REVIEW=0 "$RUNNER" --dry-run >"$TMP/b.log" 2>&1 || true
+if grep -q 'would launch' "$TMP/b.log" && ! grep -q 'NOT launching' "$TMP/b.log"; then
+  echo "PASS [B]: normal target reached the launch decision"
+else
+  echo "FAIL [B]: expected launch, got:"; sed 's/^/    /' "$TMP/b.log"; fail=1
+fi
+
+exit "$fail"


### PR DESCRIPTION
Closes #767

## Problem

The runner → session context pipe was **body-only**, so both operator-steering channels were dropped:

1. **Comments never read.** The bootstrap prompt read only the epic body and passed the issue *number* to `/sprint`; `gh issue view` omits comments unless `--comments` is passed. Operator grooming/feedback comments were invisible to sessions — observed on **#490**, where PR #763 shipped without ever reading the grooming comment.
2. **`needs-product-review` did nothing.** The runner only checked `sprint-verified` / `runner-paused`, so a review-gated sprint launched and self-closed like any other.

## Fix

- **`sprint-bootstrap.prompt`** step 3 now reads the target issue **with comments** (`gh issue view <n> --comments`) and treats comments as **binding guidance** that overrides the body on conflict; a comment requesting a decision / product review / posing an open question is a **STOP-and-surface** signal.
- **`sprint-runner.sh`** skips (does not launch) a target whose issue carries `needs-product-review`, with a log + desktop notification. Fail-open on `gh` error — the predecessor gate (which also queries `gh`) skips the tick anyway.

## Test

`scripts/tests/sprint-runner-review-gate.test.sh` — hermetic (mocks `gh`+`screen`, runs `--dry-run` so no worktree/screen is created):
- review-labelled target ⇒ **skipped** (no launch);
- normal target ⇒ reaches the launch decision.

```
PASS [A]: needs-product-review target was skipped, not launched
PASS [B]: normal target reached the launch decision
```

The existing #694 dry-run regression test still passes. `bash -n` clean; pre-commit (typecheck + lint + yaml lint) 0 errors.

> Note: the runner was paused (`runner-paused` on #606) during this edit so the live 5-min job couldn't pick up a half-edited script; restored to `main` + unpaused after pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)