### PR TITLE
feat(tables): column-group show/hide model for the club table (#819)

### DIFF
--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -13,8 +13,16 @@ import { useColumnFilters } from '../hooks/useColumnFilters'
 import { ColumnHeader } from './ColumnHeader'
 import { FiltersPanel } from './filters/FiltersPanel'
 import { ActiveFiltersBar } from './ActiveFiltersBar'
+import { ColumnGroupsMenu } from './ColumnGroupsMenu'
 import { describeActiveFilters } from '../utils/clubFilterDescribe'
-import { SortField, SortDirection, COLUMN_CONFIGS } from './filters/types'
+import {
+  SortField,
+  SortDirection,
+  COLUMN_CONFIGS,
+  COLUMN_GROUPS,
+  STICKY_COLUMN_FIELD,
+} from './filters/types'
+import { useColumnGroupVisibility } from '../hooks/useColumnGroupVisibility'
 import { CLOSE_TO_DISTINGUISHED_MAX_MEMBERS } from '../utils/closeToDistinguished'
 import ClubCard from './ClubCard'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -64,8 +72,10 @@ const DESKTOP_ONLY_FIELDS: ReadonlySet<SortField> = new Set([
 ])
 
 // The sticky key column — pinned at left:0 so the row stays labelled while the
-// metric columns scroll horizontally (Lesson 105). It is never hidden.
-const STICKY_FIELD: SortField = 'name'
+// metric columns scroll horizontally (Lesson 105). It is never hidden, by the
+// responsive model OR the column-group toggle (ADR-006 §3). Sourced from the
+// column model so the two stay in lockstep.
+const STICKY_FIELD: SortField = STICKY_COLUMN_FIELD
 
 /** Responsive priority class for a column header/cell, by field. */
 const colPriorityClass = (field: SortField): string =>
@@ -74,6 +84,13 @@ const colPriorityClass = (field: SortField): string =>
     : DESKTOP_ONLY_FIELDS.has(field)
       ? 'clubs-table__col--desktop'
       : ''
+
+// Groups offered in the show/hide menu: only those with at least one column in
+// the current table (so "Changes" stays out until #795 lands its delta cols).
+// COLUMN_CONFIGS is static, so this resolves once at module load.
+const AVAILABLE_COLUMN_GROUPS = COLUMN_GROUPS.filter(g =>
+  COLUMN_CONFIGS.some(c => c.group === g.id)
+)
 
 /** Row-tint key for the sticky cell, so it can repaint OPAQUE per row status
  *  (a sticky cell must be opaque or scrolled columns bleed through it). Mirrors
@@ -263,6 +280,21 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   // (lesson 105) — but the old 640px value made the table→card swap a cliff
   // with no tablet tier. The tablet tier is what #812 adds.
   const isMobile = useIsMobile(768)
+
+  // Column-group show/hide (#819, ADR-006 §4). Persisted to localStorage so the
+  // selection survives reload. This is orthogonal to the responsive priority
+  // model above: the group toggle removes a column from the DOM entirely, while
+  // `colPriorityClass` governs the CSS-level responsive hiding of columns that
+  // ARE rendered — no parallel responsive logic.
+  const { isGroupHidden, toggleGroup } = useColumnGroupVisibility()
+  const visibleFields = useMemo(() => {
+    const set = new Set<SortField>()
+    for (const c of COLUMN_CONFIGS) {
+      // The sticky key column is the row's label — never hidden by a group.
+      if (c.field === STICKY_FIELD || !isGroupHidden(c.group)) set.add(c.field)
+    }
+    return set
+  }, [isGroupHidden])
 
   // Use column filters hook with optional URL-initialized state (#272)
   const {
@@ -623,6 +655,16 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
               </span>
             )}
           </button>
+          {/* Column-group show/hide (#819). Only meaningful for the desktop
+              table — the mobile card view carries the full record regardless,
+              so the control is hidden there. */}
+          {!isMobile && (
+            <ColumnGroupsMenu
+              groups={AVAILABLE_COLUMN_GROUPS}
+              isGroupHidden={isGroupHidden}
+              onToggle={toggleGroup}
+            />
+          )}
         </div>
 
         {/* Results Count and Quick Filters */}
@@ -981,7 +1023,9 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
             <table id="clubs-table" className="w-full table-auto">
               <thead className="clubs-table-sticky-head">
                 <tr>
