### PR TITLE
docs(tables): ADR-006 — data-table page layout & column-model standard (#809)

### DIFF
--- a/docs/architecture-decisions/006-data-table-page-layout-and-column-model.md
+++ b/docs/architecture-decisions/006-data-table-page-layout-and-column-model.md
@@ -1,0 +1,169 @@
+# ADR-006: Data-table page layout & column-model standard
+
+**Status**: Accepted
+**Date**: 2026-05-27
+**Issue**: #809 (epic #813 — table UX program, Epic A foundational sprint)
+**Source review**: [`docs/design/table-ux-review-2026-05-27.md`](../design/table-ux-review-2026-05-27.md) §3 (architect), §4 (proposed epics)
+
+## Context
+
+The district landing table and the club table independently reinvent the same
+mechanism — `table-auto` + `whitespace-nowrap`, an `overflow-x-auto` wrapper,
+hand-tuned CSS widths, and hardcoded sticky pixels — with ad-hoc or absent
+responsive behaviour. The review doc grounds the specifics in code:
+
+- **Width.** `.districts-page { max-width: 1280px }` (`app-shell.css:389`) is a
+  prose-readability cap misapplied to a data grid; on a 2560px display ~half the
+  width is empty. The 13-column club table inside the same 1280 page (~1196px
+  usable) **cannot fit below ~1600px** → an obligatory horizontal-scroll trap on
+  nearly every desktop.
+- **Responsive.** The landing table has **zero `@media` rules** and no card view;
+  below ~1300px it forces horizontal scroll, and at 375px its two hardcoded sticky
+  columns (~380px) alone overflow the viewport. The club table has a single 640px
+  cliff that swaps the whole table for a card list — no tablet tier.
+- **No column model, no shared primitive.** Every new column is hand-wired CSS,
+  which is exactly why width keeps breaking. Recent column-adding branches (#688
+  distinguished-remaining, #687 base/current/Δ) and the in-flight #795 delta
+  columns keep widening a layer that has no abstraction to absorb them.
+
+This ADR locks the table-page standard up front so Epics A (full-width +
+responsive), B (filtering overhaul), and C (scalable column model + #795 delta
+columns) all build against one set of answers, and so future column additions
+don't re-break width. It is doc-only; the implementing sprints (#810–#812 and
+the B/C epics) apply it.
+
+## Decision
+
+### 1. Full-width policy — a dedicated `--page-max-wide` token
+
+Data-table pages use a wider cap; prose pages stay narrow.
+
+- **`--page-max-wide: 1600px`** — the new token. Applied to the data-table page
+  containers (`.districts-page`, `.district-detail-page`, and the club table
+  page) in Sprint 2 (#810).
+- **Prose / narrative pages keep `max-width: 1280px`** (the existing default).
+  The 1280 cap is a readability rule for text columns and stays there; it is not
+  the right cap for a data grid.
+
+A wider **capped** width was chosen over fluid/edge-to-edge (see Alternatives):
+1600px holds the club table's full column set without horizontal scroll on a
+standard desktop while still bounding line length on ultra-wide displays. Width
+is a CSS-token change (**R10** — override at the CSS level, reversible).
+
+### 2. Responsive breakpoint tiers
+
+Four tiers, matching the QE verification breakpoints (375 / 768 / 1280 / 1600):
+
+| Tier        | Range         | Layout                                                                                |
+| ----------- | ------------- | ------------------------------------------------------------------------------------- |
+| **Mobile**  | `< 768px`     | Card view only (true mobile). **No horizontal scroll at 375px.** ≥44px touch targets. |
+| **Tablet**  | `768–1279px`  | Table with **low-priority columns hidden**; sticky key column + visible scroll-cue.   |
+| **Desktop** | `1280–1599px` | Full table; sticky key column + scroll-cue as needed.                                 |
+| **Wide**    | `≥ 1600px`    | Full table, container capped at `--page-max-wide` (1600px).                           |
+
+The card view appears **only at true mobile**, not as a desktop→mobile cliff; the
+tablet tier degrades by hiding columns, not by swapping representations.
+
+### 3. Per-column priority responsive model
+
+Each table declares a **priority** per column. Degradation rules:
+
+- Columns hide in ascending priority order as the viewport narrows (tablet tier
+  hides the lowest-priority columns first).
+- The **key column** (district name / club name) is **sticky** and never hidden,
+  with a visible **scroll-cue** affordance when content is clipped.
+- Replace the **hardcoded sticky pixel offsets** with a robust sticky mechanism
+  (no `left: 120px` magic numbers).
+- No horizontal scroll at 375px; the card view carries the full record there.
+
+### 4. Per-table column descriptor (the column model)
+
+Each table defines its columns as descriptors — the basis for Epics A/B/C:
+
+```
+ColumnDescriptor {
+  id          // stable key
+  header      // display label
+  priority    // responsive hide order (lower hides first)
+  group       // for column-group show/hide (Identity / Membership /
+              //   Renewals / Recognition / Changes)
+  align       // 'left' | 'right' | 'center'
+  width/min   // explicit width or min-width (replaces table-auto guesswork)
+  sticky      // is this the sticky key column
+  visibility  // current shown/hidden state (drives tier hiding + group toggle)
+  formatter   // cell-render function
+}
+```
+
+This is introduced **per table first**. The existing filter pipeline
+`original → filtered → searchFiltered → sorted` stays intact (**R11**) — the
+column model and the UI overhaul are presentation over that pipeline, not a
+rewrite of it.
+
+### 5. Filter model — a dedicated Filters panel/drawer
+
+Decided 2026-05-27 (review §5 Q3). The club table consolidates its three current
+filtering mechanisms (status segmented control, quick-filter chips, hidden
+per-column header dropdowns) into:
+
+- **One visible search box** (club/name) at the top, URL-synced.
+- A **dedicated Filters panel/drawer** replacing the undiscoverable ~2.5px header
+  dropdowns; instant-apply (drop the mandatory "Apply" button).
+- **One intent-based preset row** (merge the two overlapping quick-filter sets;
+  remove the hidden auto-sort side effect on "Close to Distinguished").
+- An **active-filters summary bar** ("3 filters · Clear all") and a zero-results
+  empty state that names the offending filter. URL-sync all filters.
+
+This is the Epic B target; the column model (this ADR) is the substrate it sits on.
+
+### 6. Evaluate-then-extract for a shared `DataTable` primitive (R6)
+
+Introduce the **per-table column model now**; converge both tables onto it;
+**then** extract a shared headless `DataTable` primitive **only if the overlap
+proves real** once both tables have converged. We do not build a shared primitive
+up front — that is premature abstraction (**R6** — verify actual code overlap,
+don't assume from similar names). If the overlap turns out thin, Epic C's extract
+step closes won't-do.
+
+### 7. #795 delta columns land as an opt-in group, not always-on
+
+The in-flight delta columns (#795) land via the column model as an opt-in
+**"Changes"** group (Epic C), **not** as five always-on columns added to a table
+that already overflows. (Recorded here because it is the column-model decision
+that motivated the group dimension; the disposition itself is owned by Epic C / #797.)
+
+## Consequences
+
+**Easier:**
+
+- Data tables get the width they need; one token (`--page-max-wide`) controls it
+  and is trivially reversible.
+- A new column is a descriptor entry with a priority and group, not a round of
+  hand-tuned CSS — column growth stops re-breaking width.
+- Graceful responsive degradation (hide-by-priority at tablet, card view at true
+  mobile) replaces the current scroll-trap / hard cliff.
+- One legible filter model replaces three overlapping mechanisms.
+
+**Harder / costs:**
+
+- Both tables must be migrated onto the column model (Sprints #811, #812) before
+  the shared-primitive question can even be evaluated.
+- A robust sticky mechanism must replace the hardcoded pixel offsets.
+- Column-hiding and width/container changes can shift layout — every implementing
+  sprint must **guard CLS** (Lighthouse ≤0.1; lessons 107/113) and verify at
+  375 / 768 / 1280 / 1600 + dark mode on the PR preview channel.
+
+## Alternatives Considered
+
+- **Fluid / edge-to-edge width** (no cap). Rejected: ultra-wide displays would
+  stretch rows to unreadable line lengths; a 1600px cap holds the full club-table
+  column set without scroll while bounding the extreme. (Review §5 Q1.)
+- **Extract a shared `DataTable` primitive first.** Rejected per **R6**: the two
+  tables share a _smell_, not yet a verified abstraction. Build the column model
+  per table, prove the overlap, then extract — or don't.
+- **Ship #795's delta columns as always-on columns.** Rejected: adding five
+  columns to a 13-column table that already overflows makes the disliked
+  experience worse; they belong to a comparison context (opt-in "Changes" group,
+  Epic C). (Review §2.)
+- **Keep the 1280 cap and rely on horizontal scroll.** Rejected: the obligatory
+  scroll trap on nearly every desktop is the originating complaint.

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -19,13 +19,14 @@ Each ADR follows this template:
 
 ## Index
 
-| ADR                                                 | Title                                         | Status   | Date     |
-| --------------------------------------------------- | --------------------------------------------- | -------- | -------- |
-| [001](001-cdn-only-frontend.md)                     | CDN-only frontend (no API server)             | Accepted | Jan 2026 |
-| [002](002-staging-environment.md)                   | Staging environment and deployment flow       | Accepted | Apr 2026 |
-| [003](003-staging-bucket-cors-preview-channels.md)  | Staging bucket CORS for Firebase previews     | Accepted | May 2026 |
-| [004](004-release-gated-production-deploy.md)       | Release-gated production deploys              | Accepted | May 2026 |
-| [005](005-district-subpage-ia-and-secondary-nav.md) | District subpage IA map + secondary route-nav | Accepted | May 2026 |
+| ADR                                                   | Title                                          | Status   | Date     |
+| ----------------------------------------------------- | ---------------------------------------------- | -------- | -------- |
+| [001](001-cdn-only-frontend.md)                       | CDN-only frontend (no API server)              | Accepted | Jan 2026 |
+| [002](002-staging-environment.md)                     | Staging environment and deployment flow        | Accepted | Apr 2026 |
+| [003](003-staging-bucket-cors-preview-channels.md)    | Staging bucket CORS for Firebase previews      | Accepted | May 2026 |
+| [004](004-release-gated-production-deploy.md)         | Release-gated production deploys               | Accepted | May 2026 |
+| [005](005-district-subpage-ia-and-secondary-nav.md)   | District subpage IA map + secondary route-nav  | Accepted | May 2026 |
+| [006](006-data-table-page-layout-and-column-model.md) | Data-table page layout & column-model standard | Accepted | May 2026 |
 
 ## When to Write an ADR
 

--- a/docs/design/table-ux-review-2026-05-27.md
+++ b/docs/design/table-ux-review-2026-05-27.md
@@ -1,0 +1,151 @@
+# Review & recommendations: district + club tables
+
+**Date:** 2026-05-27 · **Status:** recommendations for operator to turn into epics
+**Skills applied:** ron-pm, ron-ux, ron-sa, ron-qe (frameworks read & applied)
+**Operator complaints:** column layout, non-full-width, responsive behaviour (both
+tables); plus the club table's filter pickers and a confusing _double_ set of quick
+filters. **Constraint:** #795 (What Changed Phase 3) is in flight to add **more**
+columns to the club table.
+
+---
+
+## 1. What's actually wrong (grounded in code)
+
+### District landing table (`DistrictsPage.tsx`, `app-shell.css`)
+
+- **Width:** `.districts-page { max-width: 1280px }` (app-shell.css:389) caps the page; on
+  a 2560px display ~half the width is empty. Tables benefit from width — the 1280 cap is a
+  prose-readability rule misapplied to a data grid.
+- **Responsive:** the 7-col table is `table-auto`, wrapped in `overflow-x-auto`, with
+  **zero `@media` rules** and **no card view**. Two sticky columns are hardcoded
+  (`--rank-col-w: 120px`, district pinned at `left:120px`, app-shell.css:916/944). Below
+  ~1300px it just forces horizontal scroll; at 375px the sticky pair (~380px) alone
+  overflows the viewport. No scroll-cue affordance.
+
+### Club table (`ClubsTable.tsx`, `ColumnHeader.tsx`, `filters/`, `useColumnFilters.ts`)
+
+- **Width/columns:** 13 columns, `table-auto` + `whitespace-nowrap`, no explicit widths,
+  inside a 1280px page (~1196px usable). It **cannot fit** below ~1600px → obligatory
+  horizontal-scroll trap on nearly every desktop.
+- **Responsive cliff:** a single 640px breakpoint swaps the whole table for a card list
+  (`useIsMobile(640)`). No tablet tier; the desktop→mobile transition is a cliff.
+- **Filter pickers (poor UX):** per-column filters hide behind a ~2.5px dropdown arrow in
+  each header (undiscoverable; fails 44px touch target). Each filter is a multi-step chore:
+  click header → pick operator → type/select → **mandatory "Apply"** → 300ms debounce →
+  close. Text filters debounce _and_ show Apply/Clear — ambiguous whether typing applies.
+  **There is no visible search box** — name search is buried in the "Club" column header.
+  Column filters are session-only (lost on reload; only `status` + `search` are URL-synced).
+- **The double quick-filters (the specific complaint):**
+  - **Set #1 — Status segmented** (All / Thriving / Vulnerable / Intervention), living
+    _inside_ the results-count row (ClubsTable.tsx:379–493). Filters `status`. URL-synced.
+  - **Set #2 — Quick-filter chips** (Close to Distinguished / Needs members / Missing
+    renewals / President's tier only), a separate row (ClubsTable.tsx:495–646). Session-only.
+    "Close to Distinguished" has a **hidden side effect**: it silently re-sorts the table
+    (lines 511–513).
+  - They **overlap** (`membersNeeded`, `distinguished` are reachable from chips _and_ from
+    per-column pickers; they silently AND together → confusing empty results) and read as
+    two unrelated systems. Three filtering mechanisms total, none showing a unified summary.
+
+### Cross-cutting (architect's view)
+
+Both tables independently reinvent: `table-auto` + nowrap, an `overflow-x-auto` wrapper,
+hand-tuned CSS widths, hardcoded sticky pixels, ad-hoc responsive (or none). Same smell,
+duplicated twice — and growing (recent column-adding branches: #688 distinguished-remaining,
+#687 base/current/Δ, and now #795). There is **no column model and no shared table
+primitive**; every new column is hand-wired CSS, which is exactly why width keeps breaking.
+
+---
+
+## 2. The #795 collision (decide this first)
+
+#795 adds delta columns (Δ members, Δ payments, DCP-tier transition, health transition,
+distinguished flip) to the club table. Adding 5 always-on columns to a 13-col table that
+already overflows makes the disliked experience worse and fails the PM cohesion test
+("simpler to explain"). The delta columns belong to a **comparison context**, not the
+default view. Recommendation: **#795 should land its columns as an opt-in "Changes" column
+group via the new column model (Epic C), not as always-on columns.** Until that's decided,
+#795 (epic #797 Sprint 3) should be paused/re-scoped so it doesn't ship into a table we're
+about to restructure.
+
+---
+
+## 3. Recommendations by hat
+
+**PM (ron-pm).** Two distinct jobs: _scan/compare districts_ (landing) and _find/triage
+clubs_ (club table). The table is the product here. Cut scope to: (1) give tables the width
+they need, (2) make responsive degradation graceful, (3) collapse three filter mechanisms
+into one legible model, (4) make a growing column set sustainable (groups + opt-in). Ship
+simplest-first; don't build a full column-customisation suite before fixing width + filters.
+
+**UX (ron-ux).** Full-width for data pages; tiered responsive (priority columns hide at
+tablet, sticky key column + scroll-cue, card view only at true mobile); no h-scroll at
+375px; 44px touch targets. One visible search box. Replace hidden header dropdowns with a
+discoverable, instant-apply filter model + an **active-filters summary bar**
+("3 filters · Clear all"). One intent-based preset row (merge the two quick-filter sets);
+kill the hidden auto-sort surprise. Zero-results empty state names the offending filter.
+
+**Architect (ron-sa).** Introduce a **column model** (id, header, priority, group, align,
+width/min, sticky, visibility, formatter) per table first; converge both tables onto it;
+**then** extract a shared headless `DataTable` primitive _only if_ the overlap is real
+(R6 — verify, don't assume; avoid premature abstraction). Keep the existing filter pipeline
+`original → filtered → searchFiltered → sorted` (R11) — the UI overhaul is presentation over
+that pipeline, not a rewrite. Replace hardcoded sticky px with a robust sticky mechanism.
+Width is a CSS-level token change (R10), reversible. **Write an ADR** for the table-page
+standard (full-width policy + column-model). Each step ships in ≤3 commits, stays green.
+
+**QE (ron-qe).** Unit-test the column-visibility resolution and the consolidated filter
+logic; keep existing `useColumnFilters` tests green; don't drop the 55% threshold. Add
+**Playwright at 375 / 768 / 1280 / 1600 + dark mode** asserting: no horizontal overflow at
+375, correct column set per breakpoint, filter round-trips. **Guard CLS** (Lighthouse ≤0.1;
+lessons 107/113) — width/container and column-hiding changes can shift layout. Verify on the
+PR preview channel per the Full DoD.
+
+---
+
+## 4. Proposed epics & sub-issues
+
+### Epic A — Full-width & responsive table system (both tables) · _foundational_
+
+- **A0** ADR: table-page layout standard (full-width policy, responsive priority-column
+  model, sticky strategy). Decision up front.
+- **A1** Full-width container policy — new `--page-max-wide` token applied to
+  `.districts-page` + `.district-detail-page`; prose pages stay narrow. CSS-level (R10).
+- **A2** Landing table: priority-column model + explicit widths; sticky key column +
+  scroll-cue; replace hardcoded sticky px.
+- **A3** Club table: same priority-column model; tablet tier (hide low-priority cols);
+  card view only at true mobile.
+- **A4** Mobile/touch polish — ≥44px targets, spacing, no h-scroll at 375px; dark mode.
+- _Verify:_ Playwright 375/768/1280/1600 + dark mode + CLS guard.
+
+### Epic B — Club table filtering & toolbar overhaul · _club-specific_
+
+- **B1** Visible search box (club/name) at the top; URL-synced.
+- **B2** Merge the two quick-filter sets into **one** intent-based preset row + health
+  segmentation; remove the hidden auto-sort side effect.
+- **B3** Replace hidden per-column header dropdowns with the chosen model (Filters panel
+  _or_ discoverable inline + instant-apply; drop the mandatory Apply button). _(direction =
+  open decision Q3)_
+- **B4** Active-filters summary bar + zero-results empty state; URL-sync all filters.
+- _Keep the filter pipeline intact (R11). Unit tests + Playwright interaction tests._
+
+### Epic C — Scalable column model & the delta columns (#795) · _depends on A_
+
+- **C1** Column groups + show/hide (Identity / Membership / Renewals / Recognition /
+  Changes); persist selection.
+- **C2** Land #795's delta columns as the opt-in **Changes** group (coordinate with epic
+  #797 Sprint 3 — re-scope #795 onto this).
+- **C3** _Evaluate-then-extract_ a shared headless `DataTable` primitive — only if A proved
+  real overlap (R6); else close won't-do.
+
+**Sequencing:** A → (B ∥ C1) → C2. A is the unblocker; B and the column model can proceed in
+parallel once A lands; #795's columns land last via C2. Suggested #606 order: **A first**
+(foundational, user-visible), then B, then C — and **#795 paused** pending C2.
+
+---
+
+## 5. Decisions to validate (see chat)
+
+1. Full-width target: fluid/edge-to-edge vs a wider cap (~1600).
+2. #795 disposition: pause & re-scope into Epic C (recommended) vs ship-then-refactor.
+3. Filter model direction: dedicated Filters panel/drawer vs discoverable inline + instant-apply.
+4. Create these epics + sub-issues now and queue in #606?


### PR DESCRIPTION
Sprint 1 of epic #813 (table UX program, Epic A foundational). Refs #809.

## What

Doc-only. Writes **ADR-006** capturing the decided standard for data-table pages so future column additions don't re-break width, and commits the source review doc the ADR cites (it was previously uncommitted in the operator's working tree, referenced by repo-relative path in #809).

## ADR decisions

- **Full-width policy:** new `--page-max-wide: 1600px` token for data-table pages; prose pages stay at 1280.
- **Responsive tiers:** mobile `<768` (card view, no h-scroll at 375, ≥44px targets) · tablet `768–1279` (hide low-priority cols, sticky key col + scroll-cue) · desktop `1280–1599` · wide `≥1600` (capped).
- **Per-column priority model** + per-table **column descriptor** (id/header/priority/group/align/width/sticky/visibility/formatter) — basis for Epics A/B/C.
- **Dedicated Filters panel/drawer** (decided 2026-05-27); merge the double quick-filters; visible search box; active-filters summary bar.
- **Evaluate-then-extract** a shared `DataTable` primitive only after overlap proves real (R6); keep the filter pipeline intact (R11); width is a CSS-token change (R10).
- #795 delta columns land as an opt-in "Changes" group (Epic C), not always-on.

## AC

- [x] ADR committed (Status: Accepted), cites the review doc (`docs/design/table-ux-review-2026-05-27.md`).
- [x] Names the `--page-max-wide` token value (1600px) and the breakpoint tiers (375/768/1280/1600).
- [x] No code change beyond docs (ADR + index + cited review doc). **No preview surface** — PR touches only `docs/**`, which `pr-preview.yml` does not match; verification is the full test suite + doc-link/format checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)