### PR TITLE
feat(clubs): merge the two quick-filter sets into one preset row; kill hidden auto-sort (#815)

### DIFF
--- a/frontend/src/__tests__/accessibility/ClubsControlsDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/ClubsControlsDarkModeContrast.test.ts
@@ -145,15 +145,12 @@ interface Surface {
 
 const SURFACES: Surface[] = [
   {
-    name: 'segmented active label',
-    fg: ['.clubs-status-segmented__btn--active', 'color'],
-    expectFgToken: 'var(--link)',
-    bgToken: 'var(--loyal-50)',
-  },
-  {
-    name: 'segmented active count badge',
+    // #815: the segmented status control merged into the single preset row;
+    // the active health-band chip is now `.clubs-quick-filter-chip--active`
+    // (covered below), and its count badge inverts to --link on --surface.
+    name: 'health preset active count badge',
     fg: [
-      '.clubs-status-segmented__btn--active .clubs-status-segmented__count',
+      '.clubs-quick-filter-chip--active .clubs-quick-filter-chip__count',
       'color',
     ],
     expectFgToken: 'var(--link)',

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -314,6 +314,35 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   const isNeedsMembersActive =
     membersNeededValue?.[0] === 2 && membersNeededValue?.[1] === null
 
+  // Health-band presets (#815 B2). Merged into the ONE preset row below: the
+  // old segmented `role="tablist"` status control and the quick-filter chips
+  // read as two unrelated systems (table-ux-review §1). These filter the same
+  // `status` field, single-select (choosing one replaces the prior; clicking
+  // the active one clears it). "All" is the absence of an active band — the
+  // "Total / Showing N" count line already carries the total. `aria-pressed`
+  // (not `role="tab"`): a filter toggles a set, it doesn't switch a panel — and
+  // it unifies the affordance with the intent chips in the same row.
+  const statusFilterValue = (() => {
+    const f = getFilter('status')
+    return Array.isArray(f?.value) ? (f.value as string[]) : []
+  })()
+  const isStatusActive = (status: string) =>
+    statusFilterValue.length === 1 && statusFilterValue[0] === status
+  const setStatusPreset = (status: string) => {
+    setFilter(
+      'status',
+      isStatusActive(status)
+        ? null
+        : { field: 'status', type: 'categorical', value: [status] }
+    )
+  }
+  const statusCounts = {
+    thriving: clubs.filter(c => c.currentStatus === 'thriving').length,
+    vulnerable: clubs.filter(c => c.currentStatus === 'vulnerable').length,
+    intervention: clubs.filter(c => c.currentStatus === 'intervention-required')
+      .length,
+  }
+
   // Status-pill modifier + label come from the shared clubHealthStatus helpers
   // so the desktop row and the mobile ClubCard render the same datum
   // identically (lesson 052). Token-driven via the CSS layer so dark mode
@@ -549,128 +578,42 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
             )}
           </div>
 
-          {/* Status segmented filter (#361) — All / Thriving / Vulnerable
-              / Intervention with counts, per design mockup. Sits above the
-              quick-filter chips so users can narrow by club health first,
-              then refine. */}
-          {(() => {
-            const statusFilter = getFilter('status')
-            const activeStatuses =
-              statusFilter && Array.isArray(statusFilter.value)
-                ? (statusFilter.value as string[])
-                : []
-            const isActive = (status: string) =>
-              activeStatuses.length === 1 && activeStatuses[0] === status
-            const isAllActive = activeStatuses.length === 0
-            const counts = {
-              all: clubs.length,
-              thriving: clubs.filter(c => c.currentStatus === 'thriving')
-                .length,
-              vulnerable: clubs.filter(c => c.currentStatus === 'vulnerable')
-                .length,
-              intervention: clubs.filter(
-                c => c.currentStatus === 'intervention-required'
-              ).length,
-            }
-            const setStatus = (status: string | null) => {
-              if (status === null) {
-                setFilter('status', null)
-              } else {
-                setFilter('status', {
-                  field: 'status',
-                  type: 'categorical',
-                  value: [status],
-                })
-              }
-            }
-            return (
-              <div
-                className="clubs-status-segmented"
-                role="tablist"
-                aria-label="Filter clubs by health status"
-              >
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={isAllActive}
-                  onClick={() => setStatus(null)}
-                  className={
-                    'clubs-status-segmented__btn' +
-                    (isAllActive ? ' clubs-status-segmented__btn--active' : '')
-                  }
-                >
-                  All{' '}
-                  <span className="clubs-status-segmented__count">
-                    {counts.all}
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={isActive('thriving')}
-                  onClick={() =>
-                    setStatus(isActive('thriving') ? null : 'thriving')
-                  }
-                  className={
-                    'clubs-status-segmented__btn' +
-                    (isActive('thriving')
-                      ? ' clubs-status-segmented__btn--active'
-                      : '')
-                  }
-                >
-                  Thriving{' '}
-                  <span className="clubs-status-segmented__count">
-                    {counts.thriving}
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={isActive('vulnerable')}
-                  onClick={() =>
-                    setStatus(isActive('vulnerable') ? null : 'vulnerable')
-                  }
-                  className={
-                    'clubs-status-segmented__btn' +
-                    (isActive('vulnerable')
-                      ? ' clubs-status-segmented__btn--active'
-                      : '')
-                  }
-                >
-                  Vulnerable{' '}
-                  <span className="clubs-status-segmented__count">
-                    {counts.vulnerable}
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={isActive('intervention-required')}
-                  onClick={() =>
-                    setStatus(
-                      isActive('intervention-required')
-                        ? null
-                        : 'intervention-required'
-                    )
-                  }
-                  className={
-                    'clubs-status-segmented__btn' +
-                    (isActive('intervention-required')
-                      ? ' clubs-status-segmented__btn--active'
-                      : '')
-                  }
-                >
-                  Intervention{' '}
-                  <span className="clubs-status-segmented__count">
-                    {counts.intervention}
-                  </span>
-                </button>
-              </div>
-            )
-          })()}
-
+          {/* ONE preset row (#815 B2): health bands + intent presets, merged
+              from the former segmented control and the separate chip strip.
+              Health bands first (single-select, with counts) so a leader can
+              narrow by health, then layer an intent preset on top. */}
           <div className="clubs-quick-filters">
             <span className="clubs-quick-filters__label">Quick filters:</span>
+
+            {/* Health bands — Thriving / Vulnerable / Intervention, single-select
+                (#361 → #815). Each carries its count; "All" = none active. */}
+            {(
+              [
+                ['thriving', 'Thriving', statusCounts.thriving],
+                ['vulnerable', 'Vulnerable', statusCounts.vulnerable],
+                [
+                  'intervention-required',
+                  'Intervention',
+                  statusCounts.intervention,
+                ],
+              ] as const
+            ).map(([value, label, count]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setStatusPreset(value)}
+                className={
+                  'clubs-quick-filter-chip' +
+                  (isStatusActive(value)
+                    ? ' clubs-quick-filter-chip--active'
+                    : '')
+                }
+                aria-pressed={isStatusActive(value)}
+              >
+                {label}
+                <span className="clubs-quick-filter-chip__count">{count}</span>
+              </button>
+            ))}
 
             {/* ⭐ Close to Distinguished — 1–4 more members (#433).
                 Threshold shared with ClubDetailPage banner. */}
@@ -680,14 +623,14 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                 if (isCloseToDistinguishedActive) {
                   setFilter('membersNeeded', null)
                 } else {
+                  // Filter only — no hidden auto-sort (#815 B2). The chip used
+                  // to silently re-sort by membersNeeded, surprising the user
+                  // and overriding any column sort they'd chosen.
                   setFilter('membersNeeded', {
                     field: 'membersNeeded',
                     type: 'numeric',
                     value: [1, CLOSE_TO_DISTINGUISHED_MAX_MEMBERS],
                   })
-                  setSortField('membersNeeded')
-                  setSortDirection('asc')
-                  onSortChange?.('membersNeeded', 'asc')
                 }
               }}
               className={

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -336,12 +336,19 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
         : { field: 'status', type: 'categorical', value: [status] }
     )
   }
