### PR TITLE
feat(tables): full-width (~1600) container policy for data-table pages (#810)

### DIFF
--- a/frontend/src/styles/__tests__/page-width-tokens.test.ts
+++ b/frontend/src/styles/__tests__/page-width-tokens.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+/* #810 (epic #813, Epic A Sprint 2) — full-width container policy for the two
+   data-table pages, per ADR-006 §1.
+
+   The 1280px cap is a prose-readability rule misapplied to a data grid. This
+   sprint introduces a `--page-max-wide` (1600px) token and applies it to the
+   district landing (`.districts-page`) and district-detail / clubs
+   (`.district-detail-page`) page containers. Prose / chrome containers
+   (`.app-shell__page`, `.placeholder-page`, the footer) keep the 1280 cap.
+
+   These are source-text guards (cf. rt-brand-v1.test.ts): jsdom has no layout,
+   so the real 1440/1920 + dark-mode + CLS verification runs in Playwright on
+   the PR preview (Full DoD). What these guards lock is the *wiring contract* —
+   the token is defined, both table pages reference it (R10: one token, no
+   per-component width hacks), and the prose pages are deliberately left narrow. */
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const redesignTokensPath = resolve(__dirname, '../tokens/redesign.css')
+const appShellPath = resolve(__dirname, '../components/app-shell.css')
+
+const redesignCss = readFileSync(redesignTokensPath, 'utf-8')
+const appShellCss = readFileSync(appShellPath, 'utf-8')
+
+describe('full-width data-table page policy (#810, ADR-006 §1)', () => {
+  it('redesign.css declares --page-max-wide: 1600px in :root', () => {
+    expect(redesignCss).toMatch(/--page-max-wide:\s*1600px/)
+  })
+
+  it('the district landing page (.districts-page) uses the wide token', () => {
+    // Targets the exact `.districts-page {` rule, not `.districts-page-root`
+    // / `.districts-page-header` (next char after `page` is `-`, not `{`).
+    expect(appShellCss).toMatch(
+      /\.districts-page\s*\{[^}]*max-width:\s*var\(--page-max-wide\)/
+    )
+  })
+
+  it('the district-detail (clubs) page uses the wide token', () => {
+    expect(appShellCss).toMatch(
+      /\.district-detail-page\s*\{[^}]*max-width:\s*var\(--page-max-wide\)/
+    )
+  })
+
+  it('prose / chrome containers keep the 1280px cap (not widened)', () => {
+    expect(appShellCss).toMatch(
+      /\.app-shell__page\s*\{[^}]*max-width:\s*1280px/
+    )
+    expect(appShellCss).toMatch(
+      /\.placeholder-page\s*\{[^}]*max-width:\s*1280px/
+    )
+    expect(appShellCss).toMatch(
+      /\.app-shell-footer__inner\s*\{[^}]*max-width:\s*1280px/
+    )
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -387,7 +387,8 @@
   }
 
   .districts-page {
-    max-width: 1280px;
+    /* Data-table page: wide cap (#810, ADR-006 §1). Prose pages stay 1280. */
+    max-width: var(--page-max-wide);
     margin-left: auto;
     margin-right: auto;
     padding: 32px 24px;
@@ -2582,7 +2583,8 @@
   }
 
   .district-detail-page {
-    max-width: 1280px;
+    /* Data-table page (clubs): wide cap (#810, ADR-006 §1). */
+    max-width: var(--page-max-wide);
     margin-left: auto;
     margin-right: auto;
     padding: 24px 24px 32px;

--- a/frontend/src/styles/tokens/redesign.css
+++ b/frontend/src/styles/tokens/redesign.css
@@ -57,6 +57,13 @@
   --rds-shadow: 0 1px 2px rgba(15, 23, 32, .04), 0 1px 3px rgba(15, 23, 32, .06);
   --rds-shadow-lg: 0 1px 2px rgba(15, 23, 32, .04), 0 8px 24px rgba(15, 23, 32, .08);
 
+  /* Page-content max-width for DATA-TABLE pages (#810, ADR-006 §1). The data
+     grid wants width: the 13-col club table can't fit below ~1600px. Prose /
+     narrative pages keep their own 1280px cap (a text-readability rule, not a
+     grid one) — do NOT route prose containers through this token. Theme-
+     independent, so it lives only here in :root, not the dark block. */
+  --page-max-wide: 1600px;
+
   /* RGB triple for the AppShell top-bar translucent surface.
      The bar uses rgba(var(--rds-surface-rgb), 0.72) + backdrop-filter to
      achieve the blurred glassy look from the handoff. We can't put the

--- a/tasks/lessons/120-a-css-class-named-as-a-page-may-be-shared-chrome-for-a-whole-route-family.md
+++ b/tasks/lessons/120-a-css-class-named-as-a-page-may-be-shared-chrome-for-a-whole-route-family.md
@@ -1,0 +1,72 @@
+---
+id: '120'
+category: lesson
+tags: [css, frontend, scope, router, architecture]
+auto_load: true
+date: 2026-05-27
+issues: [810, 813]
+---
+
+# Lesson 120 — A CSS class named like "a page" may be shared chrome for a whole route family
+
+**Date:** 2026-05-27
+**Issue:** #810 (epic #813 Sprint 2 — full-width container policy)
+**PR:** [#824](https://github.com/taverns-red/toast-stats/pull/824)
+
+## What happened
+
+ADR-006 §1 said to widen the "data-table page containers" and named two classes:
+`.districts-page` and `.district-detail-page`. The obvious reading — and the one
+the ADR author wrote — is that `.district-detail-page` _is_ the clubs table page.
+A fresh-context review found it isn't: `.district-detail-page` is the shared
+wrapper rendered by **seven** distinct district sub-routes
+(`DistrictDetailPage`, `DistrictClubsPage`, `DistrictRankingsPage`,
+`DistrictDivisionsPage`, `DistrictTrendsPage`, `DistrictChangesPage`,
+`DistrictAnalyticsPage`) — clubs/rankings/divisions tables _and_ chart/narrative
+pages, all emitting identical `<div className="district-detail-page-root"><div
+className="district-detail-page">`. Widening the class to 1600px widens the chart
+pages too, which the ADR's own prose carve-out ("narrative pages keep 1280")
+argues against.
+
+There was **no CSS-level discriminator** to widen only the clubs table — the
+markup is byte-identical across all seven. Scoping to clubs alone would have
+required a per-page modifier class, which the AC explicitly forbade ("CSS-level
+change via token, no per-component width hacks"). The two spec constraints
+collided. The operator resolved it (widen the whole family — most sub-pages are
+data-dense, and it's a reversible token, R10), but the collision was invisible
+until someone counted the consumers of the class.
+
+## The transferable lesson
+
+**When a ticket or ADR scopes a change by a CSS class and talks about it as "the
+X page," verify the class→page cardinality before treating a class-level edit as
+page-scoped.** A `.foo-page` class is often shared chrome for an entire route
+family, not one screen. `grep -rl 'className="foo-page"' src/pages` answers it in
+one command. If the class is shared, a "widen/restyle this page" instruction
+silently applies to every sibling route — which may contradict the same spec's
+carve-out for the narrative siblings. Surface the cardinality and the resulting
+scope decision to the operator rather than guessing; it's cheap to check and
+expensive to ship wrong on a foundational sprint others build on.
+
+## How to apply
+
+- Before a class-scoped CSS change described as page-specific, count the
+  consumers: `grep -rl 'className="<class>"' src/pages src/components`. >1 hit =
+  it's shared; the change is route-family-wide, not page-scoped.
+- If the spec names a single page but the class is shared, you usually can't
+  honor "no per-component hacks" _and_ "this page only" at once — there's no CSS
+  selector for "this route" without a per-page marker. Name the tension; let the
+  operator pick (see [[098-curated-lesson-manifest-beats-tag-inference-when-the-operator-knows]] — operator curation wins on scope).
+- A fresh-context review is what caught this; the author's mental model had the
+  class fused to one page. This is exactly the "obvious to the author" blind spot
+  the mandatory review step exists for — don't skip it because the diff is three
+  lines.
+
+## Related
+
+- `docs/architecture-decisions/006-data-table-page-layout-and-column-model.md` §1
+  — the ADR whose class naming conflated `.district-detail-page` with the clubs
+  page; this lesson is the gloss the implementing sprint added.
+- [[080-a-district-scoped-surface-lives-next-to-the-data-it-consumes]] — the
+  inverse: a surface's _route_ home vs where its issue stub guessed; both are
+  "the IA isn't what the ticket's noun implies."

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -85,6 +85,7 @@
 - **118** [data-pipeline, analytics, collector-cli, find-a-club] — "Missing from Find-A-Club" is a registry-visibility signal, not a data gap (#490, #757)
 - **119** [automation, sprint-runner, prompts, process] — An issue's cited doc may be uncommitted in the operator's main checkout, not missing (#809, #813)
 - **119** [ci, tests, seo, frontend, verification, performance] — Before gating a Lighthouse SEO audit at `error`, verify which audits survive the localhost/preview host (#778, #785)
+- **120** [css, frontend, scope, router, architecture] — A CSS class named like "a page" may be shared chrome for a whole route family (#810, #813)
 - **120** [tests, vitest, flaky, react, frontend] — `await waitFor` for an already-flushed effect leaks a deferred render into the next test (#780, #785)
 - **121** [ci, tests, seo, verification, frontend] — A "presence-implying" audit may only validate; pair it with a drift guard (#782, #785)
 - **122** [ci, lighthouse, security, csp, verification, frontend] — A CSP in hosting config is invisible to the localhost Lighthouse gate; verify headers on the deployed surface (#783, #785)


### PR DESCRIPTION
Epic A Sprint 2 of #813 (table UX program). Implements ADR-006 §1.

## What
- New `--page-max-wide: 1600px` token in `redesign.css` `:root` (theme-independent).
- Applied to the two data-table page containers: `.districts-page` (district landing) and `.district-detail-page`.
- Prose / chrome containers (`.app-shell__page`, `.placeholder-page`, footer) keep their 1280px cap.

## Scope decision (operator-confirmed)
`.district-detail-page` is the shared wrapper for all 7 district sub-pages (clubs table, rankings, divisions, trends, changes, analytics, overview) — there is no CSS-level discriminator to widen only the clubs table without a per-page modifier. Per ADR-006 §1's literal class naming and the AC's "CSS-level change via token (R10); no per-component width hacks", the operator chose to **widen the whole `.district-detail-page` family** (chart/rankings/division pages get more width too). Reversible token change (R10).

## Tests
- `frontend/src/styles/__tests__/page-width-tokens.test.ts` — guards the wiring contract: token defined, both table pages reference it (no per-component hacks), prose pages stay narrow. Source-text guards (jsdom has no layout).
- Full frontend suite green: 2849 tests.

## Verification
Live verification on the PR preview channel (1440/1920 + dark mode + CLS guard ≤0.1) to follow per Full DoD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)