### PR TITLE
feat(tables): club table — priority-column responsive model + tablet tier (#812)

### DIFF
--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react'
+import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { ClubTrend } from '../hooks/useDistrictAnalytics'
 import type { ClubHealthStatus } from '../hooks/useDistrictAnalytics'
 import { ExportButton } from './ExportButton'
@@ -40,6 +40,49 @@ const TIER_MODIFIER: Record<ConfirmedTier, string> = {
   President: 'clubs-tier-pill--presidents',
   Smedley: 'clubs-tier-pill--smedley',
 }
+
+// Per-column responsive priority (ADR-006 §3, #812). The table renders only at
+// the tablet tier and up (≥768px; below that is the card view). Two visibility
+// levels:
+//   • Core (always shown when the table renders): Club (sticky key), Status,
+//     Members, Needed, DCP, Tier — the triage set a leader scans first.
+//   • Detail (clubs-table__col--desktop — hidden 768–1279, revealed ≥1280):
+//     Div, Area, New, Oct Renew, Apr Renew, Club Status, Years.
+// The card view at true mobile carries the full record, so nothing is lost.
+const DESKTOP_ONLY_FIELDS: ReadonlySet<SortField> = new Set([
+  'division',
+  'area',
+  'newMembers',
+  'octoberRenewals',
+  'aprilRenewals',
+  'clubStatus',
+  'yearsChartered',
+])
+
+// The sticky key column — pinned at left:0 so the row stays labelled while the
+// metric columns scroll horizontally (Lesson 105). It is never hidden.
+const STICKY_FIELD: SortField = 'name'
+
+/** Responsive priority class for a column header/cell, by field. */
+const colPriorityClass = (field: SortField): string =>
+  field === STICKY_FIELD
+    ? 'clubs-table__sticky-col'
+    : DESKTOP_ONLY_FIELDS.has(field)
+      ? 'clubs-table__col--desktop'
+      : ''
+
+/** Row-tint key for the sticky cell, so it can repaint OPAQUE per row status
+ *  (a sticky cell must be opaque or scrolled columns bleed through it). Mirrors
+ *  the row bg set by getRowColor: intervention → red-50, vulnerable → yellow-50,
+ *  everything else → the themed --surface (no repaint needed). */
+const rowTint = (
+  status: 'thriving' | 'vulnerable' | 'intervention-required'
+): 'intervention' | 'vulnerable' | 'none' =>
+  status === 'intervention-required'
+    ? 'intervention'
+    : status === 'vulnerable'
+      ? 'vulnerable'
+      : 'none'
 
 /**
  * Props for the ClubsTable component
@@ -123,11 +166,14 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   const [sortDirection, setSortDirection] = useState<SortDirection>(
     initialSortDirection ?? 'asc'
   )
-  // Collapse the table to cards at 640px per HANDOFF §126 (epic #665 Sprint 5,
-  // #671) — was 768px. Below 640 a 13-column table can't fit without a scroll
-  // trap; clubs are browsed one-at-a-time, so card-collapse is the right
-  // pattern (lesson 105).
-  const isMobile = useIsMobile(640)
+  // Collapse the table to cards at the 768px tablet boundary (ADR-006 §2, epic
+  // #813 Sprint 4, #812). The card view is for TRUE mobile only (< 768px);
+  // 768–1279px shows the table with low-priority columns hidden (the
+  // priority-column model below), and ≥1280px shows the full set. Clubs are
+  // browsed one-at-a-time, so card-collapse at true mobile is the right pattern
+  // (lesson 105) — but the old 640px value made the table→card swap a cliff
+  // with no tablet tier. The tablet tier is what #812 adds.
+  const isMobile = useIsMobile(768)
 
   // Use column filters hook with optional URL-initialized state (#272)
   const {
@@ -328,6 +374,36 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
     }
     onSortChange?.(newField, newDirection)
   }
+
+  // Show the right-edge scroll-cue ONLY when the table actually overflows to
+  // the right. A permanent fade would wash out the right-aligned numeric
+  // columns on a wide desktop where the full set fits and nothing scrolls — a
+  // false affordance. Toggled imperatively via a data-attr on the scroll-wrap
+  // (gated in CSS) so scroll/resize don't re-render the whole table. Mirrors
+  // the landing rankings table (#811).
+  const tableScrollRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const el = tableScrollRef.current
+    if (!el) return
+    const update = () => {
+      const moreToRight = el.scrollWidth - el.clientWidth - el.scrollLeft > 1
+      el.parentElement?.setAttribute(
+        'data-scrollable-right',
+        String(moreToRight)
+      )
+    }
+    update()
+    el.addEventListener('scroll', update, { passive: true })
+    let ro: ResizeObserver | undefined
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(update)
+      ro.observe(el)
+    }
+    return () => {
+      el.removeEventListener('scroll', update)
+      ro?.disconnect()
+    }
+  }, [sortedClubs, isMobile])
 
   return (
     <div className="redesign-panel">
@@ -764,207 +840,233 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
           (role/tabindex/aria-label) so keyboard-only users can scroll it
           (WCAG 2.1.1; axe scrollable-region-focusable). */}
       {!isLoading && sortedClubs.length > 0 && !isMobile && (
-        <div
-          className="clubs-table-scroll overflow-x-auto"
-          role="region"
-          aria-label="All clubs table"
-          tabIndex={0}
-        >
-          <table id="clubs-table" className="w-full table-auto">
-            <thead className="clubs-table-sticky-head">
-              <tr>
-                {COLUMN_CONFIGS.map(config => (
-                  <th key={config.field} className="p-0">
-                    <ColumnHeader
-                      field={config.field}
-                      label={config.label}
-                      sortable={config.sortable}
-                      filterable={config.filterable}
-                      filterType={config.filterType}
-                      currentSort={{
-                        field: sortField,
-                        direction: sortDirection,
-                      }}
-                      currentFilter={getFilter(config.field)}
-                      onSort={handleSort}
-                      onFilter={setFilter}
-                      {...(config.filterOptions && {
-                        options: config.filterOptions,
-                      })}
-                    />
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {sortedClubs.map(club => (
-                <tr
-                  key={club.clubId}
-                  onClick={() => onClubClick?.(club)}
-                  className={`${getRowColor(club.currentStatus)} cursor-pointer transition-colors`}
-                >
-                  {/* Cell order MUST match COLUMN_CONFIGS (filters/types.ts):
-                      Club, Div, Area, Status, Members, Needed, New, Oct Renew,
-                      Apr Renew, DCP, Tier, Club Status, Years (#669). */}
-                  <td className="px-2 py-3 whitespace-nowrap">
-                    <div className="font-medium text-sm">{club.clubName}</div>
-                  </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center">
-                    {club.divisionName}
-                  </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center">
-                    {club.areaName}
-                  </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-center">
-                    <span
-                      className={`clubs-status-pill ${getStatusPillModifier(club.currentStatus)}`}
+        <div className="clubs-table__scroll-wrap">
+          <div
+            ref={tableScrollRef}
+            className="clubs-table-scroll overflow-x-auto"
+            role="region"
+            aria-label="All clubs table"
+            tabIndex={0}
+          >
+            <table id="clubs-table" className="w-full table-auto">
+              <thead className="clubs-table-sticky-head">
+                <tr>
+                  {COLUMN_CONFIGS.map(config => (
+                    <th
+                      key={config.field}
+                      className={`p-0 ${colPriorityClass(config.field)}`.trim()}
                     >
-                      {getStatusLabel(club.currentStatus)}
-                    </span>
-                  </td>
-                  {/* Members — current / base (#669). Base omitted when the
-                      snapshot has no membershipBase (pre-merge data). */}
-                  <td className="px-2 py-3 whitespace-nowrap text-sm text-center clubs-members-cell">
-                    <span className="tabular-nums">
-                      {club.latestMembership}
-                    </span>
-                    {club.membershipBase !== undefined && (
-                      <span className="clubs-cell-muted tabular-nums">
-                        {' / '}
-                        {club.membershipBase}
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center font-medium">
-                    {club.membersNeeded > 0 ? (
-                      <span className="text-tm-true-maroon">
-                        {club.membersNeeded}
-                      </span>
-                    ) : (
-                      <span className="clubs-cell-muted">—</span>
-                    )}
-                  </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
-                    {club.newMembers !== undefined ? (
-                      <span
-                        className={
-                          club.newMembers === 0 ? 'clubs-cell-muted' : undefined
-                        }
+                      <ColumnHeader
+                        field={config.field}
+                        label={config.label}
+                        sortable={config.sortable}
+                        filterable={config.filterable}
+                        filterType={config.filterType}
+                        currentSort={{
+                          field: sortField,
+                          direction: sortDirection,
+                        }}
+                        currentFilter={getFilter(config.field)}
+                        onSort={handleSort}
+                        onFilter={setFilter}
+                        {...(config.filterOptions && {
+                          options: config.filterOptions,
+                        })}
+                      />
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {sortedClubs.map(club => {
+                  const tint = rowTint(club.currentStatus)
+                  return (
+                    <tr
+                      key={club.clubId}
+                      onClick={() => onClubClick?.(club)}
+                      className={`${getRowColor(club.currentStatus)} cursor-pointer transition-colors`}
+                    >
+                      {/* Cell order MUST match COLUMN_CONFIGS (filters/types.ts):
+                      Club, Div, Area, Status, Members, Needed, New, Oct Renew,
+                      Apr Renew, DCP, Tier, Club Status, Years (#669). The
+                      responsive priority class on each cell MUST match its
+                      header above (colPriorityClass, #812). */}
+                      {/* Club — the sticky key column. data-row-tint lets the CSS
+                        repaint it opaque to match the row's status bg so the
+                        scrolled columns don't bleed through (Lesson 105). */}
+                      <td
+                        className="px-2 py-3 whitespace-nowrap clubs-table__sticky-col"
+                        data-row-tint={tint}
                       >
-                        {club.newMembers}
-                      </span>
-                    ) : (
-                      <span className="clubs-cell-muted">—</span>
-                    )}
-                  </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
-                    {club.octoberRenewals !== undefined ? (
-                      <span
-                        className={
-                          club.octoberRenewals === 0
-                            ? 'clubs-cell-muted'
-                            : undefined
-                        }
-                      >
-                        {club.octoberRenewals}
-                      </span>
-                    ) : (
-                      <span className="clubs-cell-muted">—</span>
-                    )}
-                  </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
-                    {club.aprilRenewals !== undefined ? (
-                      <span
-                        className={
-                          club.aprilRenewals === 0
-                            ? 'clubs-cell-muted'
-                            : undefined
-                        }
-                      >
-                        {club.aprilRenewals}
-                      </span>
-                    ) : (
-                      <span className="clubs-cell-muted">—</span>
-                    )}
-                  </td>
-                  {/* DCP — inline progress bar over the canonical goals-achieved
-                      count (0–10). Reads latestDcpGoals from the analytics
-                      trend; no Goals-1-N inference (DCP-independence tripwire). */}
-                  <td className="px-2 py-3 whitespace-nowrap text-center">
-                    {(() => {
-                      const goals = Math.max(
-                        0,
-                        Math.min(10, club.latestDcpGoals)
-                      )
-                      const pct = (goals / 10) * 100
-                      return (
-                        <div className="clubs-dcp-cell">
-                          <span className="clubs-dcp-cell__val tabular-nums">
-                            {goals}/10
-                          </span>
-                          <div
-                            className="clubs-dcp-bar"
-                            role="progressbar"
-                            aria-valuenow={goals}
-                            aria-valuemin={0}
-                            aria-valuemax={10}
-                            aria-label="DCP goals achieved"
-                          >
-                            <div
-                              className="clubs-dcp-bar__fill"
-                              style={{ width: `${pct}%` }}
-                            />
-                          </div>
+                        <div className="font-medium text-sm">
+                          {club.clubName}
                         </div>
-                      )
-                    })()}
-                  </td>
-                  {/* Tier — DCP recognition pill (#669). Color by tier; a
-                      provisional tier shows the striped-yellow "projected"
-                      treatment instead (membership unconfirmed pre-April). */}
-                  <td className="px-2 py-3 whitespace-nowrap text-center">
-                    {club.distinguishedLevel !== 'NotDistinguished' ? (
-                      (() => {
-                        const provisional = isProvisionallyDistinguished(club)
-                        const modifier = provisional
-                          ? 'clubs-tier-pill--projected'
-                          : TIER_MODIFIER[club.distinguishedLevel]
-                        return (
+                      </td>
+                      <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center clubs-table__col--desktop">
+                        {club.divisionName}
+                      </td>
+                      <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center clubs-table__col--desktop">
+                        {club.areaName}
+                      </td>
+                      <td className="px-2 py-3 whitespace-nowrap text-center">
+                        <span
+                          className={`clubs-status-pill ${getStatusPillModifier(club.currentStatus)}`}
+                        >
+                          {getStatusLabel(club.currentStatus)}
+                        </span>
+                      </td>
+                      {/* Members — current / base (#669). Base omitted when the
+                      snapshot has no membershipBase (pre-merge data). */}
+                      <td className="px-2 py-3 whitespace-nowrap text-sm text-center clubs-members-cell">
+                        <span className="tabular-nums">
+                          {club.latestMembership}
+                        </span>
+                        {club.membershipBase !== undefined && (
+                          <span className="clubs-cell-muted tabular-nums">
+                            {' / '}
+                            {club.membershipBase}
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center font-medium">
+                        {club.membersNeeded > 0 ? (
+                          <span className="text-tm-true-maroon">
+                            {club.membersNeeded}
+                          </span>
+                        ) : (
+                          <span className="clubs-cell-muted">—</span>
+                        )}
+                      </td>
+                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
+                        {club.newMembers !== undefined ? (
                           <span
-                            className={`clubs-tier-pill ${modifier}`}
-                            title={
-                              provisional
-                                ? 'Provisional — membership not yet confirmed by April renewals'
-                                : 'Confirmed — April renewals recorded'
+                            className={
+                              club.newMembers === 0
+                                ? 'clubs-cell-muted'
+                                : undefined
                             }
                           >
-                            {TIER_DISPLAY[club.distinguishedLevel]}
-                            {provisional ? '*' : ''}
+                            {club.newMembers}
                           </span>
-                        )
-                      })()
-                    ) : (
-                      <span className="text-sm clubs-cell-muted">—</span>
-                    )}
-                  </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm text-center">
-                    {club.clubStatus ? (
-                      <span>{club.clubStatus}</span>
-                    ) : (
-                      <span className="clubs-cell-muted">—</span>
-                    )}
-                  </td>
-                  <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center">
-                    {club.yearsChartered !== null ? (
-                      <span>{club.yearsChartered}</span>
-                    ) : (
-                      <span className="clubs-cell-muted">—</span>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                        ) : (
+                          <span className="clubs-cell-muted">—</span>
+                        )}
+                      </td>
+                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
+                        {club.octoberRenewals !== undefined ? (
+                          <span
+                            className={
+                              club.octoberRenewals === 0
+                                ? 'clubs-cell-muted'
+                                : undefined
+                            }
+                          >
+                            {club.octoberRenewals}
+                          </span>
+                        ) : (
+                          <span className="clubs-cell-muted">—</span>
+                        )}
+                      </td>
+                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
+                        {club.aprilRenewals !== undefined ? (
+                          <span
+                            className={
+                              club.aprilRenewals === 0
+                                ? 'clubs-cell-muted'
+                                : undefined
+                            }
+                          >
+                            {club.aprilRenewals}
+                          </span>
+                        ) : (
+                          <span className="clubs-cell-muted">—</span>
+                        )}
+                      </td>
+                      {/* DCP — inline progress bar over the canonical goals-achieved
+                      count (0–10). Reads latestDcpGoals from the analytics
+                      trend; no Goals-1-N inference (DCP-independence tripwire). */}
+                      <td className="px-2 py-3 whitespace-nowrap text-center">
+                        {(() => {
+                          const goals = Math.max(
+                            0,
+                            Math.min(10, club.latestDcpGoals)
+                          )
+                          const pct = (goals / 10) * 100
+                          return (
+                            <div className="clubs-dcp-cell">
+                              <span className="clubs-dcp-cell__val tabular-nums">
+                                {goals}/10
+                              </span>
+                              <div
+                                className="clubs-dcp-bar"
+                                role="progressbar"
+                                aria-valuenow={goals}
+                                aria-valuemin={0}
+                                aria-valuemax={10}
+                                aria-label="DCP goals achieved"
+                              >
+                                <div
+                                  className="clubs-dcp-bar__fill"
+                                  style={{ width: `${pct}%` }}
+                                />
+                              </div>
+                            </div>
+                          )
+                        })()}
+                      </td>
+                      {/* Tier — DCP recognition pill (#669). Color by tier; a
+                      provisional tier shows the striped-yellow "projected"
+                      treatment instead (membership unconfirmed pre-April). */}
+                      <td className="px-2 py-3 whitespace-nowrap text-center">
+                        {club.distinguishedLevel !== 'NotDistinguished' ? (
+                          (() => {
+                            const provisional =
+                              isProvisionallyDistinguished(club)
+                            const modifier = provisional
+                              ? 'clubs-tier-pill--projected'
+                              : TIER_MODIFIER[club.distinguishedLevel]
+                            return (
+                              <span
+                                className={`clubs-tier-pill ${modifier}`}
+                                title={
+                                  provisional
+                                    ? 'Provisional — membership not yet confirmed by April renewals'
+                                    : 'Confirmed — April renewals recorded'
+                                }
+                              >
+                                {TIER_DISPLAY[club.distinguishedLevel]}
+                                {provisional ? '*' : ''}
+                              </span>
+                            )
+                          })()
+                        ) : (
+                          <span className="text-sm clubs-cell-muted">—</span>
+                        )}
+                      </td>
+                      <td className="px-2 py-3 whitespace-nowrap text-sm text-center clubs-table__col--desktop">
+                        {club.clubStatus ? (
+                          <span>{club.clubStatus}</span>
+                        ) : (
+                          <span className="clubs-cell-muted">—</span>
+                        )}
+                      </td>
+                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
+                        {club.yearsChartered !== null ? (
+                          <span>{club.yearsChartered}</span>
+                        ) : (
+                          <span className="clubs-cell-muted">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+          {/* Right-edge fade cue: "there's more →". Shown only when the table
+              overflows right (data-scrollable-right, set by the effect above);
+              pointer-events:none so it never blocks taps/scroll (#812). */}
+          <div className="clubs-table__scroll-cue" aria-hidden="true" />
         </div>
       )}
     </div>

--- a/frontend/src/components/__tests__/ClubsTable.priorityResponsive.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.priorityResponsive.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * ClubsTable priority-column responsive model + sticky key column + scroll-cue
+ * (#812, epic #813 Sprint 4).
+ *
+ * Mirrors the landing rankings table contract (#811) for the club table, per
+ * ADR-006 §2–3. The club table differs from the districts leaderboard in one
+ * way that matters here: a club is BROWSED one-at-a-time, not compared
+ * row-vs-row, so card-collapse at true mobile is the right pattern (Lesson
+ * 105). Hence the responsive contract:
+ *   (1) the card view appears at TRUE mobile only — `< 768px` (ADR-006 §2),
+ *       not the old 640px cliff (asserted in ClubsTable.responsive.test.tsx);
+ *   (2) the table (rendered at tablet ≥768 and up) has ONE sticky key column
+ *       (Club) pinned at left:0 — a robust sticky, no hardcoded px offset;
+ *   (3) a per-column priority model hides the low-priority "detail" columns at
+ *       the tablet tier (768–1279) and reveals them at desktop (≥1280) via the
+ *       `clubs-table__col--desktop` class;
+ *   (4) a right-edge scroll-cue affordance signals clipped columns.
+ *
+ * jsdom has no layout and can't evaluate media queries (Lesson 66), so this
+ * asserts the structural hooks (classes, data-attrs, elements) the CSS keys
+ * off; the live per-breakpoint behaviour is proven on the PR preview channel
+ * in Playwright at 375 / 768 / 1280 / 1600 + dark mode.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, cleanup, within } from '@testing-library/react'
+import { ClubsTable } from '../ClubsTable'
+import { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+const makeClub = (over: Partial<ClubTrend> = {}): ClubTrend => ({
+  clubId: 'c1',
+  clubName: 'Alpha',
+  divisionId: 'div-1',
+  divisionName: 'Division A',
+  areaId: 'area-1',
+  areaName: 'Area 1',
+  distinguishedLevel: 'NotDistinguished',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: new Date().toISOString(), count: 20 }],
+  dcpGoalsTrend: [{ date: new Date().toISOString(), goalsAchieved: 5 }],
+  ...over,
+})
+
+// jsdom matchMedia defaults to no-match → ClubsTable renders the desktop
+// table, which is the surface under test here.
+const stubDesktopMatchMedia = () => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  )
+}
+
+describe('ClubsTable priority-column responsive model (#812)', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('pins the Club key column with the sticky-col class on header and body', () => {
+    stubDesktopMatchMedia()
+    const { container } = render(
+      <ClubsTable clubs={[makeClub()]} districtId="61" isLoading={false} />
+    )
+    const headerCells = container.querySelectorAll('#clubs-table thead th')
+    // Club is the first column (COLUMN_CONFIGS order) and the only sticky one.
+    expect(headerCells[0].className).toContain('clubs-table__sticky-col')
+    const stickyHeaders = container.querySelectorAll(
+      '#clubs-table thead th.clubs-table__sticky-col'
+    )
+    expect(stickyHeaders).toHaveLength(1)
+
+    const bodyRow = container.querySelector('#clubs-table tbody tr')!
+    const firstCell = bodyRow.querySelector('td')!
+    expect(firstCell.className).toContain('clubs-table__sticky-col')
+    // The pinned cell carries the club name (the row's identity).
+    expect(within(firstCell as HTMLElement).getByText('Alpha')).toBeTruthy()
+  })
+
+  it('tags the sticky cell with data-row-tint so it repaints opaque per row status', () => {
+    stubDesktopMatchMedia()
+    const { container } = render(
+      <ClubsTable
+        clubs={[
+          makeClub({
+            clubId: 't',
+            clubName: 'Thrive',
+            currentStatus: 'thriving',
+          }),
+          makeClub({
+            clubId: 'v',
+            clubName: 'Vuln',
+            currentStatus: 'vulnerable',
+          }),
+          makeClub({
+            clubId: 'i',
+            clubName: 'Inter',
+            currentStatus: 'intervention-required',
+          }),
+        ]}
+        districtId="61"
+        isLoading={false}
+      />
+    )
+    const tintOf = (name: string) => {
+      const cell = within(
+        container.querySelector('#clubs-table tbody') as HTMLElement
+      )
+        .getByText(name)
+        .closest('td')
+      return cell?.getAttribute('data-row-tint')
+    }
+    expect(tintOf('Thrive')).toBe('none')
+    expect(tintOf('Vuln')).toBe('vulnerable')
+    expect(tintOf('Inter')).toBe('intervention')
+  })
+
+  it('hides the detail columns at tablet via clubs-table__col--desktop, keeps the core set always shown', () => {
+    stubDesktopMatchMedia()
+    const { container } = render(
+      <ClubsTable clubs={[makeClub()]} districtId="61" isLoading={false} />
+    )
+    // Map header label → its th, so the assertion reads off the spec column set.
+    const headerByLabel = new Map<string, Element>()
+    container.querySelectorAll('#clubs-table thead th').forEach(th => {
+      const label = th.textContent?.trim() ?? ''
+      // ColumnHeader wraps the label in a button; first non-empty token is it.
+      headerByLabel.set(label.split(/\s+/)[0] ?? '', th)
+    })
+
+    // Detail columns hidden at the tablet tier (revealed ≥1280).
+    const desktopOnly = ['Div', 'Area', 'New', 'Oct', 'Apr', 'Club', 'Years']
+    // NB: 'Club' here matches the "Club Status" header's first token, NOT the
+    // sticky "Club" column (column 0), which is asserted separately below.
+    const headers = Array.from(
+      container.querySelectorAll('#clubs-table thead th')
+    )
+    // Index-based: the desktop-only columns are 1,2,6,7,8,11,12 (0-based) in the
+    // COLUMN_CONFIGS order: Club, Div, Area, Status, Members, Needed, New, Oct,
+    // Apr, DCP, Tier, ClubStatus, Years.
+    const desktopOnlyIdx = [1, 2, 6, 7, 8, 11, 12]
+    const coreIdx = [0, 3, 4, 5, 9, 10]
+    desktopOnlyIdx.forEach(i => {
+      expect(headers[i].className).toContain('clubs-table__col--desktop')
+    })
+    coreIdx.forEach(i => {
+      expect(headers[i].className).not.toContain('clubs-table__col--desktop')
+    })
+    // The sticky column (Club, col 0) is core, never a desktop-only hide.
+    expect(headers[0].className).toContain('clubs-table__sticky-col')
+    expect(headers[0].className).not.toContain('clubs-table__col--desktop')
+    void desktopOnly
+    void headerByLabel
+  })
+
+  it('applies the same priority classes to body cells in column order', () => {
+    stubDesktopMatchMedia()
+    const { container } = render(
+      <ClubsTable clubs={[makeClub()]} districtId="61" isLoading={false} />
+    )
+    const cells = Array.from(
+      container.querySelectorAll('#clubs-table tbody tr:first-child td')
+    )
+    const desktopOnlyIdx = [1, 2, 6, 7, 8, 11, 12]
+    desktopOnlyIdx.forEach(i => {
+      expect(cells[i].className).toContain('clubs-table__col--desktop')
+    })
+    expect(cells[0].className).toContain('clubs-table__sticky-col')
+  })
+
+  it('wraps the scroller and renders a right-edge scroll-cue affordance', () => {
+    stubDesktopMatchMedia()
+    const { container } = render(
+      <ClubsTable clubs={[makeClub()]} districtId="61" isLoading={false} />
+    )
+    const wrap = container.querySelector('.clubs-table__scroll-wrap')
+    expect(wrap).not.toBeNull()
+    // The scroller (the overflow container) lives inside the wrap.
+    expect(wrap!.querySelector('.clubs-table-scroll')).not.toBeNull()
+    // The cue is a sibling overlay inside the wrap.
+    expect(wrap!.querySelector('.clubs-table__scroll-cue')).not.toBeNull()
+  })
+})

--- a/frontend/src/components/__tests__/ClubsTable.responsive.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.responsive.test.tsx
@@ -1,11 +1,13 @@
 /**
- * Responsive collapse breakpoint for ClubsTable (#671, epic #665 Sprint 5).
+ * Responsive collapse breakpoint for ClubsTable (#671 → #812).
  *
- * HANDOFF §126: "Tables in District page collapse to card layout under
- * ~640px." The table→card collapse must therefore key off a 640px breakpoint
- * (matchMedia `(max-width: 639px)`), not the legacy 768px. This asserts the
- * query string ClubsTable hands to matchMedia via useIsMobile — falsifiable:
- * at 768 it would read `(max-width: 767px)`.
+ * ADR-006 §2 (epic #813 table-UX program) re-establishes the tablet tier: the
+ * card view is for TRUE mobile only (`< 768px`), and 768–1279px shows the table
+ * with low-priority columns hidden (the priority-column model, #812) rather
+ * than the old 640px desktop→mobile cliff (#671). The table→card collapse must
+ * therefore key off a 768px breakpoint (matchMedia `(max-width: 767px)`). This
+ * asserts the query string ClubsTable hands to matchMedia via useIsMobile —
+ * falsifiable: at the old 640 it would read `(max-width: 639px)`.
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, cleanup } from '@testing-library/react'
@@ -26,13 +28,13 @@ const CLUB: ClubTrend = {
   dcpGoalsTrend: [{ date: new Date().toISOString(), goalsAchieved: 5 }],
 }
 
-describe('ClubsTable responsive collapse (#671)', () => {
+describe('ClubsTable responsive collapse (#671 → #812)', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
   })
 
-  it('collapses to cards at the 640px breakpoint (matchMedia 639px)', () => {
+  it('collapses to cards at the 768px tablet boundary (matchMedia 767px)', () => {
     const queries: string[] = []
     vi.stubGlobal(
       'matchMedia',
@@ -51,7 +53,7 @@ describe('ClubsTable responsive collapse (#671)', () => {
       })
     )
     render(<ClubsTable clubs={[CLUB]} districtId="61" isLoading={false} />)
-    expect(queries).toContain('(max-width: 639px)')
-    expect(queries).not.toContain('(max-width: 767px)')
+    expect(queries).toContain('(max-width: 767px)')
+    expect(queries).not.toContain('(max-width: 639px)')
   })
 })

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -3003,6 +3003,106 @@
     overflow-y: auto;
   }
 
+  /* ── Club table: priority columns + sticky key column + scroll-cue (#812,
+     epic #813 Sprint 4, ADR-006 §2–3) ──
+     Mirrors the landing rankings table (#811) for the club table. The card
+     view is true-mobile only (< 768px, ClubsTable useIsMobile); the table
+     renders at the tablet tier and up. */
+
+  /* Positioning context for the right-edge scroll-cue overlay. */
+  .clubs-table__scroll-wrap {
+    position: relative;
+  }
+
+  /* Single sticky key column (Club) pinned at left:0 — a robust sticky, no
+     hardcoded px offset. Themed background (var(--surface)) so it converges on
+     the SAME surface scale as the default table row, not the lighter
+     --surface-card path (Lesson 116). The cell must be OPAQUE or scrolled
+     columns bleed through; the right inset box-shadow draws the sticky/scroll
+     seam (border-collapse drops a positioned cell's own border). */
+  .clubs-table__sticky-col {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    background-color: var(--surface);
+    box-shadow: inset -1px 0 0 var(--line);
+  }
+
+  /* The Club header cell is the corner: it pins both top (via
+     .clubs-table-sticky-head th) AND left (here), so it must layer above both
+     the other sticky headers and the body sticky cells. It keeps the header
+     surface (--surface-2 from .clubs-table-sticky-head th wins on specificity);
+     only the stacking order needs raising. */
+  .clubs-table-sticky-head th.clubs-table__sticky-col {
+    z-index: 3;
+  }
+
+  /* Keep the sticky cell in sync with the row-hover swap — only for untinted
+     (default-status) rows, which hover to --surface-3 (matching
+     .clubs-table-row:hover). Tinted rows handle their own hover below. */
+  #clubs-table tbody tr:hover .clubs-table__sticky-col[data-row-tint='none'] {
+    background-color: var(--surface-3);
+  }
+
+  /* Tinted rows (vulnerable / intervention) repaint the sticky cell opaque to
+     match the row's status bg (the <tr> carries bg-yellow-50 / bg-red-50 on its
+     transparent cells; the pinned cell carries no Tailwind bg, so it needs the
+     literal here). Light literals = Tailwind yellow-50 / red-50; the hover
+     literals = yellow-100 / red-100, matching the row's hover:bg-*-100. Dark
+     variants live in dark-mode.css (Lesson 096). */
+  .clubs-table__sticky-col[data-row-tint='vulnerable'] {
+    background-color: #fefce8;
+  }
+  .clubs-table__sticky-col[data-row-tint='intervention'] {
+    background-color: #fef2f2;
+  }
+  #clubs-table
+    tbody
+    tr:hover
+    .clubs-table__sticky-col[data-row-tint='vulnerable'] {
+    background-color: #fef9c3;
+  }
+  #clubs-table
+    tbody
+    tr:hover
+    .clubs-table__sticky-col[data-row-tint='intervention'] {
+    background-color: #fee2e2;
+  }
+
+  /* Per-column responsive priority. The detail columns are hidden by default
+     (tablet tier, 768–1279) and revealed at desktop (≥1280). The core set
+     (Club sticky, Status, Members, Needed, DCP, Tier) is always shown when the
+     table renders. The card view carries the full record below 768. */
+  .clubs-table__col--desktop {
+    display: none;
+  }
+  @media (min-width: 1280px) {
+    .clubs-table__col--desktop {
+      display: table-cell;
+    }
+  }
+
+  /* Right-edge fade discoverability cue. Themed (transparent → --surface, so it
+     remaps in dark); pointer-events:none so it never blocks taps/scroll. Shown
+     ONLY when the table overflows to the right (data-scrollable-right, set by
+     ClubsTable) — a permanent fade would wash out the right-most column on a
+     wide desktop where nothing scrolls. */
+  .clubs-table__scroll-cue {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 40px;
+    pointer-events: none;
+    background: linear-gradient(to right, rgba(0, 0, 0, 0), var(--surface));
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+  .clubs-table__scroll-wrap[data-scrollable-right='true']
+    .clubs-table__scroll-cue {
+    opacity: 1;
+  }
+
   /* ── Clubs table chrome re-skin (#668, epic #665 Sprint 2) ──
      Replaces the legacy gray Tailwind utilities (text-gray-*, bg-gray-50,
      border-gray-200, divide-gray-200, font-tm-headline) with redesign tokens.

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -3018,14 +3018,21 @@
      hardcoded px offset. Themed background (var(--surface)) so it converges on
      the SAME surface scale as the default table row, not the lighter
      --surface-card path (Lesson 116). The cell must be OPAQUE or scrolled
-     columns bleed through; the right inset box-shadow draws the sticky/scroll
-     seam (border-collapse drops a positioned cell's own border). */
+     columns bleed through. Two inset box-shadows: the right one draws the
+     sticky/scroll seam; the bottom one re-draws the row rule (#clubs-table
+     tbody tr border-bottom) on the pinned cell — an opaque positioned cell can
+     mask the row border behind it, leaving a gap in the hairline down the Club
+     column. Both use var(--line) to match that row rule, on every row (the
+     club table keeps the bottom rule on the last row too — no :last-child
+     special case, unlike the districts table #811). */
   .clubs-table__sticky-col {
     position: sticky;
     left: 0;
     z-index: 2;
     background-color: var(--surface);
-    box-shadow: inset -1px 0 0 var(--line);
+    box-shadow:
+      inset -1px 0 0 var(--line),
+      inset 0 -1px 0 var(--line);
   }
 
   /* The Club header cell is the corner: it pins both top (via

--- a/frontend/src/styles/dark-mode.css
+++ b/frontend/src/styles/dark-mode.css
@@ -512,12 +512,13 @@
 }
 
 /* Club table sticky key column (#812). Default bg is themed var(--surface)
-   (dark-safe); only the status-tinted-row repaints need a dark variant. These
-   match the bg-yellow-50 / bg-red-50 (resting) and bg-yellow-100 / bg-red-100
-   (hover) dark remaps used elsewhere in this file, so the opaque pinned cell
-   stays consistent with the rest of its tinted row in dark mode. No !important
-   (the cell carries no Tailwind bg utility to override, and it would desync the
-   row-hover highlight — Lesson 107). */
+   (dark-safe); only the status-tinted-row repaints need a dark variant. The
+   resting values match the .bg-yellow-50 / .bg-red-50 dark remaps (0.10); the
+   hover values match the .hover\:bg-yellow-100:hover / .hover\:bg-red-100:hover
+   dark remaps (0.20) — the row's NON-sticky cells carry those hover utilities,
+   so the opaque pinned cell must land on the same alpha or it shows a seam down
+   the hovered tinted row. No !important (the cell carries no Tailwind bg utility
+   to override, and it would desync the row-hover highlight — Lesson 107). */
 [data-theme='dark'] .clubs-table__sticky-col[data-row-tint='vulnerable'] {
     background-color: rgba(161, 98, 7, 0.1);
 }
@@ -529,14 +530,14 @@
     tbody
     tr:hover
     .clubs-table__sticky-col[data-row-tint='vulnerable'] {
-    background-color: rgba(161, 98, 7, 0.18);
+    background-color: rgba(161, 98, 7, 0.2);
 }
 [data-theme='dark']
     #clubs-table
     tbody
     tr:hover
     .clubs-table__sticky-col[data-row-tint='intervention'] {
-    background-color: rgba(185, 28, 28, 0.18);
+    background-color: rgba(185, 28, 28, 0.2);
 }
 
 /* ═══════════════════════════════════════════

--- a/frontend/src/styles/dark-mode.css
+++ b/frontend/src/styles/dark-mode.css
@@ -511,6 +511,34 @@
     background-color: rgba(37, 99, 235, 0.1);
 }
 
+/* Club table sticky key column (#812). Default bg is themed var(--surface)
+   (dark-safe); only the status-tinted-row repaints need a dark variant. These
+   match the bg-yellow-50 / bg-red-50 (resting) and bg-yellow-100 / bg-red-100
+   (hover) dark remaps used elsewhere in this file, so the opaque pinned cell
+   stays consistent with the rest of its tinted row in dark mode. No !important
+   (the cell carries no Tailwind bg utility to override, and it would desync the
+   row-hover highlight — Lesson 107). */
+[data-theme='dark'] .clubs-table__sticky-col[data-row-tint='vulnerable'] {
+    background-color: rgba(161, 98, 7, 0.1);
+}
+[data-theme='dark'] .clubs-table__sticky-col[data-row-tint='intervention'] {
+    background-color: rgba(185, 28, 28, 0.1);
+}
+[data-theme='dark']
+    #clubs-table
+    tbody
+    tr:hover
+    .clubs-table__sticky-col[data-row-tint='vulnerable'] {
+    background-color: rgba(161, 98, 7, 0.18);
+}
+[data-theme='dark']
+    #clubs-table
+    tbody
+    tr:hover
+    .clubs-table__sticky-col[data-row-tint='intervention'] {
+    background-color: rgba(185, 28, 28, 0.18);
+}
+
 /* ═══════════════════════════════════════════
    Gradient Backgrounds (Summary Cards)
    Light gradients → dark translucent gradients

--- a/tasks/lessons/126-porting-a-sticky-column-must-re-derive-the-border-restoration-for-this-tables-border-model.md
+++ b/tasks/lessons/126-porting-a-sticky-column-must-re-derive-the-border-restoration-for-this-tables-border-model.md
@@ -1,0 +1,98 @@
+---
+id: '126'
+category: lesson
+tags: [css, frontend, responsive, tables, dark-mode]
+auto_load: true
+date: 2026-05-27
+issues: [812, 813, 811]
+---
+
+# Lesson 126 — Porting a sticky-column treatment to a sibling table must re-derive the border restoration for THAT table's border-collapse model
+
+**Date:** 2026-05-27
+**Issue:** #812 (epic #813 Sprint 4 — club table priority-column responsive model), porting the pattern #811 established for the landing rankings table.
+
+## What happened
+
+#812 added a sticky key column (`position: sticky; left: 0`) to the club table,
+mirroring the landing rankings table (#811). The obvious move is to copy #811's
+sticky-cell CSS verbatim, including its row-rule restoration:
+
+```css
+/* districts (#811) */
+.districts-rankings-table__sticky-col {
+  box-shadow:
+    inset -1px 0 0 var(--line),
+    inset 0 -1px 0 var(--line-2);
+}
+.districts-rankings-table tbody tr:last-child .…__sticky-col {
+  box-shadow: inset -1px 0 0 var(--line); /* zero the bottom on the last row */
+}
+```
+
+That recipe is tuned for the **districts** table, which is
+`border-collapse: collapse` (app-shell.css:1122). Under collapse, a positioned
+(sticky) cell is taken out of the collapsed-border model and **drops the
+collapsed borders entirely** — so #811 restores both the right seam AND the
+bottom row rule with insets, and zeroes the bottom on the last row (the table
+draws no rule under the final row).
+
+The **club** table is `border-collapse: separate` (the default — its `<table>`
+is just `table-auto`, with no collapse rule). Its row rule comes from
+`#clubs-table tbody tr { border-bottom: 1px solid var(--line) }` on **every**
+row including the last. The failure mode is different: the opaque sticky cell
+**masks** the row border behind it (a gap in the hairline down the Club column),
+not a dropped collapsed border. So the correct treatment for the club table is:
+
+```css
+.clubs-table__sticky-col {
+  box-shadow:
+    inset -1px 0 0 var(--line),
+    inset 0 -1px 0 var(--line);
+}
+/* NO :last-child override — the club table keeps the bottom rule on every row */
+```
+
+Copying #811 verbatim would have zeroed the last row's rule (wrong here) and
+used `--line-2` for the bottom (the club row rule is `--line`).
+
+## The transferable lesson
+
+**A sticky/positioned-cell border restoration is a function of the table's
+`border-collapse` model and where its row rules are declared — not a reusable
+snippet.** Before porting a sticky-column treatment to another table, check (1)
+is it `collapse` or `separate`, (2) where does its row rule live (`tr`
+border-bottom vs collapsed cell borders), (3) does the last row keep or drop its
+rule. The visible-seam symptom looks identical across tables; the cause and the
+fix differ. This matters now because ADR-006 §6 plans an
+**evaluate-then-extract** shared `DataTable` primitive once both tables converge
+— and the sticky-cell border logic is exactly the kind of detail that looks
+shareable but carries per-table assumptions. The extraction must parameterize
+the border model, not hardcode one table's recipe.
+
+Corollary (verification): the dark-mode "is the sticky cell a dark surface?"
+check failed on the live preview because the **first real club row was
+vulnerable-status**, so its cell was a (correct) translucent amber tint, not the
+untinted `--surface`. Target the specific state you mean to measure
+(`[data-row-tint='none']`), never "the first row" — real data does not promise a
+default-status first row (Lesson 108 family: measure the right node).
+
+## How to apply
+
+- Porting a positioned-cell treatment between tables: confirm the target's
+  `border-collapse` value and row-rule source first; re-derive the box-shadow
+  insets and any `:last-child` override for THAT model. Don't copy the sibling's.
+- When asserting a themed background on a real-data row in a preview smoke,
+  select by the state (`[data-row-tint='none']`), not by row position.
+
+## Related
+
+- [[105-match-the-mobile-table-pattern-to-the-datas-purpose-not-a-sibling-tables-precedent]]
+  — same epic family: reuse shaped to the table's purpose, not blanket-copied
+  from a sibling. This is the CSS-mechanism counterpart.
+- [[116-bg-white-routes-to-a-lighter-dark-scale-than-redesign-panel-neighbours]]
+  — the sticky cell's bg must converge on `--surface` (the shared scale), the
+  reason the dark-surface check exists.
+- [[108-verify-a-sticky-header-by-measuring-the-sticky-cell-not-the-thead-wrapper]]
+  — measure the node that owns the property; the corollary above is the
+  real-data-shape version of the same discipline.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -92,3 +92,4 @@
 - **123** [analytics, data-pipeline, dcp, frontend, verification] — `totals.distinguished*` is unpopulated mid-year; count distinguished from `clubPerformance` (#793, #797)
 - **124** [router, react, hooks, frontend, verification] — Validate URL-synced range state at the page that owns it, not at the picker (#794, #797)
 - **125** [cls, performance, frontend, verification, ci] — A CLS fix for the loading state must cover the error/empty states too (#811, #488, #750)
+- **126** [css, frontend, responsive, tables, dark-mode] — Porting a sticky-column treatment to a sibling table must re-derive the border restoration for THAT table's border-collapse model (#812, #813, #811)


### PR DESCRIPTION
## Sprint 4 of epic #813 (table-UX program, Epic A) — issue #812

Applies the table-page standard (ADR-006 §2–3) to the **club table**, mirroring the landing rankings table (#811). Gives the club table a real **tablet tier** instead of the old 640px desktop→mobile cliff.

### What changed
- **Responsive tiers (ADR-006 §2):** card view is now true-mobile only (`< 768px`, was 640); the table renders at tablet (768–1279) and up.
- **Priority-column model (§3):** a per-column priority hides the 7 low-priority *detail* columns (Div, Area, New, Oct/Apr Renew, Club Status, Years) at the tablet tier via `clubs-table__col--desktop`, revealing them at desktop (≥1280). The core triage set (Club, Status, Members, Needed, DCP, Tier) stays at every table width.
- **Sticky key column:** the Club column is pinned at `left:0` with a robust `position:sticky` (no hardcoded px). Themed `--surface` background (Lesson 116) + `data-row-tint` so the opaque pinned cell repaints to match vulnerable/intervention row tints (light + dark). Bottom inset box-shadow re-draws the row rule the opaque cell would otherwise mask.
- **Scroll-cue:** a conditional right-edge fade (shown only when the table overflows right), driven by a `ResizeObserver` + scroll listener toggling `data-scrollable-right` — no per-frame re-render.

### Tests (TDD)
- New `ClubsTable.priorityResponsive.test.tsx` (5 cases): sticky-col on header+body, single sticky column, `data-row-tint` per status, desktop-only hide on the right column indices, scroll-wrap + scroll-cue present.
- `ClubsTable.responsive.test.tsx` re-pinned 640→768 to track the ADR-006 §2 tablet boundary (spec change, not assertion-pinning — Lesson 81).
- Full frontend suite green (2860 tests); `/simplify` pass applied (sticky-col row-rule restore + dark hover-alpha match); fresh-context AC review clean.

### Verification
Live verification on the PR preview channel (Playwright dual-engine at 375/768/1280/1600 + dark, CLS guard) to follow in a comment per the Full DoD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)