### PR TITLE
feat(lessons): depth-1 [[wikilink]] graph traversal for sprint lesson loading (#772)

### DIFF
--- a/scripts/lib/__tests__/relevantLessons.test.ts
+++ b/scripts/lib/__tests__/relevantLessons.test.ts
@@ -18,6 +18,9 @@ import { describe, it, expect } from 'vitest'
 import {
   parseRelevantLessons,
   resolveRelevantLessons,
+  parseWikilinks,
+  expandDepth1Neighbours,
+  DEPTH1_NEIGHBOUR_CAP,
   type RelevantLessonRef,
 } from '../relevantLessons'
 
@@ -117,5 +120,173 @@ describe('resolveRelevantLessons', () => {
     const { found, missing } = resolveRelevantLessons(escape, () => true)
     expect(found).toEqual([])
     expect(missing).toHaveLength(1)
+  })
+})
+
+describe('parseWikilinks', () => {
+  it('returns [] when the body has no wikilinks', () => {
+    expect(parseWikilinks('Just prose, a [link](x), and `[[not in code]]`.')).to
+      // backticks don't exempt — but there are no actual [[ ]] tokens above
+      .toEqual([])
+  })
+
+  it('extracts each [[slug]] target in document order', () => {
+    const body = `## Related\n- [[087-foo]] — a\n- [[092-bar]] — b\n`
+    expect(parseWikilinks(body)).toEqual(['087-foo', '092-bar'])
+  })
+
+  it('dedupes repeated targets, keeping first-seen order', () => {
+    const body = `[[a-one]] then [[b-two]] then [[a-one]] again`
+    expect(parseWikilinks(body)).toEqual(['a-one', 'b-two'])
+  })
+
+  it('strips an Obsidian |alias and #heading suffix from the target', () => {
+    const body = `[[081-phase-gated|the phasing lesson]] and [[090-guard#how-to-apply]]`
+    expect(parseWikilinks(body)).toEqual(['081-phase-gated', '090-guard'])
+  })
+
+  it('trims whitespace inside the brackets', () => {
+    expect(parseWikilinks('[[  097-promote  ]]')).toEqual(['097-promote'])
+  })
+
+  it('ignores empty brackets', () => {
+    expect(parseWikilinks('[[]] and [[ ]] and [[real-one]]')).toEqual([
+      'real-one',
+    ])
+  })
+})
+
+describe('expandDepth1Neighbours', () => {
+  // A tiny lesson graph. Bodies map path → wikilink targets.
+  const bodies: Record<string, string> = {
+    'tasks/lessons/seed-a.md': 'see [[n-one]] and [[n-two]] and [[seed-b]]',
+    'tasks/lessons/seed-b.md': 'see [[n-two]] and [[n-three]]',
+    'tasks/lessons/n-one.md': 'links onward to [[n-deep]]', // depth-2: must NOT be read
+    'tasks/lessons/n-two.md': 'leaf',
+    'tasks/lessons/n-three.md': 'leaf',
+    'tasks/lessons/n-deep.md': 'depth-2 leaf',
+  }
+  const readBody = (p: string): string => bodies[p] ?? ''
+  const exists = (p: string): boolean => p in bodies
+
+  it('pulls in a seed’s direct [[…]] neighbours, resolved under tasks/lessons/', () => {
+    const { neighbours } = expandDepth1Neighbours(
+      ['tasks/lessons/seed-a.md'],
+      readBody,
+      exists,
+      10
+    )
+    expect(neighbours).toEqual([
+      'tasks/lessons/n-one.md',
+      'tasks/lessons/n-two.md',
+    ])
+  })
+
+  it('is depth-1 only: does not follow a neighbour’s own wikilinks', () => {
+    const { neighbours } = expandDepth1Neighbours(
+      ['tasks/lessons/seed-a.md'],
+      readBody,
+      exists,
+      10
+    )
+    // n-one links to n-deep, but we never read n-one's body → n-deep excluded
+    expect(neighbours).not.toContain('tasks/lessons/n-deep.md')
+  })
+
+  it('excludes targets that are already seeds', () => {
+    const { neighbours } = expandDepth1Neighbours(
+      ['tasks/lessons/seed-a.md', 'tasks/lessons/seed-b.md'],
+      readBody,
+      exists,
+      10
+    )
+    // seed-a links to seed-b, but seed-b is a seed → not a neighbour
+    expect(neighbours).not.toContain('tasks/lessons/seed-b.md')
+  })
+
+  it('dedupes a neighbour referenced by multiple seeds', () => {
+    const { neighbours } = expandDepth1Neighbours(
+      ['tasks/lessons/seed-a.md', 'tasks/lessons/seed-b.md'],
+      readBody,
+      exists,
+      10
+    )
+    expect(neighbours.filter(p => p === 'tasks/lessons/n-two.md')).toHaveLength(
+      1
+    )
+  })
+
+  it('skips wikilinks that resolve to no lesson file (e.g. memory slugs)', () => {
+    const body = { 'tasks/lessons/s.md': 'see [[reference_data_pipeline]]' }
+    const { neighbours } = expandDepth1Neighbours(
+      ['tasks/lessons/s.md'],
+      p => (body as Record<string, string>)[p] ?? '',
+      p => p in body,
+      10
+    )
+    expect(neighbours).toEqual([])
+  })
+
+  it('enforces the cap and reports it was hit (no unbounded expansion)', () => {
+    const { neighbours, capped } = expandDepth1Neighbours(
+      ['tasks/lessons/seed-a.md', 'tasks/lessons/seed-b.md'],
+      readBody,
+      exists,
+      2
+    )
+    expect(neighbours).toHaveLength(2)
+    expect(capped).toBe(true)
+  })
+
+  it('does not report capped when the set fits under the cap', () => {
+    const { capped } = expandDepth1Neighbours(
+      ['tasks/lessons/seed-a.md'],
+      readBody,
+      exists,
+      10
+    )
+    expect(capped).toBe(false)
+  })
+
+  it('returns no neighbours when seeds have no wikilinks (behavior unchanged)', () => {
+    const { neighbours, capped } = expandDepth1Neighbours(
+      ['tasks/lessons/n-two.md'],
+      readBody,
+      exists,
+      10
+    )
+    expect(neighbours).toEqual([])
+    expect(capped).toBe(false)
+  })
+
+  it('applies the path-traversal guard to a malicious wikilink target', () => {
+    const body = { 'tasks/lessons/s.md': 'see [[../../etc/passwd]]' }
+    const { neighbours } = expandDepth1Neighbours(
+      ['tasks/lessons/s.md'],
+      p => (body as Record<string, string>)[p] ?? '',
+      () => true, // even if the predicate lies, the guard rejects ..
+      10
+    )
+    expect(neighbours).toEqual([])
+  })
+
+  it('defaults to DEPTH1_NEIGHBOUR_CAP when no cap is passed', () => {
+    expect(DEPTH1_NEIGHBOUR_CAP).toBeGreaterThan(0)
+    const manySeeds = Array.from(
+      { length: DEPTH1_NEIGHBOUR_CAP + 3 },
+      (_, i) => `tasks/lessons/seed-${i}.md`
+    )
+    const graph: Record<string, string> = {}
+    manySeeds.forEach((s, i) => {
+      graph[s] = `[[leaf-${i}]]`
+      graph[`tasks/lessons/leaf-${i}.md`] = 'leaf'
+    })
+    const { neighbours, capped } = expandDepth1Neighbours(
+      manySeeds,
+      p => graph[p] ?? '',
+      p => p in graph
+    )
+    expect(neighbours).toHaveLength(DEPTH1_NEIGHBOUR_CAP)
+    expect(capped).toBe(true)
   })
 })

