### PR TITLE
feat(changes): Phase 1 — snapshot diff engine + default district digest (#793)

### DIFF
--- a/docs/design/what-changed-feature.md
+++ b/docs/design/what-changed-feature.md
@@ -9,12 +9,12 @@ never a date-to-date diff.
 
 ## §1. Phasing
 
-| Phase | Issue | Scope |
-| ----- | ----- | ----- |
-| 1 | #793 | Pure `diffSnapshots` engine + `SnapshotDiff` type + **default** district digest page at `/district/:id/changes` (from = previous recorded date, to = latest). No date picker. |
-| 2 | #794 | Arbitrary date-pair picker (from/to, URL-synced, per-district index). |
-| 3 | #795 | Per-club delta table + diff CSV export. |
-| 4 | #796 | (optional) Pre-computed GCS digest + cross-district view. |
+| Phase | Issue | Scope                                                                                                                                                                         |
+| ----- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | #793  | Pure `diffSnapshots` engine + `SnapshotDiff` type + **default** district digest page at `/district/:id/changes` (from = previous recorded date, to = latest). No date picker. |
+| 2     | #794  | Arbitrary date-pair picker (from/to, URL-synced, per-district index).                                                                                                         |
+| 3     | #795  | Per-club delta table + diff CSV export.                                                                                                                                       |
+| 4     | #796  | (optional) Pre-computed GCS digest + cross-district view.                                                                                                                     |
 
 ## §2. Architectural spine
 

--- a/docs/design/what-changed-feature.md
+++ b/docs/design/what-changed-feature.md
@@ -1,0 +1,94 @@
+# "What Changed" — snapshot-to-snapshot diff
+
+**Epic:** #797 · **Authored:** 2026-05-27 (Sprint 1, #793)
+
+Surface _what changed between two recorded snapshot dates_ for a district —
+default "since the previous recorded date," and (Phase 2) any arbitrary date
+pair in history. The app today shows current state and continuous trends but
+never a date-to-date diff.
+
+## §1. Phasing
+
+| Phase | Issue | Scope |
+| ----- | ----- | ----- |
+| 1 | #793 | Pure `diffSnapshots` engine + `SnapshotDiff` type + **default** district digest page at `/district/:id/changes` (from = previous recorded date, to = latest). No date picker. |
+| 2 | #794 | Arbitrary date-pair picker (from/to, URL-synced, per-district index). |
+| 3 | #795 | Per-club delta table + diff CSV export. |
+| 4 | #796 | (optional) Pre-computed GCS digest + cross-district view. |
+
+## §2. Architectural spine
+
+- **Pure diff engine** `diffSnapshots(from, to): SnapshotDiff` in
+  `analytics-core` — no I/O, fully unit-testable, and reusable by a future
+  collector pre-compute step (Phase 4) without a rewrite.
+- **Client-side first** — fetch two dated snapshots and diff in a hook
+  (`useSnapshotDiff`). Defer GCS pre-compute to Phase 4 (R7 — don't build
+  backend before need).
+- `from`/`to` are owned by the **page** and passed as props (R3); the hook
+  never re-derives them from response data.
+
+## §3. The load-bearing data finding (Lesson 115 — verified 2026-05-27)
+
+The diff MUST be computed from two actual dated
+`snapshots/{date}/district_{id}.json` files (`PerDistrictData.data`,
+type `DistrictStatisticsFile`). Two traps were verified against the live
+staging CDN for District 61 (2026-05-25 → 2026-05-26):
+
+1. **`district_{id}_analytics.json` delta fields are single-snapshot** — they
+   read `0` on the frontend. Building on them ships a feature that always says
+   "nothing changed." (Epic constraint, Lesson 115.)
+2. **`totals.distinguishedClubs` / `selectDistinguishedClubs` /
+   `presidentDistinguishedClubs` are unpopulated mid-year** — all three read
+   `0` even when `clubPerformance` shows 49–50 distinguished clubs. The
+   authoritative per-club tier is the raw `clubPerformance`
+   `Club Distinguished Status` field (`'' | D | S | P | M`). **Distinguished
+   aggregates and flips are counted from that field, never from `totals.*`.**
+   (Verified: D61 went 49 → 50 distinguished, one `'' → D` flip, while
+   `totals.distinguishedClubs` stayed `0` on both dates.)
+
+Real deltas verified for the D61 pair: membership 2716 → 2742 (+26), payments
+5723 → 5749 (+26), clubs 161 → 162 (one club joined: "iA Montreal
+Toastmasters", Active), 7 clubs changed membership/goals.
+
+## §4. `SnapshotDiff` shape (`packages/shared-contracts`)
+
+Per-aggregate delta is `{ from, to, delta }` (`delta = to − from`, signed).
+
+- `districtId`, `from.date`, `to.date`, `dayCount` (calendar days between —
+  surfaced in the headline so sparse gaps are honest).
+- `totals`: `membership`, `payments`, `clubCount`, `distinguished` (the four
+  KPI cards).
+- `clubs`: `bothPresent: ClubDiff[]`, `onlyInFrom: ClubPresence[]` (left the
+  roster), `onlyInTo: ClubPresence[]` (joined the roster) — joined by `clubId`.
+  `ClubPresence` carries `clubStatus` so roster appear/disappear is
+  **classified** (Lesson 118), never shown as an error.
+- `events: DiffEvent[]` — categorized, narrative-ready, sorted by magnitude.
+  Categories: `membership`, `dcp-goals`, `distinguished`, `club-added`,
+  `club-removed`. (Payments is an aggregate KPI only; per-club payment churn
+  would double the membership noise in v1.)
+
+`ClubDiff` carries `membership`/`payments`/`dcpGoals` deltas plus
+`distinguishedFrom`/`distinguishedTo`/`distinguishedChanged`. DCP signals come
+from raw `clubPerformance` goal fields, never inferred Goals 1–N order
+(tripwire).
+
+## §5. Phase 1 frontend
+
+- `useSnapshotDiff(districtId, from, to)` — React Query keyed by the date pair,
+  fetches both dated snapshots, returns `diffSnapshots(...)`.
+- `previousRecordedDate(index, districtId)` — the per-district snapshot index
+  `[-2]` (never the global dates list). `[-1]` is `to`.
+- `DistrictChangesPage` (lazy route `/district/:districtId/changes`) — narrative
+  headline + 4 `KpiDeltaCard`s + grouped collapsible change list.
+- `DistrictSubnav` gains a "What Changed" section (a real route, per ADR-005).
+- **Empty/edge states:** only one snapshot for the district → digest disabled
+  with an explanation; no changes in range → "No recorded changes" (a valid
+  outcome, not an error).
+
+## §6. Verification
+
+Drive the real page on the PR preview channel (staging CDN) for ≥1
+representative district (D61) — assert non-zero rendered deltas (Lesson 115:
+verify the served value, not just a prop-fed unit test). Unit tests cover the
+pure engine (aggregates, all three partitions, every event category) with a
+failing test first.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,10 @@ const ClubDetailPage = React.lazy(() => import('./pages/ClubDetailPage'))
 // Code-split: DistrictClubsPage — district clubs subroute (#570, epic #568 Phase 2)
 const DistrictClubsPage = React.lazy(() => import('./pages/DistrictClubsPage'))
 
+const DistrictChangesPage = React.lazy(
+  () => import('./pages/DistrictChangesPage')
+)
+
 // Code-split: DistrictDivisionsPage — divisions subroute (#571, epic #568 Phase 3)
 const DistrictDivisionsPage = React.lazy(
   () => import('./pages/DistrictDivisionsPage')
@@ -92,6 +96,14 @@ const router = createBrowserRouter(
           element: (
             <Suspense fallback={<PageLoadingFallback />}>
               <DistrictDetailPage />
+            </Suspense>
+          ),
+        },
+        {
+          path: 'district/:districtId/changes',
+          element: (
+            <Suspense fallback={<PageLoadingFallback />}>
+              <DistrictChangesPage />
             </Suspense>
           ),
         },

--- a/frontend/src/components/DistrictSubnav.tsx
+++ b/frontend/src/components/DistrictSubnav.tsx
@@ -38,6 +38,9 @@ export interface DistrictSection {
    is the single extension point. */
 export const DISTRICT_SECTIONS: readonly DistrictSection[] = [
   { label: 'Overview', segment: '' },
+  // 'What Changed' (#793, epic #797) — a real route, sits next to Overview as
+  // the "since I last looked" companion to the current-state hub.
+  { label: 'What Changed', segment: 'changes' },
   { label: 'Clubs', segment: 'clubs' },
   { label: 'Divisions', segment: 'divisions' },
   { label: 'Trends', segment: 'trends' },

--- a/frontend/src/components/__tests__/DistrictSubnav.test.tsx
+++ b/frontend/src/components/__tests__/DistrictSubnav.test.tsx
@@ -29,6 +29,7 @@ describe('DistrictSubnav (#678, ADR-005 §3)', () => {
     renderAt('/district/61')
     const expected: Record<string, string> = {
       Overview: '/district/61',
+      'What Changed': '/district/61/changes',
       Clubs: '/district/61/clubs',
       Divisions: '/district/61/divisions',
       Trends: '/district/61/trends',
@@ -57,6 +58,7 @@ describe('DistrictSubnav (#678, ADR-005 §3)', () => {
     // Trends · Analytics · Rankings.
     expect(DISTRICT_SECTIONS.map(s => s.label)).toEqual([
       'Overview',
+      'What Changed',
       'Clubs',
       'Divisions',
       'Trends',

--- a/frontend/src/hooks/__tests__/useSnapshotDiff.test.tsx
+++ b/frontend/src/hooks/__tests__/useSnapshotDiff.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactNode } from 'react'
+import { useSnapshotDiff, previousRecordedDate } from '../useSnapshotDiff'
+import { fetchCdnDistrictSnapshot } from '../../services/cdn'
+import type {
+  PerDistrictData,
+  ClubStatisticsFile,
+} from '@toastmasters/shared-contracts'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDistrictSnapshot: vi.fn(),
+}))
+
+const mockedFetch = vi.mocked(fetchCdnDistrictSnapshot)
+
+function club(id: string, membershipCount: number): ClubStatisticsFile {
+  return {
+    clubId: id,
+    clubName: `Club ${id}`,
+    divisionId: 'A',
+    areaId: '01',
+    membershipCount,
+    paymentsCount: membershipCount,
+    dcpGoals: 0,
+    status: 'Active',
+    divisionName: 'Division A',
+    areaName: 'Area 01',
+    octoberRenewals: 0,
+    aprilRenewals: 0,
+    newMembers: 0,
+    membershipBase: membershipCount,
+    clubStatus: 'Active',
+  }
+}
+
+function wrapper(date: string, members: number): PerDistrictData {
+  return {
+    districtId: '61',
+    districtName: 'District 61',
+    collectedAt: `${date}T00:00:00Z`,
+    status: 'success',
+    data: {
+      districtId: '61',
+      snapshotDate: date,
+      clubs: [club('001', members)],
+      divisions: [],
+      areas: [],
+      totals: {
+        totalClubs: 1,
+        totalMembership: members,
+        totalPayments: members,
+        distinguishedClubs: 0,
+        selectDistinguishedClubs: 0,
+        presidentDistinguishedClubs: 0,
+      },
+      divisionPerformance: [],
+      clubPerformance: [
+        { 'Club Number': '001', 'Club Distinguished Status': '' },
+      ],
+      districtPerformance: [],
+    },
+  }
+}
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  )
+}
+
+describe('previousRecordedDate', () => {
+  it('returns the second-most-recent as `from` and the latest as `to`', () => {
+    expect(
+      previousRecordedDate(['2026-05-24', '2026-05-25', '2026-05-26'])
+    ).toEqual({ from: '2026-05-25', to: '2026-05-26' })
+  })
+
+  it('returns null when fewer than two dates are recorded', () => {
+    expect(previousRecordedDate(['2026-05-26'])).toBeNull()
+    expect(previousRecordedDate([])).toBeNull()
+  })
+})
+
+describe('useSnapshotDiff', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('fetches both dated snapshots and returns the computed diff', async () => {
+    mockedFetch.mockImplementation(
+      (date: string) =>
+        Promise.resolve(
+          wrapper(date, date === '2026-05-26' ? 26 : 20) as unknown
+        ) as Promise<unknown>
+    )
+
+    const { result } = renderHook(
+      () => useSnapshotDiff('61', '2026-05-25', '2026-05-26'),
+      { wrapper: makeWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.totals.membership).toEqual({
+      from: 20,
+      to: 26,
+      delta: 6,
+    })
+    expect(result.current.data?.from.date).toBe('2026-05-25')
+    expect(result.current.data?.to.date).toBe('2026-05-26')
+  })
+
+  it('is disabled (does not fetch) when from or to is missing', () => {
+    renderHook(() => useSnapshotDiff('61', undefined, '2026-05-26'), {
+      wrapper: makeWrapper(),
+    })
+    expect(mockedFetch).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useSnapshotDiff.ts
+++ b/frontend/src/hooks/useSnapshotDiff.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchCdnDistrictSnapshot } from '../services/cdn'
+import { diffSnapshots } from '@toastmasters/analytics-core'
+import type {
+  PerDistrictData,
+  SnapshotDiff,
+} from '@toastmasters/shared-contracts'
+
+/**
+ * Resolve the default "since the previous recorded date" pair from a district's
+ * recorded snapshot dates. `to` is the latest date, `from` is the one before it
+ * (index `[-2]`). Returns null when fewer than two dates exist (the page shows a
+ * disabled / explanatory state).
+ *
+ * Dates are assumed already sorted ascending — the per-district snapshot index
+ * is stored that way. The page owns this pair and passes it to useSnapshotDiff
+ * as props (R3 — never re-derive from response data).
+ *
+ * @see docs/design/what-changed-feature.md §5
+ */
+export function previousRecordedDate(
+  dates: string[]
+): { from: string; to: string } | null {
+  if (dates.length < 2) return null
+  return {
+    from: dates[dates.length - 2]!,
+    to: dates[dates.length - 1]!,
+  }
+}
+
+/**
+ * Fetch two dated district snapshots and compute the diff between them.
+ *
+ * Keyed by the (districtId, from, to) triple so each pair caches independently.
+ * The dated file is the `PerDistrictData` wrapper — the diff engine consumes its
+ * `.data` (`DistrictStatisticsFile`). Disabled until all three are present.
+ */
+export function useSnapshotDiff(
+  districtId: string | undefined,
+  from: string | undefined,
+  to: string | undefined
+) {
+  return useQuery<SnapshotDiff, Error>({
+    queryKey: ['snapshot-diff', districtId, from, to],
+    queryFn: async () => {
+      const [fromSnap, toSnap] = await Promise.all([
+        fetchCdnDistrictSnapshot<PerDistrictData>(from!, districtId!),
+        fetchCdnDistrictSnapshot<PerDistrictData>(to!, districtId!),
+      ])
+      return diffSnapshots(fromSnap.data, toSnap.data)
+    },
+    enabled: !!districtId && !!from && !!to,
+    staleTime: 5 * 60 * 1000,
+    retry: 2,
+  })
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -43,6 +43,7 @@
 @import './styles/components/app-shell.css';
 @import './styles/components/district-narrative.css';
 @import './styles/components/district-subnav.css';
+@import './styles/components/district-changes.css';
 @import './styles/responsive.css';
 @import './styles/dark-mode.css';
 @import './styles/print.css';

--- a/frontend/src/pages/DistrictChangesPage.tsx
+++ b/frontend/src/pages/DistrictChangesPage.tsx
@@ -1,0 +1,206 @@
+import React, { useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import { useDistricts } from '../hooks/useDistricts'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useDistrictCachedDates } from '../hooks/useDistrictData'
+import { useSnapshotDiff, previousRecordedDate } from '../hooks/useSnapshotDiff'
+import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
+import { DistrictSubnav } from '../components/DistrictSubnav'
+import { KpiDeltaCard } from '../components/KpiDeltaCard'
+import { LoadingSkeleton } from '../components/LoadingSkeleton'
+import ErrorBoundary from '../components/ErrorBoundary'
+import type {
+  DiffEvent,
+  DiffEventCategory,
+} from '@toastmasters/shared-contracts'
+
+/* District "What Changed" page (#793, epic #797 Sprint 1, ADR-005 §1).
+   Default digest — what changed between the district's previous recorded
+   snapshot date and the latest one. No date picker yet (Phase 2, #794); the
+   from/to pair is owned here and passed to useSnapshotDiff as props (R3). */
+
+/** Human-friendly date, e.g. "May 25, 2026". Date-only, UTC-safe. */
+function fmtDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`)
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+/* Display order + headings for the grouped change list. Roster moves first
+   (most material), then recognition, then the per-club metric churn. */
+const CATEGORY_GROUPS: { category: DiffEventCategory; heading: string }[] = [
+  { category: 'club-added', heading: 'Clubs that joined' },
+  { category: 'club-removed', heading: 'Clubs that left' },
+  { category: 'distinguished', heading: 'Distinguished status changes' },
+  { category: 'membership', heading: 'Membership changes' },
+  { category: 'dcp-goals', heading: 'DCP goal changes' },
+]
+
+const ChangeGroup: React.FC<{ heading: string; events: DiffEvent[] }> = ({
+  heading,
+  events,
+}) => {
+  if (events.length === 0) return null
+  return (
+    <details className="changes-group" open>
+      <summary className="changes-group__summary">
+        {heading}{' '}
+        <span className="changes-group__count">({events.length})</span>
+      </summary>
+      <ul className="changes-group__list">
+        {events.map(e => (
+          <li key={`${e.category}-${e.clubId}`} className="changes-group__item">
+            {e.label}
+          </li>
+        ))}
+      </ul>
+    </details>
+  )
+}
+
+const DistrictChangesPage: React.FC = () => {
+  const { districtId } = useParams<{ districtId: string }>()
+
+  const { data: districtsData } = useDistricts()
+  const selectedDistrict = districtsData?.districts?.find(
+    d => d.id === districtId
+  )
+  const rawName = selectedDistrict?.name || districtId || ''
+  const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
+  useDocumentTitle(districtName ? `${districtName} — What Changed` : null)
+
+  const { data: cachedDates, isLoading: datesLoading } = useDistrictCachedDates(
+    districtId || ''
+  )
+  const dates = useMemo(() => cachedDates?.dates ?? [], [cachedDates?.dates])
+  const pair = useMemo(() => previousRecordedDate(dates), [dates])
+
+  const {
+    data: diff,
+    isLoading: diffLoading,
+    isError,
+  } = useSnapshotDiff(districtId, pair?.from, pair?.to)
+
+  const eventsByCategory = useMemo(() => {
+    const map = new Map<DiffEventCategory, DiffEvent[]>()
+    for (const e of diff?.events ?? []) {
+      const list = map.get(e.category) ?? []
+      list.push(e)
+      map.set(e.category, list)
+    }
+    return map
+  }, [diff?.events])
+
+  if (!districtId) return null
+
+  const enoughHistory = !datesLoading && dates.length >= 2
+  const onlyOneSnapshot = !datesLoading && dates.length < 2
+
+  return (
+    <ErrorBoundary>
+      <div className="district-detail-page-root">
+        <div className="district-detail-page">
+          <h1 className="district-changes__title">{districtName}</h1>
+
+          <SubpageBreadcrumb
+            crumbs={[{ label: districtName, to: `/district/${districtId}` }]}
+          />
+
+          <DistrictSubnav districtId={districtId} />
+
+          <section aria-label="What changed" className="district-changes">
+            {onlyOneSnapshot && (
+              <p
+                className="district-changes__empty"
+                data-testid="changes-single"
+              >
+                Only one snapshot has been recorded for {districtName} so far. A
+                change digest needs at least two recorded dates — check back
+                after the next update.
+              </p>
+            )}
+
+            {enoughHistory && (datesLoading || diffLoading) && (
+              <LoadingSkeleton variant="card" height="220px" />
+            )}
+
+            {enoughHistory && isError && (
+              <p
+                className="district-changes__empty"
+                data-testid="changes-error"
+              >
+                Couldn’t load the change digest for {districtName}. Please try
+                again.
+              </p>
+            )}
+
+            {diff && (
+              <>
+                <p
+                  className="district-changes__headline"
+                  data-testid="changes-headline"
+                >
+                  Changes for {districtName} from {fmtDate(diff.from.date)} to{' '}
+                  {fmtDate(diff.to.date)}
+                  {diff.dayCount > 0 &&
+                    ` · ${diff.dayCount} day${diff.dayCount === 1 ? '' : 's'}`}
+                </p>
+
+                <div className="district-changes__kpis">
+                  <KpiDeltaCard
+                    title="Membership"
+                    current={diff.totals.membership.delta}
+                    secondaryLabel={`${diff.totals.membership.from.toLocaleString()} → ${diff.totals.membership.to.toLocaleString()}`}
+                  />
+                  <KpiDeltaCard
+                    title="Payments"
+                    current={diff.totals.payments.delta}
+                    secondaryLabel={`${diff.totals.payments.from.toLocaleString()} → ${diff.totals.payments.to.toLocaleString()}`}
+                  />
+                  <KpiDeltaCard
+                    title="Clubs"
+                    current={diff.totals.clubCount.delta}
+                    secondaryLabel={`${diff.totals.clubCount.from.toLocaleString()} → ${diff.totals.clubCount.to.toLocaleString()}`}
+                  />
+                  <KpiDeltaCard
+                    title="Distinguished clubs"
+                    current={diff.totals.distinguished.delta}
+                    secondaryLabel={`${diff.totals.distinguished.from.toLocaleString()} → ${diff.totals.distinguished.to.toLocaleString()}`}
+                  />
+                </div>
+
+                {diff.events.length === 0 ? (
+                  <p
+                    className="district-changes__empty"
+                    data-testid="changes-none"
+                  >
+                    No recorded changes between these two dates.
+                  </p>
+                ) : (
+                  <div
+                    className="district-changes__list"
+                    data-testid="changes-list"
+                  >
+                    {CATEGORY_GROUPS.map(({ category, heading }) => (
+                      <ChangeGroup
+                        key={category}
+                        heading={heading}
+                        events={eventsByCategory.get(category) ?? []}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </section>
+        </div>
+      </div>
+    </ErrorBoundary>
+  )
+}
+
+export default DistrictChangesPage

--- a/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import DistrictChangesPage from '../DistrictChangesPage'
+import { useDistrictCachedDates } from '../../hooks/useDistrictData'
+import { useSnapshotDiff } from '../../hooks/useSnapshotDiff'
+import { useDistricts } from '../../hooks/useDistricts'
+import type { SnapshotDiff } from '@toastmasters/shared-contracts'
+
+vi.mock('../../hooks/useDistrictData')
+vi.mock('../../hooks/useDistricts')
+vi.mock('../../hooks/useSnapshotDiff', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../hooks/useSnapshotDiff')
+  >('../../hooks/useSnapshotDiff')
+  return { ...actual, useSnapshotDiff: vi.fn() }
+})
+
+const mockedDates = vi.mocked(useDistrictCachedDates)
+const mockedDiff = vi.mocked(useSnapshotDiff)
+const mockedDistricts = vi.mocked(useDistricts)
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/district/61/changes']}>
+      <Routes>
+        <Route
+          path="/district/:districtId/changes"
+          element={<DistrictChangesPage />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+const ag = (from: number, to: number) => ({ from, to, delta: to - from })
+
+function diffFixture(over: Partial<SnapshotDiff> = {}): SnapshotDiff {
+  return {
+    districtId: '61',
+    from: { date: '2026-05-25' },
+    to: { date: '2026-05-26' },
+    dayCount: 1,
+    totals: {
+      membership: ag(2716, 2742),
+      payments: ag(5723, 5749),
+      clubCount: ag(161, 162),
+      distinguished: ag(49, 50),
+    },
+    clubs: { bothPresent: [], onlyInFrom: [], onlyInTo: [] },
+    events: [
+      {
+        category: 'club-added',
+        clubId: '28680300',
+        clubName: 'iA Montreal Toastmasters',
+        label: 'iA Montreal Toastmasters (Active) joined the roster',
+        magnitude: 1,
+      },
+      {
+        category: 'distinguished',
+        clubId: '00002959',
+        clubName: 'Club 00002959',
+        label: 'Club 00002959 became Distinguished',
+        magnitude: 1,
+      },
+    ],
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedDistricts.mockReturnValue({
+    data: { districts: [{ id: '61', name: '61' }] },
+  } as unknown as ReturnType<typeof useDistricts>)
+})
+
+describe('DistrictChangesPage', () => {
+  it('renders headline, four KPI cards, and grouped events for a real diff', () => {
+    mockedDates.mockReturnValue({
+      data: { dates: ['2026-05-25', '2026-05-26'] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDistrictCachedDates>)
+    mockedDiff.mockReturnValue({
+      data: diffFixture(),
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useSnapshotDiff>)
+
+    renderPage()
+    expect(screen.getByTestId('changes-headline')).toHaveTextContent(
+      /from May 25, 2026 to May 26, 2026/
+    )
+    expect(screen.getAllByTestId('kpi-delta-card')).toHaveLength(4)
+    expect(screen.getByTestId('changes-list')).toBeInTheDocument()
+    expect(screen.getByText(/Clubs that joined/)).toBeInTheDocument()
+    expect(
+      screen.getByText('iA Montreal Toastmasters (Active) joined the roster')
+    ).toBeInTheDocument()
+  })
+
+  it('shows a "no recorded changes" message when the diff has no events', () => {
+    mockedDates.mockReturnValue({
+      data: { dates: ['2026-05-25', '2026-05-26'] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDistrictCachedDates>)
+    mockedDiff.mockReturnValue({
+      data: diffFixture({ events: [] }),
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useSnapshotDiff>)
+
+    renderPage()
+    expect(screen.getByTestId('changes-none')).toBeInTheDocument()
+    expect(screen.queryByTestId('changes-list')).not.toBeInTheDocument()
+  })
+
+  it('explains the disabled state when only one snapshot exists', () => {
+    mockedDates.mockReturnValue({
+      data: { dates: ['2026-05-26'] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDistrictCachedDates>)
+    mockedDiff.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useSnapshotDiff>)
+
+    renderPage()
+    expect(screen.getByTestId('changes-single')).toBeInTheDocument()
+    expect(screen.queryByTestId('changes-headline')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/styles/components/district-changes.css
+++ b/frontend/src/styles/components/district-changes.css
@@ -1,0 +1,96 @@
+/* District "What Changed" page (#793, epic #797 Sprint 1).
+   Uses the redesign token set (--ink*, --surface*, --line) so light/dark remap
+   together (Lessons 093/094). The KPI cards themselves are KpiDeltaCard
+   (#681), which carries its own dark-mode overrides in dark-mode.css. */
+
+.district-changes__title {
+  font-family: var(--display, var(--sans));
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 0.5rem;
+}
+
+.district-changes {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.district-changes__headline {
+  font-family: var(--sans);
+  font-size: 1rem;
+  color: var(--ink-2);
+}
+
+.district-changes__kpis {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .district-changes__kpis {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .district-changes__kpis {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.district-changes__empty {
+  font-family: var(--sans);
+  color: var(--ink-3);
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.district-changes__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.changes-group {
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.changes-group__summary {
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  font-family: var(--sans);
+  font-weight: 600;
+  color: var(--ink);
+  background: var(--surface-2);
+}
+
+.changes-group__summary:focus-visible {
+  outline: 2px solid var(--focus, var(--link));
+  outline-offset: -2px;
+}
+
+.changes-group__count {
+  color: var(--ink-3);
+  font-weight: 400;
+}
+
+.changes-group__list {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+}
+
+.changes-group__item {
+  padding: 0.5rem 1rem;
+  font-family: var(--sans);
+  color: var(--ink-2);
+  border-top: 1px solid var(--line);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       }
     },
     "frontend": {
-      "version": "3.1.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.0",
@@ -7630,7 +7630,7 @@
     },
     "packages/analytics-core": {
       "name": "@toastmasters/analytics-core",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@toastmasters/shared-contracts": "^1.0.0",
@@ -7670,7 +7670,7 @@
     },
     "packages/collector-cli": {
       "name": "@toastmasters/collector-cli",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.19.0",

--- a/packages/analytics-core/src/analytics/diffSnapshots.test.ts
+++ b/packages/analytics-core/src/analytics/diffSnapshots.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest'
+import { diffSnapshots } from './diffSnapshots.js'
+import type {
+  DistrictStatisticsFile,
+  ClubStatisticsFile,
+  ScrapedRecord,
+} from '@toastmasters/shared-contracts'
+
+function club(
+  over: Partial<ClubStatisticsFile> & { clubId: string }
+): ClubStatisticsFile {
+  return {
+    clubName: `Club ${over.clubId}`,
+    divisionId: 'A',
+    areaId: '01',
+    membershipCount: 20,
+    paymentsCount: 25,
+    dcpGoals: 0,
+    status: 'Active',
+    divisionName: 'Division A',
+    areaName: 'Area 01',
+    octoberRenewals: 0,
+    aprilRenewals: 0,
+    newMembers: 0,
+    membershipBase: 20,
+    clubStatus: 'Active',
+    ...over,
+  }
+}
+
+function perf(clubId: string, distinguished: string | null): ScrapedRecord {
+  return {
+    'Club Number': clubId,
+    'Club Distinguished Status': distinguished,
+  }
+}
+
+function snapshot(opts: {
+  date: string
+  clubs: ClubStatisticsFile[]
+  perf?: ScrapedRecord[]
+}): DistrictStatisticsFile {
+  const { clubs } = opts
+  return {
+    districtId: '61',
+    snapshotDate: opts.date,
+    clubs,
+    divisions: [],
+    areas: [],
+    totals: {
+      totalClubs: clubs.length,
+      totalMembership: clubs.reduce((s, c) => s + c.membershipCount, 0),
+      totalPayments: clubs.reduce((s, c) => s + c.paymentsCount, 0),
+      // Deliberately 0 — mirrors live data where totals.distinguished* is
+      // unpopulated mid-year (Lesson 115). The engine must NOT read these.
+      distinguishedClubs: 0,
+      selectDistinguishedClubs: 0,
+      presidentDistinguishedClubs: 0,
+    },
+    divisionPerformance: [],
+    clubPerformance: opts.perf ?? clubs.map(c => perf(c.clubId, '')),
+    districtPerformance: [],
+  }
+}
+
+describe('diffSnapshots', () => {
+  it('computes signed aggregate deltas from totals (membership, payments, clubCount)', () => {
+    const from = snapshot({
+      date: '2026-05-25',
+      clubs: [club({ clubId: '001', membershipCount: 20, paymentsCount: 22 })],
+    })
+    const to = snapshot({
+      date: '2026-05-26',
+      clubs: [club({ clubId: '001', membershipCount: 26, paymentsCount: 25 })],
+    })
+    const diff = diffSnapshots(from, to)
+    expect(diff.totals.membership).toEqual({ from: 20, to: 26, delta: 6 })
+    expect(diff.totals.payments).toEqual({ from: 22, to: 25, delta: 3 })
+    expect(diff.totals.clubCount).toEqual({ from: 1, to: 1, delta: 0 })
+    expect(diff.districtId).toBe('61')
+    expect(diff.from.date).toBe('2026-05-25')
+    expect(diff.to.date).toBe('2026-05-26')
+    expect(diff.dayCount).toBe(1)
+  })
+
+  it('counts distinguished from clubPerformance, NOT totals (Lesson 115)', () => {
+    // totals.distinguishedClubs stays 0 in both; clubPerformance tells the truth.
+    const from = snapshot({
+      date: '2026-05-25',
+      clubs: [club({ clubId: '001' }), club({ clubId: '002' })],
+      perf: [perf('001', 'D'), perf('002', '')],
+    })
+    const to = snapshot({
+      date: '2026-05-26',
+      clubs: [club({ clubId: '001' }), club({ clubId: '002' })],
+      perf: [perf('001', 'D'), perf('002', 'S')],
+    })
+    const diff = diffSnapshots(from, to)
+    // 1 distinguished -> 2 distinguished, despite totals.distinguishedClubs == 0
+    expect(diff.totals.distinguished).toEqual({ from: 1, to: 2, delta: 1 })
+  })
+
+  it('partitions clubs into bothPresent / onlyInFrom / onlyInTo', () => {
+    const from = snapshot({
+      date: '2026-05-25',
+      clubs: [club({ clubId: '001' }), club({ clubId: 'gone' })],
+    })
+    const to = snapshot({
+      date: '2026-05-26',
+      clubs: [club({ clubId: '001' }), club({ clubId: 'new' })],
+    })
+    const diff = diffSnapshots(from, to)
+    expect(diff.clubs.bothPresent.map(c => c.clubId)).toEqual(['001'])
+    expect(diff.clubs.onlyInFrom.map(c => c.clubId)).toEqual(['gone'])
+    expect(diff.clubs.onlyInTo.map(c => c.clubId)).toEqual(['new'])
+  })
+
+  it('classifies roster appear/disappear with clubStatus, not as an error (Lesson 118)', () => {
+    const from = snapshot({
+      date: '2026-05-25',
+      clubs: [club({ clubId: 'susp', clubStatus: 'Suspended' })],
+    })
+    const to = snapshot({
+      date: '2026-05-26',
+      clubs: [club({ clubId: 'new', clubStatus: 'Active' })],
+    })
+    const diff = diffSnapshots(from, to)
+    expect(diff.clubs.onlyInFrom[0]?.clubStatus).toBe('Suspended')
+    expect(diff.clubs.onlyInTo[0]?.clubStatus).toBe('Active')
+    const added = diff.events.find(e => e.category === 'club-added')
+    const removed = diff.events.find(e => e.category === 'club-removed')
+    expect(added?.label).toMatch(/Active/)
+    expect(removed?.label).toMatch(/Suspended/)
+  })
+
+  it('emits a per-club ClubDiff with signed membership/dcpGoals/distinguished change', () => {
+    const from = snapshot({
+      date: '2026-05-25',
+      clubs: [club({ clubId: '001', membershipCount: 20, dcpGoals: 3 })],
+      perf: [perf('001', '')],
+    })
+    const to = snapshot({
+      date: '2026-05-26',
+      clubs: [club({ clubId: '001', membershipCount: 18, dcpGoals: 6 })],
+      perf: [perf('001', 'D')],
+    })
+    const cd = diffSnapshots(from, to).clubs.bothPresent[0]!
+    expect(cd.membership.delta).toBe(-2)
+    expect(cd.dcpGoals.delta).toBe(3)
+    expect(cd.distinguishedFrom).toBe('')
+    expect(cd.distinguishedTo).toBe('D')
+    expect(cd.distinguishedChanged).toBe(true)
+  })
+
+  it('produces categorized events for every change kind', () => {
+    const from = snapshot({
+      date: '2026-05-25',
+      clubs: [
+        club({ clubId: '001', membershipCount: 20, dcpGoals: 2 }),
+        club({ clubId: 'gone' }),
+      ],
+      perf: [perf('001', ''), perf('gone', '')],
+    })
+    const to = snapshot({
+      date: '2026-05-26',
+      clubs: [
+        club({ clubId: '001', membershipCount: 23, dcpGoals: 5 }),
+        club({ clubId: 'new' }),
+      ],
+      perf: [perf('001', 'D'), perf('new', '')],
+    })
+    const cats = new Set(diffSnapshots(from, to).events.map(e => e.category))
+    expect(cats).toEqual(
+      new Set([
+        'membership',
+        'dcp-goals',
+        'distinguished',
+        'club-added',
+        'club-removed',
+      ])
+    )
+  })
+
+  it('returns no events when nothing changed (valid outcome)', () => {
+    const a = snapshot({
+      date: '2026-05-25',
+      clubs: [club({ clubId: '001' })],
+    })
+    const b = snapshot({
+      date: '2026-05-26',
+      clubs: [club({ clubId: '001' })],
+    })
+    expect(diffSnapshots(a, b).events).toEqual([])
+  })
+
+  it('sorts events by descending absolute magnitude', () => {
+    const from = snapshot({
+      date: '2026-05-25',
+      clubs: [
+        club({ clubId: 'big', membershipCount: 20 }),
+        club({ clubId: 'small', membershipCount: 20 }),
+      ],
+    })
+    const to = snapshot({
+      date: '2026-05-26',
+      clubs: [
+        club({ clubId: 'big', membershipCount: 30 }),
+        club({ clubId: 'small', membershipCount: 19 }),
+      ],
+    })
+    const events = diffSnapshots(from, to).events
+    expect(Math.abs(events[0]!.magnitude)).toBeGreaterThanOrEqual(
+      Math.abs(events[1]!.magnitude)
+    )
+    expect(events[0]!.clubId).toBe('big')
+  })
+
+  it('tolerates null distinguished status from clubPerformance', () => {
+    const from = snapshot({
+      date: '2026-05-25',
+      clubs: [club({ clubId: '001' })],
+      perf: [perf('001', null)],
+    })
+    const to = snapshot({
+      date: '2026-05-26',
+      clubs: [club({ clubId: '001' })],
+      perf: [perf('001', null)],
+    })
+    const diff = diffSnapshots(from, to)
+    expect(diff.totals.distinguished).toEqual({ from: 0, to: 0, delta: 0 })
+    expect(diff.clubs.bothPresent[0]!.distinguishedChanged).toBe(false)
+  })
+})

--- a/packages/analytics-core/src/analytics/diffSnapshots.ts
+++ b/packages/analytics-core/src/analytics/diffSnapshots.ts
@@ -1,0 +1,228 @@
+/**
+ * Pure snapshot-to-snapshot diff engine ("What Changed", epic #797 Sprint 1).
+ *
+ * `diffSnapshots(from, to)` takes two dated `DistrictStatisticsFile` snapshots
+ * and returns a `SnapshotDiff`: aggregate KPI deltas, a three-way club
+ * partition, and a categorized, narrative-ready event list. No I/O — reusable
+ * by a future collector pre-compute step (Phase 4) without rewrite.
+ *
+ * Load-bearing data facts (verified against live staging CDN, 2026-05-27):
+ *   - Distinguished counts/flips come from raw `clubPerformance`
+ *     "Club Distinguished Status" (`'' | D | S | P | M`), NOT `totals.*` —
+ *     those are unpopulated mid-year and would always read 0 (Lesson 115).
+ *   - Roster appear/disappear is a visibility/status signal, classified by
+ *     `clubStatus`, never an error (Lesson 118).
+ *   - DCP signals use the raw `dcpGoals` count, never inferred Goals 1-N order.
+ *
+ * @module diffSnapshots
+ * @see docs/design/what-changed-feature.md §3-§4
+ */
+
+import type {
+  DistrictStatisticsFile,
+  ClubStatisticsFile,
+  AggregateDelta,
+  ClubDiff,
+  ClubPresence,
+  DiffEvent,
+  SnapshotDiff,
+} from '@toastmasters/shared-contracts'
+
+function aggregate(from: number, to: number): AggregateDelta {
+  return { from, to, delta: to - from }
+}
+
+/** Calendar days between two YYYY-MM-DD dates (absolute, whole days). */
+function dayCountBetween(fromDate: string, toDate: string): number {
+  const a = Date.parse(`${fromDate}T00:00:00Z`)
+  const b = Date.parse(`${toDate}T00:00:00Z`)
+  if (Number.isNaN(a) || Number.isNaN(b)) return 0
+  return Math.round(Math.abs(b - a) / 86_400_000)
+}
+
+/** Per-club distinguished status code keyed by clubId, from clubPerformance. */
+function distinguishedByClub(
+  snapshot: DistrictStatisticsFile
+): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const row of snapshot.clubPerformance) {
+    const clubId = String(row['Club Number'] ?? '')
+    if (!clubId) continue
+    const raw = row['Club Distinguished Status']
+    map.set(clubId, raw == null ? '' : String(raw))
+  }
+  return map
+}
+
+const TIER_NAMES: Record<string, string> = {
+  D: 'Distinguished',
+  S: 'Select Distinguished',
+  P: "President's Distinguished",
+  M: 'Distinguished',
+}
+
+function tierName(code: string): string {
+  return TIER_NAMES[code] ?? 'Distinguished'
+}
+
+function membershipLabel(name: string, delta: number): string {
+  const n = Math.abs(delta)
+  const noun = n === 1 ? 'member' : 'members'
+  return delta > 0 ? `${name} gained ${n} ${noun}` : `${name} lost ${n} ${noun}`
+}
+
+function dcpLabel(name: string, delta: number): string {
+  const n = Math.abs(delta)
+  const noun = n === 1 ? 'goal' : 'goals'
+  return delta > 0
+    ? `${name} met ${n} more DCP ${noun}`
+    : `${name} dropped ${n} DCP ${noun}`
+}
+
+function distinguishedLabel(name: string, from: string, to: string): string {
+  if (!from && to) return `${name} became ${tierName(to)}`
+  if (from && !to) return `${name} lost Distinguished status`
+  return `${name} moved to ${tierName(to)}`
+}
+
+function presence(club: ClubStatisticsFile): ClubPresence {
+  return {
+    clubId: club.clubId,
+    clubName: club.clubName,
+    divisionId: club.divisionId,
+    areaId: club.areaId,
+    clubStatus: club.clubStatus ?? club.status,
+  }
+}
+
+function rosterLabel(verb: string, club: ClubStatisticsFile): string {
+  const status = club.clubStatus ?? club.status
+  return `${club.clubName} (${status}) ${verb} the roster`
+}
+
+export function diffSnapshots(
+  from: DistrictStatisticsFile,
+  to: DistrictStatisticsFile
+): SnapshotDiff {
+  const fromDist = distinguishedByClub(from)
+  const toDist = distinguishedByClub(to)
+
+  const fromClubs = new Map(from.clubs.map(c => [c.clubId, c]))
+  const toClubs = new Map(to.clubs.map(c => [c.clubId, c]))
+
+  const distinguishedCount = (m: Map<string, string>): number =>
+    [...m.values()].filter(s => s !== '').length
+
+  const bothPresent: ClubDiff[] = []
+  const onlyInFrom: ClubPresence[] = []
+  const onlyInTo: ClubPresence[] = []
+  const events: DiffEvent[] = []
+
+  for (const [clubId, fromClub] of fromClubs) {
+    const toClub = toClubs.get(clubId)
+    if (!toClub) {
+      onlyInFrom.push(presence(fromClub))
+      events.push({
+        category: 'club-removed',
+        clubId,
+        clubName: fromClub.clubName,
+        label: rosterLabel('left', fromClub),
+        magnitude: -1,
+      })
+      continue
+    }
+
+    const distFrom = fromDist.get(clubId) ?? ''
+    const distTo = toDist.get(clubId) ?? ''
+    const membership = aggregate(
+      fromClub.membershipCount,
+      toClub.membershipCount
+    )
+    const payments = aggregate(fromClub.paymentsCount, toClub.paymentsCount)
+    const dcpGoals = aggregate(fromClub.dcpGoals, toClub.dcpGoals)
+
+    bothPresent.push({
+      clubId,
+      clubName: toClub.clubName,
+      divisionId: toClub.divisionId,
+      areaId: toClub.areaId,
+      membership,
+      payments,
+      dcpGoals,
+      distinguishedFrom: distFrom,
+      distinguishedTo: distTo,
+      distinguishedChanged: distFrom !== distTo,
+    })
+
+    if (membership.delta !== 0) {
+      events.push({
+        category: 'membership',
+        clubId,
+        clubName: toClub.clubName,
+        label: membershipLabel(toClub.clubName, membership.delta),
+        magnitude: membership.delta,
+      })
+    }
+    if (dcpGoals.delta !== 0) {
+      events.push({
+        category: 'dcp-goals',
+        clubId,
+        clubName: toClub.clubName,
+        label: dcpLabel(toClub.clubName, dcpGoals.delta),
+        magnitude: dcpGoals.delta,
+      })
+    }
+    if (distFrom !== distTo) {
+      const gained = !distFrom && distTo
+      const lost = distFrom && !distTo
+      events.push({
+        category: 'distinguished',
+        clubId,
+        clubName: toClub.clubName,
+        label: distinguishedLabel(toClub.clubName, distFrom, distTo),
+        magnitude: gained ? 1 : lost ? -1 : 0,
+      })
+    }
+  }
+
+  for (const [clubId, toClub] of toClubs) {
+    if (fromClubs.has(clubId)) continue
+    onlyInTo.push(presence(toClub))
+    events.push({
+      category: 'club-added',
+      clubId,
+      clubName: toClub.clubName,
+      label: rosterLabel('joined', toClub),
+      magnitude: 1,
+    })
+  }
+
+  // Biggest absolute change first; stable tie-break by name then clubId.
+  events.sort((a, b) => {
+    const byMag = Math.abs(b.magnitude) - Math.abs(a.magnitude)
+    if (byMag !== 0) return byMag
+    const byName = a.clubName.localeCompare(b.clubName)
+    return byName !== 0 ? byName : a.clubId.localeCompare(b.clubId)
+  })
+
+  return {
+    districtId: to.districtId,
+    from: { date: from.snapshotDate },
+    to: { date: to.snapshotDate },
+    dayCount: dayCountBetween(from.snapshotDate, to.snapshotDate),
+    totals: {
+      membership: aggregate(
+        from.totals.totalMembership,
+        to.totals.totalMembership
+      ),
+      payments: aggregate(from.totals.totalPayments, to.totals.totalPayments),
+      clubCount: aggregate(from.totals.totalClubs, to.totals.totalClubs),
+      distinguished: aggregate(
+        distinguishedCount(fromDist),
+        distinguishedCount(toDist)
+      ),
+    },
+    clubs: { bothPresent, onlyInFrom, onlyInTo },
+    events,
+  }
+}

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -17,6 +17,9 @@ export {
 export { DataTransformer } from './transformation/index.js'
 export type { Logger, DataTransformerConfig } from './transformation/index.js'
 
+// Snapshot diff engine ("What Changed", epic #797)
+export { diffSnapshots } from './analytics/diffSnapshots.js'
+
 // Analytics computation
 export {
   AnalyticsComputer,

--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -103,6 +103,26 @@ export {
   type ClubHealthStatusSchemaType,
 } from './schemas/club-health-status.schema.js'
 
+// Snapshot diff ("What Changed", epic #797) — schema + inferred types
+export {
+  AggregateDeltaSchema,
+  DiffEventCategorySchema,
+  ClubDiffSchema,
+  ClubPresenceSchema,
+  DiffEventSchema,
+  SnapshotDiffSideSchema,
+  SnapshotDiffTotalsSchema,
+  SnapshotDiffSchema,
+  type AggregateDelta,
+  type DiffEventCategory,
+  type ClubDiff,
+  type ClubPresence,
+  type DiffEvent,
+  type SnapshotDiffSide,
+  type SnapshotDiffTotals,
+  type SnapshotDiff,
+} from './schemas/snapshot-diff.schema.js'
+
 // Validation helpers
 export {
   validatePerDistrictData,

--- a/packages/shared-contracts/src/schemas/snapshot-diff.schema.ts
+++ b/packages/shared-contracts/src/schemas/snapshot-diff.schema.ts
@@ -1,0 +1,114 @@
+/**
+ * Zod schema + inferred types for the snapshot-to-snapshot diff
+ * ("What Changed", epic #797).
+ *
+ * The diff is computed by the pure `diffSnapshots(from, to)` engine in
+ * analytics-core from two dated `DistrictStatisticsFile` snapshots and consumed
+ * by the frontend `useSnapshotDiff` hook / `DistrictChangesPage`.
+ *
+ * Types are inferred from the schema (single source of truth) — same convention
+ * as snapshot-pointer.schema.ts.
+ *
+ * @module snapshot-diff.schema
+ * @see docs/design/what-changed-feature.md §4
+ */
+
+import { z } from 'zod'
+
+/** A signed before/after pair. `delta === to - from`. */
+export const AggregateDeltaSchema = z.object({
+  from: z.number(),
+  to: z.number(),
+  delta: z.number(),
+})
+export type AggregateDelta = z.infer<typeof AggregateDeltaSchema>
+
+/**
+ * Category of a single change event. Payments is intentionally aggregate-only
+ * in Phase 1 (per-club payment churn would double the membership noise).
+ */
+export const DiffEventCategorySchema = z.enum([
+  'membership',
+  'dcp-goals',
+  'distinguished',
+  'club-added',
+  'club-removed',
+])
+export type DiffEventCategory = z.infer<typeof DiffEventCategorySchema>
+
+/** Per-club delta for a club present in BOTH snapshots. */
+export const ClubDiffSchema = z.object({
+  clubId: z.string(),
+  clubName: z.string(),
+  divisionId: z.string(),
+  areaId: z.string(),
+  membership: AggregateDeltaSchema,
+  payments: AggregateDeltaSchema,
+  dcpGoals: AggregateDeltaSchema,
+  /**
+   * Raw `clubPerformance` "Club Distinguished Status" code
+   * (`'' | D | S | P | M`). Authoritative per-club tier — `totals.*` distinguished
+   * counts are unpopulated mid-year (Lesson 115). Never inferred from goal order.
+   */
+  distinguishedFrom: z.string(),
+  distinguishedTo: z.string(),
+  distinguishedChanged: z.boolean(),
+})
+export type ClubDiff = z.infer<typeof ClubDiffSchema>
+
+/**
+ * A club present in only one snapshot (joined or left the roster). Carries
+ * `clubStatus` so appear/disappear is classified, not flagged as an error
+ * (Lesson 118).
+ */
+export const ClubPresenceSchema = z.object({
+  clubId: z.string(),
+  clubName: z.string(),
+  divisionId: z.string(),
+  areaId: z.string(),
+  clubStatus: z.string().optional(),
+})
+export type ClubPresence = z.infer<typeof ClubPresenceSchema>
+
+/** A narrative-ready, categorized change event. `magnitude` is signed (sort key). */
+export const DiffEventSchema = z.object({
+  category: DiffEventCategorySchema,
+  clubId: z.string(),
+  clubName: z.string(),
+  label: z.string(),
+  magnitude: z.number(),
+})
+export type DiffEvent = z.infer<typeof DiffEventSchema>
+
+/** Minimal per-side summary (extended in later phases). */
+export const SnapshotDiffSideSchema = z.object({
+  date: z.string(),
+})
+export type SnapshotDiffSide = z.infer<typeof SnapshotDiffSideSchema>
+
+/** District-level aggregate deltas — the four KPI cards. */
+export const SnapshotDiffTotalsSchema = z.object({
+  membership: AggregateDeltaSchema,
+  payments: AggregateDeltaSchema,
+  clubCount: AggregateDeltaSchema,
+  /** Count of clubs with any distinguished status, from `clubPerformance`. */
+  distinguished: AggregateDeltaSchema,
+})
+export type SnapshotDiffTotals = z.infer<typeof SnapshotDiffTotalsSchema>
+
+/** The complete diff between two dated district snapshots. */
+export const SnapshotDiffSchema = z.object({
+  districtId: z.string(),
+  from: SnapshotDiffSideSchema,
+  to: SnapshotDiffSideSchema,
+  /** Calendar days between from.date and to.date (honest about sparse gaps). */
+  dayCount: z.number(),
+  totals: SnapshotDiffTotalsSchema,
+  clubs: z.object({
+    bothPresent: z.array(ClubDiffSchema),
+    onlyInFrom: z.array(ClubPresenceSchema),
+    onlyInTo: z.array(ClubPresenceSchema),
+  }),
+  events: z.array(DiffEventSchema),
+})
+export type SnapshotDiff = z.infer<typeof SnapshotDiffSchema>


### PR DESCRIPTION
## Sprint 1 of epic #797 — "What Changed" snapshot-to-snapshot diff

Ships the diff engine and the **default district digest** at
`/district/:districtId/changes` — "what changed since the previous recorded
date." Refs #793.

### What landed
- **`packages/shared-contracts`** — `SnapshotDiff` Zod schema + inferred types
  (`AggregateDelta`, `ClubDiff`, `ClubPresence`, `DiffEvent`).
- **`packages/analytics-core`** — pure `diffSnapshots(from, to): SnapshotDiff`:
  aggregate KPI deltas, three-way club partition
  (`bothPresent`/`onlyInFrom`/`onlyInTo`), categorized event list. No I/O —
  reusable by a future collector pre-compute (Phase 4).
- **`frontend`** — `useSnapshotDiff` hook (keyed by the date pair) +
  `previousRecordedDate` helper over the per-district index `[-2]`;
  `DistrictChangesPage` (lazy route) with narrative headline, 4 KPI cards
  (reusing the existing `KpiDeltaCard` from #681), and a grouped collapsible
  change list; `DistrictSubnav` "What Changed" link.
- **`docs/design/what-changed-feature.md`** — authored (was referenced but
  missing).

### Load-bearing data findings (verified vs live staging CDN, D61)
- Diff reads two actual dated `snapshots/{date}/district_{id}.json` files, never
  the single-snapshot `_analytics.json` delta fields (Lesson 115).
- **Distinguished counts/flips come from raw `clubPerformance`
  "Club Distinguished Status", NOT `totals.distinguishedClubs`** — the latter
  reads `0` mid-year even when 49–50 clubs are distinguished (Lesson 115 trap,
  caught and tested).
- Roster appear/disappear classified by `clubStatus`, never an error (Lesson 118).
- DCP signals from raw goal fields, never inferred Goals 1–N order (tripwire).

### Tests
- `diffSnapshots` — 9 unit tests (aggregates, all 3 partitions, every event
  category, distinguished-from-clubPerformance, null tolerance, sort), failing
  test first.
- `useSnapshotDiff` / `previousRecordedDate` — 4 tests.
- `DistrictChangesPage` — 3 tests (real diff, no-changes, single-snapshot).
- `DistrictSubnav` — updated for the new section.
- Full suite green: frontend 2827, analytics-core 812, shared-contracts 134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