-                  {COLUMN_CONFIGS.map(config => (
+                  {COLUMN_CONFIGS.filter(config =>
+                    visibleFields.has(config.field)
+                  ).map(config => (
                     <th
                       key={config.field}
                       className={`p-0 ${colPriorityClass(config.field)}`.trim()}
@@ -1025,161 +1069,185 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                           {club.clubName}
                         </div>
                       </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center clubs-table__col--desktop">
-                        {club.divisionName}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center clubs-table__col--desktop">
-                        {club.areaName}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-center">
-                        <span
-                          className={`clubs-status-pill ${getStatusPillModifier(club.currentStatus)}`}
-                        >
-                          {getStatusLabel(club.currentStatus)}
-                        </span>
-                      </td>
+                      {visibleFields.has('division') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center clubs-table__col--desktop">
+                          {club.divisionName}
+                        </td>
+                      )}
+                      {visibleFields.has('area') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center clubs-table__col--desktop">
+                          {club.areaName}
+                        </td>
+                      )}
+                      {visibleFields.has('status') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-center">
+                          <span
+                            className={`clubs-status-pill ${getStatusPillModifier(club.currentStatus)}`}
+                          >
+                            {getStatusLabel(club.currentStatus)}
+                          </span>
+                        </td>
+                      )}
                       {/* Members — current / base (#669). Base omitted when the
                       snapshot has no membershipBase (pre-merge data). */}
-                      <td className="px-2 py-3 whitespace-nowrap text-sm text-center clubs-members-cell">
-                        <span className="tabular-nums">
-                          {club.latestMembership}
-                        </span>
-                        {club.membershipBase !== undefined && (
-                          <span className="clubs-cell-muted tabular-nums">
-                            {' / '}
-                            {club.membershipBase}
+                      {visibleFields.has('membership') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-sm text-center clubs-members-cell">
+                          <span className="tabular-nums">
+                            {club.latestMembership}
                           </span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center font-medium">
-                        {club.membersNeeded > 0 ? (
-                          <span className="text-tm-true-maroon">
-                            {club.membersNeeded}
-                          </span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
-                        {club.newMembers !== undefined ? (
-                          <span
-                            className={
-                              club.newMembers === 0
-                                ? 'clubs-cell-muted'
-                                : undefined
-                            }
-                          >
-                            {club.newMembers}
-                          </span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
-                        {club.octoberRenewals !== undefined ? (
-                          <span
-                            className={
-                              club.octoberRenewals === 0
-                                ? 'clubs-cell-muted'
-                                : undefined
-                            }
-                          >
-                            {club.octoberRenewals}
-                          </span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
-                        {club.aprilRenewals !== undefined ? (
-                          <span
-                            className={
-                              club.aprilRenewals === 0
-                                ? 'clubs-cell-muted'
-                                : undefined
-                            }
-                          >
-                            {club.aprilRenewals}
-                          </span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
+                          {club.membershipBase !== undefined && (
+                            <span className="clubs-cell-muted tabular-nums">
+                              {' / '}
+                              {club.membershipBase}
+                            </span>
+                          )}
+                        </td>
+                      )}
+                      {visibleFields.has('membersNeeded') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center font-medium">
+                          {club.membersNeeded > 0 ? (
+                            <span className="text-tm-true-maroon">
+                              {club.membersNeeded}
+                            </span>
+                          ) : (
+                            <span className="clubs-cell-muted">—</span>
+                          )}
+                        </td>
+                      )}
+                      {visibleFields.has('newMembers') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
+                          {club.newMembers !== undefined ? (
+                            <span
+                              className={
+                                club.newMembers === 0
+                                  ? 'clubs-cell-muted'
+                                  : undefined
+                              }
+                            >
+                              {club.newMembers}
+                            </span>
+                          ) : (
+                            <span className="clubs-cell-muted">—</span>
+                          )}
+                        </td>
+                      )}
+                      {visibleFields.has('octoberRenewals') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
+                          {club.octoberRenewals !== undefined ? (
+                            <span
+                              className={
+                                club.octoberRenewals === 0
+                                  ? 'clubs-cell-muted'
+                                  : undefined
+                              }
+                            >
+                              {club.octoberRenewals}
+                            </span>
+                          ) : (
+                            <span className="clubs-cell-muted">—</span>
+                          )}
+                        </td>
+                      )}
+                      {visibleFields.has('aprilRenewals') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
+                          {club.aprilRenewals !== undefined ? (
+                            <span
+                              className={
+                                club.aprilRenewals === 0
+                                  ? 'clubs-cell-muted'
+                                  : undefined
+                              }
+                            >
+                              {club.aprilRenewals}
+                            </span>
+                          ) : (
+                            <span className="clubs-cell-muted">—</span>
+                          )}
+                        </td>
+                      )}
                       {/* DCP — inline progress bar over the canonical goals-achieved
                       count (0–10). Reads latestDcpGoals from the analytics
                       trend; no Goals-1-N inference (DCP-independence tripwire). */}
-                      <td className="px-2 py-3 whitespace-nowrap text-center">
-                        {(() => {
-                          const goals = Math.max(
-                            0,
-                            Math.min(10, club.latestDcpGoals)
-                          )
-                          const pct = (goals / 10) * 100
-                          return (
-                            <div className="clubs-dcp-cell">
-                              <span className="clubs-dcp-cell__val tabular-nums">
-                                {goals}/10
-                              </span>
-                              <div
-                                className="clubs-dcp-bar"
-                                role="progressbar"
-                                aria-valuenow={goals}
-                                aria-valuemin={0}
-                                aria-valuemax={10}
-                                aria-label="DCP goals achieved"
-                              >
+                      {visibleFields.has('dcpGoals') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-center">
+                          {(() => {
+                            const goals = Math.max(
+                              0,
+                              Math.min(10, club.latestDcpGoals)
+                            )
+                            const pct = (goals / 10) * 100
+                            return (
+                              <div className="clubs-dcp-cell">
+                                <span className="clubs-dcp-cell__val tabular-nums">
+                                  {goals}/10
+                                </span>
                                 <div
-                                  className="clubs-dcp-bar__fill"
-                                  style={{ width: `${pct}%` }}
-                                />
+                                  className="clubs-dcp-bar"
+                                  role="progressbar"
+                                  aria-valuenow={goals}
+                                  aria-valuemin={0}
+                                  aria-valuemax={10}
+                                  aria-label="DCP goals achieved"
+                                >
+                                  <div
+                                    className="clubs-dcp-bar__fill"
+                                    style={{ width: `${pct}%` }}
+                                  />
+                                </div>
                               </div>
-                            </div>
-                          )
-                        })()}
-                      </td>
+                            )
+                          })()}
+                        </td>
+                      )}
                       {/* Tier — DCP recognition pill (#669). Color by tier; a
                       provisional tier shows the striped-yellow "projected"
                       treatment instead (membership unconfirmed pre-April). */}
-                      <td className="px-2 py-3 whitespace-nowrap text-center">
-                        {club.distinguishedLevel !== 'NotDistinguished' ? (
-                          (() => {
-                            const provisional =
-                              isProvisionallyDistinguished(club)
-                            const modifier = provisional
-                              ? 'clubs-tier-pill--projected'
-                              : TIER_MODIFIER[club.distinguishedLevel]
-                            return (
-                              <span
-                                className={`clubs-tier-pill ${modifier}`}
-                                title={
-                                  provisional
-                                    ? 'Provisional — membership not yet confirmed by April renewals'
-                                    : 'Confirmed — April renewals recorded'
-                                }
-                              >
-                                {TIER_DISPLAY[club.distinguishedLevel]}
-                                {provisional ? '*' : ''}
-                              </span>
-                            )
-                          })()
-                        ) : (
-                          <span className="text-sm clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm text-center clubs-table__col--desktop">
-                        {club.clubStatus ? (
-                          <span>{club.clubStatus}</span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
-                        {club.yearsChartered !== null ? (
-                          <span>{club.yearsChartered}</span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
+                      {visibleFields.has('distinguished') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-center">
+                          {club.distinguishedLevel !== 'NotDistinguished' ? (
+                            (() => {
+                              const provisional =
+                                isProvisionallyDistinguished(club)
+                              const modifier = provisional
+                                ? 'clubs-tier-pill--projected'
+                                : TIER_MODIFIER[club.distinguishedLevel]
+                              return (
+                                <span
+                                  className={`clubs-tier-pill ${modifier}`}
+                                  title={
+                                    provisional
+                                      ? 'Provisional — membership not yet confirmed by April renewals'
+                                      : 'Confirmed — April renewals recorded'
+                                  }
+                                >
+                                  {TIER_DISPLAY[club.distinguishedLevel]}
+                                  {provisional ? '*' : ''}
+                                </span>
+                              )
+                            })()
+                          ) : (
+                            <span className="text-sm clubs-cell-muted">—</span>
+                          )}
+                        </td>
+                      )}
+                      {visibleFields.has('clubStatus') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-sm text-center clubs-table__col--desktop">
+                          {club.clubStatus ? (
+                            <span>{club.clubStatus}</span>
+                          ) : (
+                            <span className="clubs-cell-muted">—</span>
+                          )}
+                        </td>
+                      )}
+                      {visibleFields.has('yearsChartered') && (
+                        <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
+                          {club.yearsChartered !== null ? (
+                            <span>{club.yearsChartered}</span>
+                          ) : (
+                            <span className="clubs-cell-muted">—</span>
+                          )}
+                        </td>
+                      )}
                     </tr>
                   )
                 })}

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -71,15 +71,14 @@ const DESKTOP_ONLY_FIELDS: ReadonlySet<SortField> = new Set([
   'yearsChartered',
 ])
 
-// The sticky key column — pinned at left:0 so the row stays labelled while the
-// metric columns scroll horizontally (Lesson 105). It is never hidden, by the
-// responsive model OR the column-group toggle (ADR-006 §3). Sourced from the
-// column model so the two stay in lockstep.
-const STICKY_FIELD: SortField = STICKY_COLUMN_FIELD
+// The sticky key column (`STICKY_COLUMN_FIELD`, sourced from the column model)
+// is pinned at left:0 so the row stays labelled while the metric columns scroll
+// horizontally (Lesson 105). It is never hidden, by the responsive model OR the
+// column-group toggle (ADR-006 §3).
 
 /** Responsive priority class for a column header/cell, by field. */
 const colPriorityClass = (field: SortField): string =>
-  field === STICKY_FIELD
+  field === STICKY_COLUMN_FIELD
     ? 'clubs-table__sticky-col'
     : DESKTOP_ONLY_FIELDS.has(field)
       ? 'clubs-table__col--desktop'
@@ -291,7 +290,8 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
     const set = new Set<SortField>()
     for (const c of COLUMN_CONFIGS) {
       // The sticky key column is the row's label — never hidden by a group.
-      if (c.field === STICKY_FIELD || !isGroupHidden(c.group)) set.add(c.field)
+      if (c.field === STICKY_COLUMN_FIELD || !isGroupHidden(c.group))
+        set.add(c.field)
     }
     return set
   }, [isGroupHidden])

--- a/frontend/src/components/ColumnGroupsMenu.tsx
+++ b/frontend/src/components/ColumnGroupsMenu.tsx
@@ -1,0 +1,113 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import type { ColumnGroup } from './filters/types'
+
+interface ColumnGroupsMenuProps {
+  /** Groups offered for show/hide, in display order. Empty groups (e.g.
+   *  "Changes" until #795) are filtered out by the caller, so each entry here
+   *  has at least one column. */
+  groups: readonly { id: ColumnGroup; label: string }[]
+  isGroupHidden: (group: ColumnGroup) => boolean
+  onToggle: (group: ColumnGroup) => void
+}
+
+/**
+ * "Columns" show/hide control for the club table (#819, ADR-006 §4).
+ *
+ * A discoverable trigger opens a popover of per-group checkboxes (checked =
+ * visible). A checkbox — not a `role="tab"`/segmented control — is the honest
+ * affordance for "show/hide this set of columns" (Lesson 128). The popover
+ * closes on Escape or an outside click and returns focus to the trigger
+ * (WCAG 2.4.3), mirroring the Filters drawer's focus contract.
+ */
+export const ColumnGroupsMenu: React.FC<ColumnGroupsMenuProps> = ({
+  groups,
+  isGroupHidden,
+  onToggle,
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+    triggerRef.current?.focus()
+  }, [])
+
+  // Dismiss on Escape or a click outside the control (popover + trigger).
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    const onPointerDown = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (
+        !popoverRef.current?.contains(target) &&
+        !triggerRef.current?.contains(target)
+      ) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onPointerDown)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onPointerDown)
+    }
+  }, [isOpen, close])
+
+  const hiddenCount = groups.filter(g => isGroupHidden(g.id)).length
+
+  return (
+    <div className="clubs-columns-menu">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="clubs-filters-trigger"
+        onClick={() => setIsOpen(o => !o)}
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 6h16M4 6v12M10 6v12M16 6v12M4 18h16"
+          />
+        </svg>
+        <span>Columns</span>
+        {hiddenCount > 0 && (
+          <span className="clubs-filters-trigger__badge">{hiddenCount}</span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div
+          ref={popoverRef}
+          className="clubs-columns-menu__popover"
+          role="group"
+          aria-label="Show or hide column groups"
+        >
+          <p className="clubs-columns-menu__heading">Column groups</p>
+          {groups.map(g => (
+            <label key={g.id} className="clubs-columns-menu__item">
+              <input
+                type="checkbox"
+                checked={!isGroupHidden(g.id)}
+                onChange={() => onToggle(g.id)}
+              />
+              <span>{g.label}</span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ColumnGroupsMenu.tsx
+++ b/frontend/src/components/ColumnGroupsMenu.tsx
@@ -57,16 +57,20 @@ export const ColumnGroupsMenu: React.FC<ColumnGroupsMenuProps> = ({
   }, [isOpen, close])
 
   const hiddenCount = groups.filter(g => isGroupHidden(g.id)).length
+  const popoverId = 'clubs-columns-menu-popover'
 
   return (
     <div className="clubs-columns-menu">
+      {/* Disclosure pattern: the popover is a region of checkboxes, not a menu
+          — so it's `aria-expanded` + `aria-controls`, NOT `aria-haspopup="menu"`
+          (which would promise menuitem semantics it doesn't have). */}
       <button
         ref={triggerRef}
         type="button"
         className="clubs-filters-trigger"
         onClick={() => setIsOpen(o => !o)}
-        aria-haspopup="true"
         aria-expanded={isOpen}
+        aria-controls={popoverId}
       >
         <svg
           className="w-4 h-4"
@@ -91,6 +95,7 @@ export const ColumnGroupsMenu: React.FC<ColumnGroupsMenuProps> = ({
       {isOpen && (
         <div
           ref={popoverRef}
+          id={popoverId}
           className="clubs-columns-menu__popover"
           role="group"
           aria-label="Show or hide column groups"

--- a/frontend/src/components/__tests__/ClubsTable.columnGroups.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.columnGroups.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Column-group show/hide for the club table (#819, epic #821 Sprint 1 — Epic C / C1).
+ *
+ * ADR-006 §4: a growing column set is made sustainable by grouping columns
+ * (Identity / Membership / Renewals / Recognition / Changes) and letting the
+ * user hide whole groups, with the selection persisted across reloads.
+ *
+ * Falsifiable invariants:
+ *   1. Default render is unchanged — every column visible (no regression).
+ *   2. A "Columns" control lists the non-empty groups; "Changes" is absent
+ *      (empty until #795).
+ *   3. Hiding a group removes its header cells AND the matching body cells —
+ *      header count === per-row <td> count in every state (lockstep).
+ *   4. The sticky key column (Club) survives hiding the Identity group.
+ *   5. The hidden selection persists to localStorage and rehydrates on remount.
+ *
+ * jsdom has no layout (Lesson 66); the responsive CSS hiding is proven live on
+ * the PR preview channel. Here we assert the DOM the group toggle controls.
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, cleanup, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ClubsTable } from '../ClubsTable'
+import { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import { COLUMN_GROUP_VISIBILITY_STORAGE_KEY } from '../../hooks/useColumnGroupVisibility'
+
+const makeClub = (over: Partial<ClubTrend> = {}): ClubTrend => ({
+  clubId: 'c1',
+  clubName: 'Alpha Club',
+  divisionId: 'div-1',
+  divisionName: 'A',
+  areaId: 'area-1',
+  areaName: '1',
+  distinguishedLevel: 'NotDistinguished',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: '2026-03-01T00:00:00.000Z', count: 20 }],
+  dcpGoalsTrend: [{ date: '2026-03-01T00:00:00.000Z', goalsAchieved: 5 }],
+  ...over,
+})
+
+// jsdom matchMedia → no-match → ClubsTable renders the desktop table.
+const stubDesktopMatchMedia = () => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  )
+}
+
+const headerCount = () =>
+  document.querySelectorAll('#clubs-table thead th').length
+const firstRowCellCount = () =>
+  document.querySelectorAll('#clubs-table tbody tr:first-child td').length
+const headerLabels = () =>
+  Array.from(
+    document.querySelectorAll<HTMLElement>(
+      '#clubs-table thead th .clubs-col-header span.flex-1'
+    )
+  ).map(el => el.textContent?.trim() ?? '')
+
+beforeEach(() => {
+  localStorage.clear()
+  stubDesktopMatchMedia()
+})
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+const renderTable = () =>
+  render(<ClubsTable clubs={[makeClub()]} districtId="61" isLoading={false} />)
+
+describe('ClubsTable column groups (#819)', () => {
+  it('renders all columns by default, header/body in lockstep', () => {
+    renderTable()
+    expect(headerCount()).toBe(13)
+    expect(firstRowCellCount()).toBe(13)
+  })
+
+  it('exposes a Columns control listing non-empty groups (no Changes yet)', async () => {
+    const user = userEvent.setup()
+    renderTable()
+    await user.click(screen.getByRole('button', { name: /columns/i }))
+    expect(
+      screen.getByRole('checkbox', { name: /identity/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: /membership/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: /renewals/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: /recognition/i })
+    ).toBeInTheDocument()
+    // Changes group is empty until #795 → no toggle for it.
+    expect(
+      screen.queryByRole('checkbox', { name: /changes/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides a group: removes its headers AND matching body cells (lockstep)', async () => {
+    const user = userEvent.setup()
+    renderTable()
+    await user.click(screen.getByRole('button', { name: /columns/i }))
+    // Renewals = Oct Renew + Apr Renew (2 columns).
+    await user.click(screen.getByRole('checkbox', { name: /renewals/i }))
+
+    expect(headerLabels()).not.toContain('Oct Renew')
+    expect(headerLabels()).not.toContain('Apr Renew')
+    expect(headerCount()).toBe(11)
+    // Body stays in lockstep with the header.
+    expect(firstRowCellCount()).toBe(11)
+  })
+
+  it('keeps the sticky Club column when the Identity group is hidden', async () => {
+    const user = userEvent.setup()
+    renderTable()
+    await user.click(screen.getByRole('button', { name: /columns/i }))
+    await user.click(screen.getByRole('checkbox', { name: /identity/i }))
+
+    const labels = headerLabels()
+    // Club (sticky key) survives; the other Identity columns go.
+    expect(labels).toContain('Club')
+    expect(labels).not.toContain('Div')
+    expect(labels).not.toContain('Area')
+    expect(labels).not.toContain('Years')
+    expect(headerCount()).toBe(firstRowCellCount())
+    // The club name is still rendered in the body.
+    const firstRow = document.querySelector(
+      '#clubs-table tbody tr:first-child'
+    ) as HTMLElement
+    expect(within(firstRow).getByText('Alpha Club')).toBeInTheDocument()
+  })
+
+  it('persists the hidden group and rehydrates on remount', async () => {
+    const user = userEvent.setup()
+    const { unmount } = renderTable()
+    await user.click(screen.getByRole('button', { name: /columns/i }))
+    await user.click(screen.getByRole('checkbox', { name: /recognition/i }))
+    expect(
+      JSON.parse(
+        localStorage.getItem(COLUMN_GROUP_VISIBILITY_STORAGE_KEY) || '[]'
+      )
+    ).toContain('recognition')
+
+    unmount()
+    renderTable()
+    // Recognition = Status + DCP + Tier (3 columns) stay hidden after reload.
+    expect(headerLabels()).not.toContain('DCP')
+    expect(headerLabels()).not.toContain('Tier')
+    expect(headerCount()).toBe(10)
+    expect(firstRowCellCount()).toBe(10)
+  })
+})

--- a/frontend/src/components/__tests__/ClubsTable.columnGroups.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.columnGroups.test.tsx
@@ -144,6 +144,28 @@ describe('ClubsTable column groups (#819)', () => {
     expect(within(firstRow).getByText('Alpha Club')).toBeInTheDocument()
   })
 
+  it('keeps the sticky Club column even when every group is hidden', async () => {
+    const user = userEvent.setup()
+    renderTable()
+    await user.click(screen.getByRole('button', { name: /columns/i }))
+    for (const name of [
+      /identity/i,
+      /membership/i,
+      /renewals/i,
+      /recognition/i,
+    ])
+      await user.click(screen.getByRole('checkbox', { name }))
+
+    // Only the sticky key column remains; header/body still in lockstep.
+    expect(headerLabels()).toEqual(['Club'])
+    expect(headerCount()).toBe(1)
+    expect(firstRowCellCount()).toBe(1)
+    const firstRow = document.querySelector(
+      '#clubs-table tbody tr:first-child'
+    ) as HTMLElement
+    expect(within(firstRow).getByText('Alpha Club')).toBeInTheDocument()
+  })
+
   it('persists the hidden group and rehydrates on remount', async () => {
     const user = userEvent.setup()
     const { unmount } = renderTable()

--- a/frontend/src/components/__tests__/columnGroups.types.test.ts
+++ b/frontend/src/components/__tests__/columnGroups.types.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Column-group metadata guard (#819, epic #821 Sprint 1 — Epic C / C1).
+ *
+ * ADR-006 §4 adds a `group` dimension to the column descriptor so a growing
+ * column set can be shown/hidden by group (Identity / Membership / Renewals /
+ * Recognition / Changes) instead of every column being always-on. These are
+ * falsifiable invariants of the metadata, independent of the UI:
+ *
+ *   1. Every column declares a group drawn from the canonical group set.
+ *   2. COLUMN_GROUPS lists the five groups in display order.
+ *   3. The sticky key column (Club/name) is flagged so the group toggle never
+ *      hides the row's own label (ADR-006 §3 — key column never hidden).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  COLUMN_CONFIGS,
+  COLUMN_GROUPS,
+  COLUMN_GROUP_IDS,
+  STICKY_COLUMN_FIELD,
+  type ColumnGroup,
+} from '../filters/types'
+
+describe('column-group metadata (#819)', () => {
+  it('lists the five canonical groups in display order', () => {
+    expect(COLUMN_GROUPS.map(g => g.id)).toEqual([
+      'identity',
+      'membership',
+      'renewals',
+      'recognition',
+      'changes',
+    ])
+    // Every group carries a human label for the show/hide control.
+    for (const g of COLUMN_GROUPS) {
+      expect(g.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('assigns every column to a canonical group', () => {
+    const valid = new Set<ColumnGroup>(COLUMN_GROUP_IDS)
+    for (const c of COLUMN_CONFIGS) {
+      expect(valid.has(c.group)).toBe(true)
+    }
+  })
+
+  it('names the sticky key column, and it belongs to Identity', () => {
+    expect(STICKY_COLUMN_FIELD).toBe('name')
+    const sticky = COLUMN_CONFIGS.find(c => c.field === STICKY_COLUMN_FIELD)
+    expect(sticky?.group).toBe('identity')
+  })
+
+  it('the Changes group is empty until #795 lands the delta columns', () => {
+    expect(COLUMN_CONFIGS.filter(c => c.group === 'changes')).toHaveLength(0)
+  })
+})

--- a/frontend/src/components/filters/types.ts
+++ b/frontend/src/components/filters/types.ts
@@ -28,6 +28,47 @@ export type SortField =
 export type SortDirection = 'asc' | 'desc'
 
 /**
+ * Column groups for the show/hide model (ADR-006 §4, #819 epic #821 Sprint 1).
+ *
+ * A growing column set (#688, #687, and #795's delta columns) overflows when
+ * every column is always-on. Each column declares a `group`; the user shows or
+ * hides whole groups (Identity / Membership / Renewals / Recognition /
+ * Changes). `changes` is reserved for #795's opt-in delta columns (Sprint 2)
+ * and is empty until then.
+ */
+export type ColumnGroup =
+  | 'identity'
+  | 'membership'
+  | 'renewals'
+  | 'recognition'
+  | 'changes'
+
+/** Canonical group ids, in display order. */
+export const COLUMN_GROUP_IDS: readonly ColumnGroup[] = [
+  'identity',
+  'membership',
+  'renewals',
+  'recognition',
+  'changes',
+] as const
+
+/** Group id + human label for the show/hide control, in display order. */
+export const COLUMN_GROUPS: readonly { id: ColumnGroup; label: string }[] = [
+  { id: 'identity', label: 'Identity' },
+  { id: 'membership', label: 'Membership' },
+  { id: 'renewals', label: 'Renewals' },
+  { id: 'recognition', label: 'Recognition' },
+  { id: 'changes', label: 'Changes' },
+] as const
+
+/**
+ * The sticky key column. It is the row's own label, so the group show/hide
+ * control never hides it (ADR-006 §3 — key column never hidden), even when its
+ * group (Identity) is hidden.
+ */
+export const STICKY_COLUMN_FIELD: SortField = 'name'
+
+/**
  * Filter operators for different data types
  */
 export type FilterOperator =
@@ -65,6 +106,8 @@ export interface ColumnConfig {
   filterType: 'text' | 'numeric' | 'categorical'
   filterOptions?: string[]
   sortCustom?: (a: unknown, b: unknown) => number
+  /** Show/hide group this column belongs to (ADR-006 §4, #819). */
+  group: ColumnGroup
 }
 
 /**
@@ -146,6 +189,7 @@ export interface ProcessedClubTrend extends ClubTrend {
 export const COLUMN_CONFIGS: ColumnConfig[] = [
   {
     field: 'name',
+    group: 'identity',
     label: 'Club',
     sortable: true,
     filterable: true,
@@ -153,6 +197,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'division',
+    group: 'identity',
     label: 'Div',
     sortable: true,
     filterable: true,
@@ -160,6 +205,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'area',
+    group: 'identity',
     label: 'Area',
     sortable: true,
     filterable: true,
@@ -167,6 +213,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'status',
+    group: 'recognition',
     label: 'Status',
     sortable: true,
     filterable: true,
@@ -175,6 +222,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'membership',
+    group: 'membership',
     label: 'Members',
     sortable: true,
     filterable: true,
@@ -182,6 +230,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'membersNeeded',
+    group: 'membership',
     label: 'Needed',
     sortable: true,
     filterable: true,
@@ -189,6 +238,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'newMembers',
+    group: 'membership',
     label: 'New',
     sortable: true,
     filterable: true,
@@ -196,6 +246,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'octoberRenewals',
+    group: 'renewals',
     label: 'Oct Renew',
     sortable: true,
     filterable: true,
@@ -203,6 +254,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'aprilRenewals',
+    group: 'renewals',
     label: 'Apr Renew',
     sortable: true,
     filterable: true,
@@ -210,6 +262,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'dcpGoals',
+    group: 'recognition',
     label: 'DCP',
     sortable: true,
     filterable: true,
@@ -217,6 +270,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'distinguished',
+    group: 'recognition',
     label: 'Tier',
     sortable: true,
     filterable: true,
@@ -243,6 +297,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'clubStatus',
+    group: 'identity',
     label: 'Club Status',
     sortable: true,
     filterable: true,
@@ -251,6 +306,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   },
   {
     field: 'yearsChartered',
+    group: 'identity',
     label: 'Years',
     sortable: true,
     filterable: false,

--- a/frontend/src/hooks/__tests__/useColumnGroupVisibility.test.ts
+++ b/frontend/src/hooks/__tests__/useColumnGroupVisibility.test.ts
@@ -1,0 +1,72 @@
+/**
+ * useColumnGroupVisibility (#819, epic #821 Sprint 1).
+ *
+ * A localStorage-backed set of HIDDEN column groups for the club table. Chosen
+ * over URL sync because group visibility is a durable per-user VIEW preference
+ * (like dark mode), not shareable filter data — keeping it out of the URL
+ * avoids the filter↔URL reconcile race surface (lessons 070/130). Default is
+ * all-visible (empty hidden set) so the table is unchanged until the user opts
+ * to hide a group.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  useColumnGroupVisibility,
+  COLUMN_GROUP_VISIBILITY_STORAGE_KEY,
+} from '../useColumnGroupVisibility'
+
+beforeEach(() => localStorage.clear())
+afterEach(() => localStorage.clear())
+
+describe('useColumnGroupVisibility (#819)', () => {
+  it('defaults to all groups visible (no hidden groups)', () => {
+    const { result } = renderHook(() => useColumnGroupVisibility())
+    expect(result.current.hiddenGroups.size).toBe(0)
+    expect(result.current.isGroupHidden('membership')).toBe(false)
+  })
+
+  it('toggles a group hidden and back visible', () => {
+    const { result } = renderHook(() => useColumnGroupVisibility())
+    act(() => result.current.toggleGroup('renewals'))
+    expect(result.current.isGroupHidden('renewals')).toBe(true)
+    act(() => result.current.toggleGroup('renewals'))
+    expect(result.current.isGroupHidden('renewals')).toBe(false)
+  })
+
+  it('persists the hidden set to localStorage', () => {
+    const { result } = renderHook(() => useColumnGroupVisibility())
+    act(() => result.current.toggleGroup('recognition'))
+    const stored = JSON.parse(
+      localStorage.getItem(COLUMN_GROUP_VISIBILITY_STORAGE_KEY) || '[]'
+    )
+    expect(stored).toContain('recognition')
+  })
+
+  it('rehydrates the hidden set from localStorage on mount', () => {
+    localStorage.setItem(
+      COLUMN_GROUP_VISIBILITY_STORAGE_KEY,
+      JSON.stringify(['identity', 'renewals'])
+    )
+    const { result } = renderHook(() => useColumnGroupVisibility())
+    expect(result.current.isGroupHidden('identity')).toBe(true)
+    expect(result.current.isGroupHidden('renewals')).toBe(true)
+    expect(result.current.isGroupHidden('membership')).toBe(false)
+  })
+
+  it('ignores unknown / malformed stored ids', () => {
+    localStorage.setItem(
+      COLUMN_GROUP_VISIBILITY_STORAGE_KEY,
+      JSON.stringify(['identity', 'bogus', 42])
+    )
+    const { result } = renderHook(() => useColumnGroupVisibility())
+    expect(result.current.isGroupHidden('identity')).toBe(true)
+    expect(result.current.hiddenGroups.size).toBe(1)
+  })
+
+  it('survives a corrupt (non-JSON) stored value', () => {
+    localStorage.setItem(COLUMN_GROUP_VISIBILITY_STORAGE_KEY, '{not json')
+    const { result } = renderHook(() => useColumnGroupVisibility())
+    expect(result.current.hiddenGroups.size).toBe(0)
+  })
+})

--- a/frontend/src/hooks/useColumnGroupVisibility.ts
+++ b/frontend/src/hooks/useColumnGroupVisibility.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from 'react'
+import { COLUMN_GROUP_IDS, type ColumnGroup } from '../components/filters/types'
+
+/**
+ * localStorage key for the club table's hidden column groups (#819).
+ * Namespaced so it can't collide with other persisted preferences.
+ */
+export const COLUMN_GROUP_VISIBILITY_STORAGE_KEY =
+  'toast-stats:clubs-table:hidden-groups'
+
+const VALID_GROUPS = new Set<ColumnGroup>(COLUMN_GROUP_IDS)
+
+/** Read + sanitise the persisted hidden-group set. Unknown/malformed ids and a
+ *  corrupt (non-JSON) value both degrade to "nothing hidden" — a bad store
+ *  must never wedge the table into an unusable column set. */
+const readStored = (): Set<ColumnGroup> => {
+  try {
+    const raw = localStorage.getItem(COLUMN_GROUP_VISIBILITY_STORAGE_KEY)
+    if (!raw) return new Set()
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return new Set()
+    return new Set(
+      parsed.filter((g): g is ColumnGroup => VALID_GROUPS.has(g as ColumnGroup))
+    )
+  } catch {
+    return new Set()
+  }
+}
+
+export interface ColumnGroupVisibility {
+  /** Groups the user has hidden. Empty = all visible (the default). */
+  hiddenGroups: Set<ColumnGroup>
+  isGroupHidden: (group: ColumnGroup) => boolean
+  /** Flip a group between hidden and visible, persisting the result. */
+  toggleGroup: (group: ColumnGroup) => void
+}
+
+/**
+ * Persisted show/hide state for the club table's column groups (#819).
+ *
+ * The hidden set is the source of truth (default empty = all visible, so the
+ * table is unchanged until the user opts in). Writes mirror to localStorage so
+ * the selection survives reloads; reads sanitise against the canonical group
+ * ids so a stale/corrupt store can't hide phantom groups or crash the table.
+ */
+export const useColumnGroupVisibility = (): ColumnGroupVisibility => {
+  const [hiddenGroups, setHiddenGroups] = useState<Set<ColumnGroup>>(readStored)
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        COLUMN_GROUP_VISIBILITY_STORAGE_KEY,
+        JSON.stringify([...hiddenGroups])
+      )
+    } catch {
+      // Private-mode / quota failures are non-fatal: the in-memory set still
+      // drives the table for this session; we just can't persist it.
+    }
+  }, [hiddenGroups])
+
+  const isGroupHidden = useCallback(
+    (group: ColumnGroup) => hiddenGroups.has(group),
+    [hiddenGroups]
+  )
+
+  const toggleGroup = useCallback((group: ColumnGroup) => {
+    setHiddenGroups(prev => {
+      const next = new Set(prev)
+      if (next.has(group)) next.delete(group)
+      else next.add(group)
+      return next
+    })
+  }, [])
+
+  return { hiddenGroups, isGroupHidden, toggleGroup }
+}

--- a/frontend/src/hooks/useColumnGroupVisibility.ts
+++ b/frontend/src/hooks/useColumnGroupVisibility.ts
@@ -1,31 +1,28 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useMemo } from 'react'
+import { usePersistedState } from './usePersistedState'
+import { storageKey } from '../utils/localStorageStore'
 import { COLUMN_GROUP_IDS, type ColumnGroup } from '../components/filters/types'
 
 /**
- * localStorage key for the club table's hidden column groups (#819).
- * Namespaced so it can't collide with other persisted preferences.
+ * Persisted-store NAME for the club table's hidden column groups (#819).
+ * Passed to the versioned localStorage primitive (#420), which prefixes it
+ * with `toast-stats:v<N>:` so it migrates with every other persisted key.
  */
-export const COLUMN_GROUP_VISIBILITY_STORAGE_KEY =
-  'toast-stats:clubs-table:hidden-groups'
+export const COLUMN_GROUP_VISIBILITY_STORAGE_NAME = 'clubs-table:hidden-groups'
+
+/** The fully-qualified localStorage key (versioned). Exposed for tests. */
+export const COLUMN_GROUP_VISIBILITY_STORAGE_KEY = storageKey(
+  COLUMN_GROUP_VISIBILITY_STORAGE_NAME
+)
 
 const VALID_GROUPS = new Set<ColumnGroup>(COLUMN_GROUP_IDS)
 
-/** Read + sanitise the persisted hidden-group set. Unknown/malformed ids and a
- *  corrupt (non-JSON) value both degrade to "nothing hidden" — a bad store
- *  must never wedge the table into an unusable column set. */
-const readStored = (): Set<ColumnGroup> => {
-  try {
-    const raw = localStorage.getItem(COLUMN_GROUP_VISIBILITY_STORAGE_KEY)
-    if (!raw) return new Set()
-    const parsed: unknown = JSON.parse(raw)
-    if (!Array.isArray(parsed)) return new Set()
-    return new Set(
-      parsed.filter((g): g is ColumnGroup => VALID_GROUPS.has(g as ColumnGroup))
-    )
-  } catch {
-    return new Set()
-  }
-}
+/** Keep only known group ids; a stale/corrupt store must never hide phantom
+ *  groups or wedge the table into an unusable column set. */
+const sanitize = (raw: unknown): ColumnGroup[] =>
+  Array.isArray(raw)
+    ? raw.filter((g): g is ColumnGroup => VALID_GROUPS.has(g as ColumnGroup))
+    : []
 
 export interface ColumnGroupVisibility {
   /** Groups the user has hidden. Empty = all visible (the default). */
@@ -39,38 +36,36 @@ export interface ColumnGroupVisibility {
  * Persisted show/hide state for the club table's column groups (#819).
  *
  * The hidden set is the source of truth (default empty = all visible, so the
- * table is unchanged until the user opts in). Writes mirror to localStorage so
- * the selection survives reloads; reads sanitise against the canonical group
- * ids so a stale/corrupt store can't hide phantom groups or crash the table.
+ * table is unchanged until the user opts in). Built on `usePersistedState`
+ * (#416) over the versioned store (#420) rather than URL sync, because group
+ * visibility is a durable per-user VIEW preference (like dark mode), not
+ * shareable filter data — keeping it out of the URL avoids the filter↔URL
+ * reconcile race surface (lessons 070/130). Reads sanitise against the
+ * canonical group ids so a stale store can't hide phantom groups.
  */
 export const useColumnGroupVisibility = (): ColumnGroupVisibility => {
-  const [hiddenGroups, setHiddenGroups] = useState<Set<ColumnGroup>>(readStored)
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(
-        COLUMN_GROUP_VISIBILITY_STORAGE_KEY,
-        JSON.stringify([...hiddenGroups])
-      )
-    } catch {
-      // Private-mode / quota failures are non-fatal: the in-memory set still
-      // drives the table for this session; we just can't persist it.
-    }
-  }, [hiddenGroups])
+  const [stored, setStored] = usePersistedState<ColumnGroup[]>(
+    COLUMN_GROUP_VISIBILITY_STORAGE_NAME,
+    []
+  )
+  const hiddenGroups = useMemo(() => new Set(sanitize(stored)), [stored])
 
   const isGroupHidden = useCallback(
     (group: ColumnGroup) => hiddenGroups.has(group),
     [hiddenGroups]
   )
 
-  const toggleGroup = useCallback((group: ColumnGroup) => {
-    setHiddenGroups(prev => {
-      const next = new Set(prev)
-      if (next.has(group)) next.delete(group)
-      else next.add(group)
-      return next
-    })
-  }, [])
+  const toggleGroup = useCallback(
+    (group: ColumnGroup) => {
+      setStored(prev => {
+        const next = new Set(sanitize(prev))
+        if (next.has(group)) next.delete(group)
+        else next.add(group)
+        return [...next]
+      })
+    },
+    [setStored]
+  )
 
   return { hiddenGroups, isGroupHidden, toggleGroup }
 }

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -3311,6 +3311,60 @@
     line-height: 1;
   }
 
+  /* Column-group show/hide menu (#819). The trigger reuses
+     .clubs-filters-trigger; this is the anchor + dropdown popover. All colors
+     are tokens so dark mode follows the CSS layer (R10) with no overrides. */
+  .clubs-columns-menu {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .clubs-columns-menu__popover {
+    position: absolute;
+    top: calc(100% + 0.4rem);
+    right: 0;
+    z-index: 40;
+    min-width: 12rem;
+    padding: 0.5rem;
+    border: 1px solid var(--line);
+    border-radius: 0.5rem;
+    background-color: var(--surface);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+  }
+
+  .clubs-columns-menu__heading {
+    margin: 0 0 0.25rem;
+    padding: 0 0.5rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--ink-2);
+  }
+
+  .clubs-columns-menu__item {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    min-height: 44px;
+    padding: 0 0.5rem;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    color: var(--ink);
+    cursor: pointer;
+  }
+
+  .clubs-columns-menu__item:hover {
+    background-color: var(--surface-3);
+  }
+
+  .clubs-columns-menu__item input {
+    width: 1rem;
+    height: 1rem;
+    accent-color: var(--rt-stats, #d4873f);
+    cursor: pointer;
+  }
+
   /* Overlay + right-anchored slide-over. */
   .clubs-filters-overlay {
     position: fixed;


### PR DESCRIPTION
## Sprint 1 of epic #821 — column-group show/hide for the club table (Epic C / C1)

Closes nothing automatically — see the tick-before-close ordering in the runner protocol (#626/#106); the sub-issue is closed by the runner after verification.

Makes a growing club-table column set sustainable. Columns now carry a **group** (Identity / Membership / Renewals / Recognition / Changes); a "Columns" menu lets the user hide whole groups, and the selection persists across reloads. Implements ADR-006 §4 (column descriptor `group`) and §6's *introduce the per-table column model first*.

### Acceptance criteria (#819)
- [x] **Columns are grouped; user can show/hide groups** — `group` on every `ColumnConfig`; `ColumnGroupsMenu` popover of per-group checkboxes.
- [x] **Selection persists across reload** — `useColumnGroupVisibility` on the versioned `usePersistedState`/`localStorageStore` (#416/#420), key `toast-stats:v1:clubs-table:hidden-groups`.
- [x] **Builds on #813 priority model (no parallel responsive logic)** — group toggle removes a column from the DOM; the `clubs-table__col--desktop` CSS priority model is untouched and orthogonal.
- [x] **Tests green; preview-verified** — 2925 frontend tests pass; live Playwright (Chromium + WebKit) at 375/768/1280/1600 + dark mode below.

### Key decisions
- **localStorage, not URL.** Group visibility is a durable per-user *view* preference (like dark mode), not shareable filter data — keeping it out of the URL avoids the filter↔URL reconcile race surface (lessons 070/130).
- **Sticky Club column never hidden** (ADR-006 §3): force-added to `visibleFields` regardless of the Identity toggle. Tested even with *all* groups hidden.
- **"Changes" group is reserved-empty** until #795 lands the delta columns (Sprint 2) — `AVAILABLE_COLUMN_GROUPS` filters it out of the menu so there's no dead toggle.
- **Show/hide control = checkboxes** (disclosure pattern: `aria-expanded` + `aria-controls`, not `aria-haspopup="menu"`/`role=tab`), per lesson 128.

### Header/body lockstep (#669 tripwire)
The header maps `COLUMN_CONFIGS.filter(visibleFields.has)`; each body `<td>` is gated on the **same** `visibleFields` set. Tests assert `headerCount === per-row <td> count` under default, single-group-hidden, and all-hidden states.

### Reviewed (fresh-context) — applied
- /simplify: persistence moved onto the existing versioned store; dropped a redundant `STICKY_FIELD` alias.
- review: corrected the trigger to disclosure semantics; added the all-groups-hidden coverage test.

### Deferred (noted, not done here)
- **Data-driven body cells / formatter + shared `DataTable` primitive** — explicitly Epic C / Sprint 3 (#820) per ADR-006 §6 (evaluate-then-extract). The 13 per-cell guards are a known third copy of the column list; the lockstep tests are the guard until then.
- **Extract a shared `useOnClickOutside`** — the dismissal effect mirrors ~6 existing components; no shared hook exists, extraction is out of this sprint's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
