### PR TITLE
feat(brand): link footer Red Taverns attribution to portal (#779)

### DIFF
--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -147,6 +147,19 @@ describe('AppShell (#354)', () => {
       expect(footer).toHaveTextContent(/a red taverns production/i)
     })
 
+    it('links the "Red Taverns" attribution to the portal with utm params (#779)', () => {
+      renderShell()
+      const footer = screen.getByRole('contentinfo')
+      const link = within(footer).getByRole('link', { name: 'Red Taverns' })
+      expect(link).toHaveAttribute(
+        'href',
+        'https://taverns.red?utm_source=toast-stats&utm_medium=footer'
+      )
+      // External link hygiene — matches the existing data-source / license links.
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
     it('renders the data source + license + version line', () => {
       renderShell()
       const footer = screen.getByRole('contentinfo')

--- a/frontend/src/components/AppShell/AppShellFooter.tsx
+++ b/frontend/src/components/AppShell/AppShellFooter.tsx
@@ -13,7 +13,18 @@ const AppShellFooter: React.FC = () => {
   return (
     <footer role="contentinfo" className="app-shell-footer">
       <div className="app-shell-footer__inner">
-        <div>Toast Stats · ts.taverns.red · A Red Taverns production</div>
+        <div>
+          Toast Stats · ts.taverns.red · A{' '}
+          <a
+            href="https://taverns.red?utm_source=toast-stats&utm_medium=footer"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="app-shell-footer__link"
+          >
+            Red Taverns
+          </a>{' '}
+          production
+        </div>
         <div className="app-shell-footer__meta">
           <span data-testid="app-version">
             Data:{' '}


### PR DESCRIPTION
Closes #779 (epic #785, Sprint 2).

## What
The footer's `A Red Taverns production` line was plain text — an impressed visitor had no path from "this is impressive" to "who is Red Taverns?". This links the **Red Taverns** words to the live portal `https://taverns.red` with funnel attribution params.

## Acceptance criteria
- [x] "Red Taverns" words link to `https://taverns.red`
- [x] utm params appended: `?utm_source=toast-stats&utm_medium=footer`
- [x] `target="_blank" rel="noopener noreferrer"` (matches existing data-source / license links)
- [x] Test asserts link text, href (incl. utm), target, rel
- [x] Optional `--rt-stats` hover accent: **skipped** — the footer is existing chrome and Phase-2 chrome re-skin is blocked on the rename decision (ops#37). A brand-token hover here would pre-empt it; link stays on `--link` like its siblings.

## Tests
TDD: failing test added first (no "Red Taverns" link), then implementation. Full frontend suite green (2803 tests). `AppShell.test.tsx` footer block: 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)