### PR TITLE
feat(clubs): opt-in 'Changes' column group + diff CSV export (#795)

### DIFF
--- a/frontend/src/components/ChangeIndicator.tsx
+++ b/frontend/src/components/ChangeIndicator.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+
+export interface ChangeIndicatorProps {
+  /** Signed delta (positive = increase, negative = decrease, 0 = no change). */
+  value: number
+  /** Optional formatter for the magnitude (e.g. `n => \`${n} goals\``). */
+  format?: (magnitude: number) => string
+  /** Extra classes appended to the span (lesson 077 — override, no variant enum). */
+  className?: string
+}
+
+/**
+ * #795 (epic #797 Sprint 3) — compact inline signed-delta indicator for the
+ * per-club delta table.
+ *
+ * Same a11y contract as KpiDeltaCard (#681): the signed actual is rendered
+ * (lesson 102 — never a clamped gap), and direction is conveyed by sign +
+ * arrow + a screen-reader word, never colour alone (WCAG 1.4.1). The
+ * `text-green-700`/`text-red-700` utilities carry dark-mode overrides in
+ * dark-mode.css (lesson 067). Zero renders a neutral muted em-dash — no sign,
+ * no arrow, no colour.
+ */
+export const ChangeIndicator: React.FC<ChangeIndicatorProps> = ({
+  value,
+  format,
+  className,
+}) => {
+  const isUp = value > 0
+  const isDown = value < 0
+  const magnitude = Math.abs(value)
+  const formatted = format ? format(magnitude) : magnitude.toLocaleString()
+
+  if (!isUp && !isDown) {
+    return (
+      <span
+        data-testid="change-indicator"
+        className={`change-indicator change-indicator--zero${
+          className ? ` ${className}` : ''
+        }`}
+      >
+        —
+      </span>
+    )
+  }
+
+  // U+2212 minus for negatives; '+' for positives.
+  const display = isUp ? `+${formatted}` : `−${formatted}`
+  const colorClass = isUp ? 'text-green-700' : 'text-red-700'
+
+  return (
+    <span
+      data-testid="change-indicator"
+      className={`change-indicator inline-flex items-center gap-1 tabular-nums ${colorClass}${
+        className ? ` ${className}` : ''
+      }`}
+    >
+      <span
+        data-testid="change-indicator-arrow"
+        aria-hidden="true"
+        className="change-indicator__arrow"
+      >
+        {isUp ? '▲' : '▼'}
+      </span>
+      <span>{display}</span>
+      <span className="sr-only">{isUp ? 'increase' : 'decrease'}</span>
+    </span>
+  )
+}
+
+export default ChangeIndicator

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -8,9 +8,10 @@ import {
   type ColumnPinningState,
   type VisibilityState,
 } from '@tanstack/react-table'
+import type { SnapshotDiff } from '@toastmasters/shared-contracts'
 import { ClubTrend } from '../hooks/useDistrictAnalytics'
 import { ExportButton } from './ExportButton'
-import { exportClubPerformance } from '../utils/csvExport'
+import { exportClubPerformance, exportSnapshotDiff } from '../utils/csvExport'
 import { LoadingSkeleton } from './LoadingSkeleton'
 import { useColumnFilters } from '../hooks/useColumnFilters'
 import { ColumnHeader } from './ColumnHeader'
@@ -34,6 +35,10 @@ import {
   clubColumnPriorityClass,
   clubColumnTdClass,
 } from './clubsColumns'
+import {
+  buildClubsDeltaColumns,
+  CLUBS_DELTA_COLUMN_IDS,
+} from './clubsDeltaColumns'
 import { CLOSE_TO_DISTINGUISHED_MAX_MEMBERS } from '../utils/closeToDistinguished'
 import ClubCard from './ClubCard'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -49,6 +54,10 @@ import { useDebounce } from '../hooks/useDebounce'
  *  Passed to the versioned localStorage primitive (#420), which prefixes it
  *  with `toast-stats:v<N>:` so it migrates with every other persisted key. */
 const HIDDEN_GROUPS_STORAGE_NAME = 'clubs-table:hidden-groups'
+/** Persisted opt-in toggle for the Changes group (#795). Stored independently
+ *  of HIDDEN_GROUPS so the default (off) is honoured even for users whose
+ *  hidden-groups store predates the group's existence. */
+const CHANGES_VISIBLE_STORAGE_NAME = 'clubs-table:changes-visible'
 
 const VALID_GROUPS = new Set<ColumnGroup>(COLUMN_GROUP_IDS)
 /** A stale/corrupt store must never hide phantom groups or wedge the table
@@ -57,13 +66,6 @@ const sanitizeHiddenGroups = (raw: unknown): ColumnGroup[] =>
   Array.isArray(raw)
     ? raw.filter((g): g is ColumnGroup => VALID_GROUPS.has(g as ColumnGroup))
     : []
-
-// Groups offered in the show/hide menu: only those with at least one column in
-// the current table (so "Changes" stays out until #795 lands its delta cols).
-// COLUMN_CONFIGS is static, so this resolves once at module load.
-const AVAILABLE_COLUMN_GROUPS = COLUMN_GROUPS.filter(g =>
-  COLUMN_CONFIGS.some(c => c.group === g.id)
-)
 
 /** Row-tint key for the sticky cell, so it can repaint OPAQUE per row status
  *  (a sticky cell must be opaque or scrolled columns bleed through it). Mirrors
@@ -182,6 +184,14 @@ interface ClubsTableProps {
   /** Reference date for anniversary computation. Defaults to `new Date()`.
    *  Tests inject a fixed date to keep year counts deterministic (#448). */
   referenceDate?: Date
+  /**
+   * Snapshot-to-snapshot diff for the opt-in "Changes" column group (#795).
+   * When provided, ClubsTable surfaces the five delta columns under the Changes
+   * group (hidden by default, opt-in via the Columns menu) AND offers a sibling
+   * CSV export of the diff. Absent ⇒ no Changes group, no diff export — the
+   * table is byte-identical to its pre-#795 self.
+   */
+  snapshotDiff?: SnapshotDiff | undefined
 }
 
 /**
@@ -228,6 +238,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   initialFilterState,
   onFilterChange,
   referenceDate,
+  snapshotDiff,
 }) => {
   const [sortField, setSortField] = useState<SortField>(
     initialSortField ?? 'name'
@@ -417,16 +428,30 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   const [storedHiddenGroups, setStoredHiddenGroups] = usePersistedState<
     ColumnGroup[]
   >(HIDDEN_GROUPS_STORAGE_NAME, [])
-  const hiddenGroups = useMemo(
-    () => new Set(sanitizeHiddenGroups(storedHiddenGroups)),
-    [storedHiddenGroups]
+  // Opt-in show for the Changes group (#795). Stored as a boolean (default
+  // false) so the Changes columns stay hidden until the user toggles them on,
+  // independently of the hide-on-toggle behaviour the other groups use. The
+  // pre-existing `hiddenGroups` store can be `[]` for users who saved it before
+  // 'changes' existed — without a separate flag, they'd be opted IN by default.
+  const [changesVisible, setChangesVisible] = usePersistedState<boolean>(
+    CHANGES_VISIBLE_STORAGE_NAME,
+    false
   )
+  const hiddenGroups = useMemo(() => {
+    const s = new Set(sanitizeHiddenGroups(storedHiddenGroups))
+    if (!changesVisible) s.add('changes')
+    return s
+  }, [storedHiddenGroups, changesVisible])
   const isGroupHidden = useCallback(
     (group: ColumnGroup) => hiddenGroups.has(group),
     [hiddenGroups]
   )
   const toggleGroup = useCallback(
     (group: ColumnGroup) => {
+      if (group === 'changes') {
+        setChangesVisible(v => !v)
+        return
+      }
       setStoredHiddenGroups(prev => {
         const next = new Set(sanitizeHiddenGroups(prev))
         if (next.has(group)) next.delete(group)
@@ -434,7 +459,47 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
         return [...next]
       })
     },
-    [setStoredHiddenGroups]
+    [setStoredHiddenGroups, setChangesVisible]
+  )
+
+  // The 'changes' group is offered ONLY when a snapshot diff is provided —
+  // toggling a column set with nothing in it would be a dead control. The other
+  // groups are offered when at least one column claims them (so 'identity',
+  // 'membership', 'renewals', 'recognition' are always offered today; this
+  // shape is forward-compatible if any of them ever empties out).
+  const availableColumnGroups = useMemo(
+    () =>
+      COLUMN_GROUPS.filter(
+        g =>
+          (g.id === 'changes' && !!snapshotDiff) ||
+          (g.id !== 'changes' && COLUMN_CONFIGS.some(c => c.group === g.id))
+      ),
+    [snapshotDiff]
+  )
+
+  // ClubDiff lookup keyed by clubId, recomputed only when the diff changes.
+  // The delta column defs close over this Map so each cell can render its
+  // row's own diff without re-walking `snapshotDiff.clubs.bothPresent`.
+  const clubDiffsById = useMemo(() => {
+    const m = new Map<
+      string,
+      import('@toastmasters/shared-contracts').ClubDiff
+    >()
+    if (snapshotDiff) {
+      for (const c of snapshotDiff.clubs.bothPresent) m.set(c.clubId, c)
+    }
+    return m
+  }, [snapshotDiff])
+
+  // Delta column defs (#795). Only appended when a diff is provided — absent ⇒
+  // the table is byte-identical to its pre-#795 self. The 'changes' group's
+  // visibility is driven by `hiddenGroups` (opt-in, default hidden).
+  const tableColumns = useMemo(
+    () =>
+      snapshotDiff
+        ? [...clubsColumns, ...buildClubsDeltaColumns(clubDiffsById)]
+        : clubsColumns,
+    [snapshotDiff, clubDiffsById]
   )
 
   const columnVisibility = useMemo<VisibilityState>(() => {
@@ -444,12 +509,19 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
       if (c.field === STICKY_COLUMN_FIELD) continue
       if (hiddenGroups.has(c.group)) vis[c.field] = false
     }
+    // Delta columns belong to the 'changes' group; hide the whole set when the
+    // group is hidden. They live outside COLUMN_CONFIGS (they're display-only
+    // columns, no filter or sort metadata to register) so the loop above
+    // doesn't reach them.
+    if (hiddenGroups.has('changes')) {
+      for (const id of CLUBS_DELTA_COLUMN_IDS) vis[id] = false
+    }
     return vis
   }, [hiddenGroups])
 
   const table = useReactTable<ProcessedClubTrend>({
     data: nameSortedClubs,
-    columns: clubsColumns,
+    columns: tableColumns,
     state: { sorting, columnPinning, columnVisibility },
     // columnVisibility is fully controlled by hiddenGroups above — TanStack
     // never writes it directly, so onColumnVisibilityChange is intentionally
@@ -523,29 +595,46 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
       <div className="p-6 clubs-panel-header">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-xl font-bold clubs-panel-title">All Clubs</h3>
-          <ExportButton
-            onExport={() =>
-              exportClubPerformance(
-                sortedClubs.map(club => ({
-                  clubId: club.clubId,
-                  clubName: club.clubName,
-                  divisionName: club.divisionName,
-                  areaName: club.areaName,
-                  membershipTrend: club.membershipTrend,
-                  dcpGoalsTrend: club.dcpGoalsTrend,
-                  currentStatus: club.currentStatus,
-                  distinguishedLevel: club.distinguishedLevel,
-                  riskFactors: club.riskFactors,
-                  octoberRenewals: club.octoberRenewals,
-                  aprilRenewals: club.aprilRenewals,
-                  newMembers: club.newMembers,
-                })),
-                districtId
-              )
-            }
-            label="Export Clubs"
-            disabled={sortedClubs.length === 0}
-          />
+          <div className="clubs-export-group">
+            <ExportButton
+              onExport={() =>
+                exportClubPerformance(
+                  sortedClubs.map(club => ({
+                    clubId: club.clubId,
+                    clubName: club.clubName,
+                    divisionName: club.divisionName,
+                    areaName: club.areaName,
+                    membershipTrend: club.membershipTrend,
+                    dcpGoalsTrend: club.dcpGoalsTrend,
+                    currentStatus: club.currentStatus,
+                    distinguishedLevel: club.distinguishedLevel,
+                    riskFactors: club.riskFactors,
+                    octoberRenewals: club.octoberRenewals,
+                    aprilRenewals: club.aprilRenewals,
+                    newMembers: club.newMembers,
+                  })),
+                  districtId
+                )
+              }
+              label="Export Clubs"
+              disabled={sortedClubs.length === 0}
+            />
+            {/* Diff CSV export (#795). A SIBLING of the clubs export — the diff
+                rows are from/to/Δ across two snapshots, not current-snapshot
+                fields, so a single combined CSV would conflate two datasets
+                (lesson 117). Shown only when a snapshot diff is loaded. */}
+            {snapshotDiff && (
+              <ExportButton
+                onExport={() => exportSnapshotDiff(snapshotDiff)}
+                label="Export Changes"
+                disabled={
+                  snapshotDiff.clubs.bothPresent.length === 0 &&
+                  snapshotDiff.clubs.onlyInFrom.length === 0 &&
+                  snapshotDiff.clubs.onlyInTo.length === 0
+                }
+              />
+            )}
+          </div>
         </div>
 
         {/* Visible name search (#814, epic #818 Sprint 1). Recognition over
@@ -601,7 +690,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
               uses the same .clubs-filters-trigger styling for a single visual
               language. */}
           <ColumnGroupsMenu
