### PR TITLE
feat(clubs): visible search box for the club table (#814)

### DIFF
--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -445,10 +445,9 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
             filterState so a URL-derived initial value (and the dropdown) flow
             straight in. */}
         {(() => {
+          const nameFilterValue = getFilter('name')?.value
           const nameValue =
-            typeof getFilter('name')?.value === 'string'
-              ? (getFilter('name')!.value as string)
-              : ''
+            typeof nameFilterValue === 'string' ? nameFilterValue : ''
           const setSearch = (raw: string) => {
             setFilter(
               'name',

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -15,6 +15,7 @@ import { SortField, SortDirection, COLUMN_CONFIGS } from './filters/types'
 import { CLOSE_TO_DISTINGUISHED_MAX_MEMBERS } from '../utils/closeToDistinguished'
 import ClubCard from './ClubCard'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useDebounce } from '../hooks/useDebounce'
 
 // DCP tier pill maps (#669). Confirmed tiers carry their HANDOFF §256 color
 // (Smedley maroon, President's loyal-500, Select loyal-400, Distinguished
@@ -83,6 +84,77 @@ const rowTint = (
     : status === 'vulnerable'
       ? 'vulnerable'
       : 'none'
+
+/**
+ * Visible club-name search box (#814). Mirrors the column TextFilter pattern:
+ * a LOCAL input value keeps typing instant, while the heavy table re-filter is
+ * driven off a 300ms-debounced value. Without the local/debounced split the
+ * controlled input is gated on the 100+-row re-sort and drops fast keystrokes.
+ *
+ * `value` is the external `name`-filter value (URL on load, the column
+ * dropdown, or Clear-all). It is pulled into the local input whenever it
+ * changes externally; debounce coalescing means our own outbound writes settle
+ * to the same value and don't fight the user mid-type.
+ */
+const ClubSearchBox: React.FC<{
+  value: string
+  onSearchChange: (value: string) => void
+}> = ({ value, onSearchChange }) => {
+  const [input, setInput] = useState(value)
+  const debounced = useDebounce(input, 300)
+
+  // Pull external changes (Clear-all, column dropdown, back/forward) back into
+  // the local input. Render-phase sync (tracked-value compare) avoids
+  // setState-in-effect — the established pattern here, see TextFilter (#340):
+  // https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  const [trackedValue, setTrackedValue] = useState(value)
+  if (value !== trackedValue) {
+    setTrackedValue(value)
+    setInput(value)
+  }
+
+  // Push the settled input outward (filter + URL) when it diverges.
+  useEffect(() => {
+    if (debounced !== value) onSearchChange(debounced)
+  }, [debounced, value, onSearchChange])
+
+  return (
+    <div className="clubs-search">
+      <svg
+        className="clubs-search__icon"
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        />
+      </svg>
+      <input
+        type="search"
+        className="clubs-search__input"
+        placeholder="Search clubs by name…"
+        aria-label="Search clubs by name"
+        value={input}
+        onChange={e => setInput(e.target.value)}
+      />
+      {input && (
+        <button
+          type="button"
+          className="clubs-search__clear"
+          aria-label="Clear search"
+          onClick={() => setInput('')}
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  )
+}
 
 /**
  * Props for the ClubsTable component
@@ -207,6 +279,20 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
     clearAllFiltersInternal()
     onFilterChange?.({})
   }, [clearAllFiltersInternal, onFilterChange])
+
+  // Visible-search → `name` text filter (#814). Empty/whitespace clears the
+  // filter rather than writing `?search=` junk to the URL.
+  const handleSearchChange = useCallback(
+    (raw: string) => {
+      setFilter(
+        'name',
+        raw.trim()
+          ? { field: 'name', type: 'text', value: raw, operator: 'contains' }
+          : null
+      )
+    },
+    [setFilter]
+  )
 
   // Quick-filter chip active flags — derived once per render from filterState.
   // The membersNeeded filter is shared by two chips that interpret different
@@ -438,66 +524,18 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
 
         {/* Visible name search (#814, epic #818 Sprint 1). Recognition over
             recall: a prominent box at the top of the table replaces the search
-            that was buried in the hidden "Club" column-header dropdown. It is a
+            that was buried in the hidden "Club" column-header dropdown. A
             second UI entry point onto the EXISTING `name` text filter (R11), so
             it stays in sync with that dropdown and URL-syncs through the parent
-            (DistrictClubsPage maps `name` ⇄ `?search=`). Controlled off
-            filterState so a URL-derived initial value (and the dropdown) flow
-            straight in. */}
-        {(() => {
-          const nameFilterValue = getFilter('name')?.value
-          const nameValue =
-            typeof nameFilterValue === 'string' ? nameFilterValue : ''
-          const setSearch = (raw: string) => {
-            setFilter(
-              'name',
-              raw.trim()
-                ? {
-                    field: 'name',
-                    type: 'text',
-                    value: raw,
-                    operator: 'contains',
-                  }
-                : null
-            )
+            (DistrictClubsPage maps `name` ⇄ `?search=`). */}
+        <ClubSearchBox
+          value={
+            typeof getFilter('name')?.value === 'string'
+              ? (getFilter('name')!.value as string)
+              : ''
           }
-          return (
-            <div className="clubs-search">
-              <svg
-                className="clubs-search__icon"
-                aria-hidden="true"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
-              <input
-                type="search"
-                className="clubs-search__input"
-                placeholder="Search clubs by name…"
-                aria-label="Search clubs by name"
-                value={nameValue}
-                onChange={e => setSearch(e.target.value)}
-              />
-              {nameValue && (
-                <button
-                  type="button"
-                  className="clubs-search__clear"
-                  aria-label="Clear search"
-                  onClick={() => setSearch('')}
-                >
-                  ✕
-                </button>
-              )}
-            </div>
-          )
-        })()}
+          onSearchChange={handleSearchChange}
+        />
 
         {/* Results Count and Quick Filters */}
         <div className="flex flex-wrap items-center gap-4 text-sm clubs-text-muted">

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -436,6 +436,70 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
           />
         </div>
 
+        {/* Visible name search (#814, epic #818 Sprint 1). Recognition over
+            recall: a prominent box at the top of the table replaces the search
+            that was buried in the hidden "Club" column-header dropdown. It is a
+            second UI entry point onto the EXISTING `name` text filter (R11), so
+            it stays in sync with that dropdown and URL-syncs through the parent
+            (DistrictClubsPage maps `name` ⇄ `?search=`). Controlled off
+            filterState so a URL-derived initial value (and the dropdown) flow
+            straight in. */}
+        {(() => {
+          const nameValue =
+            typeof getFilter('name')?.value === 'string'
+              ? (getFilter('name')!.value as string)
+              : ''
+          const setSearch = (raw: string) => {
+            setFilter(
+              'name',
+              raw.trim()
+                ? {
+                    field: 'name',
+                    type: 'text',
+                    value: raw,
+                    operator: 'contains',
+                  }
+                : null
+            )
+          }
+          return (
+            <div className="clubs-search">
+              <svg
+                className="clubs-search__icon"
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+              <input
+                type="search"
+                className="clubs-search__input"
+                placeholder="Search clubs by name…"
+                aria-label="Search clubs by name"
+                value={nameValue}
+                onChange={e => setSearch(e.target.value)}
+              />
+              {nameValue && (
+                <button
+                  type="button"
+                  className="clubs-search__clear"
+                  aria-label="Clear search"
+                  onClick={() => setSearch('')}
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+          )
+        })()}
+
         {/* Results Count and Quick Filters */}
         <div className="flex flex-wrap items-center gap-4 text-sm clubs-text-muted">
           <div>

--- a/frontend/src/components/__tests__/ClubsTable.search.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.search.test.tsx
@@ -6,10 +6,14 @@
  * SAME `name` text filter (R11 — a new UI entry point onto the existing
  * pipeline step, not a new step). The input is URL-synced through the parent's
  * onFilterChange callback (DistrictClubsPage maps `name` ⇄ `?search=`).
+ *
+ * The box mirrors the column TextFilter: a LOCAL input value keeps typing
+ * instant while the table re-filter is driven off a 300ms-debounced value, so
+ * these tests advance fake timers to flush the debounce.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react'
 import { ClubsTable } from '../ClubsTable'
 import { ClubTrend } from '../../hooks/useDistrictAnalytics'
 import type { FilterState } from '../filters/types'
@@ -35,9 +39,16 @@ const threeClubs = () => [
   createMockClub({ clubId: 'c3', clubName: 'Gamma Society' }),
 ]
 
+// Flush the 300ms search debounce.
+const flushDebounce = () => act(() => vi.advanceTimersByTime(350))
+
 describe('ClubsTable — visible search box (#814)', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
   afterEach(() => {
+    vi.useRealTimers()
     cleanup()
     vi.restoreAllMocks()
   })
@@ -48,15 +59,27 @@ describe('ClubsTable — visible search box (#814)', () => {
     expect(input).toBeInTheDocument()
   })
 
-  it('filters the table by club name as the user types', () => {
+  it('filters the table by club name as the user types (debounced)', () => {
     render(<ClubsTable clubs={threeClubs()} districtId="123" />)
     const input = screen.getByRole('searchbox', { name: /search clubs/i })
 
     fireEvent.change(input, { target: { value: 'alpha' } })
+    flushDebounce()
 
     expect(screen.getByText('Alpha Club')).toBeInTheDocument()
     expect(screen.queryByText('Beta Club')).not.toBeInTheDocument()
     expect(screen.queryByText('Gamma Society')).not.toBeInTheDocument()
+  })
+
+  it('keeps the typed value instantly (no dropped characters)', () => {
+    render(<ClubsTable clubs={threeClubs()} districtId="123" />)
+    const input = screen.getByRole('searchbox', {
+      name: /search clubs/i,
+    }) as HTMLInputElement
+
+    // The input reflects each keystroke immediately, before the debounce fires.
+    fireEvent.change(input, { target: { value: 'gamma society' } })
+    expect(input.value).toBe('gamma society')
   })
 
   it('pre-fills the input from an initial (URL-derived) name filter', () => {
@@ -79,7 +102,6 @@ describe('ClubsTable — visible search box (#814)', () => {
       name: /search clubs/i,
     }) as HTMLInputElement
     expect(input.value).toBe('gamma')
-    // and the table is filtered to match
     expect(screen.getByText('Gamma Society')).toBeInTheDocument()
     expect(screen.queryByText('Alpha Club')).not.toBeInTheDocument()
   })
@@ -96,6 +118,7 @@ describe('ClubsTable — visible search box (#814)', () => {
     const input = screen.getByRole('searchbox', { name: /search clubs/i })
 
     fireEvent.change(input, { target: { value: 'beta' } })
+    flushDebounce()
 
     expect(onFilterChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -128,13 +151,38 @@ describe('ClubsTable — visible search box (#814)', () => {
     const input = screen.getByRole('searchbox', { name: /search clubs/i })
 
     fireEvent.change(input, { target: { value: '' } })
+    flushDebounce()
 
-    // All three clubs visible again
     expect(screen.getByText('Alpha Club')).toBeInTheDocument()
     expect(screen.getByText('Beta Club')).toBeInTheDocument()
     expect(screen.getByText('Gamma Society')).toBeInTheDocument()
-    // Parent told the name filter is gone
     const lastCall = onFilterChange.mock.calls.at(-1)?.[0]
     expect(lastCall?.name).toBeUndefined()
+  })
+
+  it('clears via the clear (✕) button', () => {
+    render(
+      <ClubsTable
+        clubs={threeClubs()}
+        districtId="123"
+        initialFilterState={{
+          name: {
+            field: 'name',
+            type: 'text',
+            value: 'alpha',
+            operator: 'contains',
+          },
+        }}
+      />
+    )
+    const clear = screen.getByRole('button', { name: /clear search/i })
+    fireEvent.click(clear)
+    flushDebounce()
+
+    const input = screen.getByRole('searchbox', {
+      name: /search clubs/i,
+    }) as HTMLInputElement
+    expect(input.value).toBe('')
+    expect(screen.getByText('Beta Club')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/__tests__/ClubsTable.search.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.search.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Tests for the visible club-name search box (#814, epic #818 Sprint 1).
+ *
+ * Today name search is buried in the hidden "Club" column-header dropdown.
+ * This sprint surfaces a prominent search input above the table, wired to the
+ * SAME `name` text filter (R11 — a new UI entry point onto the existing
+ * pipeline step, not a new step). The input is URL-synced through the parent's
+ * onFilterChange callback (DistrictClubsPage maps `name` ⇄ `?search=`).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { ClubsTable } from '../ClubsTable'
+import { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import type { FilterState } from '../filters/types'
+
+const createMockClub = (overrides: Partial<ClubTrend> = {}): ClubTrend => ({
+  clubId: 'club-1',
+  clubName: 'Test Club',
+  divisionId: 'div-1',
+  divisionName: 'Division A',
+  areaId: 'area-1',
+  areaName: 'Area 1',
+  distinguishedLevel: 'NotDistinguished',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: new Date().toISOString(), count: 20 }],
+  dcpGoalsTrend: [{ date: new Date().toISOString(), goalsAchieved: 5 }],
+  ...overrides,
+})
+
+const threeClubs = () => [
+  createMockClub({ clubId: 'c1', clubName: 'Alpha Club' }),
+  createMockClub({ clubId: 'c2', clubName: 'Beta Club' }),
+  createMockClub({ clubId: 'c3', clubName: 'Gamma Society' }),
+]
+
+describe('ClubsTable — visible search box (#814)', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders a visible search input (role=searchbox) above the table', () => {
+    render(<ClubsTable clubs={threeClubs()} districtId="123" />)
+    const input = screen.getByRole('searchbox', { name: /search clubs/i })
+    expect(input).toBeInTheDocument()
+  })
+
+  it('filters the table by club name as the user types', () => {
+    render(<ClubsTable clubs={threeClubs()} districtId="123" />)
+    const input = screen.getByRole('searchbox', { name: /search clubs/i })
+
+    fireEvent.change(input, { target: { value: 'alpha' } })
+
+    expect(screen.getByText('Alpha Club')).toBeInTheDocument()
+    expect(screen.queryByText('Beta Club')).not.toBeInTheDocument()
+    expect(screen.queryByText('Gamma Society')).not.toBeInTheDocument()
+  })
+
+  it('pre-fills the input from an initial (URL-derived) name filter', () => {
+    const initialFilterState: FilterState = {
+      name: {
+        field: 'name',
+        type: 'text',
+        value: 'gamma',
+        operator: 'contains',
+      },
+    }
+    render(
+      <ClubsTable
+        clubs={threeClubs()}
+        districtId="123"
+        initialFilterState={initialFilterState}
+      />
+    )
+    const input = screen.getByRole('searchbox', {
+      name: /search clubs/i,
+    }) as HTMLInputElement
+    expect(input.value).toBe('gamma')
+    // and the table is filtered to match
+    expect(screen.getByText('Gamma Society')).toBeInTheDocument()
+    expect(screen.queryByText('Alpha Club')).not.toBeInTheDocument()
+  })
+
+  it('notifies the parent (URL-sync contract) with the name filter on type', () => {
+    const onFilterChange = vi.fn()
+    render(
+      <ClubsTable
+        clubs={threeClubs()}
+        districtId="123"
+        onFilterChange={onFilterChange}
+      />
+    )
+    const input = screen.getByRole('searchbox', { name: /search clubs/i })
+
+    fireEvent.change(input, { target: { value: 'beta' } })
+
+    expect(onFilterChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: expect.objectContaining({
+          field: 'name',
+          type: 'text',
+          value: 'beta',
+        }),
+      })
+    )
+  })
+
+  it('clears the name filter (and shows all clubs) when emptied', () => {
+    const onFilterChange = vi.fn()
+    render(
+      <ClubsTable
+        clubs={threeClubs()}
+        districtId="123"
+        onFilterChange={onFilterChange}
+        initialFilterState={{
+          name: {
+            field: 'name',
+            type: 'text',
+            value: 'alpha',
+            operator: 'contains',
+          },
+        }}
+      />
+    )
+    const input = screen.getByRole('searchbox', { name: /search clubs/i })
+
+    fireEvent.change(input, { target: { value: '' } })
+
+    // All three clubs visible again
+    expect(screen.getByText('Alpha Club')).toBeInTheDocument()
+    expect(screen.getByText('Beta Club')).toBeInTheDocument()
+    expect(screen.getByText('Gamma Society')).toBeInTheDocument()
+    // Parent told the name filter is gone
+    const lastCall = onFilterChange.mock.calls.at(-1)?.[0]
+    expect(lastCall?.name).toBeUndefined()
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -3200,6 +3200,14 @@
     color: var(--ink);
   }
 
+  /* Visible focus ring (WCAG 2.4.7) — a colour swap alone is too weak an
+     indicator on a small glyph; match the input's focus affordance. */
+  .clubs-search__clear:focus-visible {
+    outline: none;
+    border-radius: 0.375rem;
+    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+  }
+
   /* Muted text outside the table grid (results count, empty-state copy,
      mobile sort label) — was text-gray-{400,500,600}. */
   .clubs-text-muted {

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -3131,6 +3131,75 @@
     font-family: var(--serif);
   }
 
+  /* Visible name search box (#814, epic #818 Sprint 1). A prominent input at
+     the top of the table — recognition over recall — wired to the existing
+     `name` text filter. Token-driven so dark mode "just works" (R10). */
+  .clubs-search {
+    position: relative;
+    display: flex;
+    align-items: center;
+    margin-bottom: 1rem;
+    max-width: 28rem;
+  }
+
+  .clubs-search__icon {
+    position: absolute;
+    left: 12px;
+    width: 18px;
+    height: 18px;
+    color: var(--ink-3);
+    pointer-events: none;
+  }
+
+  /* appearance:none so the 44px min-height applies in WebKit/Safari too — a
+     styled native control otherwise renders at its intrinsic height there
+     (lesson 111). Also strips the WebKit search decorations (cancel/results
+     button) so our own clear button is the only affordance. */
+  .clubs-search__input {
+    appearance: none;
+    width: 100%;
+    min-height: 44px;
+    padding: 0 40px 0 38px;
+    border: 1px solid var(--line);
+    border-radius: 0.5rem;
+    background-color: var(--surface);
+    color: var(--ink);
+    font-size: 0.875rem;
+  }
+
+  .clubs-search__input::placeholder {
+    color: var(--ink-3);
+  }
+
+  .clubs-search__input:focus {
+    outline: none;
+    border-color: var(--rt-stats, #d4873f);
+    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+  }
+
+  .clubs-search__input::-webkit-search-decoration,
+  .clubs-search__input::-webkit-search-cancel-button {
+    appearance: none;
+  }
+
+  /* 44px touch target for the clear control (WCAG 2.5.5). */
+  .clubs-search__clear {
+    position: absolute;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    color: var(--ink-3);
+    font-size: 0.875rem;
+  }
+
+  .clubs-search__clear:hover,
+  .clubs-search__clear:focus {
+    color: var(--ink);
+  }
+
   /* Muted text outside the table grid (results count, empty-state copy,
      mobile sort label) — was text-gray-{400,500,600}. */
   .clubs-text-muted {

--- a/tasks/lessons/127-a-controlled-input-bound-to-an-expensive-filter-drops-fast-keystrokes.md
+++ b/tasks/lessons/127-a-controlled-input-bound-to-an-expensive-filter-drops-fast-keystrokes.md
@@ -1,0 +1,89 @@
+---
+id: '127'
+category: lesson
+tags: [frontend, react, performance, tests, playwright, verification]
+auto_load: true
+date: 2026-05-27
+issues: [814, 818]
+---
+
+# Lesson 127 — A controlled input bound to an expensive derived filter drops fast keystrokes
+
+**Date:** 2026-05-27
+**Issue:** #814 (epic #818 Sprint 1 — visible club-table search box)
+**PR:** [#828](https://github.com/taverns-red/toast-stats/pull/828)
+
+## What happened
+
+The visible club search box was first wired the obvious way: a single
+controlled `<input value={getFilter('name')?.value} onChange={setFilter…}>`.
+Every keystroke called `setFilter`, which re-filtered **and re-sorted ~162
+club rows** synchronously, then re-rendered the whole table. Unit tests
+(3 clubs, `fireEvent.change` with the full string in one event) passed. The
+dual-engine preview smoke (`pressSequentially`, 20ms/char, against the real
+162-club D61 preview) failed: typing `"zzqqxxnomatch"` left the URL stuck at
+`?search=zzqq` — **only the first four characters landed.**
+
+A controlled input's displayed value is gated on the render that consumes its
+`onChange`. When that render is expensive (a 162-row re-sort), keystrokes
+arrive faster than React commits; React resets the DOM input to the stale
+controlled value mid-burst and the extra characters are silently dropped. The
+URL was a faithful mirror of a genuinely broken input, not a separate bug.
+
+Chromium flake-passed on retry (a fresh, faster load occasionally kept up);
+WebKit failed outright. A Chromium-only or jsdom-only check would have shipped
+this.
+
+## The fix — local input state + debounced push (the pattern already in the repo)
+
+Mirror the existing column `TextFilter`: keep a **local** input state so typing
+is instant and cheap, and drive the expensive filter off a **300ms-debounced**
+value.
+
+```tsx
+const [input, setInput] = useState(value)
+const debounced = useDebounce(input, 300)
+// pull external resets (Clear-all / dropdown / back-forward) in, render-phase
+// (no setState-in-effect — the react-hooks lint rule blocks it; #340):
+const [tracked, setTracked] = useState(value)
+if (value !== tracked) {
+  setTracked(value)
+  setInput(value)
+}
+// push the settled value out (filter + URL) when it diverges:
+useEffect(() => {
+  if (debounced !== value) onSearchChange(debounced)
+}, [debounced, value, onSearchChange])
+```
+
+`value={input}` (not the derived filter value) is the key line: the input is no
+longer gated on the re-sort, so no characters drop. Debounce coalescing means
+the box only emits the final value, and the render-phase tracked-value sync
+pulls external changes back in without fighting the user mid-type.
+
+## How to apply
+
+- **A controlled text input whose `onChange` does non-trivial work (filter +
+  sort a large list, a network call, a heavy recompute) needs a local value +
+  debounce.** Binding `value=` straight to the expensive derived state drops
+  fast keystrokes. This repo already has `useDebounce` and the `TextFilter`
+  reference — reach for it, don't reinvent instant filtering.
+- **Test typing the way a human types — character by character on real data
+  volume.** A unit test that sets the whole string in one `fireEvent.change`
+  with 3 rows cannot reproduce a dropped-keystroke race. The live
+  `pressSequentially` smoke against the 162-row preview is what surfaced it
+  (same "verify on the engine/volume that ships" family as lessons 108/110/111).
+- To sync local state from a prop without `setState`-in-effect (the
+  `react-hooks/set-state-in-effect` lint error), use the render-phase
+  tracked-value compare, not a `useEffect`.
+
+## Related
+
+- `frontend/src/components/filters/TextFilter.tsx` — the local-value + 300ms
+  `useDebounce` reference this should have followed from the start (#340).
+- [[070-setSearchParams-prev-races-in-batched-updates]] — sibling URL-state
+  footgun; there the URL was clobbered by a same-batch writer, here the input
+  itself dropped input before the URL ever saw it.
+- [[111-native-select-ignores-min-height-in-webkit-defeating-touch-targets]] —
+  same sprint family: a defect invisible to Chromium/jsdom, caught only by the
+  dual-engine live smoke.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -93,3 +93,4 @@
 - **124** [router, react, hooks, frontend, verification] — Validate URL-synced range state at the page that owns it, not at the picker (#794, #797)
 - **125** [cls, performance, frontend, verification, ci] — A CLS fix for the loading state must cover the error/empty states too (#811, #488, #750)
 - **126** [css, frontend, responsive, tables, dark-mode] — Porting a sticky-column treatment to a sibling table must re-derive the border restoration for THAT table's border-collapse model (#812, #813, #811)
+- **127** [frontend, react, performance, tests, playwright, verification] — A controlled input bound to an expensive derived filter drops fast keystrokes (#814, #818)


### PR DESCRIPTION
Epic #818 Sprint 1. Closes nothing automatically — the sprint runner ticks the epic + closes #814 after preview verification (tick-before-close ordering, #626/#106).

## What
A prominent, visible **search box** above the district clubs table. Previously club-name search was buried in the hidden "Club" column-header dropdown (recognition over recall, ron-ux). The box is a **second UI entry point onto the existing `name` text filter** — not a new pipeline step (R11) — so it stays in sync with the column dropdown and URL-syncs through the parent (`DistrictClubsPage` maps `name` ⇄ `?search=`).

## Acceptance criteria
- [x] Visible search input above the table; filters by club name.
- [x] URL-synced (`?search=`) and survives reload/back — reuses the already-wired `name`⇄`?search=` mapping.
- [x] Keeps the existing filter pipeline (R11); existing `useColumnFilters` tests green.
- [x] 44px touch target (`appearance:none` + `min-height:44px`, lesson 111 — applies in WebKit); dark mode (token-driven, R10); focus rings on input + clear button (WCAG 2.4.7).

## Tests
- New: `ClubsTable.search.test.tsx` (5) — renders searchbox, filters on type, pre-fills from URL-derived initial state, notifies parent for URL-sync, clears on empty.
- Full frontend suite: **2865 passing, 0 regressions** (incl. `DistrictClubsPage` URL-sync + `useColumnFilters`).

## Review
- `/simplify`: deduped repeated `getFilter('name')` call.
- Fresh-context `/review`: APPROVE-WITH-NITS; the one Medium (no visible focus ring on clear button) is fixed.
- Lesson 070 race checked — typing fires only the single `handleFilterChange` `setSearchParams`; no same-batch sort write, so no collision.

Preview verification (dual-engine Playwright smoke on the PR preview) to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)