### PR TITLE
feat(seo): per-route document titles (#780)

### DIFF
--- a/frontend/src/hooks/__tests__/useDocumentTitle.test.tsx
+++ b/frontend/src/hooks/__tests__/useDocumentTitle.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Per-route document title hook (#780, epic #785, finding F-SA3).
+ *
+ * A small head manager: pages call useDocumentTitle(segment) to self-title.
+ * The branded default (shipped statically in index.html by #778) is the
+ * single fallback — passing null/undefined keeps it, and unmounting a titled
+ * page restores it so SPA back-navigation to the landing page is correct.
+ *
+ * document.title stays the single source of truth that useGoogleAnalytics
+ * reads for page_view (no new runtime dependency / provider).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import {
+  useDocumentTitle,
+  formatPageTitle,
+  DEFAULT_TITLE,
+  SITE_NAME,
+} from '../useDocumentTitle'
+
+describe('formatPageTitle (#780)', () => {
+  it('suffixes a page segment with the site name', () => {
+    expect(formatPageTitle('District 93')).toBe('District 93 — Toast Stats')
+  })
+
+  it('returns the branded default for an empty/nullish segment', () => {
+    expect(formatPageTitle(null)).toBe(DEFAULT_TITLE)
+    expect(formatPageTitle(undefined)).toBe(DEFAULT_TITLE)
+    expect(formatPageTitle('')).toBe(DEFAULT_TITLE)
+  })
+
+  it("the default matches #778's shipped index.html <title> exactly", () => {
+    // Drift between this constant and the static title regresses the share
+    // card AND the SPA fallback in one move — pin them together.
+    expect(DEFAULT_TITLE).toBe(
+      'Toast Stats — Toastmasters District Performance'
+    )
+    expect(SITE_NAME).toBe('Toast Stats')
+  })
+})
+
+describe('useDocumentTitle (#780)', () => {
+  afterEach(() => {
+    document.title = DEFAULT_TITLE
+  })
+
+  it('sets document.title to the formatted page title on mount', () => {
+    renderHook(() => useDocumentTitle('Methodology'))
+    expect(document.title).toBe('Methodology — Toast Stats')
+  })
+
+  it('restores the branded default when the titled page unmounts', () => {
+    const { unmount } = renderHook(() => useDocumentTitle('District 61'))
+    expect(document.title).toBe('District 61 — Toast Stats')
+    unmount()
+    expect(document.title).toBe(DEFAULT_TITLE)
+  })
+
+  it('updates the title when the segment changes', () => {
+    const { rerender } = renderHook(
+      ({ segment }) => useDocumentTitle(segment),
+      { initialProps: { segment: 'District 61' } }
+    )
+    expect(document.title).toBe('District 61 — Toast Stats')
+    rerender({ segment: 'District 93' })
+    expect(document.title).toBe('District 93 — Toast Stats')
+  })
+
+  it('holds the branded default while a segment is still loading (null)', () => {
+    renderHook(() => useDocumentTitle(null))
+    expect(document.title).toBe(DEFAULT_TITLE)
+  })
+})

--- a/frontend/src/hooks/useDocumentTitle.ts
+++ b/frontend/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react'
+
+/**
+ * Per-route document titles (#780, epic #785, finding F-SA3).
+ *
+ * A deliberately small head manager — no `react-helmet-async` dependency or
+ * provider. The app already manages `document.title` imperatively, and
+ * `useGoogleAnalytics` reads it as the single source for the `page_view`
+ * title; a hook keeps that contract intact while letting each route self-title
+ * for share/deep-link value.
+ */
+
+/** Short product name, used as the title suffix on sub-pages. */
+export const SITE_NAME = 'Toast Stats'
+
+/**
+ * The branded default shipped statically in `index.html` (#778). Sub-pages
+ * fall back to this, and a titled page restores it on unmount so SPA
+ * back-navigation to the landing page shows the right title. Kept in lockstep
+ * with the static `<title>` by the `head-metadata` and `useDocumentTitle`
+ * tests — drift regresses both the share card and the fallback.
+ */
+export const DEFAULT_TITLE = 'Toast Stats — Toastmasters District Performance'
+
+/**
+ * Format a page title from its distinguishing segment. A nullish/empty segment
+ * (e.g. a route whose data is still loading) yields the branded default rather
+ * than a bare " — Toast Stats".
+ */
+export function formatPageTitle(segment?: string | null): string {
+  return segment ? `${segment} — ${SITE_NAME}` : DEFAULT_TITLE
+}
+
+/**
+ * Set `document.title` to `formatPageTitle(segment)` while mounted, restoring
+ * the branded default on unmount. Pass `null`/`undefined` to hold the default
+ * (the loading state) without emitting an empty-segment title.
+ */
+export function useDocumentTitle(segment?: string | null): void {
+  useEffect(() => {
+    document.title = formatPageTitle(segment)
+    return () => {
+      document.title = DEFAULT_TITLE
+    }
+  }, [segment])
+}

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import { useParams, useNavigate, useLocation, Link } from 'react-router-dom'
 import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useDistricts } from '../hooks/useDistricts'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
 import {
@@ -378,15 +379,9 @@ const ClubDetailPage: React.FC = () => {
   // panel meta and the chart's aria-label so they stay in sync.
   const programYearLabelDisplay = programYear.label.replace(/-/g, '–')
 
-  // Set page title
-  React.useEffect(() => {
-    if (club) {
-      document.title = `${club.clubName} — ${districtName} | Toast Stats`
-    }
-    return () => {
-      document.title = 'Toast Stats'
-    }
-  }, [club, districtName])
+  // Per-route title (#780): club + district, falling back to the branded
+  // default while the club is still loading or absent.
+  useDocumentTitle(club ? `${club.clubName} — ${districtName}` : null)
 
   // ── Loading state ────────────────────────────────────────────────────────
 

--- a/frontend/src/pages/DistrictAnalyticsPage.tsx
+++ b/frontend/src/pages/DistrictAnalyticsPage.tsx
@@ -113,7 +113,7 @@ const DistrictAnalyticsPage: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
-  useDocumentTitle(`${districtName} Analytics`)
+  useDocumentTitle(districtName ? `${districtName} Analytics` : null)
 
   const availableDates = cachedDatesInProgramYear.sort((a, b) =>
     b.localeCompare(a)

--- a/frontend/src/pages/DistrictAnalyticsPage.tsx
+++ b/frontend/src/pages/DistrictAnalyticsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { useDistricts } from '../hooks/useDistricts'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
 import { useDistrictStatistics } from '../hooks/useMembershipData'
@@ -112,6 +113,7 @@ const DistrictAnalyticsPage: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
+  useDocumentTitle(`${districtName} Analytics`)
 
   const availableDates = cachedDatesInProgramYear.sort((a, b) =>
     b.localeCompare(a)

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -250,7 +250,7 @@ const DistrictClubsPage: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
-  useDocumentTitle(`${districtName} Clubs`)
+  useDocumentTitle(districtName ? `${districtName} Clubs` : null)
 
   const availableDates = cachedDatesInProgramYear.sort((a, b) =>
     b.localeCompare(a)

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -6,6 +6,7 @@ import {
   useSearchParams,
 } from 'react-router-dom'
 import { useDistricts } from '../hooks/useDistricts'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
@@ -249,6 +250,7 @@ const DistrictClubsPage: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
+  useDocumentTitle(`${districtName} Clubs`)
 
   const availableDates = cachedDatesInProgramYear.sort((a, b) =>
     b.localeCompare(a)

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-router-dom'
 import { redirectLegacyDistrictTab } from '../utils/legacyTabRedirect'
 import { useDistricts } from '../hooks/useDistricts'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
 import { DistrictSubnav } from '../components/DistrictSubnav'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
@@ -212,6 +213,7 @@ const DistrictDetailPageInner: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
+  useDocumentTitle(districtName)
 
   // Get all clubs from analytics
   const allClubs = analytics?.allClubs || []

--- a/frontend/src/pages/DistrictDivisionsPage.tsx
+++ b/frontend/src/pages/DistrictDivisionsPage.tsx
@@ -104,7 +104,7 @@ const DistrictDivisionsPage: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
-  useDocumentTitle(`${districtName} Divisions`)
+  useDocumentTitle(districtName ? `${districtName} Divisions` : null)
 
   const availableDates = cachedDatesInProgramYear.sort((a, b) =>
     b.localeCompare(a)

--- a/frontend/src/pages/DistrictDivisionsPage.tsx
+++ b/frontend/src/pages/DistrictDivisionsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { useDistricts } from '../hooks/useDistricts'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
 import { useDistrictStatistics } from '../hooks/useMembershipData'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
@@ -103,6 +104,7 @@ const DistrictDivisionsPage: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
+  useDocumentTitle(`${districtName} Divisions`)
 
   const availableDates = cachedDatesInProgramYear.sort((a, b) =>
     b.localeCompare(a)

--- a/frontend/src/pages/DistrictRankingsPage.tsx
+++ b/frontend/src/pages/DistrictRankingsPage.tsx
@@ -89,7 +89,7 @@ const DistrictRankingsPage: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
-  useDocumentTitle(`${districtName} Rankings`)
+  useDocumentTitle(districtName ? `${districtName} Rankings` : null)
 
   const availableDates = cachedDatesInProgramYear.sort((a, b) =>
     b.localeCompare(a)

--- a/frontend/src/pages/DistrictRankingsPage.tsx
+++ b/frontend/src/pages/DistrictRankingsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { useDistricts } from '../hooks/useDistricts'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
 import {
@@ -88,6 +89,7 @@ const DistrictRankingsPage: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
+  useDocumentTitle(`${districtName} Rankings`)
 
   const availableDates = cachedDatesInProgramYear.sort((a, b) =>
     b.localeCompare(a)

--- a/frontend/src/pages/DistrictTrendsPage.tsx
+++ b/frontend/src/pages/DistrictTrendsPage.tsx
@@ -135,7 +135,7 @@ const DistrictTrendsPage: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
-  useDocumentTitle(`${districtName} Trends`)
+  useDocumentTitle(districtName ? `${districtName} Trends` : null)
 
   const availableDates = cachedDatesInProgramYear.sort((a, b) =>
     b.localeCompare(a)

--- a/frontend/src/pages/DistrictTrendsPage.tsx
+++ b/frontend/src/pages/DistrictTrendsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { useDistricts } from '../hooks/useDistricts'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
 import { useAggregatedAnalytics } from '../hooks/useAggregatedAnalytics'
 import { useTimeSeries } from '../hooks/useTimeSeries'
@@ -134,6 +135,7 @@ const DistrictTrendsPage: React.FC = () => {
 
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
+  useDocumentTitle(`${districtName} Trends`)
 
   const availableDates = cachedDatesInProgramYear.sort((a, b) =>
     b.localeCompare(a)

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 /* History page (#367). The 2026 design specifies year-end snapshot
    cards (top 5 districts + headline metrics + notable note) for each
@@ -20,6 +21,7 @@ const PROGRAM_YEARS_ON_FILE = [
 ]
 
 const HistoryPage: React.FC = () => {
+  useDocumentTitle('Program Year History')
   return (
     <div className="placeholder-page">
       <p className="placeholder-page__eyebrow">

--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 /* Methodology page (#368). Authored fresh from analytics-core as the
    source of truth — Borda formula, DCP thresholds, club health
@@ -29,6 +30,7 @@ const SECTIONS: ReadonlyArray<{ id: string; num: string; title: string }> = [
 ]
 
 const MethodologyPage: React.FC = () => {
+  useDocumentTitle('Methodology')
   return (
     <div className="methodology-page">
       <header className="methodology-page__header">

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -147,6 +147,16 @@ describe('ClubDetailPage (#208)', () => {
     expect(breadcrumbLink).toHaveAttribute('href', '/district/61')
   })
 
+  it('self-titles the document with club and district (#780)', () => {
+    renderWithRoute()
+    // render() flushes the title effect inside act(), so the title is set
+    // synchronously — no waitFor (whose polling would leak a deferred render
+    // into the next test and consume its mockReturnValueOnce).
+    expect(document.title).toBe(
+      'St Lawrence Toastmasters — District 61 — Toast Stats'
+    )
+  })
+
   it('renders the District › Clubs › Club trail with a Clubs crumb (#577)', () => {
     renderWithRoute()
 

--- a/frontend/src/pages/__tests__/DistrictAnalyticsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictAnalyticsPage.test.tsx
@@ -167,6 +167,13 @@ describe('DistrictAnalyticsPage (#680 — ADR-005)', () => {
     expect(screen.getByTestId('education-levels-card')).toBeInTheDocument()
   })
 
+  it('self-titles the document per route (#780)', async () => {
+    renderAt('/district/61/analytics')
+    await waitFor(() =>
+      expect(document.title).toBe('District 61 Analytics — Toast Stats')
+    )
+  })
+
   it('derives the top DCP list from analytics.allClubs (sorted, capped)', async () => {
     renderAt('/district/61/analytics')
     await screen.findByTestId('top-growth-clubs')

--- a/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
@@ -224,6 +224,13 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
     expect(screen.getByText(/beta speakers/i)).toBeInTheDocument()
   })
 
+  it('self-titles the document per route (#780)', async () => {
+    renderAt('/district/61/clubs')
+    await waitFor(() =>
+      expect(document.title).toBe('District 61 Clubs — Toast Stats')
+    )
+  })
+
   it('shows a back-to-district breadcrumb crumb, not the old back button (#577)', async () => {
     renderAt('/district/61/clubs')
 

--- a/frontend/src/pages/__tests__/DistrictDetailPage.AnalyticsTab.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.AnalyticsTab.test.tsx
@@ -168,6 +168,13 @@ describe('DistrictDetailPage — Analytics section (post-#569 narrative merge)',
       expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
     })
 
+    it('self-titles the document per route (#780)', async () => {
+      renderWithProviders('/district/57')
+      await waitFor(() =>
+        expect(document.title).toBe('District 57 — Toast Stats')
+      )
+    })
+
     it('exposes CTA links to the Clubs / Divisions / Rankings routes', () => {
       renderWithProviders()
       expect(

--- a/frontend/src/pages/__tests__/DistrictDivisionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDivisionsPage.test.tsx
@@ -169,6 +169,13 @@ describe('DistrictDivisionsPage (#571 — Phase 3)', () => {
     ).toBeInTheDocument()
   })
 
+  it('self-titles the document per route (#780)', async () => {
+    renderAt('/district/61/divisions')
+    await waitFor(() =>
+      expect(document.title).toBe('District 61 Divisions — Toast Stats')
+    )
+  })
+
   it('renders the District section subnav with Divisions active (#678)', async () => {
     renderAt('/district/61/divisions')
     await screen.findByTestId('division-performance-cards')

--- a/frontend/src/pages/__tests__/DistrictRankingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictRankingsPage.test.tsx
@@ -158,6 +158,13 @@ describe('DistrictRankingsPage (#571 — Phase 3)', () => {
     expect(await screen.findByTestId('global-rankings-tab')).toBeInTheDocument()
   })
 
+  it('self-titles the document per route (#780)', async () => {
+    renderAt('/district/61/rankings')
+    await waitFor(() =>
+      expect(document.title).toBe('District 61 Rankings — Toast Stats')
+    )
+  })
+
   it('renders the District section subnav with Rankings active (#678)', async () => {
     renderAt('/district/61/rankings')
     await screen.findByTestId('global-rankings-tab')

--- a/frontend/src/pages/__tests__/DistrictTrendsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictTrendsPage.test.tsx
@@ -196,6 +196,13 @@ describe('DistrictTrendsPage (#680 — ADR-005)', () => {
     expect(screen.getByTestId('year-over-year-comparison')).toBeInTheDocument()
   })
 
+  it('self-titles the document per route (#780)', async () => {
+    renderAt('/district/61/trends')
+    await waitFor(() =>
+      expect(document.title).toBe('District 61 Trends — Toast Stats')
+    )
+  })
+
   it('feeds MembershipTrendChart the aggregated time-series points', async () => {
     renderAt('/district/61/trends')
     await screen.findByTestId('membership-trend-chart')

--- a/frontend/src/pages/__tests__/staticPageTitles.test.tsx
+++ b/frontend/src/pages/__tests__/staticPageTitles.test.tsx
@@ -1,0 +1,35 @@
+/* Per-route document titles for the static content pages (#780, epic #785).
+   Methodology and History have no async data, so their title is deterministic
+   on mount — the simplest end of the per-route title contract (F-SA3). */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import MethodologyPage from '../MethodologyPage'
+import HistoryPage from '../HistoryPage'
+
+afterEach(() => cleanup())
+
+describe('static page document titles (#780)', () => {
+  it('titles the Methodology page', async () => {
+    render(
+      <MemoryRouter>
+        <MethodologyPage />
+      </MemoryRouter>
+    )
+    await waitFor(() =>
+      expect(document.title).toBe('Methodology — Toast Stats')
+    )
+  })
+
+  it('titles the History page', async () => {
+    render(
+      <MemoryRouter>
+        <HistoryPage />
+      </MemoryRouter>
+    )
+    await waitFor(() =>
+      expect(document.title).toBe('Program Year History — Toast Stats')
+    )
+  })
+})

--- a/tasks/lessons/120-await-waitfor-for-an-already-flushed-effect-leaks-a-render-into-the-next-test.md
+++ b/tasks/lessons/120-await-waitfor-for-an-already-flushed-effect-leaks-a-render-into-the-next-test.md
@@ -1,0 +1,84 @@
+---
+id: '120'
+category: lesson
+tags: [tests, vitest, flaky, react, frontend]
+auto_load: true
+date: 2026-05-27
+issues: [780, 785]
+---
+
+# Lesson 120 — `await waitFor` for an already-flushed effect leaks a deferred render into the next test
+
+**Date:** 2026-05-27
+**Issue:** #780 (epic #785 Sprint 3 — per-route document titles)
+
+## What happened
+
+Adding a per-route `document.title` assertion to `ClubDetailPage.test.tsx`,
+I reached for the reflexive async form:
+
+```ts
+it('self-titles the document', async () => {
+  renderWithRoute()
+  await waitFor(() => expect(document.title).toBe('… — Toast Stats'))
+})
+```
+
+It made the title assertion pass — but a **later, unrelated** test in the same
+file (`renders the chartered date segment`) started failing. That test injects
+a one-shot mock:
+
+```ts
+vi.mocked(useDistrictAnalytics).mockReturnValueOnce({
+  /* club w/ charterDate */
+})
+renderWithRoute()
+```
+
+The `mockReturnValueOnce` value was being consumed by a **deferred re-render
+left over from my `waitFor` test** (the lazy-chart imports / async effects that
+`waitFor`'s polling kept alive past the test body), so the chartered-date
+render fell through to the default mock and the charter date never appeared.
+On `origin/main` all 26 tests passed; my one `await waitFor` turned a green
+file red two tests away.
+
+## The transferable lesson
+
+**When the value you're asserting is set by an effect that
+`render()` already flushes inside `act()`, assert it synchronously — don't
+reach for `await waitFor`.** `document.title` (and other effect-set globals)
+are committed by the time `render()` returns under React Testing Library.
+`waitFor` adds nothing there except a polling window that keeps the component's
+async machinery (lazy imports, microtask re-renders) running _after your test
+body returns_. That deferred work is what reaches into the next test and
+consumes a queued `mockReturnValueOnce`. A synchronous `expect` ends the test
+cleanly with nothing pending.
+
+`mockReturnValueOnce` is the canary: it only returns its value for the _next_
+call, so it is acutely sensitive to a stray render arriving from a prior test.
+A leak that a persistent `mockReturnValue` would absorb silently, a
+`…Once` surfaces as a confusing failure in a test you didn't touch.
+
+## How to apply
+
+- Effect-set global (`document.title`, a `data-*` attribute, a class on
+  `<html>`) that `render()`/`act()` already flushed? Assert it **synchronously**
+  right after render. Reserve `await waitFor`/`findBy*` for state that genuinely
+  resolves later (network, debounce, real timers).
+- A test fails "for no reason" two tests after one you edited? Suspect an
+  async leak from the edited test, especially if the failing test uses
+  `mockReturnValueOnce`. The trigger is almost always a `waitFor`/`findBy*`
+  whose component kept rendering past the assertion.
+- Prefer `mockReturnValue` over `mockReturnValueOnce` when a test only needs a
+  stable return — it is leak-tolerant. Keep `…Once` for the rare case you are
+  deliberately asserting call-sequence behaviour, and know it raises the
+  isolation bar for every test that mounts the same component.
+
+## Related
+
+- [[053-renderwithproviders-bloat-as-contention-amplifier]] — sibling theme:
+  test-harness side effects amplify into unrelated tests. There it was provider
+  bloat under parallelism; here it is a `waitFor` keeping a render alive.
+- `frontend/src/pages/__tests__/ClubDetailPage.test.tsx` — the synchronous
+  title assertion, with a comment pinning _why_ it must not use `waitFor`.
+- `frontend/src/hooks/useDocumentTitle.ts` — the hook under test.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -84,3 +84,4 @@
 - **117** [monorepo, analytics, refactor, tdd, data-pipeline] — A "delegate to X" refactor ticket is a trap when the two impls have diverged in output (#306, #757)
 - **118** [data-pipeline, analytics, collector-cli, find-a-club] — "Missing from Find-A-Club" is a registry-visibility signal, not a data gap (#490, #757)
 - **119** [ci, tests, seo, frontend, verification, performance] — Before gating a Lighthouse SEO audit at `error`, verify which audits survive the localhost/preview host (#778, #785)
+- **120** [tests, vitest, flaky, react, frontend] — `await waitFor` for an already-flushed effect leaks a deferred render into the next test (#780, #785)


### PR DESCRIPTION
## What & why

Closes the per-route document title gap (#780, epic #785, audit finding **F-SA3**). Every route previously reported the same `<title>` shipped statically in `index.html` (#778), so deep links to a district/club shared identically and uninformatively. This wires each meaningful route to self-title for share/SEO/deep-link value.

## Approach

A deliberately small **`useDocumentTitle` hook** — **no `react-helmet-async` dependency or provider**. The app already manages `document.title` imperatively and `useGoogleAnalytics` reads it as the single source for `page_view`; a hook keeps that contract intact. (AC explicitly allowed "react-helmet-async **or** a small useDocumentTitle hook" — the hook is the lighter, cohesive choice.)

- `formatPageTitle(segment)` → `"<segment> — Toast Stats"`, or the branded default for a nullish/empty segment.
- `DEFAULT_TITLE` is pinned (by test) to the exact static `<title>` from #778, so drift regresses both the share card and the SPA fallback in one move.
- Restores `DEFAULT_TITLE` on unmount → SPA back-navigation to the landing page shows the right title.

## Routes wired

| Route | Title |
|---|---|
| `/district/:id` | `District 93 — Toast Stats` |
| `/district/:id/{clubs,divisions,rankings,trends,analytics}` | `District 93 <Section> — Toast Stats` |
| `/district/:id/club/:cid` | `<Club> — District 93 — Toast Stats` (migrated off the old ad-hoc effect) |
| `/methodology`, `/history` | `Methodology — Toast Stats`, `Program Year History — Toast Stats` |

**Scope line:** exactly the AC-named families (district, club, methodology, history). The landing page and other secondary routes (awards/regions/region/division/area) intentionally fall back to the branded default.

## Tests

- `useDocumentTitle.test.tsx` — formatter contract, default-fallback, restore-on-unmount, segment-change, and a drift guard pinning `DEFAULT_TITLE` to index.html.
- Per-route `document.title` assertions on all 6 district pages + club + the two static pages.
- Full frontend suite green: **2819 tests, 0 regressions.**

## DoD
- [x] Failing tests written first (RED commits), then GREEN.
- [x] No assertion pinning; full suite green.
- [x] /simplify + fresh-context review (APPROVE-WITH-NITS — the one nit, an empty-`districtName` guard on subpages, is applied).
- [x] Lesson 120 filed (a `waitFor` for an already-flushed effect leaked a render into a sibling test's `mockReturnValueOnce`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)