-            groups={AVAILABLE_COLUMN_GROUPS}
+            groups={availableColumnGroups}
             isGroupHidden={isGroupHidden}
             onToggle={toggleGroup}
           />

--- a/frontend/src/components/__tests__/ChangeIndicator.test.tsx
+++ b/frontend/src/components/__tests__/ChangeIndicator.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { ChangeIndicator } from '../ChangeIndicator'
+
+/* #795 (epic #797 Sprint 3) — inline signed-delta indicator for the per-club
+   delta table. Same a11y contract as KpiDeltaCard (lesson 102: render the
+   signed actual; WCAG 1.4.1: direction by arrow + sr word, never colour
+   alone), shaped for a compact table cell. Zero renders a neutral em-dash. */
+
+afterEach(() => cleanup())
+
+describe('ChangeIndicator (#795)', () => {
+  it('formats a positive delta with a leading + and green colour', () => {
+    render(<ChangeIndicator value={26} />)
+    const el = screen.getByTestId('change-indicator')
+    expect(el).toHaveTextContent('+26')
+    expect(el.className).toContain('text-green-700')
+  })
+
+  it('formats a negative delta with a typographic minus and red colour', () => {
+    render(<ChangeIndicator value={-8} />)
+    const el = screen.getByTestId('change-indicator')
+    // U+2212 minus, not a hyphen.
+    expect(el).toHaveTextContent('−8')
+    expect(el.className).toContain('text-red-700')
+  })
+
+  it('renders zero as a neutral em-dash with no sign, arrow, or colour', () => {
+    render(<ChangeIndicator value={0} />)
+    const el = screen.getByTestId('change-indicator')
+    expect(el).toHaveTextContent('—')
+    expect(el.textContent).not.toContain('+')
+    expect(el.className).not.toContain('text-green-700')
+    expect(el.className).not.toContain('text-red-700')
+    expect(
+      screen.queryByTestId('change-indicator-arrow')
+    ).not.toBeInTheDocument()
+  })
+
+  it('conveys direction without colour alone (arrow + sr-only word)', () => {
+    render(<ChangeIndicator value={5} />)
+    expect(screen.getByTestId('change-indicator-arrow')).toBeInTheDocument()
+    expect(screen.getByText(/increase/i)).toBeInTheDocument()
+  })
+
+  it('says "decrease" for a negative delta', () => {
+    render(<ChangeIndicator value={-5} />)
+    expect(screen.getByText(/decrease/i)).toBeInTheDocument()
+  })
+
+  it('formats thousands with locale separators', () => {
+    render(<ChangeIndicator value={1234} />)
+    expect(screen.getByTestId('change-indicator')).toHaveTextContent('+1,234')
+  })
+
+  it('applies an optional className override (lesson 077)', () => {
+    render(<ChangeIndicator value={3} className="custom-cls" />)
+    expect(screen.getByTestId('change-indicator').className).toContain(
+      'custom-cls'
+    )
+  })
+
+  it('formats the value via an optional formatter', () => {
+    render(<ChangeIndicator value={2} format={n => `${n} goals`} />)
+    expect(screen.getByTestId('change-indicator')).toHaveTextContent('+2 goals')
+  })
+})

