### PR TITLE
feat(tables): landing rankings table — priority-column responsive model + sticky fix (#811)

### DIFF
--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -991,320 +991,353 @@ const DistrictsPage: React.FC = () => {
               <InfoTooltip text="Paid Clubs = clubs that have met renewal obligations for the program year. Total Payments = year-to-date membership payment count. Distinguished = clubs achieving Distinguished status or higher. Score = Borda-count composite of the three rankings. Higher is better on all four." />
             </span>
           </div>
-          <div className="overflow-x-auto">
-            <table
-              className="districts-rankings-table"
-              aria-label="District rankings"
+          {/* Non-trap horizontal scroll (Lesson 105). This is a LEADERBOARD —
+              its value is comparing districts across rows — so it keeps the
+              table and makes the scroll non-trap rather than card-collapsing
+              (which would destroy the comparison; that pattern is right for
+              the club table, not this one). Three moves: (1) the scroller is a
+              focusable, labelled region (WCAG 2.1.1 / axe
+              scrollable-region-focusable); (2) the District identity column is
+              the single sticky key column (no hardcoded second-sticky px seam);
+              (3) the right-edge scroll-cue signals more columns. Low-priority
+              columns hide at tablet/mobile via the __col--tablet/--desktop
+              priority classes so a phone shows a sensible set. Don't "fix" this
+              into a card collapse. */}
+          <div className="districts-rankings-table__scroll-wrap">
+            <div
+              className="overflow-x-auto districts-rankings-table__scroll"
+              role="region"
+              tabIndex={0}
+              aria-label="District rankings — scroll horizontally to see all metrics"
             >
-              <caption className="sr-only">
-                District rankings by Paid Clubs, Total Payments, Distinguished
-                club count, and Borda-count Score.
-              </caption>
-              <thead>
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-0 z-10">
-                    District
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-[200px] z-10 sticky-column-shadow">
-                    Rank
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Tier
-                  </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Paid Clubs
-                  </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Total Payments
-                  </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Distinguished
-                  </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Score
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {displayRankings.map(district => {
-                  const rank = district.displayRank
-                  const isPinned = pinnedDistrictIds.has(district.districtId)
-                  const pinDisabled =
-                    !isPinned && pinnedDistrictIds.size >= MAX_PINNED
-                  const isMine = isMyDistrict(district.districtId)
-                  const rawTier =
-                    competitiveAwards?.distinguishedDistrict?.[
-                      district.districtId
-                    ]?.currentTier ?? null
-                  // The row-level data-tier hook is only meaningful for
-                  // ACHIEVED tiers; CSS rules like [data-tier="Smedley"]
-                  // never want to match NotDistinguished. So absence is
-                  // the signal there too — same convention as the chip.
-                  const ddpTier =
-                    rawTier && rawTier !== 'NotDistinguished' ? rawTier : null
-                  return (
-                    <tr
-                      key={district.districtId}
-                      data-testid={`district-row-${district.districtId}`}
-                      data-tier={ddpTier ?? undefined}
-                      onClick={() => handleDistrictClick(district.districtId)}
-                      className={`cursor-pointer ${
-                        isMine
-                          ? 'bg-yellow-50 border-l-4 border-l-tm-loyal-blue'
-                          : isPinned
-                            ? 'bg-blue-50'
-                            : ''
-                      }`}
-                    >
-                      {/* District cell first (#436) — primary entity. The
-                          number is rendered as a standalone chip so the
-                          click affordance reads as obviously interactive.
-                          (#417) Star button toggles 'my district'.
-                          Sticky cell background must honour the row's
-                          isMine/isPinned tint, not stay white (#546 review). */}
-                      <td
-                        className={`px-6 py-4 whitespace-nowrap sticky left-0 z-10 ${
+              <table
+                className="districts-rankings-table"
+                aria-label="District rankings"
+              >
+                <caption className="sr-only">
+                  District rankings by Paid Clubs, Total Payments, Distinguished
+                  club count, and Borda-count Score.
+                </caption>
+                <thead>
+                  <tr>
+                    <th className="districts-rankings-table__sticky-col px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      District
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Rank
+                    </th>
+                    <th className="districts-rankings-table__col--desktop px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Tier
+                    </th>
+                    <th className="districts-rankings-table__col--tablet px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Paid Clubs
+                    </th>
+                    <th className="districts-rankings-table__col--tablet px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Total Payments
+                    </th>
+                    <th className="districts-rankings-table__col--tablet px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Distinguished
+                    </th>
+                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Score
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {displayRankings.map(district => {
+                    const rank = district.displayRank
+                    const isPinned = pinnedDistrictIds.has(district.districtId)
+                    const pinDisabled =
+                      !isPinned && pinnedDistrictIds.size >= MAX_PINNED
+                    const isMine = isMyDistrict(district.districtId)
+                    const rawTier =
+                      competitiveAwards?.distinguishedDistrict?.[
+                        district.districtId
+                      ]?.currentTier ?? null
+                    // The row-level data-tier hook is only meaningful for
+                    // ACHIEVED tiers; CSS rules like [data-tier="Smedley"]
+                    // never want to match NotDistinguished. So absence is
+                    // the signal there too — same convention as the chip.
+                    const ddpTier =
+                      rawTier && rawTier !== 'NotDistinguished' ? rawTier : null
+                    return (
+                      <tr
+                        key={district.districtId}
+                        data-testid={`district-row-${district.districtId}`}
+                        data-tier={ddpTier ?? undefined}
+                        onClick={() => handleDistrictClick(district.districtId)}
+                        className={`cursor-pointer ${
                           isMine
-                            ? 'bg-yellow-50'
+                            ? 'bg-yellow-50 border-l-4 border-l-tm-loyal-blue'
                             : isPinned
                               ? 'bg-blue-50'
-                              : 'bg-white'
+                              : ''
                         }`}
                       >
-                        <div className="flex items-center gap-3 flex-wrap">
-                          <button
-                            type="button"
-                            onClick={e => {
-                              e.stopPropagation()
-                              setMyDistrict(isMine ? null : district.districtId)
-                            }}
-                            aria-label={
-                              isMine
-                                ? `Unset District ${district.districtId} as my district`
-                                : `Set District ${district.districtId} as my district`
-                            }
-                            aria-pressed={isMine}
-                            title={
-                              isMine
-                                ? 'Click to clear · this district pins to top across visits'
-                                : 'Click to mark as my district · pins to top across visits'
-                            }
-                            className={`flex-shrink-0 w-6 h-6 inline-flex items-center justify-center rounded transition-colors ${
-                              isMine
-                                ? 'text-yellow-500 hover:text-gray-400'
-                                : 'text-gray-300 hover:text-yellow-500'
-                            }`}
-                          >
-                            <svg
-                              className="w-4 h-4"
-                              fill={isMine ? 'currentColor' : 'none'}
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                              aria-hidden="true"
+                        {/* District cell first (#436) — primary entity, and the
+                          single sticky key column (#811). The number is a
+                          standalone chip so the click affordance reads as
+                          interactive. (#417) Star toggles 'my district'.
+                          The sticky cell needs an opaque themed background so
+                          scrolled columns don't bleed through; data-row-tint
+                          lets the CSS repaint the isMine/isPinned tint (token-
+                          based, dark-safe — replaces the old hardcoded bg-white
+                          that routed to the lighter dark scale, Lesson 116). */}
+                        <td
+                          data-testid={`district-cell-${district.districtId}`}
+                          data-row-tint={
+                            isMine ? 'mine' : isPinned ? 'pinned' : 'none'
+                          }
+                          className="districts-rankings-table__sticky-col px-6 py-4 whitespace-nowrap"
+                        >
+                          <div className="flex items-center gap-3 flex-wrap">
+                            <button
+                              type="button"
+                              onClick={e => {
+                                e.stopPropagation()
+                                setMyDistrict(
+                                  isMine ? null : district.districtId
+                                )
+                              }}
+                              aria-label={
+                                isMine
+                                  ? `Unset District ${district.districtId} as my district`
+                                  : `Set District ${district.districtId} as my district`
+                              }
+                              aria-pressed={isMine}
+                              title={
+                                isMine
+                                  ? 'Click to clear · this district pins to top across visits'
+                                  : 'Click to mark as my district · pins to top across visits'
+                              }
+                              className={`districts-rankings-table__touch-btn flex-shrink-0 inline-flex items-center justify-center rounded transition-colors ${
+                                isMine
+                                  ? 'text-yellow-500 hover:text-gray-400'
+                                  : 'text-gray-300 hover:text-yellow-500'
+                              }`}
                             >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
-                              />
-                            </svg>
-                          </button>
-                          <DistrictChipAndName
-                            districtId={district.districtId}
-                            name={district.districtName}
-                            nameClassName="text-sm font-medium text-gray-900"
-                            ariaHidden
-                          />
-                          {/* Competitive award winner badges (#331) */}
-                          {competitiveAwards?.byDistrict?.[district.districtId]
-                            ?.extensionIsWinner && (
-                            <span
-                              title="President's Extension Award winner"
-                              className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-800 border border-yellow-200"
-                            >
-                              <span aria-hidden="true">🏆</span>
-                              <span className="ml-1">Extension</span>
-                            </span>
-                          )}
-                          {competitiveAwards?.byDistrict?.[district.districtId]
-                            ?.twentyPlusIsWinner && (
-                            <span
-                              title="President's 20-Plus Award winner"
-                              className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-800 border border-yellow-200"
-                            >
-                              <span aria-hidden="true">🏆</span>
-                              <span className="ml-1">20-Plus</span>
-                            </span>
-                          )}
-                          {competitiveAwards?.byDistrict?.[district.districtId]
-                            ?.retentionIsWinner && (
-                            <span
-                              title="District Club Retention Award winner"
-                              className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-800 border border-yellow-200"
-                            >
-                              <span aria-hidden="true">🏆</span>
-                              <span className="ml-1">Retention</span>
-                            </span>
-                          )}
-                          {/* Region collapses into the District cell as
+                              <svg
+                                className="w-4 h-4"
+                                fill={isMine ? 'currentColor' : 'none'}
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                                aria-hidden="true"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
+                                />
+                              </svg>
+                            </button>
+                            <DistrictChipAndName
+                              districtId={district.districtId}
+                              name={district.districtName}
+                              nameClassName="text-sm font-medium text-gray-900"
+                              ariaHidden
+                            />
+                            {/* Competitive award winner badges (#331) */}
+                            {competitiveAwards?.byDistrict?.[
+                              district.districtId
+                            ]?.extensionIsWinner && (
+                              <span
+                                title="President's Extension Award winner"
+                                className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-800 border border-yellow-200"
+                              >
+                                <span aria-hidden="true">🏆</span>
+                                <span className="ml-1">Extension</span>
+                              </span>
+                            )}
+                            {competitiveAwards?.byDistrict?.[
+                              district.districtId
+                            ]?.twentyPlusIsWinner && (
+                              <span
+                                title="President's 20-Plus Award winner"
+                                className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-800 border border-yellow-200"
+                              >
+                                <span aria-hidden="true">🏆</span>
+                                <span className="ml-1">20-Plus</span>
+                              </span>
+                            )}
+                            {competitiveAwards?.byDistrict?.[
+                              district.districtId
+                            ]?.retentionIsWinner && (
+                              <span
+                                title="District Club Retention Award winner"
+                                className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-800 border border-yellow-200"
+                              >
+                                <span aria-hidden="true">🏆</span>
+                                <span className="ml-1">Retention</span>
+                              </span>
+                            )}
+                            {/* Region collapses into the District cell as
                               a quiet "· R<n>" suffix (#546) — saves the
                               standalone Region column's width. */}
-                          {district.region && (
-                            <span
-                              data-testid={`district-region-suffix-${district.districtId}`}
-                              className="text-xs text-gray-500"
+                            {district.region && (
+                              <span
+                                data-testid={`district-region-suffix-${district.districtId}`}
+                                className="text-xs text-gray-500"
+                              >
+                                · R{district.region}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        {/* Rank cell — second column (#436). No longer a second
+                          sticky column (#811): the old `left-[200px]` magic
+                          offset was a fragile px seam (AC #2) and the sticky
+                          pair (~380px) alone overflowed a 375px phone. Only the
+                          District identity column sticks now; this cell scrolls
+                          and inherits the row tint through its transparent bg. */}
+                        <td
+                          data-testid={`rank-cell-${district.districtId}`}
+                          className="px-6 py-4 whitespace-nowrap"
+                        >
+                          <div className="flex items-center gap-2">
+                            <button
+                              onClick={e => {
+                                e.stopPropagation()
+                                togglePin(district.districtId)
+                              }}
+                              disabled={pinDisabled}
+                              aria-label={
+                                isPinned
+                                  ? `Unpin District ${district.districtId}`
+                                  : `Pin District ${district.districtId}`
+                              }
+                              className={`districts-rankings-table__touch-btn flex-shrink-0 flex items-center justify-center rounded transition-colors ${
+                                isPinned
+                                  ? 'text-tm-loyal-blue hover:text-red-500'
+                                  : pinDisabled
+                                    ? 'text-gray-300 cursor-not-allowed'
+                                    : 'text-gray-400 hover:text-tm-loyal-blue'
+                              }`}
                             >
-                              · R{district.region}
+                              <svg
+                                className="w-4 h-4"
+                                fill={isPinned ? 'currentColor' : 'none'}
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+                                />
+                              </svg>
+                            </button>
+                            <span
+                              data-testid={`rank-badge-${district.districtId}`}
+                              className={`inline-flex items-center justify-center w-10 h-10 rounded-full font-bold ${getRankBadgeColor(rank)}`}
+                            >
+                              {rank}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="districts-rankings-table__col--desktop px-4 py-4 whitespace-nowrap">
+                          {ddpTier ? (
+                            <DistrictTierChip
+                              districtId={district.districtId}
+                              tier={ddpTier}
+                            />
+                          ) : (
+                            // Empty Tier cell: the column header "Tier"
+                            // already provides context; an aria-label here
+                            // would chatter on every NotDistinguished row
+                            // (which is the majority).
+                            <span
+                              className="text-gray-400 text-sm"
+                              aria-hidden="true"
+                            >
+                              —
                             </span>
                           )}
-                        </div>
-                      </td>
-                      {/* Rank cell — now second column (#436). Pin button
-                          stays adjacent to rank badge for symmetry with
-                          the existing comparison-pin UX. Sticky background
-                          must honour the row tint (#546 review). */}
-                      <td
-                        className={`px-6 py-4 whitespace-nowrap sticky left-[200px] z-10 sticky-column-shadow ${
-                          isMine
-                            ? 'bg-yellow-50'
-                            : isPinned
-                              ? 'bg-blue-50'
-                              : 'bg-white'
-                        }`}
-                      >
-                        <div className="flex items-center gap-2">
-                          <button
-                            onClick={e => {
-                              e.stopPropagation()
-                              togglePin(district.districtId)
-                            }}
-                            disabled={pinDisabled}
-                            aria-label={
-                              isPinned
-                                ? `Unpin District ${district.districtId}`
-                                : `Pin District ${district.districtId}`
-                            }
-                            className={`flex-shrink-0 w-6 h-6 flex items-center justify-center rounded transition-colors ${
-                              isPinned
-                                ? 'text-tm-loyal-blue hover:text-red-500'
-                                : pinDisabled
-                                  ? 'text-gray-300 cursor-not-allowed'
-                                  : 'text-gray-400 hover:text-tm-loyal-blue'
-                            }`}
-                          >
-                            <svg
-                              className="w-4 h-4"
-                              fill={isPinned ? 'currentColor' : 'none'}
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
+                        </td>
+                        <td className="districts-rankings-table__col--tablet px-6 py-4 whitespace-nowrap text-right">
+                          <div className="text-sm font-medium text-gray-900">
+                            {formatNumber(district.paidClubs)}
+                          </div>
+                          <div className="text-xs flex items-center justify-end gap-1">
+                            <span className="text-tm-loyal-blue font-tm-body">
+                              #{district.clubsRank}
+                            </span>
+                            <span className="text-gray-400">•</span>
+                            <span
+                              className={
+                                formatPercentage(district.clubGrowthPercent)
+                                  .color
+                              }
                             >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
-                              />
-                            </svg>
-                          </button>
-                          <span
-                            className={`inline-flex items-center justify-center w-10 h-10 rounded-full font-bold ${getRankBadgeColor(rank)}`}
-                          >
-                            {rank}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-4 py-4 whitespace-nowrap">
-                        {ddpTier ? (
-                          <DistrictTierChip
-                            districtId={district.districtId}
-                            tier={ddpTier}
-                          />
-                        ) : (
-                          // Empty Tier cell: the column header "Tier"
-                          // already provides context; an aria-label here
-                          // would chatter on every NotDistinguished row
-                          // (which is the majority).
-                          <span
-                            className="text-gray-400 text-sm"
-                            aria-hidden="true"
-                          >
-                            —
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-right">
-                        <div className="text-sm font-medium text-gray-900">
-                          {formatNumber(district.paidClubs)}
-                        </div>
-                        <div className="text-xs flex items-center justify-end gap-1">
-                          <span className="text-tm-loyal-blue font-tm-body">
-                            #{district.clubsRank}
-                          </span>
-                          <span className="text-gray-400">•</span>
-                          <span
-                            className={
-                              formatPercentage(district.clubGrowthPercent).color
-                            }
-                          >
-                            {formatPercentage(district.clubGrowthPercent).text}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-right">
-                        <div className="text-sm font-medium text-gray-900">
-                          {formatNumber(district.totalPayments)}
-                        </div>
-                        <div className="text-xs flex items-center justify-end gap-1">
-                          <span className="text-tm-loyal-blue font-tm-body">
-                            #{district.paymentsRank}
-                          </span>
-                          <span className="text-gray-400">•</span>
-                          <span
-                            className={
-                              formatPercentage(district.paymentGrowthPercent)
-                                .color
-                            }
-                          >
-                            {
-                              formatPercentage(district.paymentGrowthPercent)
-                                .text
-                            }
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-right">
-                        <div className="text-sm font-medium text-gray-900">
-                          {formatNumber(district.distinguishedClubs)}
-                        </div>
-                        <div className="text-xs flex items-center justify-end gap-1">
-                          <span className="text-tm-loyal-blue font-tm-body">
-                            #{district.distinguishedRank}
-                          </span>
-                          <span className="text-gray-400">•</span>
-                          <span
-                            className={
-                              formatPercentage(district.distinguishedPercent)
-                                .color
-                            }
-                          >
-                            {
-                              formatPercentage(district.distinguishedPercent)
-                                .text
-                            }
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-right">
-                        <div className="text-sm font-bold text-tm-loyal-blue font-tm-headline">
-                          {formatNumber(Math.round(district.aggregateScore))}
-                        </div>
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
+                              {
+                                formatPercentage(district.clubGrowthPercent)
+                                  .text
+                              }
+                            </span>
+                          </div>
+                        </td>
+                        <td className="districts-rankings-table__col--tablet px-6 py-4 whitespace-nowrap text-right">
+                          <div className="text-sm font-medium text-gray-900">
+                            {formatNumber(district.totalPayments)}
+                          </div>
+                          <div className="text-xs flex items-center justify-end gap-1">
+                            <span className="text-tm-loyal-blue font-tm-body">
+                              #{district.paymentsRank}
+                            </span>
+                            <span className="text-gray-400">•</span>
+                            <span
+                              className={
+                                formatPercentage(district.paymentGrowthPercent)
+                                  .color
+                              }
+                            >
+                              {
+                                formatPercentage(district.paymentGrowthPercent)
+                                  .text
+                              }
+                            </span>
+                          </div>
+                        </td>
+                        <td className="districts-rankings-table__col--tablet px-6 py-4 whitespace-nowrap text-right">
+                          <div className="text-sm font-medium text-gray-900">
+                            {formatNumber(district.distinguishedClubs)}
+                          </div>
+                          <div className="text-xs flex items-center justify-end gap-1">
+                            <span className="text-tm-loyal-blue font-tm-body">
+                              #{district.distinguishedRank}
+                            </span>
+                            <span className="text-gray-400">•</span>
+                            <span
+                              className={
+                                formatPercentage(district.distinguishedPercent)
+                                  .color
+                              }
+                            >
+                              {
+                                formatPercentage(district.distinguishedPercent)
+                                  .text
+                              }
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-right">
+                          <div className="text-sm font-bold text-tm-loyal-blue font-tm-headline">
+                            {formatNumber(Math.round(district.aggregateScore))}
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+            {/* Right-edge fade cue — themed (transparent → --surface, remaps in
+                dark); pointer-events:none so it never blocks taps/scroll. */}
+            <div
+              className="districts-rankings-table__scroll-cue"
+              aria-hidden="true"
+            />
           </div>
         </div>
 

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -320,6 +320,37 @@ const DistrictsPage: React.FC = () => {
     return displayRankings.slice(0, 5)
   }, [displayRankings, searchQuery])
 
+  // Show the right-edge scroll-cue ONLY when the rankings table actually
+  // overflows to the right. A permanent fade would wash out the right-aligned
+  // Score column on desktop, where the full set fits and nothing scrolls — a
+  // false affordance over the headline metric. Toggled imperatively (a
+  // data-attr on the scroll-wrap, gated in CSS) so scroll/resize don't
+  // re-render the whole table. Unlike the regions leaderboard's always-on cue
+  // (#689, 19 cols that always scroll), this one is conditional.
+  const rankingsScrollRef = useRef<HTMLDivElement>(null)
+  React.useEffect(() => {
+    const el = rankingsScrollRef.current
+    if (!el) return
+    const update = () => {
+      const moreToRight = el.scrollWidth - el.clientWidth - el.scrollLeft > 1
+      el.parentElement?.setAttribute(
+        'data-scrollable-right',
+        String(moreToRight)
+      )
+    }
+    update()
+    el.addEventListener('scroll', update, { passive: true })
+    let ro: ResizeObserver | undefined
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(update)
+      ro.observe(el)
+    }
+    return () => {
+      el.removeEventListener('scroll', update)
+      ro?.disconnect()
+    }
+  }, [displayRankings])
+
   const handleDistrictClick = (districtId: string) => {
     navigate(`/district/${districtId}`)
   }
@@ -1005,7 +1036,8 @@ const DistrictsPage: React.FC = () => {
               into a card collapse. */}
           <div className="districts-rankings-table__scroll-wrap">
             <div
-              className="overflow-x-auto districts-rankings-table__scroll"
+              ref={rankingsScrollRef}
+              className="overflow-x-auto"
               role="region"
               tabIndex={0}
               aria-label="District rankings — scroll horizontally to see all metrics"

--- a/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * DistrictsPage landing rankings table — priority-column responsive model +
+ * sticky fix (#811, epic #813 Sprint 3).
+ *
+ * The landing rankings table is a LEADERBOARD: its value is comparing
+ * districts across rows. Per Lesson 105 (#689) a ranking table keeps the
+ * table and makes the horizontal scroll non-trap — it must NOT card-collapse
+ * (which destroys the cross-row comparison). So the responsive contract is:
+ *   (1) the scroll container is a focusable, labelled region (WCAG 2.1.1, the
+ *       axe "scrollable-region-focusable" rule) with a right-edge scroll-cue;
+ *   (2) ONE sticky key column (District) pinned at left:0 — no hardcoded
+ *       second sticky (the old `left-[200px]` px seam, AC #2);
+ *   (3) a per-column priority model that hides low-priority columns at tablet
+ *       / mobile via CSS (verified for real at each breakpoint in Playwright —
+ *       jsdom has no layout, Lesson 66);
+ *   (4) ≥44px touch targets on the row action buttons (Lesson 111).
+ *
+ * jsdom can't evaluate media queries or measure px, so these assert the
+ * structural hooks (roles, classes, testids) the CSS keys off; the live
+ * per-breakpoint behaviour is proven on the PR preview channel.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import DistrictsPage from '../DistrictsPage'
+import { fetchCdnRankings } from '../../services/cdn'
+import { renderWithProviders } from '../../__tests__/test-utils'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: [],
+    count: 0,
+    generatedAt: '2025-01-01T00:00:00Z',
+  }),
+  fetchCdnSnapshotIndex: vi.fn().mockResolvedValue({}),
+  fetchCdnRankings: vi.fn(),
+  fetchCdnManifest: vi.fn().mockResolvedValue({
+    latestSnapshotDate: '2025-11-22',
+    generatedAt: '2025-01-01T00:00:00Z',
+  }),
+  cdnAnalyticsUrl: vi.fn().mockReturnValue('https://cdn.taverns.red/test'),
+  fetchFromCdn: vi.fn(),
+}))
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: () => ({
+    data: { districts: [] },
+    isLoading: false,
+    isError: false,
+  }),
+}))
+
+const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)
+
+const setupSingleRow = () => {
+  mockedFetchCdnRankings.mockResolvedValue({
+    rankings: [
+      {
+        districtId: '7',
+        districtName: 'District 7',
+        region: '7',
+        paidClubs: 100,
+        paidClubBase: 90,
+        clubGrowthPercent: 11.1,
+        totalPayments: 5000,
+        paymentBase: 4500,
+        paymentGrowthPercent: 11.1,
+        activeClubs: 100,
+        distinguishedClubs: 50,
+        selectDistinguished: 20,
+        presidentsDistinguished: 10,
+        distinguishedPercent: 50,
+        clubsRank: 1,
+        paymentsRank: 1,
+        distinguishedRank: 1,
+        aggregateScore: 300,
+        overallRank: 1,
+      },
+    ],
+    date: '2025-11-22',
+  } as never)
+}
+
+const headerByText = (re: RegExp): HTMLElement => {
+  const table = screen.getByRole('table', { name: /district rankings/i })
+  const headers = within(table).getAllByRole('columnheader')
+  const match = headers.find(h => re.test(h.textContent?.trim() ?? ''))
+  if (!match) throw new Error(`no column header matching ${re}`)
+  return match
+}
+
+describe('DistrictsPage rankings table — responsive + sticky (#811)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('wraps the table in a focusable, labelled scroll region with a scroll-cue', async () => {
+    setupSingleRow()
+    const { container } = renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    const scroller = screen.getByRole('region', { name: /scroll/i })
+    expect(scroller).toHaveAttribute('tabindex', '0')
+    expect(scroller.className).toMatch(/overflow-x-auto/)
+
+    // Right-edge discoverability cue (Lesson 105 — non-trap move #3).
+    expect(
+      container.querySelector('.districts-rankings-table__scroll-cue')
+    ).not.toBeNull()
+  })
+
+  it('makes District the single sticky key column (no hardcoded second sticky)', async () => {
+    setupSingleRow()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    const districtCell = screen.getByTestId('district-cell-7')
+    expect(districtCell.className).toMatch(
+      /districts-rankings-table__sticky-col/
+    )
+
+    // AC #2: the Rank column must NOT be a second hardcoded sticky column —
+    // that `left-[200px]` magic-number seam is exactly what this sprint removes.
+    const rankCell = screen.getByTestId('rank-cell-7')
+    expect(rankCell.className).not.toMatch(/sticky-col/)
+    expect(rankCell.className).not.toMatch(/left-\[200px\]/)
+    expect(rankCell.className).not.toMatch(/\bsticky\b/)
+  })
+
+  it('keeps the sticky District cell tint-aware (data-row-tint hook)', async () => {
+    setupSingleRow()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    // Default (untinted) row: the sticky cell must NOT hardcode bg-white
+    // (Lesson 116 — that routes to the lighter dark scale). It carries an
+    // explicit tint hook so isMine/isPinned rows repaint opaquely instead.
+    const districtCell = screen.getByTestId('district-cell-7')
+    expect(districtCell.className).not.toMatch(/bg-white/)
+    expect(districtCell).toHaveAttribute('data-row-tint')
+  })
+
+  it('assigns responsive priority classes per column', async () => {
+    setupSingleRow()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    // Always-visible (mobile 375): District (sticky), Rank, Score.
+    for (const re of [/^rank$/i, /^score$/i]) {
+      const th = headerByText(re)
+      expect(th.className).not.toMatch(/__col--tablet/)
+      expect(th.className).not.toMatch(/__col--desktop/)
+    }
+    // Tablet+ (≥768): the three metric columns.
+    for (const re of [/paid clubs/i, /total payments/i, /distinguished/i]) {
+      expect(headerByText(re).className).toMatch(/__col--tablet/)
+    }
+    // Desktop-only (≥1280): Tier.
+    expect(headerByText(/^tier$/i).className).toMatch(/__col--desktop/)
+  })
+
+  it('gives the row action buttons a ≥44px touch-target class', async () => {
+    setupSingleRow()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    const star = screen.getByRole('button', { name: /my district/i })
+    const pin = screen.getByRole('button', { name: /pin district 7/i })
+    expect(star.className).toMatch(/districts-rankings-table__touch-btn/)
+    expect(pin.className).toMatch(/districts-rankings-table__touch-btn/)
+  })
+
+  it('exposes the rank badge by a stable testid (not by sticky-ness)', async () => {
+    setupSingleRow()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    const badge = screen.getByTestId('rank-badge-7')
+    expect(badge.textContent?.trim()).toBe('1')
+  })
+})

--- a/frontend/src/pages/__tests__/DistrictsPage.search.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.search.test.tsx
@@ -282,19 +282,13 @@ describe('DistrictsPage - District Search (#91)', () => {
     // District 61 should retain its original rank of 2, NOT become rank 1
     expect(screen.getByText('District 61')).toBeInTheDocument()
 
-    // The rank badge should show "2" not "1"
-    const rankBadges = screen.getAllByText('2')
-    const rankBadge = rankBadges.find(el =>
-      el.closest('td')?.classList.contains('sticky')
-    )
-    expect(rankBadge).toBeDefined()
+    // D61's rank badge should show "2" (its original rank), not "1". The rank
+    // column is no longer a sticky cell (#811 dropped the hardcoded second
+    // sticky), so identify the badge by its stable testid instead.
+    expect(screen.getByTestId('rank-badge-61').textContent?.trim()).toBe('2')
 
-    // Rank "1" should NOT be present (District 57 is filtered out)
-    const allOnes = screen.queryAllByText('1')
-    const rankOneInSticky = allOnes.find(el =>
-      el.closest('td')?.classList.contains('sticky')
-    )
-    expect(rankOneInSticky).toBeUndefined()
+    // No surviving row should show rank "1" — D57 (rank 1) is filtered out.
+    expect(screen.queryByTestId('rank-badge-57')).toBeNull()
   })
 
   it('search suggestions do not duplicate bare-numeric districtName (#522)', async () => {

--- a/frontend/src/pages/__tests__/mobile-ux.test.tsx
+++ b/frontend/src/pages/__tests__/mobile-ux.test.tsx
@@ -39,23 +39,38 @@ describe('Issue #86 — Tab bar scroll fade indicator', () => {
   // lives in `src/components/__tests__/DistrictDetailTabs.test.tsx`.
 })
 
-// ---- Issue #85: Sticky table columns ----
+// ---- Issue #85 → #811: Sticky key column on horizontal scroll ----
+// #85 originally pinned BOTH Rank and District as sticky via inline Tailwind
+// (`sticky left-0` + `sticky left-[200px]`). #811 (epic #813) superseded that:
+// the two-sticky pair (~380px) alone overflowed a 375px phone, and the
+// `left-[200px]` magic offset was a fragile px seam (ADR-006 §3). The new model
+// pins ONE sticky key column (District) via a CSS class — no hardcoded offset —
+// so the row stays labelled while metric columns scroll. The #85 intent (a
+// labelled, scroll-stable identity column) is preserved by the single sticky
+// column; the rendered-DOM contract is covered in DistrictsPage.responsive.test.
 
-describe('Issue #85 — Sticky table columns on mobile', () => {
-  it('DistrictsPage should have sticky classes on Rank column', () => {
+describe('Issue #85 → #811 — single sticky key column', () => {
+  it('DistrictsPage marks District as the sticky key column (not inline px sticky)', () => {
     const source = fs.readFileSync(
       path.join(SRC_DIR, 'pages', 'DistrictsPage.tsx'),
       'utf-8'
     )
-    expect(source).toMatch(/sticky.*left-0/)
+    expect(source).toContain('districts-rankings-table__sticky-col')
   })
 
-  it('DistrictsPage should have sticky classes on District column', () => {
-    const source = fs.readFileSync(
-      path.join(SRC_DIR, 'pages', 'DistrictsPage.tsx'),
+  it('app-shell.css pins the key column with position:sticky, no hardcoded left offset', () => {
+    const css = fs.readFileSync(
+      path.join(SRC_DIR, 'styles', 'components', 'app-shell.css'),
       'utf-8'
     )
-    expect(source).toMatch(/sticky.*left-\[/)
+    // The sticky key-column rule resolves position:sticky + left:0 (a token-
+    // free, offset-free pin — no `left: 120px/200px` magic number seam).
+    expect(css).toMatch(
+      /\.districts-rankings-table__sticky-col\s*\{[\s\S]*?position:\s*sticky/
+    )
+    expect(css).toMatch(
+      /\.districts-rankings-table__sticky-col\s*\{[\s\S]*?left:\s*0/
+    )
   })
 
   it('index.css should define .sticky-column-shadow class', () => {

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -925,17 +925,33 @@
       inset 0 -1px 0 var(--line-2);
   }
 
+  /* The last row zeroes its real border-bottom; do the same for the sticky
+     cell's box-shadow-drawn rule so it doesn't leave a stray hairline under
+     the first column. Keep only the right (sticky/scroll seam) inset. */
+  .districts-rankings-table
+    tbody
+    tr:last-child
+    .districts-rankings-table__sticky-col {
+    box-shadow: inset -1px 0 0 var(--line);
+  }
+
   /* Header sticky cell rides the thead surface and layers above body cells. */
   .districts-rankings-table thead .districts-rankings-table__sticky-col {
     z-index: 3;
     background-color: var(--surface-2);
   }
 
-  /* Keep the pinned cell in sync with the row-hover highlight. */
+  /* Keep the sticky cell in sync with the row-hover highlight — but ONLY for
+     untinted rows. A tinted (my-district / pinned) row keeps its tint on hover
+     (its non-sticky cells use Tailwind bg-yellow-50/bg-blue-50, which sit in
+     the utilities layer and outrank the row-hover rule), so the sticky cell
+     must keep its tint too rather than flipping to --surface-2. Targeting
+     [data-row-tint='none'] makes light and dark behave identically (avoids the
+     lessons 94/95 hover asymmetry). */
   .districts-rankings-table
     tbody
     tr:hover
-    .districts-rankings-table__sticky-col {
+    .districts-rankings-table__sticky-col[data-row-tint='none'] {
     background-color: var(--surface-2);
   }
 
@@ -981,7 +997,10 @@
   }
 
   /* Right-edge fade discoverability cue. Themed (transparent → --surface, so it
-     remaps in dark); pointer-events:none so it never blocks taps/scroll. */
+     remaps in dark); pointer-events:none so it never blocks taps/scroll. Shown
+     ONLY when the table overflows to the right (data-scrollable-right, set by
+     DistrictsPage) — otherwise the fade would wash out the right-aligned Score
+     column on desktop, where the full set fits and nothing scrolls. */
   .districts-rankings-table__scroll-cue {
     position: absolute;
     top: 0;
@@ -990,6 +1009,12 @@
     width: 40px;
     pointer-events: none;
     background: linear-gradient(to right, rgba(0, 0, 0, 0), var(--surface));
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+  .districts-rankings-table__scroll-wrap[data-scrollable-right='true']
+    .districts-rankings-table__scroll-cue {
+    opacity: 1;
   }
 
   /* Region rankings: intentional, documented horizontal scroll (#689, epic

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -902,6 +902,96 @@
     overflow: hidden;
   }
 
+  /* ── Landing rankings table: non-trap scroll + priority columns (#811) ──
+     A leaderboard keeps the table and makes the horizontal scroll non-trap
+     (Lesson 105): one sticky key column, a scroll-cue, a focusable scroller —
+     NOT a card collapse. Positioning context for the right-edge cue. */
+  .districts-rankings-table__scroll-wrap {
+    position: relative;
+  }
+
+  /* Single sticky key column (District) pinned at left:0. Themed background
+     (var(--surface)) so it converges on the SAME surface scale as the table
+     body — not the lighter --surface-card the old `.sticky` dark path landed on
+     (Lesson 116). border-collapse drops a positioned cell's borders, so the row
+     rule + the sticky/scroll seam are restored with inset box-shadows. */
+  .districts-rankings-table__sticky-col {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    background-color: var(--surface);
+    box-shadow:
+      inset -1px 0 0 var(--line),
+      inset 0 -1px 0 var(--line-2);
+  }
+
+  /* Header sticky cell rides the thead surface and layers above body cells. */
+  .districts-rankings-table thead .districts-rankings-table__sticky-col {
+    z-index: 3;
+    background-color: var(--surface-2);
+  }
+
+  /* Keep the pinned cell in sync with the row-hover highlight. */
+  .districts-rankings-table
+    tbody
+    tr:hover
+    .districts-rankings-table__sticky-col {
+    background-color: var(--surface-2);
+  }
+
+  /* The sticky cell must be OPAQUE or scrolled columns bleed through; a tinted
+     row (my-district / pinned) repaints its tint here so it stays opaque. The
+     literals match Tailwind yellow-50 / blue-50 (the tints the <tr> still
+     carries for its transparent cells); dark variants live in dark-mode.css. */
+  .districts-rankings-table__sticky-col[data-row-tint='mine'] {
+    background-color: #fefce8;
+  }
+  .districts-rankings-table__sticky-col[data-row-tint='pinned'] {
+    background-color: #eff6ff;
+  }
+
+  /* ≥44px touch targets for the row action buttons (WCAG 2.5.5, Lesson 111).
+     These are <button>s, so min-height applies in WebKit without
+     appearance:none (that caveat is for native <select>). The icon stays small
+     (w-4 h-4); the padding box carries the hit area. */
+  .districts-rankings-table__touch-btn {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  /* Per-column responsive priority (ADR-006 §3). Mobile-first: low-priority
+     columns are hidden by default and revealed at each breakpoint. Always-on
+     at 375px: District (sticky), Rank, Score. */
+  .districts-rankings-table__col--tablet,
+  .districts-rankings-table__col--desktop {
+    display: none;
+  }
+  /* Tablet (≥768): + the three metric columns (Paid Clubs / Payments /
+     Distinguished). */
+  @media (min-width: 768px) {
+    .districts-rankings-table__col--tablet {
+      display: table-cell;
+    }
+  }
+  /* Desktop (≥1280): + Tier (the full set). */
+  @media (min-width: 1280px) {
+    .districts-rankings-table__col--desktop {
+      display: table-cell;
+    }
+  }
+
+  /* Right-edge fade discoverability cue. Themed (transparent → --surface, so it
+     remaps in dark); pointer-events:none so it never blocks taps/scroll. */
+  .districts-rankings-table__scroll-cue {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 40px;
+    pointer-events: none;
+    background: linear-gradient(to right, rgba(0, 0, 0, 0), var(--surface));
+  }
+
   /* Region rankings: intentional, documented horizontal scroll (#689, epic
      #683). The 19-column table can't fit a phone and a regional leaderboard
      exists to compare districts across rows, so card-collapse is wrong here

--- a/frontend/src/styles/dark-mode.css
+++ b/frontend/src/styles/dark-mode.css
@@ -495,6 +495,18 @@
     background-color: rgba(37, 99, 235, 0.10) !important;
 }
 
+/* Landing rankings table sticky key column (#811). Its default bg is the
+   themed var(--surface) (already dark-safe); only the tinted-row repaints need
+   a dark variant. Match the bg-yellow-50 / bg-blue-50 dark remaps (0.10 alpha)
+   so the opaque sticky cell stays consistent with the rest of the tinted row. */
+[data-theme='dark'] .districts-rankings-table__sticky-col[data-row-tint='mine'] {
+    background-color: rgba(161, 98, 7, 0.10) !important;
+}
+
+[data-theme='dark'] .districts-rankings-table__sticky-col[data-row-tint='pinned'] {
+    background-color: rgba(37, 99, 235, 0.10) !important;
+}
+
 /* ═══════════════════════════════════════════
    Gradient Backgrounds (Summary Cards)
    Light gradients → dark translucent gradients

--- a/frontend/src/styles/dark-mode.css
+++ b/frontend/src/styles/dark-mode.css
@@ -498,13 +498,17 @@
 /* Landing rankings table sticky key column (#811). Its default bg is the
    themed var(--surface) (already dark-safe); only the tinted-row repaints need
    a dark variant. Match the bg-yellow-50 / bg-blue-50 dark remaps (0.10 alpha)
-   so the opaque sticky cell stays consistent with the rest of the tinted row. */
+   so the opaque sticky cell stays consistent with the rest of the tinted row.
+   No !important: the cell carries no Tailwind bg utility to override, and
+   !important here would beat the row-hover rule and desync the pinned cell's
+   highlight from its row in dark mode. */
 [data-theme='dark'] .districts-rankings-table__sticky-col[data-row-tint='mine'] {
-    background-color: rgba(161, 98, 7, 0.10) !important;
+    background-color: rgba(161, 98, 7, 0.1);
 }
 
-[data-theme='dark'] .districts-rankings-table__sticky-col[data-row-tint='pinned'] {
-    background-color: rgba(37, 99, 235, 0.10) !important;
+[data-theme='dark']
+    .districts-rankings-table__sticky-col[data-row-tint='pinned'] {
+    background-color: rgba(37, 99, 235, 0.1);
 }
 
 /* ═══════════════════════════════════════════

--- a/tasks/lessons/125-a-cls-fix-for-the-loading-state-must-cover-the-error-and-empty-states-too.md
+++ b/tasks/lessons/125-a-cls-fix-for-the-loading-state-must-cover-the-error-and-empty-states-too.md
@@ -1,0 +1,76 @@
+---
+id: '125'
+category: lesson
+tags: [cls, performance, frontend, verification, ci]
+auto_load: true
+date: 2026-05-27
+issues: [811, 488, 750]
+---
+
+# Lesson 125 — A CLS fix for the loading state must cover the error/empty states too
+
+**Date:** 2026-05-27
+**Issue:** #811 (epic #813 Sprint 3 — landing rankings table) — surfaced during PR
+#825 verification.
+
+## What happened
+
+The Lighthouse CI gate on `/` failed with CLS **0.206** (budget ≤0.1) on a PR
+whose entire diff lived inside the loaded `.districts-page` table. The reflex
+read is "the table change shifted layout." The trace said otherwise: the single
+shifting node was `div.districts-page-root > div.container`
+(`<div class="container mx-auto px-4 py-8">`) — a wrapper that exists **only in
+DistrictsPage's `isError` branches**, which the diff never touched. The LCP
+element was the header orientation text (the skeleton), and no loaded-state
+markup (`District Rankings`, `districts-rankings-table`) was present in the LHR
+at all. So the run had gone **skeleton → error**, not skeleton → table: the CDN
+rankings fetch flaked on the localhost LHCI runner, and the page rendered the
+error state. Re-running the job (CDN reachable) passed at <0.1, 3/3.
+
+The root cause is a half-finished fix. #488 proved that swapping the
+`.container mx-auto px-4 py-8` wrapper for the real `.districts-page` wrapper on
+data-load was "the dominant remaining CLS source — CI attributed 0.1998 to that
+container alone," and fixed the **loading skeleton** to use `.districts-page`.
+But the two `isError` branches still render `.container mx-auto px-4 py-8`. So
+the exact 0.2 shift #488 killed for the happy path is alive on the error path,
+and it fires whenever the data source flakes — an **intermittent gate failure
+that has nothing to do with the PR under test.**
+
+## The transferable lesson
+
+**A layout-stability fix made for one async outcome (loading) must be applied to
+every sibling terminal state (error, empty, no-data) — they share the same
+geometry-swap surface.** A component with `loading | error | empty | loaded`
+states shifts CLS on _every_ transition between wrappers of different geometry,
+not just `loading → loaded`. Fixing one transition and leaving the others is a
+latent, data-dependent gate failure: green most days, red the day the upstream
+flakes, and the red lands on whatever innocent PR happens to be building then.
+
+Corollary for debugging a CLS failure: **read the `layout-shifts` audit's node
+selector before blaming the diff.** If the shifting element isn't in your diff's
+code path — here, an `isError`-only wrapper on a PR that only touched the loaded
+table — the failure is pre-existing and (often) environmental, not yours. Don't
+"fix" your code to chase a phantom (cf. Lesson 108).
+
+## How to apply
+
+- When you stabilise a component's loading→loaded swap, give the error/empty
+  states the **same outer wrapper geometry** (here: wrap them in
+  `.districts-page-root > .districts-page`, not `.container mx-auto px-4 py-8`).
+- A flaky CLS/Lighthouse gate on `/` that names an error-state node is the tell
+  that an external dependency (CDN) failed on the runner — re-run to confirm,
+  then fix the error-state geometry so the gate stops depending on CDN luck.
+- Filed follow-up to align the two `DistrictsPage` `isError` wrappers; out of
+  #811's single-responsibility scope (its diff was all loaded-state).
+
+## Related
+
+- [[079-suspense-fallback-for-maybe-null-is-pure-cls-hoist-the-guard]] — the
+  same family: a state that renders different geometry than its sibling is a CLS
+  source; reserve the slot.
+- [[107-a-deferred-async-insert-cls-source-reactivates-when-its-data-lands]] —
+  CLS sources that hide until a data condition flips; here the condition is
+  "the fetch errored," which the gate hits intermittently.
+- [[108-verify-a-sticky-header-by-measuring-the-sticky-cell-not-the-thead-wrapper]]
+  — verify the real node before touching code; the failing node, not the diff,
+  tells you where the bug is.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -91,3 +91,4 @@
 - **122** [ci, lighthouse, security, csp, verification, frontend] — A CSP in hosting config is invisible to the localhost Lighthouse gate; verify headers on the deployed surface (#783, #785)
 - **123** [analytics, data-pipeline, dcp, frontend, verification] — `totals.distinguished*` is unpopulated mid-year; count distinguished from `clubPerformance` (#793, #797)
 - **124** [router, react, hooks, frontend, verification] — Validate URL-synced range state at the page that owns it, not at the picker (#794, #797)
+- **125** [cls, performance, frontend, verification, ci] — A CLS fix for the loading state must cover the error/empty states too (#811, #488, #750)


### PR DESCRIPTION
Epic #813 (Epic A) Sprint 3. Ref: ADR-006 §3 + \`docs/design/table-ux-review-2026-05-27.md\` §1. Builds on #809 (ADR) + #810 (full-width container).

## What

The 7-col landing rankings table was \`table-auto\` + \`overflow-x-auto\` with **zero @media rules**, two hardcoded sticky columns (\`left-[200px]\` magic seam), a \`bg-white\` sticky cell (Lesson 116 dark-mode trap), and no scroll affordance. This introduces the per-column priority model + a robust single sticky key column.

**Design decision — keep the table, non-trap scroll (Lesson 105), NOT card-collapse.** The landing table is a *leaderboard*; its value is cross-row comparison, which a card collapse destroys. ADR-006 §2's generic "card at mobile" row is the right call for the *club* table (#812, browse-one-at-a-time), not this one. The #811 AC is satisfied by priority-column hiding + a non-trap scroll (no card view). Documented in a code comment per Lesson 105.

## Changes

- **Single sticky key column** = District (`.districts-rankings-table__sticky-col`, themed `var(--surface)`). Dropped the 2nd hardcoded sticky (Rank `left-[200px]`) — that px pair (~380px) alone overflowed 375px (AC #2). Converging the sticky bg on `--surface` also fixes a live Lesson-116 trap (the old `.sticky` path landed on the lighter `--surface-card`).
- **Priority-column model** (mobile-first, CSS `@media`): always (375) District·Rank·Score; `+__col--tablet` (≥768) the three metric columns; `+__col--desktop` (≥1280) Tier.
- **Non-trap scroll**: focusable `role="region"` + `aria-label` (WCAG 2.1.1) + right-edge scroll-cue, shown **only when actually overflowing** (`data-scrollable-right`) so it never washes out the right-aligned Score on desktop.
- **≥44px touch targets** on the star/pin buttons (`__touch-btn`; Lesson 111 — `<button>`s honor min-height in WebKit).
- **Dark mode**: token-based tints via `data-row-tint`; hover-sync scoped to untinted rows so light/dark behave identically (lessons 94/95).

## Tests

- New `DistrictsPage.responsive.test.tsx` — scroll region, single sticky col, no `left-[200px]`, priority classes, touch-btn, rank-badge testid.
- Updated `search.test.tsx` (rank cell no longer sticky → testid selector) and `mobile-ux.test.tsx` (#85 two-sticky design superseded by #811 — asserts the new single-sticky mechanism). Not assertion pinning — both track the real DOM contract change.
- Full frontend suite green (2855), typecheck + build + lint clean.

## Verification

Live per-breakpoint behaviour (375/768/1280/1600 + dark, both engines) + CLS guard verified on the PR preview channel — evidence to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)