### PR TITLE
fix(security): override uuid to ^11.1.1 to clear CVE-2026-41907 (#755)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4476,19 +4476,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/gcp-metadata": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
@@ -6998,19 +6985,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -7247,12 +7221,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/victory-vendor": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "fast-xml-parser": "^5.5.8",
     "flatted": "^3.3.3",
     "vite": "^8.0.14",
+    "uuid": "^11.1.1",
     "@google-cloud/storage": {
       "teeny-request": {
         "http-proxy-agent": "^7.0.0"

--- a/packages/collector-cli/src/__tests__/uuid-cve-2026-41907.guard.test.ts
+++ b/packages/collector-cli/src/__tests__/uuid-cve-2026-41907.guard.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Security regression guard — CVE-2026-41907 (uuid < 11.1.1).
+ *
+ * uuid reaches this repo only transitively, via
+ * `@toastmasters/collector-cli → @google-cloud/storage` (gaxios, teeny-request,
+ * and GCS's own `"uuid": "^8.0.0"`). There is no patched 9.x/10.x backport —
+ * the fix first ships in 11.1.1 — so the only remediation is an `overrides`
+ * entry forcing `uuid: ^11.1.1` (see docs/investigations/754-security-alert-triage.md,
+ * epic #758 / #755).
+ *
+ * This guard reads the resolved versions from the root lockfile and fails if any
+ * `uuid` node is below 11.1.1. It defends against a future `@google-cloud/storage`
+ * bump silently re-pulling a vulnerable line once the override is dropped.
+ */
+
+const MIN = { major: 11, minor: 1, patch: 1 } // 11.1.1
+
+const lockUrl = new URL('../../../../package-lock.json', import.meta.url)
+const lock = JSON.parse(readFileSync(fileURLToPath(lockUrl), 'utf8')) as {
+  packages?: Record<string, { version?: string }>
+}
+
+function isAtLeastMin(version: string): boolean {
+  const [major, minor, patch] = version
+    .split('-')[0] // drop any prerelease tag
+    .split('.')
+    .map(n => Number.parseInt(n, 10))
+  if (major !== MIN.major) return major > MIN.major
+  if (minor !== MIN.minor) return minor > MIN.minor
+  return patch >= MIN.patch
+}
+
+describe('uuid CVE-2026-41907 regression guard', () => {
+  const uuidNodes = Object.entries(lock.packages ?? {})
+    .filter(([key]) => /(^|\/)node_modules\/uuid$/.test(key))
+    .map(([key, value]) => ({ key, version: value.version ?? '0.0.0' }))
+
+  it('resolves at least one uuid node in the lockfile', () => {
+    expect(uuidNodes.length).toBeGreaterThan(0)
+  })
+
+  it('pins every resolved uuid node to >= 11.1.1', () => {
+    const vulnerable = uuidNodes.filter(n => !isAtLeastMin(n.version))
+    expect(
+      vulnerable,
+      `Vulnerable uuid (< 11.1.1, CVE-2026-41907) in lockfile:\n` +
+        vulnerable.map(n => `  ${n.key} @ ${n.version}`).join('\n')
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Resolves #755 (epic #758, Sprint 2). Remediates the open uuid security alerts triaged in #754.

## What

`uuid` reaches this repo **only transitively**, via `@toastmasters/collector-cli → @google-cloud/storage` (gaxios, teeny-request, and GCS's own `"uuid": "^8.0.0"`). No workspace imports it directly; the React frontend bundle ships **zero** uuid (CI/CLI-only exposure — see `docs/investigations/754-security-alert-triage.md`).

- There is **no patched 9.x/10.x backport** of CVE-2026-41907 — the fix first ships in **11.1.1**.
- **No parent bump removes it**: GCS `7.19.0` is latest and pins `gaxios ^6` + `uuid ^8`.
- So a top-level npm `overrides` entry forcing `uuid: ^11.1.1` is the only path. All three nested copies (`8.3.2` + two `9.0.1`) dedupe to a **single hoisted `11.1.1`** node.

The lockfile change is **uuid-only** (surgical transplant of npm's own generated `11.1.1` node) — zero unrelated dependency drift, despite main's lock being stale enough that a naive `npm install` would have churned ~750 unrelated lines.

A regression-guard test (`uuid-cve-2026-41907.guard.test.ts`) reads the resolved lockfile versions and fails if any `uuid` node drops below 11.1.1 — defending against a future GCS bump silently re-pulling a vulnerable line if the override is ever dropped.

## uuid v11 default-export caveat (Lesson 100 — ran it, didn't assume)

uuid v7+ removed the *default* export (named `v1`/`v4`/… preserved). A runtime canary loaded `@google-cloud/storage`, instantiated a `Storage` client, and confirmed `uuid.v4()` works on 11.1.1 with no consumer breaking on the removed default. (The consumers use `require('uuid')` named exports.)

## Verification

- `npm ci` installs uuid **11.1.1** (single hoisted node; nested copies gone) — lock proven installable from scratch.
- Full suite green: frontend **2794**, collector-cli **737** (+2 guard), analytics-core **803**, shared-contracts **134** — zero regressions.
- `npm audit`: **6 moderate → 1**. The uuid override cleared the uuid findings.
- Guard test: RED (8.3.2/9.0.1 flagged) → GREEN (11.1.1) proven.
- **No PR preview**: `pr-preview.yml` is path-filtered to `frontend/**` + `packages/{shared-contracts,analytics-core}/**` + firebase config. This PR touches root `package.json`/lock + `packages/collector-cli/**` only, so there's no live frontend surface to drive — verification is the full suite + the runtime canary + `npm ci` + `npm audit`.

## Acceptance criteria
- [x] `npm run test:collector-cli` + full suite pass with the override (no GCS upload-path regression).
- [ ] Dependabot #35 + code-scanning #69/#70 auto-close after merge (uuid). #59 (`@tootallnate/once`) is a stale Trivy alert — already remediated in code by `f3d3b0cd`; clears on next scan of main. *(post-merge observation)*
- [x] No new **high/critical** alerts introduced by the bump.

## Out of scope (follow-up)
`npm audit` leaves **1 moderate**: `brace-expansion` GHSA-jxxr-4gwj-5jf2 (DoS in numeric-range expansion). It is **separate, pre-existing, and not introduced by this bump** — not part of epic #758 (uuid + @tootallnate/once). Flagging for a separate issue rather than bundling unrelated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)