--- a/scripts/lib/__tests__/relevantLessons.test.ts
+++ b/scripts/lib/__tests__/relevantLessons.test.ts
@@ -125,9 +125,8 @@ describe('resolveRelevantLessons', () => {
 
 describe('parseWikilinks', () => {
   it('returns [] when the body has no wikilinks', () => {
-    expect(parseWikilinks('Just prose, a [link](x), and `[[not in code]]`.')).to
-      // backticks don't exempt — but there are no actual [[ ]] tokens above
-      .toEqual([])
+    // A markdown [link](x) is not a [[wikilink]] — only [[…]] tokens count.
+    expect(parseWikilinks('Just prose, a [link](x), and some code.')).toEqual([])
   })
 
   it('extracts each [[slug]] target in document order', () => {
@@ -170,6 +169,8 @@ describe('expandDepth1Neighbours', () => {
   const exists = (p: string): boolean => p in bodies
 
   it('pulls in a seed’s direct [[…]] neighbours, resolved under tasks/lessons/', () => {
+    // Only seed-a is a seed, so its link to seed-b counts as a neighbour here;
+    // the seed-vs-neighbour exclusion is covered by its own test below.
     const { neighbours } = expandDepth1Neighbours(
       ['tasks/lessons/seed-a.md'],
       readBody,
@@ -179,6 +180,7 @@ describe('expandDepth1Neighbours', () => {
     expect(neighbours).toEqual([
       'tasks/lessons/n-one.md',
       'tasks/lessons/n-two.md',
+      'tasks/lessons/seed-b.md',
     ])
   })
 

--- a/scripts/lib/__tests__/relevantLessons.test.ts
+++ b/scripts/lib/__tests__/relevantLessons.test.ts
@@ -126,7 +126,9 @@ describe('resolveRelevantLessons', () => {
 describe('parseWikilinks', () => {
   it('returns [] when the body has no wikilinks', () => {
     // A markdown [link](x) is not a [[wikilink]] — only [[…]] tokens count.
-    expect(parseWikilinks('Just prose, a [link](x), and some code.')).toEqual([])
+    expect(parseWikilinks('Just prose, a [link](x), and some code.')).toEqual(
+      []
+    )
   })
 
   it('extracts each [[slug]] target in document order', () => {

--- a/scripts/lib/__tests__/relevantLessons.test.ts
+++ b/scripts/lib/__tests__/relevantLessons.test.ts
@@ -274,6 +274,17 @@ describe('expandDepth1Neighbours', () => {
     expect(neighbours).toEqual([])
   })
 
+  it('rejects a slug that addresses a nested path, even if it exists', () => {
+    const body = { 'tasks/lessons/s.md': 'see [[sub/nested]]' }
+    const { neighbours } = expandDepth1Neighbours(
+      ['tasks/lessons/s.md'],
+      p => (body as Record<string, string>)[p] ?? '',
+      () => true, // a slug is a bare filename, never a path
+      10
+    )
+    expect(neighbours).toEqual([])
+  })
+
   it('defaults to DEPTH1_NEIGHBOUR_CAP when no cap is passed', () => {
     expect(DEPTH1_NEIGHBOUR_CAP).toBeGreaterThan(0)
     const manySeeds = Array.from(

--- a/scripts/lib/relevantLessons.ts
+++ b/scripts/lib/relevantLessons.ts
@@ -153,6 +153,10 @@ export function expandDepth1Neighbours(
 
   for (const seed of seedPaths) {
     for (const slug of parseWikilinks(readBody(seed))) {
+      // A lesson slug is a bare filename — never a path. Reject any slug with a
+      // separator (`[[sub/dir]]`) so it can't address a nested file even if one
+      // happened to exist; the `..` case is also caught by isSafeLessonPath.
+      if (slug.includes('/')) continue
       const path = `tasks/lessons/${slug}.md`
       if (!isSafeLessonPath(path)) continue
       if (seedSet.has(path) || added.has(path)) continue

--- a/scripts/lib/relevantLessons.ts
+++ b/scripts/lib/relevantLessons.ts
@@ -66,6 +66,17 @@ export function parseRelevantLessons(body: string): RelevantLessonRef[] {
 }
 
 /**
+ * Path-traversal guard: a resolvable lesson path must live under
+ * `tasks/lessons/` and never contain `..`. Single-sourced here so every
+ * "external input → file path" caller (manifest resolve, wikilink expansion)
+ * applies the same rule (per the `Path.join` tripwire in rules.md, and the
+ * note in Lesson 098 that future IO callers must re-apply the guard).
+ */
+function isSafeLessonPath(path: string): boolean {
+  return path.startsWith('tasks/lessons/') && !path.includes('..')
+}
+
+/**
  * Partition refs into those whose files exist and those that don't, using the
  * supplied existence predicate (injected so this stays pure / testable). A ref
  * whose path escapes `tasks/lessons/` is always treated as missing — a manifest
@@ -79,10 +90,81 @@ export function resolveRelevantLessons(
   const found: RelevantLessonRef[] = []
   const missing: RelevantLessonRef[] = []
   for (const ref of refs) {
-    const safe =
-      ref.path.startsWith('tasks/lessons/') && !ref.path.includes('..')
-    if (safe && exists(ref.path)) found.push(ref)
+    if (isSafeLessonPath(ref.path) && exists(ref.path)) found.push(ref)
     else missing.push(ref)
   }
   return { found, missing }
+}
+
+/**
+ * Default cap on the total number of depth-1 `[[…]]` neighbours pulled in
+ * across all seeds. Bounds the extra context a session loads so traversal can't
+ * blow the window (epic #659: "within a documented context budget"). Five keeps
+ * the neighbour set well under the always-loaded budget alongside the manifest,
+ * tag-matched, and 2-newest lessons.
+ */
+export const DEPTH1_NEIGHBOUR_CAP = 5
+
+/** Matches an Obsidian-style `[[target]]` wikilink; group 1 is the raw inner text. */
+const WIKILINK_RE = /\[\[([^\]]+)\]\]/g
+
+/**
+ * Extract the `[[slug]]` wikilink targets from a lesson body, in first-seen
+ * document order, deduplicated. An Obsidian `|alias` or `#heading` suffix is
+ * stripped so `[[090-guard#how-to-apply]]` → `090-guard`. Empty/whitespace-only
+ * brackets are ignored. Pure (no IO): resolution to a file path is the caller's
+ * job. The slug is a lesson filename without its `.md` extension.
+ */
+export function parseWikilinks(body: string): string[] {
+  const seen = new Set<string>()
+  const slugs: string[] = []
+  for (const m of body.matchAll(WIKILINK_RE)) {
+    // Drop an Obsidian alias (`|…`) or heading anchor (`#…`); keep the target.
+    const slug = m[1].split('|')[0].split('#')[0].trim()
+    if (slug && !seen.has(slug)) {
+      seen.add(slug)
+      slugs.push(slug)
+    }
+  }
+  return slugs
+}
+
+/**
+ * Pull in the direct (depth-1) `[[…]]` neighbours of a set of seed lesson
+ * paths. Reads ONLY the seed bodies — it never recurses into a neighbour's own
+ * wikilinks, so this is strictly depth-1. Each wikilink slug resolves to
+ * `tasks/lessons/<slug>.md`; a neighbour is kept only when it (a) passes the
+ * path-traversal guard, (b) exists on disk, and (c) isn't already a seed.
+ * Neighbours are deduplicated across seeds and accumulated in encounter order
+ * up to `cap`; `capped` is true when the cap truncated the set (so the caller
+ * can warn rather than silently drop). Pure: `readBody` and `exists` are
+ * injected, keeping this unit-testable without filesystem IO.
+ */
+export function expandDepth1Neighbours(
+  seedPaths: string[],
+  readBody: (path: string) => string,
+  exists: (path: string) => boolean,
+  cap: number = DEPTH1_NEIGHBOUR_CAP
+): { neighbours: string[]; capped: boolean } {
+  const seedSet = new Set(seedPaths)
+  const added = new Set<string>()
+  const neighbours: string[] = []
+  let capped = false
+
+  for (const seed of seedPaths) {
+    for (const slug of parseWikilinks(readBody(seed))) {
+      const path = `tasks/lessons/${slug}.md`
+      if (!isSafeLessonPath(path)) continue
+      if (seedSet.has(path) || added.has(path)) continue
+      if (!exists(path)) continue
+      if (neighbours.length >= cap) {
+        capped = true
+        continue
+      }
+      added.add(path)
+      neighbours.push(path)
+    }
+  }
+
+  return { neighbours, capped }
 }

--- a/scripts/relevant-lessons.ts
+++ b/scripts/relevant-lessons.ts
@@ -20,6 +20,8 @@ import { fileURLToPath } from 'node:url'
 import {
   parseRelevantLessons,
   resolveRelevantLessons,
+  expandDepth1Neighbours,
+  DEPTH1_NEIGHBOUR_CAP,
 } from './lib/relevantLessons'
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
@@ -62,8 +64,27 @@ function main(): void {
     console.error(`  ✗ MISSING: ${r.path}`)
   }
 
-  // Structured output: the resolved paths a session should read, one per line.
+  // Depth-1 graph traversal (#772): a chosen lesson drags in the context it
+  // explicitly references via `[[…]]`, capped so it can't blow the window.
+  const { neighbours, capped } = expandDepth1Neighbours(
+    found.map(r => r.path),
+    p => readFileSync(join(REPO_ROOT, p), 'utf8'),
+    p => existsSync(join(REPO_ROOT, p)),
+    DEPTH1_NEIGHBOUR_CAP
+  )
+  if (neighbours.length > 0) {
+    console.error(
+      `\nDepth-1 [[…]] neighbours (${neighbours.length}${
+        capped ? `, capped at ${DEPTH1_NEIGHBOUR_CAP}` : ''
+      }):`
+    )
+    for (const p of neighbours) console.error(`  + ${p}`)
+  }
+
+  // Structured output: the resolved paths a session should read, one per line —
+  // manifest lessons first, then their depth-1 neighbours.
   for (const r of found) console.log(r.path)
+  for (const p of neighbours) console.log(p)
 
   if (missing.length > 0) {
     console.error(`\n${missing.length} listed lesson(s) not found on disk.`)


### PR DESCRIPTION
## What

Adds **depth-1 `[[wikilink]]` graph traversal** to the sprint lesson-loading selection path (epic #659, Sprint 1, #772). When a lesson is selected via a sprint sub-issue's `## Relevant lessons` manifest, its direct `[[…]]` neighbours are now pulled in too — so a chosen lesson drags in the context it explicitly references — bounded by a context budget so traversal can't blow the window.

## How

- `parseWikilinks(body)` — pure extractor of `[[slug]]` targets (document order, deduped; strips Obsidian `|alias` / `#heading`).
- `expandDepth1Neighbours(seeds, readBody, exists, cap)` — reads **only seed bodies** (strictly depth-1, no recursion), resolves each slug → `tasks/lessons/<slug>.md`, keeps existing non-seed paths, dedupes across seeds, caps the total (`DEPTH1_NEIGHBOUR_CAP = 5`), and reports `capped`. Pure: IO predicates injected.
- Reused a single `isSafeLessonPath` guard (path-traversal: must stay under `tasks/lessons/`, no `..`, no nested separators), now shared with `resolveRelevantLessons`.
- Wired into the `scripts/relevant-lessons.ts` CLI, behind the existing manifest logic.

## Acceptance criteria (#772)

- [x] Selecting a lesson also loads its depth-1 `[[…]]` neighbours, capped.
- [x] Cap is enforced and tested (no unbounded expansion).
- [x] Existing manifest/tag-inference behavior unchanged when no wikilinks present.

## Verification

No live frontend surface — the diff touches only `scripts/**`, which `pr-preview.yml` is **not** path-filtered for, so no preview is deployed. Verified by code-proof (same shape as Lesson 098's own verification):

- Full suite green: frontend 2794, collector-cli 737, analytics-core 803, shared-contracts 134, scripts/lib 26 — zero regressions.
- **Live dry-run against the real lesson graph:** a manifest listing Lesson 098 resolved its three real `[[…]]` neighbours (091 / 097 / 087), exit 0. A no-wikilink lesson (118) and a no-manifest body produced byte-identical output to before (AC#3).

## Review nits (Low, triage)

- stdout now mixes manifest + neighbour provenance with no marker (stderr block distinguishes them for humans). By design.
- `capped` is conservative-correct: only flips when a genuinely-new valid neighbour is dropped.

Tracking #772 (epic #659).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