-  const statusCounts = {
-    thriving: clubs.filter(c => c.currentStatus === 'thriving').length,
-    vulnerable: clubs.filter(c => c.currentStatus === 'vulnerable').length,
-    intervention: clubs.filter(c => c.currentStatus === 'intervention-required')
-      .length,
-  }
+  // One pass, memoized on `clubs` (the sort below memoizes for the same
+  // reason) — the badges recompute only when the data changes, not on every
+  // filter/sort/scroll-cue re-render.
+  const statusCounts = useMemo(() => {
+    const counts = { thriving: 0, vulnerable: 0, intervention: 0 }
+    for (const c of clubs) {
+      if (c.currentStatus === 'thriving') counts.thriving++
+      else if (c.currentStatus === 'vulnerable') counts.vulnerable++
+      else if (c.currentStatus === 'intervention-required')
+        counts.intervention++
+    }
+    return counts
+  }, [clubs])
 
   // Status-pill modifier + label come from the shared clubHealthStatus helpers
   // so the desktop row and the mobile ClubCard render the same datum

--- a/frontend/src/components/__tests__/ClubsTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.test.tsx
@@ -709,6 +709,130 @@ describe('ClubsTable', () => {
     })
   })
 
+  describe('Consolidated preset filter row (#815)', () => {
+    it('clicking "Close to Distinguished" does NOT trigger a hidden sort change', () => {
+      const onSortChange = vi.fn()
+      const clubs = [createMockClub({ clubId: 'club-1' })]
+
+      render(
+        <ClubsTable
+          clubs={clubs}
+          districtId="test-district"
+          isLoading={false}
+          onSortChange={onSortChange}
+        />
+      )
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /close to distinguished/i })
+      )
+
+      // The chip filters; it must not silently re-sort the table (#815 B2 —
+      // the hidden auto-sort surprise removed).
+      expect(onSortChange).not.toHaveBeenCalled()
+    })
+
+    it('renders a single preset row — no separate status tablist', () => {
+      const clubs = [createMockClub({ clubId: 'club-1' })]
+
+      render(
+        <ClubsTable
+          clubs={clubs}
+          districtId="test-district"
+          isLoading={false}
+        />
+      )
+
+      expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+      expect(screen.queryByRole('tab')).not.toBeInTheDocument()
+    })
+
+    it('exposes health presets as toggle buttons (aria-pressed)', () => {
+      const clubs = [
+        createMockClub({ clubId: 'club-1', currentStatus: 'vulnerable' }),
+      ]
+
+      render(
+        <ClubsTable
+          clubs={clubs}
+          districtId="test-district"
+          isLoading={false}
+        />
+      )
+
+      const vulnerable = screen.getByRole('button', { name: /^vulnerable/i })
+      expect(vulnerable).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('clicking a health preset writes the status filter', () => {
+      const onFilterChange = vi.fn()
+      const clubs = [
+        createMockClub({ clubId: 'club-1', currentStatus: 'vulnerable' }),
+      ]
+
+      render(
+        <ClubsTable
+          clubs={clubs}
+          districtId="test-district"
+          isLoading={false}
+          onFilterChange={onFilterChange}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /^vulnerable/i }))
+
+      const lastCall =
+        onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1]
+      const filterState = lastCall![0] as Record<string, { value: string[] }>
+      expect(filterState.status!.value).toEqual(['vulnerable'])
+    })
+
+    it('health presets are single-select: a second choice replaces the first', () => {
+      const onFilterChange = vi.fn()
+      const clubs = [
+        createMockClub({ clubId: 'club-1', currentStatus: 'vulnerable' }),
+        createMockClub({ clubId: 'club-2', currentStatus: 'thriving' }),
+      ]
+
+      render(
+        <ClubsTable
+          clubs={clubs}
+          districtId="test-district"
+          isLoading={false}
+          onFilterChange={onFilterChange}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /^thriving/i }))
+      fireEvent.click(screen.getByRole('button', { name: /^vulnerable/i }))
+
+      const lastCall =
+        onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1]
+      const filterState = lastCall![0] as Record<string, { value: string[] }>
+      expect(filterState.status!.value).toEqual(['vulnerable'])
+    })
+
+    it('shows a count badge on each health preset', () => {
+      const clubs = [
+        createMockClub({ clubId: 'club-1', currentStatus: 'vulnerable' }),
+        createMockClub({ clubId: 'club-2', currentStatus: 'vulnerable' }),
+        createMockClub({ clubId: 'club-3', currentStatus: 'thriving' }),
+      ]
+
+      render(
+        <ClubsTable
+          clubs={clubs}
+          districtId="test-district"
+          isLoading={false}
+        />
+      )
+
+      expect(
+        screen.getByRole('button', { name: /^vulnerable/i })
+      ).toHaveTextContent('2')
+    })
+  })
+
   describe('Row Click Handler', () => {
     it('should call onClubClick when a row is clicked', () => {
       const onClubClick = vi.fn()

--- a/frontend/src/components/__tests__/ClubsTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.test.tsx
@@ -827,9 +827,12 @@ describe('ClubsTable', () => {
         />
       )
 
+      // Scope to the count badge so the assertion can't pass on an incidental
+      // "2" elsewhere in the label.
+      const vulnerable = screen.getByRole('button', { name: /^vulnerable/i })
       expect(
-        screen.getByRole('button', { name: /^vulnerable/i })
-      ).toHaveTextContent('2')
+        vulnerable.querySelector('.clubs-quick-filter-chip__count')?.textContent
+      ).toBe('2')
     })
   })
 