--- a/frontend/src/components/__tests__/clubsDeltaColumns.test.tsx
+++ b/frontend/src/components/__tests__/clubsDeltaColumns.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * #795 (epic #821 Sprint 3) — TanStack column model for the opt-in "Changes"
+ * column group.
+ *
+ * The base `clubsColumns` array (#835 / Sprint 1) ships the current-snapshot
+ * columns and stays unchanged (R11 — additive). The delta columns are produced
+ * by a separate factory that takes a `clubDiffsById` lookup and returns column
+ * defs the table concatenates. The factory shape keeps the closure over the
+ * lookup explicit, so each cell renders the right ClubDiff without ClubsTable
+ * needing to know about the diff schema.
+ */
+
+import React from 'react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import { flexRender, type CellContext } from '@tanstack/react-table'
+import { buildClubsDeltaColumns } from '../clubsDeltaColumns'
+import type { ProcessedClubTrend } from '../filters/types'
+import type { ClubDiff } from '@toastmasters/shared-contracts'
+
+afterEach(() => cleanup())
+
+const club = (
+  overrides: Partial<ProcessedClubTrend> = {}
+): ProcessedClubTrend =>
+  ({
+    clubId: 'c1',
+    clubName: 'Alpha',
+    divisionId: 'A',
+    divisionName: 'A',
+    areaId: '1',
+    areaName: '1',
+    distinguishedLevel: 'NotDistinguished',
+    currentStatus: 'thriving',
+    riskFactors: [],
+    membershipTrend: [],
+    dcpGoalsTrend: [],
+    latestMembership: 0,
+    latestDcpGoals: 0,
+    distinguishedOrder: 0,
+    membersNeeded: 0,
+    yearsChartered: null,
+    ...overrides,
+  }) as ProcessedClubTrend
+
+const diff = (over: Partial<ClubDiff> = {}): ClubDiff => ({
+  clubId: 'c1',
+  clubName: 'Alpha',
+  divisionId: 'A',
+  areaId: '1',
+  membership: { from: 20, to: 26, delta: 6 },
+  payments: { from: 20, to: 25, delta: 5 },
+  dcpGoals: { from: 4, to: 5, delta: 1 },
+  distinguishedFrom: '',
+  distinguishedTo: 'D',
+  distinguishedChanged: true,
+  ...over,
+})
+
+/** Render a column's cell against a row by invoking its `cell` renderer
+ *  with a minimal CellContext stub. */
+function renderCell(
+  col: ReturnType<typeof buildClubsDeltaColumns>[number],
+  row: ProcessedClubTrend
+) {
+  const cell = (
+    col as {
+      cell?: (ctx: CellContext<ProcessedClubTrend, unknown>) => React.ReactNode
+    }
+  ).cell
+  if (!cell) throw new Error('column has no cell renderer')
+  const ctx = {
+    row: { original: row },
+    getValue: () => undefined,
+    column: { id: (col as { id?: string }).id ?? '' },
+  } as unknown as CellContext<ProcessedClubTrend, unknown>
+  return render(<>{flexRender(cell, ctx)}</>)
+}
+
+describe('buildClubsDeltaColumns (#795)', () => {
+  it('produces the five delta column ids in display order', () => {
+    const cols = buildClubsDeltaColumns(new Map())
+    expect(cols.map(c => c.id)).toEqual([
+      'deltaMembership',
+      'deltaPayments',
+      'deltaDcpGoals',
+      'tierTransition',
+      'distinguishedFlip',
+    ])
+  })
+
+  it('renders membership delta via ChangeIndicator when diff is present', () => {
+    const map = new Map<string, ClubDiff>([['c1', diff()]])
+    const cols = buildClubsDeltaColumns(map)
+    const membershipCol = cols.find(c => c.id === 'deltaMembership')!
+    renderCell(membershipCol, club({ clubId: 'c1' }))
+    const indicator = screen.getByTestId('change-indicator')
+    expect(indicator).toHaveTextContent('+6')
+    // a11y: signed direction must NOT rely on color alone (lesson 102).
+    expect(screen.getByText(/increase/i)).toBeInTheDocument()
+  })
+
+  it('renders a muted em-dash when the row has no matching diff', () => {
+    const map = new Map<string, ClubDiff>()
+    const cols = buildClubsDeltaColumns(map)
+    const membershipCol = cols.find(c => c.id === 'deltaMembership')!
+    renderCell(membershipCol, club({ clubId: 'unknown' }))
+    expect(screen.queryByTestId('change-indicator')).not.toBeInTheDocument()
+    expect(document.body).toHaveTextContent('—')
+  })
+
+  it('renders payments delta via ChangeIndicator', () => {
+    const map = new Map<string, ClubDiff>([
+      ['c1', diff({ payments: { from: 100, to: 92, delta: -8 } })],
+    ])
+    const cols = buildClubsDeltaColumns(map)
+    const col = cols.find(c => c.id === 'deltaPayments')!
+    renderCell(col, club({ clubId: 'c1' }))
+    expect(screen.getByTestId('change-indicator')).toHaveTextContent('−8')
+    expect(screen.getByText(/decrease/i)).toBeInTheDocument()
+  })
+
+  it('renders DCP-goals delta via ChangeIndicator', () => {
+    const map = new Map<string, ClubDiff>([
+      ['c1', diff({ dcpGoals: { from: 4, to: 5, delta: 1 } })],
+    ])
+    const cols = buildClubsDeltaColumns(map)
+    const col = cols.find(c => c.id === 'deltaDcpGoals')!
+    renderCell(col, club({ clubId: 'c1' }))
+    expect(screen.getByTestId('change-indicator')).toHaveTextContent('+1')
+  })
+
+  it('renders tier transition as "From → To" using display names', () => {
+    const map = new Map<string, ClubDiff>([
+      ['c1', diff({ distinguishedFrom: '', distinguishedTo: 'D' })],
+    ])
+    const cols = buildClubsDeltaColumns(map)
+    const col = cols.find(c => c.id === 'tierTransition')!
+    renderCell(col, club({ clubId: 'c1' }))
+    // Arrow direction must be conveyed by text, not color alone.
+    expect(document.body).toHaveTextContent(/None.*Distinguished/)
+  })
+
+  it('renders distinguished flip as "Became" / "Lost" / muted dash', () => {
+    const becameMap = new Map<string, ClubDiff>([
+      [
+        'c1',
+        diff({
+          distinguishedFrom: '',
+          distinguishedTo: 'D',
+          distinguishedChanged: true,
+        }),
+      ],
+    ])
+    const col = buildClubsDeltaColumns(becameMap).find(
+      c => c.id === 'distinguishedFlip'
+    )!
+    renderCell(col, club({ clubId: 'c1' }))
+    expect(document.body).toHaveTextContent(/became/i)
+    cleanup()
+
+    const lostMap = new Map<string, ClubDiff>([
+      [
+        'c1',
+        diff({
+          distinguishedFrom: 'P',
+          distinguishedTo: '',
+          distinguishedChanged: true,
+        }),
+      ],
+    ])
+    const col2 = buildClubsDeltaColumns(lostMap).find(
+      c => c.id === 'distinguishedFlip'
+    )!
+    renderCell(col2, club({ clubId: 'c1' }))
+    expect(document.body).toHaveTextContent(/lost/i)
+  })
+
+  it('renders distinguished flip as em-dash when status did not change', () => {
+    const map = new Map<string, ClubDiff>([
+      [
+        'c1',
+        diff({
+          distinguishedFrom: 'D',
+          distinguishedTo: 'D',
+          distinguishedChanged: false,
+        }),
+      ],
+    ])
+    const col = buildClubsDeltaColumns(map).find(
+      c => c.id === 'distinguishedFlip'
+    )!
+    renderCell(col, club({ clubId: 'c1' }))
+    expect(document.body).toHaveTextContent('—')
+  })
+})

--- a/frontend/src/components/clubsColumns.tsx
+++ b/frontend/src/components/clubsColumns.tsx
@@ -115,6 +115,14 @@ const TD_BASE_CLASS: Record<string, string> = {
   clubStatus: 'px-2 py-3 whitespace-nowrap text-sm text-center',
   yearsChartered:
     'px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center',
+  // Opt-in "Changes" group delta cells (#795). Same vertical rhythm as the
+  // core numeric cells; ChangeIndicator owns the colour + sign + arrow.
+  deltaMembership:
+    'px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center',
+  deltaPayments: 'px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center',
+  deltaDcpGoals: 'px-2 py-3 whitespace-nowrap text-sm tabular-nums text-center',
+  tierTransition: 'px-2 py-3 whitespace-nowrap text-sm text-center',
+  distinguishedFlip: 'px-2 py-3 whitespace-nowrap text-sm text-center',
 }
 
 /** Exact `<td>` className for a column: base + responsive priority class. */

--- a/frontend/src/components/clubsDeltaColumns.tsx
+++ b/frontend/src/components/clubsDeltaColumns.tsx
@@ -1,0 +1,125 @@
+/**
+ * TanStack column model for the opt-in "Changes" column group
+ * (#795, epic #821 Sprint 3, ADR-006 §4).
+ *
+ * The base `clubsColumns` (#835 / Sprint 1) ships the 13 current-snapshot
+ * columns and stays untouched (R11 — additive insertion, no replacement).
+ * `buildClubsDeltaColumns(clubDiffsById)` returns the five delta column defs
+ * that ClubsTable concatenates onto `clubsColumns` ONLY when a snapshot diff
+ * is loaded. Each cell looks the row up in the closed-over Map and renders via
+ * `ChangeIndicator` (signed delta, arrow + sr-only word — never colour alone,
+ * lesson 102 / WCAG 1.4.1). A row missing from the diff renders a muted
+ * em-dash, NOT a zero — zero would lie about "no change" for a club the diff
+ * doesn't cover (e.g. one that just joined the roster).
+ *
+ * Visibility is driven by ClubsTable's `hiddenGroups` set — the 'changes' group
+ * is hidden by default (opt-in via the Columns menu, per #795 acceptance).
+ */
+
+import React from 'react'
+import { createColumnHelper } from '@tanstack/react-table'
+import type { ClubDiff } from '@toastmasters/shared-contracts'
+import type { ProcessedClubTrend } from './filters/types'
+import { ChangeIndicator } from './ChangeIndicator'
+import { distinguishedTierName } from '../utils/distinguishedTier'
+
+const colHelper = createColumnHelper<ProcessedClubTrend>()
+
+const MutedDash: React.FC = () => <span className="clubs-cell-muted">—</span>
+
+/** Did this club gain a distinguished status (e.g. '' → 'D')? */
+const isBecame = (from: string, to: string): boolean => !from && !!to
+/** Did this club lose distinguished status (e.g. 'P' → '')? */
+const isLost = (from: string, to: string): boolean => !!from && !to
+
+export const CLUBS_DELTA_COLUMN_IDS = [
+  'deltaMembership',
+  'deltaPayments',
+  'deltaDcpGoals',
+  'tierTransition',
+  'distinguishedFlip',
+] as const
+
+export type ClubsDeltaColumnId = (typeof CLUBS_DELTA_COLUMN_IDS)[number]
+
+/**
+ * Build the five delta column defs over a `clubDiffsById` lookup. The closure
+ * is explicit so ClubsTable doesn't need to thread the diff into TanStack's
+ * `meta` (which would broaden the column type for every cell). Empty map ⇒
+ * every cell renders the muted em-dash (e.g. while the diff is loading).
+ */
+export const buildClubsDeltaColumns = (
+  clubDiffsById: Map<string, ClubDiff>
+) => [
+  colHelper.display({
+    id: 'deltaMembership',
+    header: 'Δ Members',
+    cell: info => {
+      const d = clubDiffsById.get(info.row.original.clubId)
+      if (!d) return <MutedDash />
+      return <ChangeIndicator value={d.membership.delta} />
+    },
+  }),
+  colHelper.display({
+    id: 'deltaPayments',
+    header: 'Δ Payments',
+    cell: info => {
+      const d = clubDiffsById.get(info.row.original.clubId)
+      if (!d) return <MutedDash />
+      return <ChangeIndicator value={d.payments.delta} />
+    },
+  }),
+  colHelper.display({
+    id: 'deltaDcpGoals',
+    header: 'Δ DCP',
+    cell: info => {
+      const d = clubDiffsById.get(info.row.original.clubId)
+      if (!d) return <MutedDash />
+      return <ChangeIndicator value={d.dcpGoals.delta} />
+    },
+  }),
+  colHelper.display({
+    id: 'tierTransition',
+    header: 'Tier change',
+    cell: info => {
+      const d = clubDiffsById.get(info.row.original.clubId)
+      if (!d) return <MutedDash />
+      if (!d.distinguishedChanged) return <MutedDash />
+      const from = distinguishedTierName(d.distinguishedFrom)
+      const to = distinguishedTierName(d.distinguishedTo)
+      return (
+        <span className="clubs-tier-transition">
+          <span>{from}</span>
+          <span aria-hidden="true" className="clubs-tier-transition__arrow">
+            {' → '}
+          </span>
+          <span>{to}</span>
+        </span>
+      )
+    },
+  }),
+  colHelper.display({
+    id: 'distinguishedFlip',
+    header: 'Distinguished?',
+    cell: info => {
+      const d = clubDiffsById.get(info.row.original.clubId)
+      if (!d || !d.distinguishedChanged) return <MutedDash />
+      if (isBecame(d.distinguishedFrom, d.distinguishedTo)) {
+        return (
+          <span className="clubs-distinguished-flip clubs-distinguished-flip--became text-green-700">
+            Became Distinguished
+          </span>
+        )
+      }
+      if (isLost(d.distinguishedFrom, d.distinguishedTo)) {
+        return (
+          <span className="clubs-distinguished-flip clubs-distinguished-flip--lost text-red-700">
+            Lost Distinguished
+          </span>
+        )
+      }
+      // Tier-to-tier change (e.g. D → P) is recorded but neither became nor lost.
+      return <MutedDash />
+    },
+  }),
+]

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -9,6 +9,7 @@ import { useDistricts } from '../hooks/useDistricts'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
+import { previousRecordedDate, useSnapshotDiff } from '../hooks/useSnapshotDiff'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
 import {
   getAvailableProgramYears,
@@ -187,6 +188,29 @@ const DistrictClubsPage: React.FC = () => {
 
   const allClubs = analytics?.allClubs || []
 
+  // Default snapshot-diff pair = (previous recorded date → latest recorded
+  // date) for this district (#795, epic #821 Sprint 3). The diff feeds the
+  // opt-in "Changes" column group ON the clubs table — independent of the
+  // dedicated "What Changed" page (`/district/:id/changes`), which owns its
+  // own URL-synced arbitrary date pair (#794). The pair is owned here and
+  // passed as props (R3 — never re-derive from response data). When fewer
+  // than two snapshots exist the hook is disabled (`enabled: !!from && !!to`)
+  // and ClubsTable gets `snapshotDiff: undefined` — the Changes group simply
+  // doesn't surface, matching the same precondition the changes page uses.
+  const sortedRecordedDates = useMemo(
+    () => [...allCachedDates].sort((a, b) => a.localeCompare(b)),
+    [allCachedDates]
+  )
+  const defaultDiffPair = useMemo(
+    () => previousRecordedDate(sortedRecordedDates),
+    [sortedRecordedDates]
+  )
+  const { data: snapshotDiff } = useSnapshotDiff(
+    districtId,
+    defaultDiffPair?.from,
+    defaultDiffPair?.to
+  )
+
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
   useDocumentTitle(districtName ? `${districtName} Clubs` : null)
@@ -249,6 +273,7 @@ const DistrictClubsPage: React.FC = () => {
                   onSortChange={handleSortChange}
                   initialFilterState={initialFilterState}
                   onFilterChange={handleFilterChange}
+                  snapshotDiff={snapshotDiff}
                 />
                 <ProspectiveClubsPanel clubs={analytics?.prospectiveClubs} />
               </>

--- a/frontend/src/utils/__tests__/csvExport.snapshotDiff.test.ts
+++ b/frontend/src/utils/__tests__/csvExport.snapshotDiff.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { SnapshotDiff } from '@toastmasters/shared-contracts'
+import { exportSnapshotDiff } from '../csvExport'
+
+/* #795 (epic #797 Sprint 3) — diff CSV export. A sibling of exportClubPerformance
+   (which exports current-snapshot fields); the diff CSV is from/to/delta data
+   for two dates, plus roster changes (lesson 118). */
+
+let captured = ''
+let capturedFilename = ''
+
+beforeEach(() => {
+  captured = ''
+  capturedFilename = ''
+  // Capture the blob text + filename without touching the real DOM download.
+  global.URL.createObjectURL = vi.fn(() => 'blob:mock')
+  global.URL.revokeObjectURL = vi.fn()
+  vi.spyOn(document.body, 'appendChild').mockImplementation((node: never) => {
+    const el = node as unknown as HTMLAnchorElement
+    capturedFilename = el.getAttribute?.('download') ?? ''
+    return node
+  })
+  vi.spyOn(document.body, 'removeChild').mockImplementation(
+    (node: never) => node
+  )
+  // Intercept Blob construction to read the CSV string synchronously, without
+  // naming the DOM lib types (eslint no-undef doesn't know them in this env).
+  const RealBlob = global.Blob
+  global.Blob = class extends RealBlob {
+    constructor(...args: ConstructorParameters<typeof Blob>) {
+      super(...args)
+      const parts = args[0] as string[]
+      captured = String(parts?.[0] ?? '')
+    }
+  } as typeof Blob
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function makeDiff(over: Partial<SnapshotDiff['clubs']> = {}): SnapshotDiff {
+  return {
+    districtId: '61',
+    from: { date: '2026-05-25' },
+    to: { date: '2026-05-26' },
+    dayCount: 1,
+    totals: {
+      membership: { from: 100, to: 110, delta: 10 },
+      payments: { from: 100, to: 110, delta: 10 },
+      clubCount: { from: 2, to: 3, delta: 1 },
+      distinguished: { from: 0, to: 1, delta: 1 },
+    },
+    clubs: {
+      bothPresent: over.bothPresent ?? [
+        {
+          clubId: 'c1',
+          clubName: 'Alpha Club',
+          divisionId: 'A',
+          areaId: '1',
+          membership: { from: 20, to: 26, delta: 6 },
+          payments: { from: 20, to: 25, delta: 5 },
+          dcpGoals: { from: 4, to: 5, delta: 1 },
+          distinguishedFrom: '',
+          distinguishedTo: 'D',
+          distinguishedChanged: true,
+        },
+      ],
+      onlyInFrom: over.onlyInFrom ?? [],
+      onlyInTo: over.onlyInTo ?? [],
+    },
+    events: [],
+  }
+}
+
+describe('exportSnapshotDiff (#795)', () => {
+  it('includes a header block with district and date range', () => {
+    exportSnapshotDiff(makeDiff())
+    expect(captured).toContain('District 61')
+    expect(captured).toContain('2026-05-25')
+    expect(captured).toContain('2026-05-26')
+  })
+
+  it('emits from/to/delta columns for each both-present club', () => {
+    exportSnapshotDiff(makeDiff())
+    const lines = captured.split('\n')
+    const header = lines.find(l => l.includes('Δ Members'))
+    expect(header).toBeDefined()
+    expect(header).toContain('Members From')
+    expect(header).toContain('Members To')
+    // The Alpha row: membership 20 → 26 (+6), payments 20 → 25 (+5), dcp 4 → 5 (+1).
+    const row = lines.find(l => l.startsWith('c1,'))
+    expect(row).toContain('20')
+    expect(row).toContain('26')
+    expect(row).toContain('6')
+  })
+
+  it('records the distinguished transition', () => {
+    exportSnapshotDiff(makeDiff())
+    const row = captured.split('\n').find(l => l.startsWith('c1,'))
+    // Became Distinguished: from '' to 'D'.
+    expect(row).toContain('Yes')
+  })
+
+  it('includes roster-change rows classified by status (lesson 118)', () => {
+    exportSnapshotDiff(
+      makeDiff({
+        bothPresent: [],
+        onlyInTo: [
+          {
+            clubId: 'p1',
+            clubName: 'Joined Co',
+            divisionId: 'B',
+            areaId: '2',
+            clubStatus: 'Active',
+          },
+        ],
+        onlyInFrom: [
+          {
+            clubId: 'p2',
+            clubName: 'Left Co',
+            divisionId: 'C',
+            areaId: '3',
+            clubStatus: 'Suspended',
+          },
+        ],
+      })
+    )
+    expect(captured).toContain('Joined Co')
+    expect(captured).toContain('Joined')
+    expect(captured).toContain('Left Co')
+    expect(captured).toContain('Left')
+    expect(captured).toContain('Suspended')
+  })
+
+  it('names the file with the district and date range', () => {
+    exportSnapshotDiff(makeDiff())
+    expect(capturedFilename).toContain('61')
+    expect(capturedFilename).toMatch(/\.csv$/)
+  })
+})

--- a/frontend/src/utils/__tests__/distinguishedTier.test.ts
+++ b/frontend/src/utils/__tests__/distinguishedTier.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { distinguishedTierName } from '../distinguishedTier'
+
+/* #795 (epic #821 Sprint 3) — domain helper for rendering the "Club
+   Distinguished Status" code (`'' | D | S | P | M`) as a display name.
+   Mirrors the private TIER_NAMES map in analytics-core's diffSnapshots so the
+   "What Changed" surfaces (table cell + CSV) cannot drift apart (lesson 117). */
+
+describe('distinguishedTierName (#795)', () => {
+  it('maps each canonical code to its display name', () => {
+    expect(distinguishedTierName('D')).toBe('Distinguished')
+    expect(distinguishedTierName('S')).toBe('Select Distinguished')
+    expect(distinguishedTierName('P')).toBe("President's Distinguished")
+    expect(distinguishedTierName('M')).toBe('Distinguished')
+  })
+
+  it('maps the empty code to "None"', () => {
+    expect(distinguishedTierName('')).toBe('None')
+  })
+
+  it('falls back to "Distinguished" for an unknown non-empty code', () => {
+    expect(distinguishedTierName('Z')).toBe('Distinguished')
+  })
+})

--- a/frontend/src/utils/csvExport.ts
+++ b/frontend/src/utils/csvExport.ts
@@ -2,6 +2,8 @@
  * Utility functions for exporting data to CSV format
  */
 
+import type { SnapshotDiff } from '@toastmasters/shared-contracts'
+import { distinguishedTierName } from './distinguishedTier'
 import { logger } from './logger'
 
 /**
@@ -619,5 +621,108 @@ export const exportClubPerformance = (
 
   const csvContent = arrayToCSV(csvData)
   const filename = generateFilename('club_performance', districtId)
+  downloadCSV(csvContent, filename)
+}
+
+/**
+ * #795 (epic #821 Sprint 3) — export a snapshot-to-snapshot diff to CSV.
+ *
+ * A sibling of `exportClubPerformance` (current-snapshot fields), NOT an
+ * extension of it: the diff CSV is from/to/delta data across two dates
+ * (R6 / lesson 117 — the two datasets diverge, so they get distinct exporters).
+ * Both-present clubs get from/to/Δ columns + the distinguished transition;
+ * roster appear/disappear is a separate, status-classified section (lesson 118),
+ * never folded into the per-club delta rows.
+ */
+export const exportSnapshotDiff = (diff: SnapshotDiff): void => {
+  const { districtId, from, to } = diff
+
+  const deltaHeaders = [
+    'Club ID',
+    'Club Name',
+    'Division',
+    'Area',
+    'Members From',
+    'Members To',
+    'Δ Members',
+    'Payments From',
+    'Payments To',
+    'Δ Payments',
+    'DCP From',
+    'DCP To',
+    'Δ DCP',
+    'Distinguished From',
+    'Distinguished To',
+    'Distinguished Changed',
+  ]
+
+  const deltaRows = diff.clubs.bothPresent.map(c => [
+    c.clubId,
+    c.clubName,
+    c.divisionId,
+    c.areaId,
+    c.membership.from,
+    c.membership.to,
+    c.membership.delta,
+    c.payments.from,
+    c.payments.to,
+    c.payments.delta,
+    c.dcpGoals.from,
+    c.dcpGoals.to,
+    c.dcpGoals.delta,
+    distinguishedTierName(c.distinguishedFrom),
+    distinguishedTierName(c.distinguishedTo),
+    c.distinguishedChanged ? 'Yes' : 'No',
+  ])
+
+  const csvData: (string | number)[][] = [
+    [`District ${districtId} - What Changed`],
+    [`From: ${from.date}  To: ${to.date}`],
+    [`Export Date: ${new Date().toISOString()}`],
+    [],
+    ['Per-club changes'],
+    deltaHeaders,
+    ...deltaRows,
+  ]
+
+  // Roster changes — classified, not flagged as an error (lesson 118).
+  if (diff.clubs.onlyInTo.length > 0 || diff.clubs.onlyInFrom.length > 0) {
+    csvData.push([])
+    csvData.push(['Roster changes'])
+    csvData.push([
+      'Club ID',
+      'Club Name',
+      'Division',
+      'Area',
+      'Roster Change',
+      'Club Status',
+    ])
+    diff.clubs.onlyInTo.forEach(c => {
+      csvData.push([
+        c.clubId,
+        c.clubName,
+        c.divisionId,
+        c.areaId,
+        'Joined',
+        c.clubStatus ?? '',
+      ])
+    })
+    diff.clubs.onlyInFrom.forEach(c => {
+      csvData.push([
+        c.clubId,
+        c.clubName,
+        c.divisionId,
+        c.areaId,
+        'Left',
+        c.clubStatus ?? '',
+      ])
+    })
+  }
+
+  const csvContent = arrayToCSV(csvData)
+  const filename = generateFilename(
+    `what_changed_${from.date}_to_${to.date}`,
+    districtId
+  )
   downloadCSV(csvContent, filename)
 }

--- a/frontend/src/utils/distinguishedTier.ts
+++ b/frontend/src/utils/distinguishedTier.ts
@@ -1,0 +1,20 @@
+/**
+ * Toastmasters DCP "Club Distinguished Status" tier codes → display names.
+ *
+ * Codes are stable domain values (`'' | D | S | P | M`) set by Toastmasters;
+ * this mirrors the private `TIER_NAMES` in analytics-core's `diffSnapshots`.
+ * One frontend home so the "What Changed" table and its CSV export can't drift
+ * apart (lesson 117 — diverged copies of the same map are a trap). The empty
+ * code means "no distinguished status" → "None".
+ */
+const TIER_NAMES: Record<string, string> = {
+  D: 'Distinguished',
+  S: 'Select Distinguished',
+  P: "President's Distinguished",
+  M: 'Distinguished',
+}
+
+export function distinguishedTierName(code: string): string {
+  if (!code) return 'None'
+  return TIER_NAMES[code] ?? 'Distinguished'
+}


### PR DESCRIPTION
## Summary
- Sprint 3 of epic #821 — five **opt-in delta columns** assigned to the existing **Changes** group, surfaced via the Columns menu. Default hidden; toggle once and they appear on every visit.
- New **Export Changes** CSV (sibling of *Export Clubs*) when a snapshot diff is loaded. Per-club from/to/Δ rows plus a status-classified roster-changes section (Lesson 118).
- Reuses preserved work from `sprint-795-club-delta-table @25492e1a` where output-equivalent (Lesson 117): `ChangeIndicator` a11y cell, `distinguishedTierName`, `exportSnapshotDiff`. The delta column defs are new — with TanStack live, the right shape is column defs on the existing table.

## Acceptance criteria
- [x] Delta columns added additively (R11) — existing `clubsColumns` array, ClubsTable tests, and the migration's column-id-order contract are all untouched.
- [x] Transition cells reuse `ChangeIndicator` (arrow + sign + sr-only word — never colour alone, WCAG 1.4.1 / Lesson 102).
- [x] Opt-in via the Columns menu (rescoped from the original "Changed only" filter per the issue's most recent comment). Default hidden, persisted as `clubs-table:changes-visible`.
- [x] `exportSnapshotDiff` includes Δ columns and downloads cleanly; filename includes the date range.
- [x] Distinguished flip: Became / Lost / em-dash for v1 (taxonomy deferred — epic open question).
- [x] Zero regressions: 2949 frontend tests pass (2355 unit + 594 integration), typecheck clean.
- [ ] Live verification on PR preview channel — see test plan below.

## TDD evidence (Red → Green)
Four spec files fail with `Cannot resolve import` / `TypeError: not a function` before the source files are added; all 24 cases pass after the source files land. Verified locally before the commit.

## Test plan
- [ ] PR preview deploys, the **Live URL** appears in the sticky `pr-preview` comment.
- [ ] Playwright smoke at the preview URL (Chromium + WebKit per Lesson 711): open the clubs page, the Columns menu lists a **Changes** group, toggling it on reveals five delta cells per row rendered via `ChangeIndicator`, the **Export Changes** button is visible.
- [ ] Capture screenshots at 375 / 768 / 1280 and dark mode.
- [ ] Smoke the dedicated `/district/:id/changes` page is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)