### PR TITLE
fix(sprint-runner): refuse to auto-complete an epic with 0 parseable sprints (#771)

### DIFF
--- a/scripts/sprint-runner.sh
+++ b/scripts/sprint-runner.sh
@@ -165,6 +165,14 @@ find_first_unchecked_sprint() {
   printf '%s %s\n' "$n" "$issue"
 }
 
+# Count epic-body lines matching the runner's sprint format, ANY checkbox state.
+# Lets mode_run tell a genuinely-complete epic (>=1 such line, none unchecked)
+# from a malformed/ungroomed one (0 such lines) so it won't silently
+# auto-complete an epic whose checklist the runner can't parse (#771).
+count_sprint_lines() {
+  printf '%s\n' "$1" | grep -cE '^- \[.\] \*\*Sprint [0-9]+\*\* — #[0-9]+' || true
+}
+
 # Find a sprint line in the epic body by its issue number (#630).
 # Echoes the full line (incl. checkbox state) or empty if no match.
 # Boundary (`#N([^0-9]|$)`) so #1 doesn't match #10/#100.
@@ -634,6 +642,18 @@ mode_run() {
   local pair
   pair=$(find_first_unchecked_sprint "$body")
   if [[ -z "$pair" ]]; then
+    # Malformed-epic guard (#771): "no unchecked sprint" is ambiguous — it also
+    # happens when the checklist has checkbox lines that don't match the
+    # `- [ ] **Sprint N** — #issue` format (prose bullets, missing #ref, etc.).
+    # Auto-ticking that silently skips real work (observed on #659). Only treat
+    # the epic as complete with positive evidence: >=1 parseable sprint line.
+    if (( $(count_sprint_lines "$body") == 0 )); then
+      local cbx
+      cbx=$(printf '%s\n' "$body" | grep -cE '^- \[.\]' || true)
+      log "Epic #$EPIC has $cbx checkbox line(s) but ZERO parseable '- [ ] **Sprint N** — #issue' sprints — refusing to auto-complete (malformed/ungroomed). Convert items to sprint sub-issues. NOT advancing."
+      notify "sprint-runner" "Epic #$EPIC: 0 parseable sprints — not auto-completing (malformed)"
+      exit 0
+    fi
     log "Epic #$EPIC has no unchecked sprints — complete."
     # Auto-advance ONLY when EPIC was resolved from META_EPIC (not pinned).
     if [[ "$EPIC_SOURCE" == "resolved via"* ]]; then

--- a/scripts/tests/sprint-runner-dry-run.test.sh
+++ b/scripts/tests/sprint-runner-dry-run.test.sh
@@ -23,8 +23,10 @@ trap 'rm -rf "$TMP"' EXIT
 BIN="$TMP/bin"; mkdir -p "$BIN"
 EDIT_LOG="$TMP/gh-edit.log"
 
-# Mock gh: serve META_EPIC #900 with one unchecked epic (#901) whose body has
-# zero unchecked sprints → drives mode_run into the auto-advance branch.
+# Mock gh: serve META_EPIC #900 with one unchecked epic (#901) whose body is a
+# genuinely-complete sprint list (one ticked sprint, none unchecked) → drives
+# mode_run into the auto-advance branch. (A zero-sprint body would now hit the
+# #771 malformed-epic guard instead of auto-advancing.)
 # Record any `gh issue edit` invocation (the mutation) to $EDIT_LOG.
 cat > "$BIN/gh" <<EOF
 #!/usr/bin/env bash
@@ -42,7 +44,7 @@ if [[ "\$sub" == "issue" && "\$verb" == "view" ]]; then
   case "\$num:\$field" in
     900:labels) ;;                                       # no labels → not paused
     900:body)   printf '%s' '- [ ] **Epic Test** — #901' ;;
-    901:body)   printf '%s' 'This epic has no sprint lines.' ;;
+    901:body)   printf '%s' '- [x] **Sprint 1** — #902' ;;  # complete: 1 sprint, all ticked (#771 guard needs >=1 parseable sprint to auto-advance)
     *) ;;
   esac
   exit 0

