### PR TITLE
feat(clubs): adopt TanStack Table for the club table (#835)

### DIFF
--- a/docs/architecture-decisions/006-data-table-page-layout-and-column-model.md
+++ b/docs/architecture-decisions/006-data-table-page-layout-and-column-model.md
@@ -132,6 +132,40 @@ The in-flight delta columns (#795) land via the column model as an opt-in
 that already overflows. (Recorded here because it is the column-model decision
 that motivated the group dimension; the disposition itself is owned by Epic C / #797.)
 
+## Addendum (2026-05-27, #835 — Epic C Sprint 1): the column-model implementation standard
+
+The §6 "evaluate-then-extract" question resolved. The #820 evaluation
+(closed) found the club table and the landing rankings table share **zero**
+code — a smell, not a verified abstraction — so **no shared `DataTable`
+primitive is built** (the up-front-primitive alternative stays rejected, R6).
+Instead the **standard for the column model is the table library, chosen per
+table**:
+
+- **Club table = TanStack Table v8** (`@tanstack/react-table`, headless, MIT).
+  The growing, sorted/filtered/pinned club table (the one #795's delta columns
+  and Sprint 2's column groups target) is migrated onto TanStack: the column
+  descriptor of §4 is realised as `createColumnHelper` `columnDef`s
+  (`frontend/src/components/clubsColumns.tsx`); sorting is TanStack
+  `SortingState` + per-column `sortingFn`s; the sticky key column is
+  `columnPinning.left`; responsive group show/hide (Sprint 2) and the opt-in
+  Changes group (Sprint 3) ride TanStack `columnVisibility`.
+- **Landing rankings table = bespoke.** ~260 LoC, read-only, not growing, and
+  zero code shared with the club table → migrating it is churn with ~0 benefit.
+  It stays hand-rolled. **This split is a deliberate decision, not drift.**
+
+**Column model vs. filter model are separate concerns.** The club table's
+**filter** metadata stays in `frontend/src/components/filters/types.ts`
+`COLUMN_CONFIGS` (consumed by the Filters drawer, the URL codec, the
+active-filters bar). TanStack `columnDef`s own **presentation / sort / sizing /
+pinning / visibility**; `COLUMN_CONFIGS` owns **filterability / filter type /
+filter options**. They are not merged — conflating them would pull the migration
+into the preserved filter UI (R11). The `original → filtered → searchFiltered →
+sorted` pipeline is intact; TanStack presents over it.
+
+Bundle cost: `@tanstack/react-table` adds **+12.0 KB gzip** to the frontend
+(351,974 → 364,249 bytes gzip total JS, measured at adoption; same vendor org as
+the TanStack Query already shipped). Recorded in the #835 PR.
+
 ## Consequences
 
 **Easier:**

--- a/docs/design/835-tanstack-club-table-migration.md
+++ b/docs/design/835-tanstack-club-table-migration.md
@@ -1,0 +1,70 @@
+# #835 — Adopt TanStack Table for the club table (Epic C / #821 Sprint 1)
+
+**Date:** 2026-05-27 · **Issue:** #835 · **Branch:** `sprint-835-tanstack-club-table`
+
+## Goal
+
+Migrate the **club table** (`ClubsTable.tsx`) onto **TanStack Table v8**
+(`@tanstack/react-table`), replacing the hand-rolled column iteration, the
+switch-statement sort comparator, and the sticky/sizing plumbing — so Sprint 2
+(column groups via `columnVisibility`) and Sprint 3 (delta columns) fall out of
+the library's native APIs. **Club table only**; the landing rankings table is
+left bespoke (deliberate split — ADR-006).
+
+## Architectural split (what moves, what stays)
+
+| Concern            | Before                                                                 | After                                                                    |
+| ------------------ | ---------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Filter pipeline    | `useColumnFilters` → `filteredClubs`                                   | **unchanged** (R11)                                                      |
+| Filter metadata    | `COLUMN_CONFIGS` (drives FiltersPanel, clubFilterUrl, codec, describe) | **unchanged** — still the filter subsystem's source of truth             |
+| Table column model | `COLUMN_CONFIGS.map(...)` header + hand-ordered `<td>`                 | **`clubsColumns.tsx`** — `createColumnHelper<ProcessedClubTrend>()` defs |
+| Sort               | local `sortField/sortDirection` + 90-line `switch` comparator          | TanStack `SortingState` + per-column `sortingFn`                         |
+| Sizing / pinning   | CSS-only sticky (`clubs-table__sticky-col`)                            | TanStack `columnPinning: { left: ['name'] }` drives it; CSS renders it   |
+| Visibility         | CSS `@media` (`clubs-table__col--desktop`)                             | CSS stays; `columnVisibility` state wired for Sprint 2                   |
+| URL-sync           | `onSortChange(field, dir)` callback to parent                          | **unchanged** — mapped at the TanStack↔props boundary                    |
+
+**Why COLUMN_CONFIGS stays:** it is consumed by `clubFilterUrl`,
+`filterUrlCodec`, `clubFilterDescribe`, and `FiltersPanel` — the filter
+subsystem the ticket says to **preserve**. The column-model migration is the
+_table presentation/sort/size/pin_ layer; conflating the filter metadata into
+TanStack defs would balloon blast radius into the preserved filter UI. The two
+column descriptions are different concerns and stay separate (recorded in ADR-006).
+
+## Behaviour-parity contract (Lesson 117 — migration, not rewrite)
+
+The migration must keep the rendered DOM and behaviour byte-identical. The
+existing ~3,500 lines of `ClubsTable.*.test.tsx` are the equivalence proof; they
+stay green **without assertion-pinning**. Preserved DOM invariants:
+
+- `#clubs-table thead th .clubs-col-header span.flex-1` header order = the 13-col
+  HANDOFF set (columnModel test).
+- Cell markup/classes: `.clubs-tier-pill[--modifier]`, `.clubs-status-pill`,
+  `.clubs-members-cell`, `.clubs-dcp-cell` + `role=progressbar`, `data-row-tint`,
+  `.clubs-table__sticky-col`, `.clubs-table__col--desktop`, row tints.
+- Sort semantics: name-asc default; custom Tier order; undefined→end; secondary
+  sort by club name; URL-sync (`?sort=&dir=`) via the parent callback.
+- Card view (<768), CSV export, search box, filter drawer, quick-filter row,
+  active-filters bar, row click-through — all unchanged.
+
+## TDD increments (each a commit referencing #835)
+
+1. **Add `@tanstack/react-table`** + record resolved bundle delta.
+2. **Red→Green: column model** `clubsColumns.tsx` — 13 defs, order, `meta.priority`
+   (sticky/desktop/core), `sortingFn`s (Tier custom, undefined-to-end, secondary
+   name). Unit test asserts order + meta + a representative sort.
+3. **Green: migrate `ClubsTable` rendering** to `useReactTable` — header via
+   `getHeaderGroups()` (reuse `ColumnHeader`), body via `getRowModel()` +
+   `flexRender`. Sorting state ⇄ props boundary; `columnPinning` left=name;
+   `columnVisibility` wired. Existing suites prove parity.
+4. **Refactor / /simplify** pass; drop the dead switch + `colPriorityClass` if
+   subsumed.
+5. **ADR-006 update** — record club=TanStack / rankings=bespoke split.
+
+## Risks
+
+- DOM drift breaking parity tests → mitigate by reusing `ColumnHeader` and
+  moving cell JSX verbatim into `cell` renderers.
+- `setSearchParams` same-batch race on sort URL-sync (Lesson 070) — the parent's
+  `handleSortChange` already guards by reconciling; keep that boundary intact.
+- Sticky-cell verify must measure the cell, not `<thead>` (Lesson 108); WebKit
+  dual-engine preview smoke (Lessons 110/111).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@tailwindcss/postcss": "^4.3.0",
     "@tanstack/react-query": "^5.100.14",
+    "@tanstack/react-table": "^8.21.3",
     "@toastmasters/shared-contracts": "^1.0.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -1,79 +1,43 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react'
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  flexRender,
+  type SortingState,
+  type ColumnPinningState,
+  type VisibilityState,
+} from '@tanstack/react-table'
 import { ClubTrend } from '../hooks/useDistrictAnalytics'
-import type { ClubHealthStatus } from '../hooks/useDistrictAnalytics'
 import { ExportButton } from './ExportButton'
 import { exportClubPerformance } from '../utils/csvExport'
 import { LoadingSkeleton } from './LoadingSkeleton'
-import { isProvisionallyDistinguished } from '../utils/provisionalDistinguished'
-import {
-  getClubHealthStatusLabel,
-  getClubHealthStatusPillModifier,
-} from '../utils/clubHealthStatus'
 import { useColumnFilters } from '../hooks/useColumnFilters'
 import { ColumnHeader } from './ColumnHeader'
 import { FiltersPanel } from './filters/FiltersPanel'
 import { ActiveFiltersBar } from './ActiveFiltersBar'
 import { describeActiveFilters } from '../utils/clubFilterDescribe'
-import { SortField, SortDirection, COLUMN_CONFIGS } from './filters/types'
+import {
+  SortField,
+  SortDirection,
+  COLUMN_CONFIGS,
+  type ProcessedClubTrend,
+} from './filters/types'
+import {
+  clubsColumns,
+  clubColumnPriorityClass,
+  clubColumnTdClass,
+} from './clubsColumns'
 import { CLOSE_TO_DISTINGUISHED_MAX_MEMBERS } from '../utils/closeToDistinguished'
 import ClubCard from './ClubCard'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDebounce } from '../hooks/useDebounce'
 
-// DCP tier pill maps (#669). Confirmed tiers carry their HANDOFF §256 color
-// (Smedley maroon, President's loyal-500, Select loyal-400, Distinguished
-// green); a provisional tier shows the striped-yellow "projected" stripe
-// instead, since the membership isn't yet confirmed by April renewals.
-// NotDistinguished has no pill — a muted em-dash (neutral "not yet").
-// Module-scope: these are constant, so they don't re-allocate per render.
-type ConfirmedTier = Exclude<
-  ClubTrend['distinguishedLevel'],
-  'NotDistinguished'
->
-
-const TIER_DISPLAY: Record<ConfirmedTier, string> = {
-  Distinguished: 'Distinguished',
-  Select: 'Select',
-  President: "President's",
-  Smedley: 'Smedley',
-}
-
-const TIER_MODIFIER: Record<ConfirmedTier, string> = {
-  Distinguished: 'clubs-tier-pill--distinguished',
-  Select: 'clubs-tier-pill--select',
-  President: 'clubs-tier-pill--presidents',
-  Smedley: 'clubs-tier-pill--smedley',
-}
-
-// Per-column responsive priority (ADR-006 §3, #812). The table renders only at
-// the tablet tier and up (≥768px; below that is the card view). Two visibility
-// levels:
-//   • Core (always shown when the table renders): Club (sticky key), Status,
-//     Members, Needed, DCP, Tier — the triage set a leader scans first.
-//   • Detail (clubs-table__col--desktop — hidden 768–1279, revealed ≥1280):
-//     Div, Area, New, Oct Renew, Apr Renew, Club Status, Years.
-// The card view at true mobile carries the full record, so nothing is lost.
-const DESKTOP_ONLY_FIELDS: ReadonlySet<SortField> = new Set([
-  'division',
-  'area',
-  'newMembers',
-  'octoberRenewals',
-  'aprilRenewals',
-  'clubStatus',
-  'yearsChartered',
-])
-
-// The sticky key column — pinned at left:0 so the row stays labelled while the
-// metric columns scroll horizontally (Lesson 105). It is never hidden.
-const STICKY_FIELD: SortField = 'name'
-
-/** Responsive priority class for a column header/cell, by field. */
-const colPriorityClass = (field: SortField): string =>
-  field === STICKY_FIELD
-    ? 'clubs-table__sticky-col'
-    : DESKTOP_ONLY_FIELDS.has(field)
-      ? 'clubs-table__col--desktop'
-      : ''
+// The column model — order, headers, responsive priority (sticky key column +
+// tablet-tier hiding), per-cell render, and the sort fns — lives in
+// `clubsColumns.tsx` (the TanStack migration, #835). The DCP tier pill maps,
+// status-rank sort key, and sticky/desktop priority that ClubsTable used to own
+// inline moved there. ClubsTable keeps only the row-level concerns below.
 
 /** Row-tint key for the sticky cell, so it can repaint OPAQUE per row status
  *  (a sticky cell must be opaque or scrolled columns bleed through it). Mirrors
@@ -367,13 +331,6 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
     return counts
   }, [clubs])
 
-  // Status-pill modifier + label come from the shared clubHealthStatus helpers
-  // so the desktop row and the mobile ClubCard render the same datum
-  // identically (lesson 052). Token-driven via the CSS layer so dark mode
-  // "just works" (R10); the label carries meaning too (never color-alone).
-  const getStatusPillModifier = getClubHealthStatusPillModifier
-  const getStatusLabel = getClubHealthStatusLabel
-
   // Get row background color based on status
   const getRowColor = (
     status: 'thriving' | 'vulnerable' | 'intervention-required'
@@ -390,109 +347,57 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
     }
   }
 
-  // Sort the filtered clubs
-  const sortedClubs = useMemo(() => {
-    const sorted = [...filteredClubs].sort((a, b) => {
-      let aValue: string | number | undefined
-      let bValue: string | number | undefined
+  // TanStack Table owns sort / sizing / pinning / visibility (#835, epic #821
+  // Sprint 1). The filter pipeline (useColumnFilters → filteredClubs) and its
+  // metadata (COLUMN_CONFIGS) are unchanged (R11) — the table presents over it.
+  //
+  // Feed the table a name-ascending base order so its STABLE sort reproduces the
+  // pre-migration "secondary sort by club name (always ascending)" tiebreak in
+  // both directions (see clubsColumns.tsx). Memoized on filteredClubs.
+  const nameSortedClubs = useMemo(
+    () =>
+      [...filteredClubs].sort((a, b) =>
+        a.clubName.toLowerCase().localeCompare(b.clubName.toLowerCase())
+      ),
+    [filteredClubs]
+  )
 
-      switch (sortField) {
-        case 'name':
-          aValue = a.clubName.toLowerCase()
-          bValue = b.clubName.toLowerCase()
-          break
-        case 'membership':
-          aValue = a.latestMembership
-          bValue = b.latestMembership
-          break
-        case 'dcpGoals':
-          aValue = a.latestDcpGoals
-          bValue = b.latestDcpGoals
-          break
-        case 'status': {
-          const statusOrder: Record<ClubHealthStatus, number> = {
-            'intervention-required': 0,
-            vulnerable: 1,
-            thriving: 2,
-          }
-          aValue = statusOrder[a.currentStatus]
-          bValue = statusOrder[b.currentStatus]
-          break
-        }
-        case 'division':
-          aValue = a.divisionName.toLowerCase()
-          bValue = b.divisionName.toLowerCase()
-          break
-        case 'area':
-          aValue = a.areaName.toLowerCase()
-          bValue = b.areaName.toLowerCase()
-          break
-        case 'distinguished': {
-          // Use the custom sort order for Distinguished column
-          aValue = a.distinguishedOrder
-          bValue = b.distinguishedOrder
-          break
-        }
-        case 'octoberRenewals':
-          aValue = a.octoberRenewals
-          bValue = b.octoberRenewals
-          break
-        case 'aprilRenewals':
-          aValue = a.aprilRenewals
-          bValue = b.aprilRenewals
-          break
-        case 'newMembers':
-          aValue = a.newMembers
-          bValue = b.newMembers
-          break
-        case 'membersNeeded':
-          aValue = a.membersNeeded
-          bValue = b.membersNeeded
-          break
-        case 'clubStatus':
-          aValue = a.clubStatus?.toLowerCase()
-          bValue = b.clubStatus?.toLowerCase()
-          break
-        case 'yearsChartered':
-          // null (missing charterDate) falls through to the
-          // undefined-handling below, sorting to end either direction.
-          aValue = a.yearsChartered ?? undefined
-          bValue = b.yearsChartered ?? undefined
-          break
-        default:
-          return 0
-      }
+  // Sort state is CONTROLLED by sortField/sortDirection — the URL-synced source
+  // of truth that ColumnHeader drives via handleSort. The table derives the row
+  // order from it; nothing calls the table's own sort API, so no onSortingChange.
+  const sorting: SortingState = useMemo(
+    () => [{ id: sortField, desc: sortDirection === 'desc' }],
+    [sortField, sortDirection]
+  )
 
-      // Handle undefined values - treat as lowest value (sort to end)
-      const aIsUndefined = aValue === undefined
-      const bIsUndefined = bValue === undefined
+  // The sticky key column ('name') is the left-pinned column (ADR-006 §3,
+  // Lesson 105); the existing CSS (.clubs-table__sticky-col) renders the
+  // stickiness, the pinning state is the model of record. columnVisibility is
+  // wired empty here — Sprint 2 (#819) drives it from the column-group toggles;
+  // the tablet-tier hiding stays CSS-@media-driven (.clubs-table__col--desktop).
+  const columnPinning: ColumnPinningState = useMemo(
+    () => ({ left: ['name'], right: [] }),
+    []
+  )
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
 
-      if (aIsUndefined && bIsUndefined) {
-        // Both undefined - use secondary sort by club name
-        return a.clubName.toLowerCase().localeCompare(b.clubName.toLowerCase())
-      }
-      if (aIsUndefined) {
-        // a is undefined, sort to end regardless of direction
-        return 1
-      }
-      if (bIsUndefined) {
-        // b is undefined, sort to end regardless of direction
-        return -1
-      }
+  const table = useReactTable<ProcessedClubTrend>({
+    data: nameSortedClubs,
+    columns: clubsColumns,
+    state: { sorting, columnPinning, columnVisibility },
+    onColumnVisibilityChange: setColumnVisibility,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    enableSortingRemoval: false,
+  })
 
-      // Both values are defined - compare normally
-      // TypeScript needs explicit assertion after undefined checks
-      const aVal = aValue as string | number
-      const bVal = bValue as string | number
-      if (aVal < bVal) return sortDirection === 'asc' ? -1 : 1
-      if (aVal > bVal) return sortDirection === 'asc' ? 1 : -1
-
-      // Equal values - use secondary sort by club name
-      return a.clubName.toLowerCase().localeCompare(b.clubName.toLowerCase())
-    })
-
-    return sorted
-  }, [filteredClubs, sortField, sortDirection])
+  const rowModel = table.getRowModel()
+  // The ordered ProcessedClubTrend[] backing CSV export, the count line, the
+  // card view, and the scroll-cue effect — mirrors the displayed row order.
+  const sortedClubs = useMemo(
+    () => rowModel.rows.map(r => r.original),
+    [rowModel]
+  )
 
   // No pagination (#667): the full sorted+filtered set renders in a single
   // sticky-header scroll container. Sort / filter / search span every row;
@@ -980,28 +885,31 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
           >
             <table id="clubs-table" className="w-full table-auto">
               <thead className="clubs-table-sticky-head">
-                <tr>
-                  {COLUMN_CONFIGS.map(config => (
-                    <th
-                      key={config.field}
-                      className={`p-0 ${colPriorityClass(config.field)}`.trim()}
-                    >
-                      <ColumnHeader
-                        field={config.field}
-                        label={config.label}
-                        sortable={config.sortable}
-                        currentSort={{
-                          field: sortField,
-                          direction: sortDirection,
-                        }}
-                        onSort={handleSort}
-                      />
-                    </th>
-                  ))}
-                </tr>
+                {table.getHeaderGroups().map(headerGroup => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map(header => (
+                      <th
+                        key={header.id}
+                        className={`p-0 ${clubColumnPriorityClass(header.column.id)}`.trim()}
+                      >
+                        <ColumnHeader
+                          field={header.column.id as SortField}
+                          label={header.column.columnDef.header as string}
+                          sortable={header.column.getCanSort()}
+                          currentSort={{
+                            field: sortField,
+                            direction: sortDirection,
+                          }}
+                          onSort={handleSort}
+                        />
+                      </th>
+                    ))}
+                  </tr>
+                ))}
               </thead>
               <tbody>
-                {sortedClubs.map(club => {
+                {rowModel.rows.map(row => {
+                  const club = row.original
                   const tint = rowTint(club.currentStatus)
                   return (
                     <tr
@@ -1009,177 +917,26 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
                       onClick={() => onClubClick?.(club)}
                       className={`${getRowColor(club.currentStatus)} cursor-pointer transition-colors`}
                     >
-                      {/* Cell order MUST match COLUMN_CONFIGS (filters/types.ts):
+                      {/* Cells render in the column-model order (clubsColumns.tsx):
                       Club, Div, Area, Status, Members, Needed, New, Oct Renew,
-                      Apr Renew, DCP, Tier, Club Status, Years (#669). The
-                      responsive priority class on each cell MUST match its
-                      header above (colPriorityClass, #812). */}
-                      {/* Club — the sticky key column. data-row-tint lets the CSS
-                        repaint it opaque to match the row's status bg so the
-                        scrolled columns don't bleed through (Lesson 105). */}
-                      <td
-                        className="px-2 py-3 whitespace-nowrap clubs-table__sticky-col"
-                        data-row-tint={tint}
-                      >
-                        <div className="font-medium text-sm">
-                          {club.clubName}
-                        </div>
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center clubs-table__col--desktop">
-                        {club.divisionName}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center clubs-table__col--desktop">
-                        {club.areaName}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-center">
-                        <span
-                          className={`clubs-status-pill ${getStatusPillModifier(club.currentStatus)}`}
+                      Apr Renew, DCP, Tier, Club Status, Years. Each td's class
+                      (base + responsive priority) comes from clubColumnTdClass;
+                      only the sticky key column ('name') carries data-row-tint so
+                      the CSS repaints it opaque to the row status bg (Lesson 105). */}
+                      {row.getVisibleCells().map(cell => (
+                        <td
+                          key={cell.id}
+                          className={clubColumnTdClass(cell.column.id)}
+                          data-row-tint={
+                            cell.column.id === 'name' ? tint : undefined
+                          }
                         >
-                          {getStatusLabel(club.currentStatus)}
-                        </span>
-                      </td>
-                      {/* Members — current / base (#669). Base omitted when the
-                      snapshot has no membershipBase (pre-merge data). */}
-                      <td className="px-2 py-3 whitespace-nowrap text-sm text-center clubs-members-cell">
-                        <span className="tabular-nums">
-                          {club.latestMembership}
-                        </span>
-                        {club.membershipBase !== undefined && (
-                          <span className="clubs-cell-muted tabular-nums">
-                            {' / '}
-                            {club.membershipBase}
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center font-medium">
-                        {club.membersNeeded > 0 ? (
-                          <span className="text-tm-true-maroon">
-                            {club.membersNeeded}
-                          </span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
-                        {club.newMembers !== undefined ? (
-                          <span
-                            className={
-                              club.newMembers === 0
-                                ? 'clubs-cell-muted'
-                                : undefined
-                            }
-                          >
-                            {club.newMembers}
-                          </span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
-                        {club.octoberRenewals !== undefined ? (
-                          <span
-                            className={
-                              club.octoberRenewals === 0
-                                ? 'clubs-cell-muted'
-                                : undefined
-                            }
-                          >
-                            {club.octoberRenewals}
-                          </span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
-                        {club.aprilRenewals !== undefined ? (
-                          <span
-                            className={
-                              club.aprilRenewals === 0
-                                ? 'clubs-cell-muted'
-                                : undefined
-                            }
-                          >
-                            {club.aprilRenewals}
-                          </span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      {/* DCP — inline progress bar over the canonical goals-achieved
-                      count (0–10). Reads latestDcpGoals from the analytics
-                      trend; no Goals-1-N inference (DCP-independence tripwire). */}
-                      <td className="px-2 py-3 whitespace-nowrap text-center">
-                        {(() => {
-                          const goals = Math.max(
-                            0,
-                            Math.min(10, club.latestDcpGoals)
-                          )
-                          const pct = (goals / 10) * 100
-                          return (
-                            <div className="clubs-dcp-cell">
-                              <span className="clubs-dcp-cell__val tabular-nums">
-                                {goals}/10
-                              </span>
-                              <div
-                                className="clubs-dcp-bar"
-                                role="progressbar"
-                                aria-valuenow={goals}
-                                aria-valuemin={0}
-                                aria-valuemax={10}
-                                aria-label="DCP goals achieved"
-                              >
-                                <div
-                                  className="clubs-dcp-bar__fill"
-                                  style={{ width: `${pct}%` }}
-                                />
-                              </div>
-                            </div>
-                          )
-                        })()}
-                      </td>
-                      {/* Tier — DCP recognition pill (#669). Color by tier; a
-                      provisional tier shows the striped-yellow "projected"
-                      treatment instead (membership unconfirmed pre-April). */}
-                      <td className="px-2 py-3 whitespace-nowrap text-center">
-                        {club.distinguishedLevel !== 'NotDistinguished' ? (
-                          (() => {
-                            const provisional =
-                              isProvisionallyDistinguished(club)
-                            const modifier = provisional
-                              ? 'clubs-tier-pill--projected'
-                              : TIER_MODIFIER[club.distinguishedLevel]
-                            return (
-                              <span
-                                className={`clubs-tier-pill ${modifier}`}
-                                title={
-                                  provisional
-                                    ? 'Provisional — membership not yet confirmed by April renewals'
-                                    : 'Confirmed — April renewals recorded'
-                                }
-                              >
-                                {TIER_DISPLAY[club.distinguishedLevel]}
-                                {provisional ? '*' : ''}
-                              </span>
-                            )
-                          })()
-                        ) : (
-                          <span className="text-sm clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm text-center clubs-table__col--desktop">
-                        {club.clubStatus ? (
-                          <span>{club.clubStatus}</span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center clubs-table__col--desktop">
-                        {club.yearsChartered !== null ? (
-                          <span>{club.yearsChartered}</span>
-                        ) : (
-                          <span className="clubs-cell-muted">—</span>
-                        )}
-                      </td>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )}
+                        </td>
+                      ))}
                     </tr>
                   )
                 })}

--- a/frontend/src/components/__tests__/clubsColumns.test.tsx
+++ b/frontend/src/components/__tests__/clubsColumns.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Column-model contract for the TanStack-migrated club table (#835, epic #821
+ * Sprint 1). `clubsColumns` is the `createColumnHelper<ProcessedClubTrend>()`
+ * descriptor array that replaces the hand-rolled `COLUMN_CONFIGS.map` header +
+ * hand-ordered `<td>` body in ClubsTable. This guards the migration's
+ * load-bearing invariants — the things the ~3,500 lines of ClubsTable.*.test
+ * assume but don't pin directly:
+ *
+ *   1. Column id order === the 13-col HANDOFF SortField order (cell order).
+ *   2. Each column declares its responsive `meta.priority`
+ *      (sticky / desktop / core), the basis for the sticky key column and the
+ *      tablet-tier column hiding (ADR-006 §3).
+ *   3. Sorting is faithful to the pre-migration switch comparator: numeric,
+ *      string (case-insensitive), the custom Tier order, undefined→end, and the
+ *      stable name-asc tiebreak — verified through a real TanStack table.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type SortingState,
+} from '@tanstack/react-table'
+import { renderHook } from '@testing-library/react'
+import { clubsColumns, clubColumnPriority } from '../clubsColumns'
+import { processClubs } from '../../utils/columnFilterUtils'
+import type { ProcessedClubTrend } from '../filters/types'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+const EXPECTED_ID_ORDER = [
+  'name',
+  'division',
+  'area',
+  'status',
+  'membership',
+  'membersNeeded',
+  'newMembers',
+  'octoberRenewals',
+  'aprilRenewals',
+  'dcpGoals',
+  'distinguished',
+  'clubStatus',
+  'yearsChartered',
+]
+
+const createMockClub = (overrides: Partial<ClubTrend> = {}): ClubTrend => ({
+  clubId: 'club-1',
+  clubName: 'Test Club',
+  divisionId: 'div-1',
+  divisionName: 'A',
+  areaId: 'area-1',
+  areaName: '1',
+  distinguishedLevel: 'NotDistinguished',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: '2026-03-01T00:00:00.000Z', count: 20 }],
+  dcpGoalsTrend: [{ date: '2026-03-01T00:00:00.000Z', goalsAchieved: 5 }],
+  ...overrides,
+})
+
+/** Build a sorted row model the way ClubsTable will: name-asc input + a single
+ *  sort entry, returning the ordered clubIds. */
+function sortedIds(clubs: ClubTrend[], sorting: SortingState): string[] {
+  const data = processClubs(clubs).sort((a, b) =>
+    a.clubName.toLowerCase().localeCompare(b.clubName.toLowerCase())
+  )
+  const { result } = renderHook(() =>
+    useReactTable<ProcessedClubTrend>({
+      data,
+      columns: clubsColumns,
+      state: { sorting },
+      getCoreRowModel: getCoreRowModel(),
+      getSortedRowModel: getSortedRowModel(),
+      onSortingChange: () => {},
+    })
+  )
+  return result.current.getRowModel().rows.map(r => r.original.clubId)
+}
+
+describe('clubsColumns — TanStack column model (#835)', () => {
+  it('exposes the 13 columns in the HANDOFF SortField order', () => {
+    expect(clubsColumns.map(c => c.id)).toEqual(EXPECTED_ID_ORDER)
+  })
+
+  it('declares the responsive priority for each column (ADR-006 §3)', () => {
+    const priority = Object.fromEntries(
+      clubsColumns.map(c => [c.id, clubColumnPriority(c.id as string)])
+    )
+    expect(priority.name).toBe('sticky')
+    for (const id of [
+      'division',
+      'area',
+      'newMembers',
+      'octoberRenewals',
+      'aprilRenewals',
+      'clubStatus',
+      'yearsChartered',
+    ]) {
+      expect(priority[id]).toBe('desktop')
+    }
+    for (const id of [
+      'status',
+      'membership',
+      'membersNeeded',
+      'dcpGoals',
+      'distinguished',
+    ]) {
+      expect(priority[id]).toBe('core')
+    }
+  })
+
+  it('sorts by name ascending by default', () => {
+    const ids = sortedIds(
+      [
+        createMockClub({ clubId: 'z', clubName: 'Zeta' }),
+        createMockClub({ clubId: 'a', clubName: 'Alpha' }),
+        createMockClub({ clubId: 'b', clubName: 'Beta' }),
+      ],
+      [{ id: 'name', desc: false }]
+    )
+    expect(ids).toEqual(['a', 'b', 'z'])
+  })
+
+  it('sorts the Tier column by the custom Distinguished order', () => {
+    const ids = sortedIds(
+      [
+        createMockClub({
+          clubId: 'none',
+          distinguishedLevel: 'NotDistinguished',
+        }),
+        createMockClub({ clubId: 'smedley', distinguishedLevel: 'Smedley' }),
+        createMockClub({ clubId: 'dist', distinguishedLevel: 'Distinguished' }),
+        createMockClub({ clubId: 'select', distinguishedLevel: 'Select' }),
+        createMockClub({ clubId: 'pres', distinguishedLevel: 'President' }),
+      ],
+      [{ id: 'distinguished', desc: false }]
+    )
+    // Ascending by the precomputed `distinguishedOrder` (the field the
+    // pre-migration switch sorted on): None(0) < Distinguished(1) < Select(2)
+    // < President(3) < Smedley(4). This is the SHIPPED order — distinct from
+    // the unused `COLUMN_CONFIGS.sortCustom` map.
+    expect(ids).toEqual(['none', 'dist', 'select', 'pres', 'smedley'])
+  })
+
+  it('sorts undefined renewals to the end regardless of direction', () => {
+    const clubs = [
+      createMockClub({ clubId: 'has5', clubName: 'A', octoberRenewals: 5 }),
+      createMockClub({
+        clubId: 'undef',
+        clubName: 'B',
+        octoberRenewals: undefined,
+      }),
+      createMockClub({ clubId: 'has9', clubName: 'C', octoberRenewals: 9 }),
+    ]
+    expect(
+      sortedIds(clubs, [{ id: 'octoberRenewals', desc: false }]).at(-1)
+    ).toBe('undef')
+    expect(
+      sortedIds(clubs, [{ id: 'octoberRenewals', desc: true }]).at(-1)
+    ).toBe('undef')
+  })
+
+  it('breaks ties with a stable name-ascending order even under desc primary', () => {
+    // All same membership → ties fall back to the name-asc input order.
+    const clubs = [
+      createMockClub({
+        clubId: 'c',
+        clubName: 'Cair',
+        membershipTrend: [{ date: '2026-03-01T00:00:00.000Z', count: 10 }],
+      }),
+      createMockClub({
+        clubId: 'a',
+        clubName: 'Aar',
+        membershipTrend: [{ date: '2026-03-01T00:00:00.000Z', count: 10 }],
+      }),
+      createMockClub({
+        clubId: 'b',
+        clubName: 'Bar',
+        membershipTrend: [{ date: '2026-03-01T00:00:00.000Z', count: 10 }],
+      }),
+    ]
+    expect(sortedIds(clubs, [{ id: 'membership', desc: true }])).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+  })
+})

--- a/frontend/src/components/clubsColumns.tsx
+++ b/frontend/src/components/clubsColumns.tsx
@@ -1,0 +1,305 @@
+/**
+ * TanStack column model for the club table (#835, epic #821 Sprint 1).
+ *
+ * This is the presentation / sort / sizing / pinning descriptor set that
+ * replaces the hand-rolled `COLUMN_CONFIGS.map` header + hand-ordered `<td>`
+ * body that ClubsTable used to carry inline. The **filter** subsystem keeps its
+ * own metadata in `filters/types.ts` `COLUMN_CONFIGS` (consumed by the Filters
+ * drawer, the URL codec, the active-filters bar) — see ADR-006: the column
+ * model and the filter model are deliberately separate concerns.
+ *
+ * Sort fidelity to the pre-migration switch comparator (Lesson 117 — a
+ * migration must not change output):
+ *   • Each `accessorFn` returns the exact value the old switch compared on
+ *     (lowercased strings; the precomputed `distinguishedOrder`; a status-rank
+ *     map). `sortingFn: 'basic'` (`a < b ? -1 : a > b ? 1 : 0`) reproduces the
+ *     old `<`/`>` comparison.
+ *   • `sortUndefined: 'last'` reproduces "undefined sorts to the end regardless
+ *     of direction" (TanStack applies it outside the desc negation).
+ *   • The old "secondary sort by club name, always ascending" is reproduced by
+ *     feeding ClubsTable's data to the table **pre-sorted by name asc**:
+ *     TanStack's sort is stable, so equal-primary rows keep that name-asc order
+ *     in both directions. (See `clubsColumns.test.tsx`.)
+ */
+
+import React from 'react'
+import { createColumnHelper } from '@tanstack/react-table'
+import type { ProcessedClubTrend } from './filters/types'
+import type { ClubTrend, ClubHealthStatus } from '../hooks/useDistrictAnalytics'
+import { isProvisionallyDistinguished } from '../utils/provisionalDistinguished'
+import {
+  getClubHealthStatusLabel,
+  getClubHealthStatusPillModifier,
+} from '../utils/clubHealthStatus'
+
+// DCP tier pill maps (#669): confirmed tiers carry their HANDOFF §256 color; a
+// provisional tier shows the striped-yellow "projected" stripe; NotDistinguished
+// has no pill (a muted em-dash). Module-scope constants — no per-render realloc.
+type ConfirmedTier = Exclude<
+  ClubTrend['distinguishedLevel'],
+  'NotDistinguished'
+>
+
+const TIER_DISPLAY: Record<ConfirmedTier, string> = {
+  Distinguished: 'Distinguished',
+  Select: 'Select',
+  President: "President's",
+  Smedley: 'Smedley',
+}
+
+const TIER_MODIFIER: Record<ConfirmedTier, string> = {
+  Distinguished: 'clubs-tier-pill--distinguished',
+  Select: 'clubs-tier-pill--select',
+  President: 'clubs-tier-pill--presidents',
+  Smedley: 'clubs-tier-pill--smedley',
+}
+
+const STATUS_RANK: Record<ClubHealthStatus, number> = {
+  'intervention-required': 0,
+  vulnerable: 1,
+  thriving: 2,
+}
+
+/** Responsive priority per column (ADR-006 §3). `sticky` = the pinned key
+ *  column (never hidden); `desktop` = revealed only ≥1280px (hidden at the
+ *  768–1279 tablet tier); `core` = always shown when the table renders. */
+export type ClubColumnPriority = 'sticky' | 'desktop' | 'core'
+
+const STICKY_FIELD = 'name'
+const DESKTOP_ONLY_FIELDS: ReadonlySet<string> = new Set([
+  'division',
+  'area',
+  'newMembers',
+  'octoberRenewals',
+  'aprilRenewals',
+  'clubStatus',
+  'yearsChartered',
+])
+
+export const clubColumnPriority = (id: string): ClubColumnPriority =>
+  id === STICKY_FIELD
+    ? 'sticky'
+    : DESKTOP_ONLY_FIELDS.has(id)
+      ? 'desktop'
+      : 'core'
+
+/** Responsive priority CSS class for a header/cell — matches the pre-migration
+ *  `colPriorityClass` exactly so the existing CSS (sticky + @media hide) and
+ *  the parity tests keep working unchanged. */
+export const clubColumnPriorityClass = (id: string): string => {
+  const p = clubColumnPriority(id)
+  return p === 'sticky'
+    ? 'clubs-table__sticky-col'
+    : p === 'desktop'
+      ? 'clubs-table__col--desktop'
+      : ''
+}
+
+// Per-column `<td>` class WITHOUT the priority class (ClubsTable appends
+// `clubColumnPriorityClass(id)`), reproducing the original cell classes exactly.
+const TD_BASE_CLASS: Record<string, string> = {
+  name: 'px-2 py-3 whitespace-nowrap',
+  division: 'px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center',
+  area: 'px-2 py-3 whitespace-nowrap text-sm clubs-cell-muted text-center',
+  status: 'px-2 py-3 whitespace-nowrap text-center',
+  membership:
+    'px-2 py-3 whitespace-nowrap text-sm text-center clubs-members-cell',
+  membersNeeded:
+    'px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center font-medium',
+  newMembers: 'px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center',
+  octoberRenewals:
+    'px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center',
+  aprilRenewals: 'px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center',
+  dcpGoals: 'px-2 py-3 whitespace-nowrap text-center',
+  distinguished: 'px-2 py-3 whitespace-nowrap text-center',
+  clubStatus: 'px-2 py-3 whitespace-nowrap text-sm text-center',
+  yearsChartered:
+    'px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center',
+}
+
+/** Exact `<td>` className for a column: base + responsive priority class. */
+export const clubColumnTdClass = (id: string): string =>
+  `${TD_BASE_CLASS[id] ?? 'px-2 py-3 whitespace-nowrap'} ${clubColumnPriorityClass(id)}`.trim()
+
+const colHelper = createColumnHelper<ProcessedClubTrend>()
+
+/** A muted em-dash placeholder, shared by the optional numeric/text columns. */
+const Dash: React.FC = () => <span className="clubs-cell-muted">—</span>
+
+/** Optional integer cell: em-dash when undefined; muted when zero. Matches the
+ *  New / Oct Renew / Apr Renew cells exactly. */
+const OptionalCount: React.FC<{ value: number | undefined }> = ({ value }) =>
+  value !== undefined ? (
+    <span className={value === 0 ? 'clubs-cell-muted' : undefined}>
+      {value}
+    </span>
+  ) : (
+    <Dash />
+  )
+
+export const clubsColumns = [
+  colHelper.accessor(c => c.clubName.toLowerCase(), {
+    id: 'name',
+    header: 'Club',
+    sortingFn: 'basic',
+    cell: info => (
+      <div className="font-medium text-sm">{info.row.original.clubName}</div>
+    ),
+  }),
+  colHelper.accessor(c => c.divisionName.toLowerCase(), {
+    id: 'division',
+    header: 'Div',
+    sortingFn: 'basic',
+    cell: info => info.row.original.divisionName,
+  }),
+  colHelper.accessor(c => c.areaName.toLowerCase(), {
+    id: 'area',
+    header: 'Area',
+    sortingFn: 'basic',
+    cell: info => info.row.original.areaName,
+  }),
+  colHelper.accessor(c => STATUS_RANK[c.currentStatus], {
+    id: 'status',
+    header: 'Status',
+    sortingFn: 'basic',
+    cell: info => {
+      const status = info.row.original.currentStatus
+      return (
+        <span
+          className={`clubs-status-pill ${getClubHealthStatusPillModifier(status)}`}
+        >
+          {getClubHealthStatusLabel(status)}
+        </span>
+      )
+    },
+  }),
+  colHelper.accessor(c => c.latestMembership, {
+    id: 'membership',
+    header: 'Members',
+    sortingFn: 'basic',
+    cell: info => {
+      const club = info.row.original
+      return (
+        <>
+          <span className="tabular-nums">{club.latestMembership}</span>
+          {club.membershipBase !== undefined && (
+            <span className="clubs-cell-muted tabular-nums">
+              {' / '}
+              {club.membershipBase}
+            </span>
+          )}
+        </>
+      )
+    },
+  }),
+  colHelper.accessor(c => c.membersNeeded, {
+    id: 'membersNeeded',
+    header: 'Needed',
+    sortingFn: 'basic',
+    cell: info =>
+      info.row.original.membersNeeded > 0 ? (
+        <span className="text-tm-true-maroon">
+          {info.row.original.membersNeeded}
+        </span>
+      ) : (
+        <Dash />
+      ),
+  }),
+  colHelper.accessor(c => c.newMembers, {
+    id: 'newMembers',
+    header: 'New',
+    sortingFn: 'basic',
+    sortUndefined: 'last',
+    cell: info => <OptionalCount value={info.row.original.newMembers} />,
+  }),
+  colHelper.accessor(c => c.octoberRenewals, {
+    id: 'octoberRenewals',
+    header: 'Oct Renew',
+    sortingFn: 'basic',
+    sortUndefined: 'last',
+    cell: info => <OptionalCount value={info.row.original.octoberRenewals} />,
+  }),
+  colHelper.accessor(c => c.aprilRenewals, {
+    id: 'aprilRenewals',
+    header: 'Apr Renew',
+    sortingFn: 'basic',
+    sortUndefined: 'last',
+    cell: info => <OptionalCount value={info.row.original.aprilRenewals} />,
+  }),
+  colHelper.accessor(c => c.latestDcpGoals, {
+    id: 'dcpGoals',
+    header: 'DCP',
+    sortingFn: 'basic',
+    cell: info => {
+      const goals = Math.max(0, Math.min(10, info.row.original.latestDcpGoals))
+      const pct = (goals / 10) * 100
+      return (
+        <div className="clubs-dcp-cell">
+          <span className="clubs-dcp-cell__val tabular-nums">{goals}/10</span>
+          <div
+            className="clubs-dcp-bar"
+            role="progressbar"
+            aria-valuenow={goals}
+            aria-valuemin={0}
+            aria-valuemax={10}
+            aria-label="DCP goals achieved"
+          >
+            <div className="clubs-dcp-bar__fill" style={{ width: `${pct}%` }} />
+          </div>
+        </div>
+      )
+    },
+  }),
+  colHelper.accessor(c => c.distinguishedOrder, {
+    id: 'distinguished',
+    header: 'Tier',
+    sortingFn: 'basic',
+    cell: info => {
+      const club = info.row.original
+      if (club.distinguishedLevel === 'NotDistinguished') {
+        return <span className="text-sm clubs-cell-muted">—</span>
+      }
+      const provisional = isProvisionallyDistinguished(club)
+      const modifier = provisional
+        ? 'clubs-tier-pill--projected'
+        : TIER_MODIFIER[club.distinguishedLevel]
+      return (
+        <span
+          className={`clubs-tier-pill ${modifier}`}
+          title={
+            provisional
+              ? 'Provisional — membership not yet confirmed by April renewals'
+              : 'Confirmed — April renewals recorded'
+          }
+        >
+          {TIER_DISPLAY[club.distinguishedLevel]}
+          {provisional ? '*' : ''}
+        </span>
+      )
+    },
+  }),
+  colHelper.accessor(c => c.clubStatus?.toLowerCase(), {
+    id: 'clubStatus',
+    header: 'Club Status',
+    sortingFn: 'basic',
+    sortUndefined: 'last',
+    cell: info =>
+      info.row.original.clubStatus ? (
+        <span>{info.row.original.clubStatus}</span>
+      ) : (
+        <Dash />
+      ),
+  }),
+  colHelper.accessor(c => c.yearsChartered ?? undefined, {
+    id: 'yearsChartered',
+    header: 'Years',
+    sortingFn: 'basic',
+    sortUndefined: 'last',
+    cell: info =>
+      info.row.original.yearsChartered !== null ? (
+        <span>{info.row.original.yearsChartered}</span>
+      ) : (
+        <Dash />
+      ),
+  }),
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.0",
         "@tanstack/react-query": "^5.100.14",
+        "@tanstack/react-table": "^8.21.3",
         "@toastmasters/shared-contracts": "^1.0.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -2159,6 +2160,39 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/tasks/lessons/120-reproduce-a-hand-rolled-comparators-tiebreak-and-undefined-rules-with-a-headless-tables-native-options.md
+++ b/tasks/lessons/120-reproduce-a-hand-rolled-comparators-tiebreak-and-undefined-rules-with-a-headless-tables-native-options.md
@@ -1,0 +1,73 @@
+---
+id: '120'
+category: lesson
+tags: [frontend, react, refactor, tests, tanstack]
+auto_load: true
+date: 2026-05-27
+issues: [835, 821]
+---
+
+# Lesson 120 — Reproduce a hand-rolled comparator's tiebreak + undefined rules with a headless table's native options, not a negation-fighting comparator
+
+**Date:** 2026-05-27
+**Issue:** #835 (epic #821 Sprint 1 — adopt TanStack Table for the club table)
+**PR:** [#836](https://github.com/taverns-red/toast-stats/pull/836)
+
+## What happened
+
+The club table's sort was a 90-line `switch` comparator with two semantics that
+do **not** survive a naive port to a headless table library (TanStack Table v8):
+
+1. **"Undefined sorts to the end regardless of direction."** A comparator that
+   returns `±1` for undefined gets **negated** by the library for `desc` — so
+   undefined flips to the _top_ in one direction.
+2. **"Secondary tiebreak by club name, ALWAYS ascending"** — even when the
+   primary sort is `desc`. A tiebreak baked into the comparator's return value
+   is also negated by `desc`, so equal-primary rows would tiebreak _descending_.
+
+You cannot encode either rule into a single comparator and hand it to a library
+that negates the result for `desc` — the negation is applied to the whole
+return value, including the parts you wanted direction-independent.
+
+## The technique (faithful migration — Lesson 117)
+
+Lean on the library's own machinery instead of fighting its negation:
+
+- **undefined-to-end** → the column's `sortUndefined: 'last'` option. TanStack
+  (and most headless tables) apply undefined placement **outside** the desc
+  negation, so it holds in both directions. Set it on exactly the columns whose
+  accessor can be `undefined`/`null` (map `null → undefined` in the accessor).
+- **always-ascending secondary tiebreak** → **pre-sort the input data** on the
+  tiebreak key, then rely on the library's **stable** sort. A stable sort never
+  reorders equal-primary rows, so they keep the pre-sort order in _both_
+  directions — `desc` negates the primary comparison but `0` (equal) negates to
+  `0`, leaving the stable order intact. (`getSortedRowModel` is stable.)
+- **primary compare** → `sortingFn: 'basic'` (`a < b ? -1 : a > b ? 1 : 0`) on an
+  accessor that returns the exact value the old `switch` compared on (lowercased
+  strings; a precomputed rank like `distinguishedOrder`; a status-rank map). This
+  reproduces the old `<`/`>` comparison; reserve `localeCompare` for the
+  pre-sort base order only (it was only the old tiebreak).
+
+## How to apply
+
+- Before adopting a headless table/grid: list every sort rule that is
+  **direction-independent** (undefined placement, a fixed secondary key). Those
+  are the ones a single negated comparator can't express — map each to a native
+  option (`sortUndefined`) or to **input pre-ordering + stable sort**, not to
+  comparator return values.
+- Prove equivalence with a test that pins the rule in **both** directions
+  (`desc: true` _and_ `desc: false`) and a ties-only fixture — a single-direction
+  test passes for the wrong reason. (`clubsColumns.test.tsx`.)
+- Keep the migration's blast radius bounded: the filter subsystem's metadata
+  (`COLUMN_CONFIGS`) is a separate concern from the table's sort/render column
+  model — don't merge them just because the library _could_ (Lesson 077 sibling).
+
+## Related
+
+- [[117-a-delegate-to-x-ticket-is-a-trap-when-the-two-impls-have-diverged-in-output]]
+  — same family: a migration must not silently change output; prove equivalence
+  field-by-field before trusting the new path.
+- [[070-setSearchParams-prev-races-in-batched-updates]] — the URL-sync sort
+  boundary this migration kept controlled, untouched.
+- `frontend/src/components/clubsColumns.tsx` — the column model; the header
+  comment documents the three sort-fidelity moves.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -86,6 +86,7 @@
 - **119** [automation, sprint-runner, prompts, process] — An issue's cited doc may be uncommitted in the operator's main checkout, not missing (#809, #813)
 - **119** [ci, tests, seo, frontend, verification, performance] — Before gating a Lighthouse SEO audit at `error`, verify which audits survive the localhost/preview host (#778, #785)
 - **120** [css, frontend, scope, router, architecture] — A CSS class named like "a page" may be shared chrome for a whole route family (#810, #813)
+- **120** [frontend, react, refactor, tests, tanstack] — Reproduce a hand-rolled comparator's tiebreak + undefined rules with a headless table's native options, not a negation-fighting comparator (#835, #821)
 - **120** [tests, vitest, flaky, react, frontend] — `await waitFor` for an already-flushed effect leaks a deferred render into the next test (#780, #785)
 - **121** [ci, tests, seo, verification, frontend] — A "presence-implying" audit may only validate; pair it with a drift guard (#782, #785)
 - **122** [ci, lighthouse, security, csp, verification, frontend] — A CSP in hosting config is invisible to the localhost Lighthouse gate; verify headers on the deployed surface (#783, #785)


### PR DESCRIPTION
**Epic C (#821) Sprint 1.** Migrates the **club table** (`ClubsTable`) onto **TanStack Table v8** (`@tanstack/react-table`, headless, MIT) — replacing the hand-rolled column iteration, the 90-line switch comparator, and the hand-ordered `<td>` body. Sets up Sprint 2 (column groups via `columnVisibility`) and Sprint 3 (delta columns). **Club table only** — the landing rankings table is left bespoke (deliberate split, ADR-006).

Closes-after-verify: #835 (verification on the PR preview channel, then label + epic tick + close per the runner protocol — intentionally NOT auto-closed here, see Lesson 106).

## What changed
- **`clubsColumns.tsx`** (new) — `createColumnHelper<ProcessedClubTrend>()` descriptors: 13 cols in the HANDOFF order, per-column responsive priority (sticky/desktop/core), `sortingFn`s faithful to the old switch, cell renderers reproducing the existing `<td>` markup verbatim.
- **`ClubsTable.tsx`** — renders via `useReactTable`: header from `getHeaderGroups()` (reuses `ColumnHeader`), body from `getRowModel()` + `flexRender`. Sort state stays **controlled** by `sortField/sortDirection` (URL-synced, `ColumnHeader`-driven); `columnPinning.left=['name']`; `columnVisibility` wired for Sprint 2.
- **ADR-006** addendum: records the *club=TanStack / rankings=bespoke* standard + the column-model/filter-model separation.

## Behaviour parity (Lesson 117 — migration, not rewrite)
The filter pipeline (`useColumnFilters → filteredClubs`) and its metadata (`COLUMN_CONFIGS`) are **unchanged** (R11) — TanStack presents over them. Sort fidelity preserved: `sortUndefined:'last'` (undefined→end both directions) + a name-asc base order fed to TanStack's *stable* sort (always-ascending name tiebreak). No assertion pinning.

- **2,915 frontend tests green**, zero regressions; new `clubsColumns.test.tsx` (6) pins the column-model + sort contract.
- Fresh-context `/review`: **APPROVE**, no High/Medium findings.
- `/simplify` (recall-biased): no in-scope findings.
- Test-partition guard: 215 files = 157 unit + 58 integration (disjoint, exhaustive).

## Bundle delta
`@tanstack/react-table` adds **+12.0 KB gzip** (351,974 → 364,249 bytes gzip total JS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)