### PR TITLE
feat(changes): Phase 2 — arbitrary date-pair picker (from/to, URL-synced) (#794)

### DIFF
--- a/frontend/src/components/DatePairPicker.tsx
+++ b/frontend/src/components/DatePairPicker.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { formatDisplayDate } from '../utils/dateFormatting'
+
+/* From/To date-pair picker for the "What Changed" digest (#794, epic #797
+   Sprint 2). Mirrors DataControlsBar's chip pattern: a visible pill label with
+   an invisible full-bleed native <select> on top — full keyboard a11y and the
+   platform popover, and the label (not the select) is the touch target, so the
+   44px minimum holds in WebKit too (Lesson 111). Offers only the dates this
+   district actually recorded; selections are reported up (the page owns the
+   pair, R3). */
+
+export interface DatePairPickerProps {
+  /** Ascending list of the district's recorded snapshot dates. */
+  dates: string[]
+  from: string | undefined
+  to: string | undefined
+  onFromChange: (date: string) => void
+  onToChange: (date: string) => void
+}
+
+const CHIP_BASE =
+  'inline-flex items-center gap-1.5 px-3 py-2 rounded-full text-xs font-medium border bg-white border-gray-200 text-gray-700 theme-dark:bg-gray-800 theme-dark:border-gray-700 theme-dark:text-gray-200'
+
+const DateChipSelect: React.FC<{
+  testId: string
+  label: string
+  value: string | undefined
+  options: string[]
+  onChange: (value: string) => void
+}> = ({ testId, label, value, options, onChange }) => (
+  <label
+    data-testid={testId}
+    className={`${CHIP_BASE} relative cursor-pointer hover:bg-gray-50 theme-dark:hover:bg-gray-700 focus-within:ring-2 focus-within:ring-tm-loyal-blue focus-within:ring-offset-1`}
+  >
+    <span className="text-gray-400 theme-dark:text-gray-500">{label}</span>
+    <span>{value ? formatDisplayDate(value) : '—'}</span>
+    <span aria-hidden="true" className="text-gray-400">
+      ▾
+    </span>
+    <select
+      data-testid={`${testId}-select`}
+      aria-label={
+        value ? `${label} date: ${formatDisplayDate(value)}` : `${label} date`
+      }
+      value={value ?? ''}
+      onChange={e => onChange(e.target.value)}
+      className="absolute inset-0 opacity-0 cursor-pointer"
+    >
+      {options.map(d => (
+        <option key={d} value={d}>
+          {formatDisplayDate(d)}
+        </option>
+      ))}
+    </select>
+  </label>
+)
+
+export const DatePairPicker: React.FC<DatePairPickerProps> = ({
+  dates,
+  from,
+  to,
+  onFromChange,
+  onToChange,
+}) => {
+  // Newest first in the dropdown — the recent dates are the common pick.
+  const sorted = [...dates].sort((a, b) => b.localeCompare(a))
+  return (
+    <div
+      role="group"
+      aria-label="Compare dates"
+      className="flex flex-wrap items-center gap-2"
+      data-testid="changes-date-pair-picker"
+    >
+      <DateChipSelect
+        testId="changes-from-chip"
+        label="From"
+        value={from}
+        options={sorted}
+        onChange={onFromChange}
+      />
+      <span aria-hidden="true" className="text-gray-400">
+        →
+      </span>
+      <DateChipSelect
+        testId="changes-to-chip"
+        label="To"
+        value={to}
+        options={sorted}
+        onChange={onToChange}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/__tests__/DatePairPicker.test.tsx
+++ b/frontend/src/components/__tests__/DatePairPicker.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DatePairPicker } from '../DatePairPicker'
+
+/* #794 (epic #797 Sprint 2) — the from/to picker for the "What Changed" page.
+   Offers only the district's recorded dates and reports selections up via
+   callbacks; the page owns the state (R3). */
+
+const DATES = ['2026-05-20', '2026-05-22', '2026-05-25', '2026-05-26']
+
+describe('DatePairPicker', () => {
+  it('renders a from and a to control reflecting the selected pair', () => {
+    render(
+      <DatePairPicker
+        dates={DATES}
+        from="2026-05-22"
+        to="2026-05-26"
+        onFromChange={vi.fn()}
+        onToChange={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('changes-from-chip')).toBeInTheDocument()
+    expect(screen.getByTestId('changes-to-chip')).toBeInTheDocument()
+    expect(screen.getByTestId('changes-from-chip-select')).toHaveValue(
+      '2026-05-22'
+    )
+    expect(screen.getByTestId('changes-to-chip-select')).toHaveValue(
+      '2026-05-26'
+    )
+  })
+
+  it('offers exactly the district index dates as from options', () => {
+    render(
+      <DatePairPicker
+        dates={DATES}
+        from="2026-05-22"
+        to="2026-05-26"
+        onFromChange={vi.fn()}
+        onToChange={vi.fn()}
+      />
+    )
+    const opts = Array.from(
+      screen.getByTestId('changes-from-chip-select').querySelectorAll('option')
+    ).map(o => (o as HTMLOptionElement).value)
+    expect(opts.sort()).toEqual([...DATES].sort())
+  })
+
+  it('reports a new from selection to onFromChange', async () => {
+    const user = userEvent.setup()
+    const onFromChange = vi.fn()
+    render(
+      <DatePairPicker
+        dates={DATES}
+        from="2026-05-22"
+        to="2026-05-26"
+        onFromChange={onFromChange}
+        onToChange={vi.fn()}
+      />
+    )
+    await user.selectOptions(
+      screen.getByTestId('changes-from-chip-select'),
+      '2026-05-20'
+    )
+    expect(onFromChange).toHaveBeenCalledWith('2026-05-20')
+  })
+})

--- a/frontend/src/hooks/__tests__/useUrlDatePair.test.tsx
+++ b/frontend/src/hooks/__tests__/useUrlDatePair.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { useUrlDatePair } from '../useUrlDatePair'
+
+/* #794 (epic #797 Sprint 2) — arbitrary date-pair picker, URL-synced.
+   The hook reads ?from / ?to, validates them against the district's recorded
+   dates, and falls back to the Phase-1 default (previous → latest) otherwise.
+   from/to round-trip through the URL (R3 — the page owns the pair). */
+
+const DATES = ['2026-05-20', '2026-05-22', '2026-05-25', '2026-05-26']
+
+/** Renders the hook's state + buttons that drive its setters, plus the live
+ *  search string so URL round-trips can be asserted directly. */
+const Harness: React.FC<{ dates?: string[] }> = ({ dates = DATES }) => {
+  const { from, to, setFrom, setTo } = useUrlDatePair(dates)
+  const { search } = useLocation()
+  return (
+    <div>
+      <span data-testid="from">{from ?? 'none'}</span>
+      <span data-testid="to">{to ?? 'none'}</span>
+      <span data-testid="search">{search}</span>
+      <button onClick={() => setFrom('2026-05-22')}>from-22</button>
+      <button onClick={() => setFrom('2026-05-20')}>from-default</button>
+      <button onClick={() => setTo('2026-05-25')}>to-25</button>
+      <button onClick={() => setTo('2026-05-26')}>to-default</button>
+    </div>
+  )
+}
+
+function renderAt(initialEntry: string, dates: string[] = DATES) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Harness dates={dates} />
+    </MemoryRouter>
+  )
+}
+
+describe('useUrlDatePair', () => {
+  it('defaults to previous → latest when no params are present', () => {
+    renderAt('/district/61/changes')
+    expect(screen.getByTestId('from')).toHaveTextContent('2026-05-25')
+    expect(screen.getByTestId('to')).toHaveTextContent('2026-05-26')
+  })
+
+  it('reads from/to out of the URL when both are present and valid', () => {
+    renderAt('/district/61/changes?from=2026-05-20&to=2026-05-25')
+    expect(screen.getByTestId('from')).toHaveTextContent('2026-05-20')
+    expect(screen.getByTestId('to')).toHaveTextContent('2026-05-25')
+  })
+
+  it('ignores a URL date that is not in this district index (falls back)', () => {
+    renderAt('/district/61/changes?from=2099-01-01&to=2026-05-25')
+    expect(screen.getByTestId('from')).toHaveTextContent('2026-05-25') // default
+    expect(screen.getByTestId('to')).toHaveTextContent('2026-05-25')
+  })
+
+  it('writes a non-default selection into the URL (round-trip)', async () => {
+    const user = userEvent.setup()
+    renderAt('/district/61/changes')
+    await user.click(screen.getByText('from-22'))
+    expect(screen.getByTestId('search')).toHaveTextContent('from=2026-05-22')
+    expect(screen.getByTestId('from')).toHaveTextContent('2026-05-22')
+  })
+
+  it('deletes the param when the selection equals the default (clean URL)', async () => {
+    const user = userEvent.setup()
+    renderAt('/district/61/changes?from=2026-05-22')
+    await user.click(screen.getByText('from-default'))
+    expect(screen.getByTestId('search')).not.toHaveTextContent('from=')
+    expect(screen.getByTestId('from')).toHaveTextContent('2026-05-20')
+  })
+
+  it('returns undefined when fewer than two dates exist', () => {
+    renderAt('/district/61/changes', ['2026-05-26'])
+    expect(screen.getByTestId('from')).toHaveTextContent('none')
+    expect(screen.getByTestId('to')).toHaveTextContent('none')
+  })
+})

--- a/frontend/src/hooks/__tests__/useUrlDatePair.test.tsx
+++ b/frontend/src/hooks/__tests__/useUrlDatePair.test.tsx
@@ -22,7 +22,7 @@ const Harness: React.FC<{ dates?: string[] }> = ({ dates = DATES }) => {
       <span data-testid="to">{to ?? 'none'}</span>
       <span data-testid="search">{search}</span>
       <button onClick={() => setFrom('2026-05-22')}>from-22</button>
-      <button onClick={() => setFrom('2026-05-20')}>from-default</button>
+      <button onClick={() => setFrom('2026-05-25')}>from-default</button>
       <button onClick={() => setTo('2026-05-25')}>to-25</button>
       <button onClick={() => setTo('2026-05-26')}>to-default</button>
     </div>
@@ -69,7 +69,7 @@ describe('useUrlDatePair', () => {
     renderAt('/district/61/changes?from=2026-05-22')
     await user.click(screen.getByText('from-default'))
     expect(screen.getByTestId('search')).not.toHaveTextContent('from=')
-    expect(screen.getByTestId('from')).toHaveTextContent('2026-05-20')
+    expect(screen.getByTestId('from')).toHaveTextContent('2026-05-25')
   })
 
   it('returns undefined when fewer than two dates exist', () => {

--- a/frontend/src/hooks/useUrlDatePair.ts
+++ b/frontend/src/hooks/useUrlDatePair.ts
@@ -1,0 +1,73 @@
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { previousRecordedDate } from './useSnapshotDiff'
+
+/**
+ * useUrlDatePair — URL-synced arbitrary date pair for the "What Changed" digest
+ * (#794, epic #797 Sprint 2).
+ *
+ * Reads `?from=YYYY-MM-DD&to=YYYY-MM-DD` from the URL. A param is honoured only
+ * when its value is one of the district's recorded snapshot `dates` (so a stale
+ * or hand-edited URL can't select a date the district never had). When a param
+ * is absent or invalid, that side falls back to the Phase-1 default — `from` =
+ * previous recorded date (`[-2]`), `to` = latest (`[-1]`) — so an empty URL
+ * reproduces the default digest exactly.
+ *
+ * The page owns this pair and passes `from`/`to` down as props (R3); the diff
+ * hook never re-derives them from response data.
+ *
+ * Setters mirror `useUrlProgramYear`: a selection equal to the default deletes
+ * its param (keeps shared URLs clean), any other value writes it, and a no-op
+ * write bails early so it can't clobber a same-batch URL update (Lesson 070).
+ *
+ * @param dates Ascending list of the district's recorded snapshot dates.
+ * @see docs/design/what-changed-feature.md §5, §4
+ */
+export function useUrlDatePair(dates: string[]): {
+  from: string | undefined
+  to: string | undefined
+  setFrom: (date: string) => void
+  setTo: (date: string) => void
+} {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const defaultPair = useMemo(() => previousRecordedDate(dates), [dates])
+
+  const urlFrom = searchParams.get('from')
+  const urlTo = searchParams.get('to')
+
+  // A URL value wins only if it's a date this district actually recorded;
+  // otherwise fall back to the Phase-1 default for that side.
+  const from = urlFrom && dates.includes(urlFrom) ? urlFrom : defaultPair?.from
+  const to = urlTo && dates.includes(urlTo) ? urlTo : defaultPair?.to
+
+  const setParam = useCallback(
+    (key: 'from' | 'to', date: string, current: string | undefined) => {
+      if (date === current) return // no-op — don't churn history (Lesson 070)
+      const isDefault = defaultPair
+        ? date === (key === 'from' ? defaultPair.from : defaultPair.to)
+        : false
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          if (isDefault) next.delete(key)
+          else next.set(key, date)
+          return next
+        },
+        { replace: true }
+      )
+    },
+    [setSearchParams, defaultPair]
+  )
+
+  const setFrom = useCallback(
+    (date: string) => setParam('from', date, from),
+    [setParam, from]
+  )
+  const setTo = useCallback(
+    (date: string) => setParam('to', date, to),
+    [setParam, to]
+  )
+
+  return { from, to, setFrom, setTo }
+}

--- a/frontend/src/pages/DistrictChangesPage.tsx
+++ b/frontend/src/pages/DistrictChangesPage.tsx
@@ -3,9 +3,11 @@ import { useParams } from 'react-router-dom'
 import { useDistricts } from '../hooks/useDistricts'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
-import { useSnapshotDiff, previousRecordedDate } from '../hooks/useSnapshotDiff'
+import { useSnapshotDiff } from '../hooks/useSnapshotDiff'
+import { useUrlDatePair } from '../hooks/useUrlDatePair'
 import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
 import { DistrictSubnav } from '../components/DistrictSubnav'
+import { DatePairPicker } from '../components/DatePairPicker'
 import { KpiDeltaCard } from '../components/KpiDeltaCard'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import ErrorBoundary from '../components/ErrorBoundary'
@@ -14,10 +16,11 @@ import type {
   DiffEventCategory,
 } from '@toastmasters/shared-contracts'
 
-/* District "What Changed" page (#793, epic #797 Sprint 1, ADR-005 §1).
-   Default digest — what changed between the district's previous recorded
-   snapshot date and the latest one. No date picker yet (Phase 2, #794); the
-   from/to pair is owned here and passed to useSnapshotDiff as props (R3). */
+/* District "What Changed" page (#793, epic #797 Sprint 1–2, ADR-005 §1).
+   What changed between two recorded snapshot dates. The from/to pair is owned
+   here via useUrlDatePair (URL-synced, #794) and passed to useSnapshotDiff as
+   props (R3); empty params fall back to the Phase-1 default (previous → latest).
+   from === to is an explicit "pick two different dates" case (R17). */
 
 /** Human-friendly date, e.g. "May 25, 2026". Date-only, UTC-safe. */
 function fmtDate(iso: string): string {
@@ -77,13 +80,17 @@ const DistrictChangesPage: React.FC = () => {
     districtId || ''
   )
   const dates = useMemo(() => cachedDates?.dates ?? [], [cachedDates?.dates])
-  const pair = useMemo(() => previousRecordedDate(dates), [dates])
+  const { from, to, setFrom, setTo } = useUrlDatePair(dates)
+
+  // from === to has no meaningful diff — surface an explicit prompt (R17) and
+  // skip the fetch rather than rendering an all-zero "nothing changed" digest.
+  const sameDate = !!from && !!to && from === to
 
   const {
     data: diff,
     isLoading: diffLoading,
     isError,
-  } = useSnapshotDiff(districtId, pair?.from, pair?.to)
+  } = useSnapshotDiff(districtId, from, sameDate ? undefined : to)
 
   const eventsByCategory = useMemo(() => {
     const map = new Map<DiffEventCategory, DiffEvent[]>()
@@ -113,6 +120,18 @@ const DistrictChangesPage: React.FC = () => {
           <DistrictSubnav districtId={districtId} />
 
           <section aria-label="What changed" className="district-changes">
+            {enoughHistory && (
+              <div className="district-changes__controls">
+                <DatePairPicker
+                  dates={dates}
+                  from={from}
+                  to={to}
+                  onFromChange={setFrom}
+                  onToChange={setTo}
+                />
+              </div>
+            )}
+
             {onlyOneSnapshot && (
               <p
                 className="district-changes__empty"
@@ -124,11 +143,20 @@ const DistrictChangesPage: React.FC = () => {
               </p>
             )}
 
-            {enoughHistory && (datesLoading || diffLoading) && (
+            {enoughHistory && sameDate && (
+              <p
+                className="district-changes__empty"
+                data-testid="changes-same-date"
+              >
+                Pick two different dates to see what changed.
+              </p>
+            )}
+
+            {enoughHistory && !sameDate && (datesLoading || diffLoading) && (
               <LoadingSkeleton variant="card" height="220px" />
             )}
 
-            {enoughHistory && isError && (
+            {enoughHistory && !sameDate && isError && (
               <p
                 className="district-changes__empty"
                 data-testid="changes-error"
@@ -138,7 +166,7 @@ const DistrictChangesPage: React.FC = () => {
               </p>
             )}
 
-            {diff && (
+            {!sameDate && diff && (
               <>
                 <p
                   className="district-changes__headline"

--- a/frontend/src/pages/DistrictChangesPage.tsx
+++ b/frontend/src/pages/DistrictChangesPage.tsx
@@ -82,15 +82,20 @@ const DistrictChangesPage: React.FC = () => {
   const dates = useMemo(() => cachedDates?.dates ?? [], [cachedDates?.dates])
   const { from, to, setFrom, setTo } = useUrlDatePair(dates)
 
-  // from === to has no meaningful diff — surface an explicit prompt (R17) and
-  // skip the fetch rather than rendering an all-zero "nothing changed" digest.
+  // The pair must be two distinct dates with from strictly before to. Each
+  // invalid shape gets its own explicit prompt (R17) and skips the fetch —
+  // from === to would diff to an all-zero "nothing changed" digest, and
+  // from > to would render reversed (negative) deltas under a "what changed"
+  // header. Dates are ISO YYYY-MM-DD, so string comparison is chronological.
   const sameDate = !!from && !!to && from === to
+  const reversed = !!from && !!to && from > to
+  const invalidPair = sameDate || reversed
 
   const {
     data: diff,
     isLoading: diffLoading,
     isError,
-  } = useSnapshotDiff(districtId, from, sameDate ? undefined : to)
+  } = useSnapshotDiff(districtId, from, invalidPair ? undefined : to)
 
   const eventsByCategory = useMemo(() => {
     const map = new Map<DiffEventCategory, DiffEvent[]>()
@@ -152,11 +157,20 @@ const DistrictChangesPage: React.FC = () => {
               </p>
             )}
 
-            {enoughHistory && !sameDate && (datesLoading || diffLoading) && (
+            {enoughHistory && reversed && (
+              <p
+                className="district-changes__empty"
+                data-testid="changes-reversed"
+              >
+                Pick a “from” date that comes before the “to” date.
+              </p>
+            )}
+
+            {enoughHistory && !invalidPair && (datesLoading || diffLoading) && (
               <LoadingSkeleton variant="card" height="220px" />
             )}
 
-            {enoughHistory && !sameDate && isError && (
+            {enoughHistory && !invalidPair && isError && (
               <p
                 className="district-changes__empty"
                 data-testid="changes-error"
@@ -166,7 +180,7 @@ const DistrictChangesPage: React.FC = () => {
               </p>
             )}
 
-            {!sameDate && diff && (
+            {!invalidPair && diff && (
               <>
                 <p
                   className="district-changes__headline"

--- a/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
@@ -20,9 +20,9 @@ const mockedDates = vi.mocked(useDistrictCachedDates)
 const mockedDiff = vi.mocked(useSnapshotDiff)
 const mockedDistricts = vi.mocked(useDistricts)
 
-function renderPage() {
+function renderPage(initialEntry = '/district/61/changes') {
   return render(
-    <MemoryRouter initialEntries={['/district/61/changes']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route
           path="/district/:districtId/changes"
@@ -97,6 +97,46 @@ describe('DistrictChangesPage', () => {
     expect(
       screen.getByText('iA Montreal Toastmasters (Active) joined the roster')
     ).toBeInTheDocument()
+  })
+
+  it('renders the date-pair picker when at least two snapshots exist (#794)', () => {
+    mockedDates.mockReturnValue({
+      data: { dates: ['2026-05-25', '2026-05-26'] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDistrictCachedDates>)
+    mockedDiff.mockReturnValue({
+      data: diffFixture(),
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useSnapshotDiff>)
+
+    renderPage()
+    expect(screen.getByTestId('changes-date-pair-picker')).toBeInTheDocument()
+    expect(screen.getByTestId('changes-from-chip-select')).toHaveValue(
+      '2026-05-25'
+    )
+    expect(screen.getByTestId('changes-to-chip-select')).toHaveValue(
+      '2026-05-26'
+    )
+  })
+
+  it('shows "Pick two different dates" when from === to (#794, R17)', () => {
+    mockedDates.mockReturnValue({
+      data: { dates: ['2026-05-25', '2026-05-26'] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDistrictCachedDates>)
+    mockedDiff.mockReturnValue({
+      data: diffFixture(),
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useSnapshotDiff>)
+
+    renderPage('/district/61/changes?from=2026-05-26&to=2026-05-26')
+    expect(screen.getByTestId('changes-same-date')).toBeInTheDocument()
+    expect(screen.queryByTestId('changes-headline')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('changes-list')).not.toBeInTheDocument()
+    // the picker stays visible so the user can correct the pair
+    expect(screen.getByTestId('changes-date-pair-picker')).toBeInTheDocument()
   })
 
   it('shows a "no recorded changes" message when the diff has no events', () => {

--- a/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
@@ -139,6 +139,24 @@ describe('DistrictChangesPage', () => {
     expect(screen.getByTestId('changes-date-pair-picker')).toBeInTheDocument()
   })
 
+  it('shows a "from before to" message when from > to (#794, R17)', () => {
+    mockedDates.mockReturnValue({
+      data: { dates: ['2026-05-25', '2026-05-26'] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDistrictCachedDates>)
+    mockedDiff.mockReturnValue({
+      data: diffFixture(),
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useSnapshotDiff>)
+
+    renderPage('/district/61/changes?from=2026-05-26&to=2026-05-25')
+    expect(screen.getByTestId('changes-reversed')).toBeInTheDocument()
+    expect(screen.queryByTestId('changes-headline')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('changes-list')).not.toBeInTheDocument()
+    expect(screen.getByTestId('changes-date-pair-picker')).toBeInTheDocument()
+  })
+
   it('shows a "no recorded changes" message when the diff has no events', () => {
     mockedDates.mockReturnValue({
       data: { dates: ['2026-05-25', '2026-05-26'] },

--- a/frontend/src/styles/components/district-changes.css
+++ b/frontend/src/styles/components/district-changes.css
@@ -17,6 +17,13 @@
   gap: 1rem;
 }
 
+.district-changes__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
 .district-changes__headline {
   font-family: var(--sans);
   font-size: 1rem;

--- a/tasks/lessons/124-validate-url-synced-range-state-at-the-page-not-the-picker.md
+++ b/tasks/lessons/124-validate-url-synced-range-state-at-the-page-not-the-picker.md
@@ -1,0 +1,61 @@
+---
+id: '124'
+category: lesson
+tags: [router, react, hooks, frontend, verification]
+auto_load: true
+date: 2026-05-27
+issues: [794, 797]
+---
+
+# Lesson 124 — Validate URL-synced range state at the page that owns it, not at the picker
+
+**Date:** 2026-05-27
+**Issue:** #794 (epic #797 Sprint 2 — arbitrary from/to date-pair picker)
+
+## What happened
+
+The "What Changed" page added a `?from=&to=` date-pair picker (`useUrlDatePair`
+
+- `DatePairPicker`). The natural instinct is to make the **picker** enforce a
+  valid pair — e.g. only offer `to` dates after the selected `from`. But the pair
+  is URL state: a shared or hand-edited link (`?from=2026-05-26&to=2026-05-20`)
+  arrives **without ever going through the picker's option list.** Any constraint
+  expressed only in the dropdown is bypassed by the very mechanism (a shareable
+  URL) the feature exists to support.
+
+R17 ("an explicit case for every value") then bites twice, not once. `from ===
+to` is the obvious invalid shape and got a guard early; `from > to` is the
+second one and was initially missed — it silently rendered **reversed,
+negative deltas** under a "Changes … from May 26 to May 20" header, because
+`delta = to − from` is honestly negative and `dayCount` is `Math.abs`-padded so
+the gap looked normal. Fresh-context review caught it.
+
+## The principle
+
+**Validate range/pair state at the page that owns it (R3), where every entry
+path converges — typed URL, shared link, back-button, and picker click all
+funnel through the same render.** A constraint placed only on the input widget
+guards one of those paths. When you enumerate the invalid shapes (R17), a
+two-ended range has at least two — equal and reversed — each deserving its own
+explicit, distinct prompt, not a single catch-all that leaves one case to
+render garbage.
+
+## How to apply
+
+- For URL-synced range inputs, compute `invalid = sameEnds || reversed` (ISO
+  `YYYY-MM-DD` compares chronologically as strings) in the owning page, skip the
+  fetch (`enabled` gate) for invalid pairs, and render a per-shape message.
+- Don't rely on the picker's option list to prevent an invalid pair — it can't
+  see a hand-edited URL. The picker reports selections; the page judges them.
+- When you add the first invalid-case guard (`from === to`), immediately ask
+  "what are the _other_ invalid shapes of this value?" — that is R17 in
+  practice, and it's exactly the case a single happy-path test won't surface.
+
+## Related
+
+- [[070-setSearchParams-prev-races-in-batched-updates]] — sibling URL-state
+  lesson; the setters here use its bail-on-no-op pattern.
+- R3 (`tasks/rules.md`) — the page owns date/filter state and passes it as
+  props; this adds "and the page is therefore where you validate it."
+- R17 — explicit case for every value; a range has more invalid values than the
+  first one you notice.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -88,3 +88,4 @@
 - **121** [ci, tests, seo, verification, frontend] — A "presence-implying" audit may only validate; pair it with a drift guard (#782, #785)
 - **122** [ci, lighthouse, security, csp, verification, frontend] — A CSP in hosting config is invisible to the localhost Lighthouse gate; verify headers on the deployed surface (#783, #785)
 - **123** [analytics, data-pipeline, dcp, frontend, verification] — `totals.distinguished*` is unpopulated mid-year; count distinguished from `clubPerformance` (#793, #797)
+- **124** [router, react, hooks, frontend, verification] — Validate URL-synced range state at the page that owns it, not at the picker (#794, #797)


### PR DESCRIPTION
## Epic #797 "What Changed" — Sprint 2 (#794)

Adds an **arbitrary date-pair picker** to the District "What Changed" page so
leaders can diff any two recorded dates, not just previous → latest. Builds on
Sprint 1's `diffSnapshots` engine + default digest (#793, #801).

### What changed
- **`useUrlDatePair(dates)`** (`frontend/src/hooks/`) — URL-synced `?from=&to=`,
  mirroring `useUrlProgramYear`. A param is honoured only when its value is one
  of the district's recorded snapshot dates; otherwise that side falls back to
  the Phase-1 default (`from` = `[-2]`, `to` = `[-1]`), so an empty URL
  reproduces the default digest. Setters delete-on-default for clean shareable
  URLs and bail-on-no-op (Lesson 070).
- **`DatePairPicker`** (`frontend/src/components/`) — two From/To chips mirroring
  `DataControlsBar`'s overlay-`<select>` pattern (visible `<label>` is the touch
  target, so the 44px minimum holds in WebKit — Lesson 111). Offers only the
  district's recorded dates.
- **`DistrictChangesPage`** wired to the URL-synced pair (owned by the page,
  passed as props — R3). Two explicit invalid-pair guards (R17): `from === to`
  → "Pick two different dates"; `from > to` → "Pick a 'from' date that comes
  before the 'to' date". Both skip the fetch.

### Acceptance criteria
- [x] from/to selectable only from dates present in this district's index.
- [x] from/to round-trip through the URL (shareable, survives reload + back).
- [x] `from == to` shows "Pick two different dates" (R17).
- [x] Headline states the day-count gap (carried from Phase 1).
- [x] State owned by the page, passed as props (R3).
- [ ] Verify at 375/768/1280 + dark mode — pending PR preview channel.
- [ ] Zero regressions; CI green — full frontend suite green locally (2845).

### Process
- TDD throughout (failing test → minimal impl per unit).
- `/simplify` (no correctness fixes) + fresh-context `/review` (APPROVE-WITH-NITS;
  the one Medium — reversed `from>to` pair — was fixed in this branch).
- Lesson 124 filed: validate URL-synced range state at the owning page, not the
  picker (a hand-edited URL bypasses picker constraints).

Closes #794 on verification (label + epic tick handled by the runner protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