--- a/scripts/tests/sprint-runner-malformed-epic.test.sh
+++ b/scripts/tests/sprint-runner-malformed-epic.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Regression test for #771: the runner must NOT auto-complete an epic whose
+# checklist has checkbox lines but ZERO parseable `**Sprint N** — #issue`
+# sprints (malformed/ungroomed). A genuinely-complete epic (>=1 parseable
+# sprint line, none unchecked) must still auto-tick.
+#
+# Hermetic: mocks `gh`+`screen`, runs --dry-run so nothing mutates. Asserts on
+# the log decision.
+#   Case A (malformed: prose checkbox, 0 sprint lines): "refusing to auto-complete"
+#   Case B (complete:   - [x] **Sprint 1** — #902):     "would auto-tick"
+#
+# Run directly: scripts/tests/sprint-runner-malformed-epic.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$SCRIPT_DIR/../sprint-runner.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+BIN="$TMP/bin"; mkdir -p "$BIN"
+
+# Mock gh: META_EPIC #900 → epic #901. #901's body depends on $MOCK_EPIC:
+#   malformed → a prose checkbox (no Sprint-N format)
+#   complete  → a checked, parseable sprint line
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+sub="$1"; verb="$2"; num="$3"
+[[ "$sub" == "issue" && "$verb" == "edit" ]] && exit 0
+if [[ "$sub" == "issue" && "$verb" == "view" ]]; then
+  field=""; args=("$@")
+  for ((i=0; i<${#args[@]}; i++)); do [[ "${args[i]}" == "--json" ]] && field="${args[i+1]}"; done
+  case "$num:$field" in
+    900:labels) ;;
+    900:body)   printf '%s' '- [ ] **Epic Test** — #901' ;;
+    901:body)
+      if [[ "${MOCK_EPIC:-malformed}" == "complete" ]]; then
+        printf '%s' '- [x] **Sprint 1** — #902'
+      else
+        printf '%s' '- [ ] **Build the thing** with no sprint number'
+      fi ;;
+  esac
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$BIN/gh"
+
+cat > "$BIN/screen" <<'EOF'
+#!/usr/bin/env bash
+echo "No Sockets found." >&2
+exit 1
+EOF
+chmod +x "$BIN/screen"
+
+export PATH="$BIN:$PATH"
+export META_EPIC=900
+export SPRINT_RUNNER_LOCK_DIR="$TMP/lock"
+export WORKTREE_BASE="$TMP/worktrees"
+unset EPIC || true
+
+fail=0
+
+# --- Case A: malformed epic must NOT auto-complete ---
+MOCK_EPIC=malformed "$RUNNER" --dry-run >"$TMP/a.log" 2>&1 || true
+if grep -q 'refusing to auto-complete' "$TMP/a.log" && ! grep -q 'would auto-tick' "$TMP/a.log"; then
+  echo "PASS [A]: malformed epic refused (not auto-completed)"
+else
+  echo "FAIL [A]: expected refusal, got:"; sed 's/^/    /' "$TMP/a.log"; fail=1
+fi
+
+# --- Case B: genuinely-complete epic still auto-ticks ---
+MOCK_EPIC=complete "$RUNNER" --dry-run >"$TMP/b.log" 2>&1 || true
+if grep -q 'would auto-tick' "$TMP/b.log" && ! grep -q 'refusing to auto-complete' "$TMP/b.log"; then
+  echo "PASS [B]: complete epic still auto-ticks"
+else
+  echo "FAIL [B]: expected auto-tick, got:"; sed 's/^/    /' "$TMP/b.log"; fail=1
+fi
+
+exit "$fail"


### PR DESCRIPTION
Closes #771

## Problem

`mode_run` treated an empty `find_first_unchecked_sprint` result as "epic complete" and auto-ticked the epic in #606. But that result is **ambiguous** — it's also returned for a *malformed* epic whose checkbox lines don't match `- [ ] **Sprint N** — #issue` (prose bullets, missing `#ref`). Auto-ticking those silently skips real work.

### Observed (#659)
Epic #659 had two prose checkboxes, zero sprint-format lines. The runner declared it complete in ~1s, launched nothing, and ticked it in #606 — its two improvements were never built. (#659 has since been reformatted into real sprint sub-issues #772/#773.)

## Fix

When no unchecked sprint is found, only treat the epic as complete if it has **≥1 parseable sprint line** (`count_sprint_lines`). With **zero** parseable sprints, log a WARNING + notify and **do not advance** — a loud stop so the operator fixes the format, consistent with the #694/#767 hardening.

## Test

- `scripts/tests/sprint-runner-malformed-epic.test.sh` (hermetic, `--dry-run`): malformed epic ⇒ refused; genuinely-complete epic ⇒ still auto-ticks.
- Updated the #694 dry-run test fixture from a zero-sprint body to a complete ticked-sprint body (the old fixture relied on the now-guarded behavior). The test's intent — dry-run doesn't mutate, normal run does — is unchanged. **Not assertion-pinning:** the expectation still asserts "a *complete* epic auto-ticks"; only the fixture that represents "complete" was corrected.

All three runner tests green; `bash -n` clean; pre-commit 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)