### PR TITLE
chore(security): Firebase Hosting security headers + CSP (#783)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,6 +12,31 @@
       ],
       "headers": [
         {
+          "source": "**",
+          "headers": [
+            {
+              "key": "Content-Security-Policy",
+              "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://storage.googleapis.com https://cdn.taverns.red https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+            },
+            {
+              "key": "X-Content-Type-Options",
+              "value": "nosniff"
+            },
+            {
+              "key": "Referrer-Policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "key": "X-Frame-Options",
+              "value": "DENY"
+            },
+            {
+              "key": "Permissions-Policy",
+              "value": "camera=(), microphone=(), geolocation=(), payment=()"
+            }
+          ]
+        },
+        {
           "source": "**/*.@(js|css)",
           "headers": [
             {
@@ -51,6 +76,31 @@
         }
       ],
       "headers": [
+        {
+          "source": "**",
+          "headers": [
+            {
+              "key": "Content-Security-Policy",
+              "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://storage.googleapis.com https://cdn.taverns.red https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+            },
+            {
+              "key": "X-Content-Type-Options",
+              "value": "nosniff"
+            },
+            {
+              "key": "Referrer-Policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "key": "X-Frame-Options",
+              "value": "DENY"
+            },
+            {
+              "key": "Permissions-Policy",
+              "value": "camera=(), microphone=(), geolocation=(), payment=()"
+            }
+          ]
+        },
         {
           "source": "**/*.@(js|css)",
           "headers": [

--- a/frontend/src/utils/errorTelemetry.ts
+++ b/frontend/src/utils/errorTelemetry.ts
@@ -121,6 +121,12 @@ export async function reportErrorRemote(
       | undefined
     if (!endpoint) return
 
+    // CSP coupling (#783): this POST is a `connect-src` sink. The endpoint is
+    // unset in every current pipeline, so it's dormant — but if remote
+    // telemetry is ever wired up, its origin MUST be added to the
+    // Content-Security-Policy `connect-src` in firebase.json, or the browser
+    // will block the request (and the catch below will swallow the violation).
+
     const report: RemoteErrorReport = {
       timestamp: new Date().toISOString(),
       message: error.message,

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -33,6 +33,16 @@ module.exports = {
         // Performance score
         'categories:performance': ['warn', { minScore: 0.9 }],
         'categories:accessibility': ['warn', { minScore: 0.9 }],
+        // Best-practices gate (#783). Enforcing (error), not just reported —
+        // a public marketing surface advertises Red Taverns' quality, so a
+        // regression below the floor should block the merge. Current build
+        // measures a stable 0.96 (3/3 local runs); 0.9 leaves headroom for
+        // run variance while still catching a real drop (console errors,
+        // deprecated APIs, insecure subresources). Note: the CSP/headers from
+        // firebase.json are NOT present in this localhost preview run, so this
+        // gate is independent of them — header verification is on the preview
+        // channel (see scripts/lib/__tests__/firebaseHeaders.test.ts).
+        'categories:best-practices': ['error', { minScore: 0.9 }],
 
         // Share/SEO metadata (#778) + robots.txt (#782). These audits run
         // against the served page, so they prove the artifacts actually ship

--- a/scripts/lib/__tests__/firebaseHeaders.test.ts
+++ b/scripts/lib/__tests__/firebaseHeaders.test.ts
@@ -52,6 +52,15 @@ function headerValue(headers: HeaderKV[], key: string): string | undefined {
 }
 
 describe('firebase.json security headers (#783)', () => {
+  it('keeps the production and staging CSP byte-identical (no drift)', () => {
+    // The CSP is duplicated verbatim across both targets (JSON has no
+    // variables). Per-target regex checks below can't catch a one-sided edit
+    // that still matches the loose patterns — this equality assertion does.
+    const cspFor = (t: string) =>
+      headerValue(catchAllHeaders(t), 'Content-Security-Policy')
+    expect(cspFor('production')).toBe(cspFor('staging'))
+  })
+
   for (const targetName of ['production', 'staging']) {
     describe(`target: ${targetName}`, () => {
       const headers = () => catchAllHeaders(targetName)

--- a/scripts/lib/__tests__/firebaseHeaders.test.ts
+++ b/scripts/lib/__tests__/firebaseHeaders.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Contract test for #783 — Firebase Hosting security headers + CSP.
+ *
+ * A public marketing surface should emit a Content-Security-Policy plus the
+ * standard hardening headers. This test pins the contract on BOTH hosting
+ * targets (production AND staging) — staging matters because per-PR preview
+ * channels inherit the staging site's hosting config, so the CSP must allow
+ * the staging CDN bucket or previews go data-blank (cf. Lesson 093: the GCS
+ * staging bucket is the preview channels' data source).
+ *
+ * Pure-text/JSON assertions, no runtime: firebase.json is strict JSON.
+ */
+
+const ROOT = join(__dirname, '..', '..', '..')
+
+interface HeaderKV {
+  key: string
+  value: string
+}
+interface HeaderRule {
+  source: string
+  headers: HeaderKV[]
+}
+interface HostingTarget {
+  target: string
+  headers?: HeaderRule[]
+}
+
+function loadHosting(): HostingTarget[] {
+  const raw = readFileSync(join(ROOT, 'firebase.json'), 'utf8')
+  return JSON.parse(raw).hosting as HostingTarget[]
+}
+
+/** The catch-all (`source: "**"`) header rule for a named target. */
+function catchAllHeaders(targetName: string): HeaderKV[] {
+  const target = loadHosting().find(t => t.target === targetName)
+  expect(target, `hosting target "${targetName}" must exist`).toBeDefined()
+  const rule = target!.headers?.find(r => r.source === '**')
+  expect(
+    rule,
+    `target "${targetName}" must have a catch-all (source "**") header rule`
+  ).toBeDefined()
+  return rule!.headers
+}
+
+function headerValue(headers: HeaderKV[], key: string): string | undefined {
+  return headers.find(h => h.key.toLowerCase() === key.toLowerCase())?.value
+}
+
+describe('firebase.json security headers (#783)', () => {
+  for (const targetName of ['production', 'staging']) {
+    describe(`target: ${targetName}`, () => {
+      const headers = () => catchAllHeaders(targetName)
+
+      it('sets X-Content-Type-Options: nosniff', () => {
+        expect(headerValue(headers(), 'X-Content-Type-Options')).toBe('nosniff')
+      })
+
+      it('sets a Referrer-Policy', () => {
+        expect(headerValue(headers(), 'Referrer-Policy')).toBe(
+          'strict-origin-when-cross-origin'
+        )
+      })
+
+      it('denies framing (X-Frame-Options)', () => {
+        expect(headerValue(headers(), 'X-Frame-Options')).toBe('DENY')
+      })
+
+      it('sets a restrictive Permissions-Policy', () => {
+        const pp = headerValue(headers(), 'Permissions-Policy')
+        expect(pp, 'Permissions-Policy must be present').toBeDefined()
+        // Powerful features the app does not use are denied.
+        expect(pp).toMatch(/camera=\(\)/)
+        expect(pp).toMatch(/microphone=\(\)/)
+        expect(pp).toMatch(/geolocation=\(\)/)
+      })
+
+      describe('Content-Security-Policy', () => {
+        const csp = () => {
+          const v = headerValue(headers(), 'Content-Security-Policy')
+          expect(v, 'CSP header must be present').toBeDefined()
+          return v!
+        }
+
+        it('defaults to self', () => {
+          expect(csp()).toMatch(/default-src 'self'/)
+        })
+
+        it('blocks plugins and base-tag/frame hijacking', () => {
+          expect(csp()).toMatch(/object-src 'none'/)
+          expect(csp()).toMatch(/base-uri 'self'/)
+          expect(csp()).toMatch(/frame-ancestors 'none'/)
+        })
+
+        it('allows Google Fonts (stylesheet + woff2)', () => {
+          expect(csp()).toMatch(
+            /style-src[^;]*https:\/\/fonts\.googleapis\.com/
+          )
+          expect(csp()).toMatch(/font-src[^;]*https:\/\/fonts\.gstatic\.com/)
+        })
+
+        it('allows BOTH CDN origins in connect-src (staging GCS + prod)', () => {
+          // Lesson 093: previews read the staging GCS bucket; prod reads
+          // cdn.taverns.red. Dropping either silently breaks data fetches.
+          expect(csp()).toMatch(
+            /connect-src[^;]*https:\/\/storage\.googleapis\.com/
+          )
+          expect(csp()).toMatch(/connect-src[^;]*https:\/\/cdn\.taverns\.red/)
+        })
+
+        it('allows Google Analytics origins', () => {
+          // GA4 loads only on the prod hostname, but the policy must permit
+          // it there: tag-manager script + analytics beacons.
+          expect(csp()).toMatch(
+            /script-src[^;]*https:\/\/www\.googletagmanager\.com/
+          )
+          expect(csp()).toMatch(
+            /connect-src[^;]*https:\/\/www\.google-analytics\.com/
+          )
+        })
+      })
+    })
+  }
+})

--- a/scripts/lib/__tests__/lighthouseGate.test.ts
+++ b/scripts/lib/__tests__/lighthouseGate.test.ts
@@ -1,0 +1,45 @@
+import { join } from 'node:path'
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Contract test for #783 — Lighthouse best-practices gate.
+ *
+ * The acceptance criterion is a *gate*, not just a reported metric. Lesson 082:
+ * a quality check that is declared but inert provides no protection. So this
+ * asserts the assertion is present AND set to `error` (enforcing) — a future
+ * edit that downgrades it to `warn` or drops it goes red here.
+ *
+ * Measured best-practices score on the current build is a stable 0.96 (3/3
+ * runs), so a 0.9 floor enforces a real regression budget without flaking.
+ */
+
+const ROOT = join(__dirname, '..', '..', '..')
+// lighthouserc.js is CommonJS; load it through require, not ESM import.
+const require = createRequire(import.meta.url)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const config: any = require(join(ROOT, 'lighthouserc.js'))
+
+describe('lighthouserc.js best-practices gate (#783)', () => {
+  const assertions = config?.ci?.assert?.assertions ?? {}
+
+  it('collects the best-practices category', () => {
+    const cats = config?.ci?.collect?.settings?.onlyCategories ?? []
+    expect(cats).toContain('best-practices')
+  })
+
+  it('asserts categories:best-practices', () => {
+    expect(assertions['categories:best-practices']).toBeDefined()
+  })
+
+  it('enforces the gate at error level (not warn) — Lesson 082', () => {
+    const [level] = assertions['categories:best-practices']
+    expect(level).toBe('error')
+  })
+
+  it('sets a real minScore floor (>= 0.9, <= measured 0.96)', () => {
+    const [, opts] = assertions['categories:best-practices']
+    expect(opts.minScore).toBeGreaterThanOrEqual(0.9)
+    expect(opts.minScore).toBeLessThanOrEqual(0.96)
+  })
+})

--- a/tasks/lessons/122-a-csp-in-hosting-config-is-invisible-to-the-localhost-lighthouse-gate.md
+++ b/tasks/lessons/122-a-csp-in-hosting-config-is-invisible-to-the-localhost-lighthouse-gate.md
@@ -1,0 +1,88 @@
+---
+id: '122'
+category: lesson
+tags: [ci, lighthouse, security, csp, verification, frontend]
+auto_load: true
+date: 2026-05-27
+issues: [783, 785]
+---
+
+# Lesson 122 — A CSP in hosting config is invisible to the localhost Lighthouse gate; verify headers on the deployed surface
+
+**Date:** 2026-05-27
+**Issue:** #783 (epic #785 Sprint 5 — Firebase Hosting security headers + CSP)
+
+## What happened
+
+#783 had two acceptance criteria that _sound_ related but live on two
+completely separate verification surfaces:
+
+1. Add a Content-Security-Policy + hardening headers via `firebase.json`.
+2. "Extend Lighthouse to a best-practices gate."
+
+The tempting mental model is "add the CSP → Lighthouse's best-practices score
+goes up → the gate proves the CSP." All three links are wrong:
+
+- **Lighthouse CI runs against `http://localhost:4173/`** (the Vite preview
+  server, per `lighthouserc.js` `startServerCommand`). That server serves the
+  static `dist/` — it does **not** serve the `firebase.json` `headers` block.
+  Those headers only exist once Firebase Hosting serves the files. So the CSP
+  is simply **absent** during every Lighthouse run.
+- Even on a real host, Lighthouse's `csp-xss` audit is **informational** — it
+  contributes 0 to the best-practices _score_. A perfect CSP doesn't raise the
+  number; a missing one doesn't lower it.
+- Therefore the best-practices gate and the CSP are **independent**. The gate
+  measures console errors / deprecated APIs / insecure subresources; the CSP is
+  an HTTP-response-header contract.
+
+## The transferable lesson
+
+**A response header set by the hosting layer is invisible to any tool that
+hits a different server.** Lighthouse-against-localhost, jsdom, and unit tests
+all run below the CDN/hosting edge, so none of them can see (or verify) headers
+that only the edge emits. Split the verification accordingly:
+
+- **The header contract** → a config-contract test (`firebase.json` is strict
+  JSON; assert the directives) **plus** a live `curl -I` / Playwright
+  `response.headers()` check **on the deployed preview channel** — that is the
+  only surface that actually emits the headers.
+- **The Lighthouse gate** → a separate quality floor, set at a level the build
+  provably clears (measured 0.96 → gate at `error`/0.9), pinned by a guard test
+  that asserts it's _enforcing_, not merely declared (Lesson 082).
+
+Don't let the two criteria contaminate each other: a green Lighthouse run is
+**not** evidence the CSP works, and a correct CSP will **not** move the
+Lighthouse score.
+
+## How to apply
+
+- Before claiming a header/CSP "verified," ask _which server answered the
+  request the tool measured_. If it's localhost/jsdom, the hosting headers
+  weren't there. Drive the actual preview/prod URL.
+- A CSP's `connect-src` must list every origin the app fetches. For this repo
+  that's BOTH CDN origins (`storage.googleapis.com` for preview/staging,
+  `cdn.taverns.red` for prod) — the preview channel reads the staging bucket
+  (see [[093-gcs-cors-has-no-subdomain-wildcard-so-dynamic-preview-hosts-need-star]]),
+  so a policy missing it makes previews go data-blank exactly where you verify.
+- The decisive preview-channel signal that the CDN read succeeded under CSP is
+  data-derived UI, not chrome: "Data fresh · <date>" and a populated snapshot
+  dropdown only render after the GCS fetch resolves. Chrome rendering alone
+  only proves `script-src 'self'` let the bundle run.
+- `script-src 'unsafe-inline'` is defensible on a public, read-only,
+  no-auth/no-PII surface whose `index.html` has inline `onload=` handlers
+  (nonces/hashes can't cover inline event handlers). Document the threat model;
+  don't pretend a nonce CSP is free when the markup forecloses it.
+
+## Related
+
+- `scripts/lib/__tests__/firebaseHeaders.test.ts` — the JSON contract test
+  (pins both targets + a cross-target equality assertion against drift).
+- `scripts/lib/__tests__/lighthouseGate.test.ts` — the enforcing-gate guard.
+- `lighthouserc.js` — the comment at `categories:best-practices` records the
+  header-independence so the next author doesn't re-conflate them.
+- [[082-a-lint-rule-can-be-present-but-inert-assert-behavior-not-severity]] —
+  same discipline applied to the Lighthouse gate: assert it enforces, not that
+  it's merely present.
+- [[081-phase-gated-deferral-tests-move-with-the-spec]] — why self-hosting the
+  fonts (the optional 3rd criterion) was deferred: lifting the font deferral
+  risks the CLS regression PR #595 caught.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -86,3 +86,4 @@
 - **119** [ci, tests, seo, frontend, verification, performance] — Before gating a Lighthouse SEO audit at `error`, verify which audits survive the localhost/preview host (#778, #785)
 - **120** [tests, vitest, flaky, react, frontend] — `await waitFor` for an already-flushed effect leaks a deferred render into the next test (#780, #785)
 - **121** [ci, tests, seo, verification, frontend] — A "presence-implying" audit may only validate; pair it with a drift guard (#782, #785)
+- **122** [ci, lighthouse, security, csp, verification, frontend] — A CSP in hosting config is invisible to the localhost Lighthouse gate; verify headers on the deployed surface (#783, #785)


### PR DESCRIPTION
Closes nothing automatically — see ordering note below. Tracking: #783 (epic #785, Sprint 5).

## What
Adds Content-Security-Policy + standard hardening headers to **both** Firebase Hosting targets, and turns the previously-reported Lighthouse best-practices score into an **enforcing** gate.

### Headers (firebase.json, both `production` + `staging`)
- `Content-Security-Policy` — `default-src 'self'` with explicit allows for every origin the app actually uses (Google Fonts, GCS staging bucket + `cdn.taverns.red`, GA4), plus `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `frame-ancestors 'none'`, `upgrade-insecure-requests`.
- `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `X-Frame-Options: DENY`, `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()`.

Added to the `staging` target too because per-PR preview channels inherit the staging site's hosting config — that's how the CSP is verifiable pre-merge (Lesson 093).

### Lighthouse best-practices gate (lighthouserc.js)
`'categories:best-practices': ['error', { minScore: 0.9 }]`. Measured a stable 0.96 (3/3 local runs); 0.9 is a real floor with headroom, not inert (Lesson 082 — asserted enforcing, pinned by a guard test).

## Security rationale (ron-sec)
Public, read-only SPA: no auth, no secrets, no user-input sink, no PII (GA4 anonymized). `script-src 'unsafe-inline'` is required because `index.html` has inline `onload=` font-preload handlers + the inline GA4/font-loading scripts, and inline event handlers can't be covered by nonces/hashes. Given the near-zero XSS blast radius, the pragmatic CSP + the unambiguously-valuable hardening headers deliver the F-SEC2 credibility/safety signal. Future hardening path (remove inline handlers → nonce-based `script-src`) is left as a follow-up.

## Deferred (per acceptance criteria + Lesson 81)
Self-hosting fonts is marked **optional** in #783 and is intentionally NOT done here: lifting the font deferral risks the CLS regression Lesson 81 documents (PR #595, 0.012 → 0.199). The CSP whitelists Google Fonts as third-party instead.

## TDD
Red→Green for both pieces, each commit references #783:
1. `test(security)` — failing firebase.json contract test (both targets)
2. `feat(security)` — headers added
3. `test(ci)` — failing Lighthouse-gate guard test
4. `feat(ci)` — gate enforced
5. `refactor(security)` — fresh-context review pass: CSP cross-target equality assertion + telemetry `connect-src` coupling comment

## Verification
- 19 firebase.json contract tests + 4 Lighthouse-gate tests green; full scripts suite 158/158; frontend 2238/2238 (pre-push).
- `lhci autorun` locally: best-practices gate passes (0.96 ≥ 0.9).
- Header presence + no-broken-resources to be verified on this PR's preview channel (curl + Playwright Chromium & WebKit) — evidence posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