--- a/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
@@ -288,16 +288,15 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
     expect(screen.queryByText(/alpha toastmasters/i)).not.toBeInTheDocument()
   })
 
-  it('writes ?status= to the URL when a status chip is activated', async () => {
+  it('writes ?status= to the URL when a health preset is activated', async () => {
     const user = userEvent.setup()
     const { router } = renderAt('/district/61/clubs')
 
     await screen.findByText(/alpha toastmasters/i)
 
-    const statusStrip = screen.getByRole('tablist', {
-      name: /filter clubs by health status/i,
-    })
-    const vulnerableChip = within(statusStrip).getByRole('tab', {
+    // #815: health bands are now toggle buttons in the single preset row, not
+    // tabs in a segmented control.
+    const vulnerableChip = screen.getByRole('button', {
       name: /^vulnerable/i,
     })
     await user.click(vulnerableChip)
@@ -308,17 +307,18 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
     })
   })
 
-  it('clears ?status= from the URL when chip is deactivated', async () => {
+  it('clears ?status= from the URL when the active health preset is toggled off', async () => {
     const user = userEvent.setup()
     const { router } = renderAt('/district/61/clubs?status=vulnerable')
 
     await screen.findByText(/beta speakers/i)
 
-    const statusStrip = screen.getByRole('tablist', {
-      name: /filter clubs by health status/i,
+    // No more "All" button (#815) — clicking the active band toggles it off.
+    const vulnerableChip = screen.getByRole('button', {
+      name: /^vulnerable/i,
     })
-    const allChip = within(statusStrip).getByRole('tab', { name: /^all\b/i })
-    await user.click(allChip)
+    expect(vulnerableChip).toHaveAttribute('aria-pressed', 'true')
+    await user.click(vulnerableChip)
 
     await waitFor(() => {
       const params = new URLSearchParams(router.state.location.search)

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -2144,74 +2144,9 @@
     margin-top: 12px;
   }
 
-  /* Clubs tab segmented status filter (#361). Larger primary filter
-     above the quick-filter chip strip — All / Thriving / Vulnerable /
-     Intervention with counts. */
-  .clubs-status-segmented {
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: 2px;
-    margin-bottom: 12px;
-    padding: 2px;
-    background-color: var(--surface-2);
-    border: 1px solid var(--line);
-    border-radius: var(--rds-radius-md);
-  }
-
-  .clubs-status-segmented__btn {
-    appearance: none;
-    border: 0;
-    padding: 6px 12px;
-    border-radius: calc(var(--rds-radius-md) - 2px);
-    background-color: transparent;
-    color: var(--ink-2);
-    font-family: var(--sans);
-    font-weight: 600;
-    font-size: 13px;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    transition: background-color 120ms ease, color 120ms ease;
-  }
-
-  .clubs-status-segmented__btn:hover {
-    color: var(--ink);
-    background-color: var(--surface-3);
-  }
-
-  /* Active = --link text on --loyal-50 per handoff (#670). --link equals
-     --loyal-500 in light (byte-identical to the old look) but remaps to a
-     dark-safe #60a5d8 — never raw --loyal-500, the navy-on-navy dark trap
-     (lessons 093/096). */
-  .clubs-status-segmented__btn--active {
-    background-color: var(--loyal-50);
-    color: var(--link);
-  }
-
-  .clubs-status-segmented__count {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 22px;
-    padding: 0 6px;
-    height: 18px;
-    border-radius: 999px;
-    background-color: var(--surface-3);
-    color: var(--ink-3);
-    font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
-    font-weight: 500;
-    font-size: 11px;
-    line-height: 1;
-  }
-
-  .clubs-status-segmented__btn--active .clubs-status-segmented__count {
-    background-color: var(--surface);
-    color: var(--link);
-  }
-
   /* Clubs tab quick-filter chip strip (#24 follow-up). Sits above the
-     ClubsTable toolbar on the District detail Clubs tab. */
+     ClubsTable toolbar on the District detail Clubs tab. Since #815 this is
+     the SINGLE preset row: health bands (with count badges) + intent presets. */
   .clubs-quick-filters {
     display: flex;
     flex-wrap: wrap;
@@ -2269,6 +2204,31 @@
      a light tint, so a white star would vanish). */
   .clubs-quick-filter-chip__star {
     color: var(--yellow-600);
+  }
+
+  /* Count badge on the health-band presets (#815). Pill of --surface-3 / --ink-3
+     at rest; on the active chip it inverts to --link on --surface to match the
+     active label (dark-safe via --link, lessons 093/096). */
+  .clubs-quick-filter-chip__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    padding: 0 6px;
+    height: 16px;
+    margin-left: 2px;
+    border-radius: 999px;
+    background-color: var(--surface-3);
+    color: var(--ink-3);
+    font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+    font-weight: 500;
+    font-size: 11px;
+    line-height: 1;
+  }
+
+  .clubs-quick-filter-chip--active .clubs-quick-filter-chip__count {
+    background-color: var(--surface);
+    color: var(--link);
   }
 
   .clubs-quick-filter-chip__clear {

--- a/tasks/lessons/128-a-filter-control-is-aria-pressed-not-role-tab.md
+++ b/tasks/lessons/128-a-filter-control-is-aria-pressed-not-role-tab.md
@@ -1,0 +1,65 @@
+---
+id: '128'
+category: lesson
+tags: [accessibility, frontend, react, ux]
+auto_load: true
+date: 2026-05-27
+issues: [815, 818]
+---
+
+# Lesson 128 — A filter control is `aria-pressed`, not `role="tab"` — tabs promise a panel switch
+
+**Date:** 2026-05-27
+**Issue:** #815 (epic #818 Sprint 2 — merge the two club-table quick-filter sets)
+**PR:** [#829](https://github.com/taverns-red/toast-stats/pull/829)
+
+## What happened
+
+The club table had a status segmented control (All / Thriving / Vulnerable /
+Intervention) built as `role="tablist"` with `role="tab"` + `aria-selected`
+children (#361), sitting above a separate `aria-pressed` quick-filter chip strip.
+Consolidating the two into one preset row (#815) forced the question of which
+ARIA model the merged row should use — and surfaced that the tab semantics were
+wrong from the start.
+
+`role="tab"` is a promise: a tab controls a `tabpanel` and switching tabs swaps
+which panel is shown (`aria-controls` → a region with `role="tabpanel"`). The
+status control had **no tabpanels** — it filtered rows in a table that was
+always present. A screen-reader user hears "tab, selected" and expects a view to
+switch; nothing switches, only the row set narrows. That's a semantic lie.
+
+A filter button toggles membership in a result set. The correct affordance is a
+**toggle button**: a plain `<button>` with `aria-pressed={active}`. The intent
+chips in the same component already used `aria-pressed` — so unifying the row on
+`aria-pressed` both fixed the mis-coded ARIA and made the merged row coherent
+(one interaction model, not two).
+
+## The principle
+
+**Before reaching for `role="tab"`/`tablist`, check whether activating the
+control switches a _panel_ or merely _filters/transforms_ the content already on
+screen.** Tabs are for mutually-exclusive views with their own panels. A control
+that filters, sorts, or toggles a facet of one persistent view is a toggle
+button — `aria-pressed`, not `aria-selected`. Single-select among several (a
+radio-like band) is still a row of `aria-pressed` buttons where activating one
+clears the others; you do not need `role="tab"` to express "one at a time."
+
+## How to apply
+
+- `role="tab"` requires a real `tabpanel` it controls. No panel swap ⇒ not a tab.
+- Filter / facet / segment controls → `<button aria-pressed>`. It reads as
+  "toggle button, pressed/not pressed," which is what a filter is.
+- Dropping a `tablist` is usually an a11y _improvement_, not a regression — but
+  update any test asserting `getByRole('tablist'|'tab')` to the button role
+  (here: `DistrictClubsPage.test.tsx`, `ClubsTable.test.tsx`). The query change
+  is the tell that the role was load-bearing in tests, not that you broke a11y.
+- When you merge two controls, let the _correct_ model win, don't average them:
+  a row mixing `role="tab"` and `aria-pressed` siblings is worse than either.
+
+## Related
+
+- [[052-close-to-distinguished-dual-metric]] — same component family; merging
+  surfaces hidden inconsistencies (there: shared label / divergent metric).
+- [[127-a-controlled-input-bound-to-an-expensive-filter-drops-fast-keystrokes]] —
+  Sprint 1 of the same epic; the dual-engine live smoke against the 162-row
+  preview is the verification pattern this sprint reused.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -94,3 +94,4 @@
 - **125** [cls, performance, frontend, verification, ci] — A CLS fix for the loading state must cover the error/empty states too (#811, #488, #750)
 - **126** [css, frontend, responsive, tables, dark-mode] — Porting a sticky-column treatment to a sibling table must re-derive the border restoration for THAT table's border-collapse model (#812, #813, #811)
 - **127** [frontend, react, performance, tests, playwright, verification] — A controlled input bound to an expensive derived filter drops fast keystrokes (#814, #818)
+- **128** [accessibility, frontend, react, ux] — A filter control is `aria-pressed`, not `role="tab"` — tabs promise a panel switch (#815, #818)


### PR DESCRIPTION
## What & why

Sprint 2 of epic #818 (B2 of `docs/design/table-ux-review-2026-05-27.md`).

The club table had **two overlapping quick-filter mechanisms** that read as
unrelated systems:

1. A `role="tablist"` **status segmented control** (All / Thriving / Vulnerable / Intervention, with counts).
2. A separate **quick-filter chip** strip (Close to Distinguished / Needs members / Missing renewals / President's tier) — where "Close to Distinguished" carried a **hidden auto-sort** side effect.

This collapses both into **one coherent preset row**: the health bands are now
`aria-pressed` toggle chips (single-select, count badges retained) living in the
same row as the intent presets. The hidden auto-sort is removed.

## Acceptance criteria

- [x] One coherent quick-filter row; no second redundant set.
- [x] No hidden auto-sort side effect (the Close-to-Distinguished chip now filters only).
- [x] Preset + per-column interactions legible *(the full active-filters summary bar is Sprint 4 / #817).*
- [x] Filter pipeline intact (R11 — UI-only change over `original → filtered → searchFiltered → sorted`); tests green; dark-mode + breakpoint verification on the preview channel.

## Notes

- **a11y improvement:** `role="tab"` falsely promised a panel switch; `aria-pressed` is the correct affordance for a filter toggle, and it unifies the row. "All" = no band active (the Total/Showing line already shows the total); clear a band by toggling it off or via "Clear all".
- **Dark-mode contrast coverage re-pointed**, not dropped — `ClubsControlsDarkModeContrast.test.ts` now covers the active health-chip count badge (`--link` on `--surface`); the active-chip label surface was already covered.
- Lesson 052's dual-metric note on "Close to Distinguished" is preserved verbatim.
- Reviewed via `/simplify` (memoized health-band counts) and a fresh-context critical review (no blockers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)