### PR TITLE
fix(area): gate area recognition on club-visit requirement — deadline-aware provisional state (#832)

### DIFF
--- a/frontend/src/components/AreaPerformanceRow.tsx
+++ b/frontend/src/components/AreaPerformanceRow.tsx
@@ -4,8 +4,8 @@ import {
   calculateAreaGapAnalysis,
   calculatePaidClubsPercentage,
   calculateDistinguishedPercentage,
-  RecognitionLevel,
 } from '../utils/areaGapAnalysis'
+import { renderRecognitionBadge } from '../utils/areaRecognitionBadge'
 
 /**
  * Props for the AreaPerformanceRow component
@@ -13,55 +13,6 @@ import {
 interface AreaPerformanceRowProps {
   /** Area performance data to display */
   area: AreaPerformance
-}
-
-/**
- * Get recognition badge styling and label based on recognition level
- *
- * Uses Toastmasters brand colors for status indicators:
- * - President's Distinguished: TM Happy Yellow background
- * - Select Distinguished: TM Cool Gray background
- * - Distinguished: TM True Maroon background
- * - Not Distinguished: Gray background
- * - Net Loss: Red background (special indicator)
- *
- * Requirements: 9.5
- */
-const getRecognitionBadge = (
-  level: RecognitionLevel,
-  meetsNoNetLossRequirement: boolean
-): { className: string; label: string } => {
-  // If no net loss requirement not met, show special indicator
-  if (!meetsNoNetLossRequirement) {
-    return {
-      className: 'bg-red-100 text-red-800 border-red-300',
-      label: 'Net Loss',
-    }
-  }
-
-  switch (level) {
-    case 'presidents':
-      return {
-        className:
-          'bg-tm-happy-yellow text-gray-900 border-yellow-500 font-semibold',
-        label: "President's Distinguished",
-      }
-    case 'select':
-      return {
-        className: 'bg-tm-cool-gray text-gray-900 border-gray-400',
-        label: 'Select Distinguished',
-      }
-    case 'distinguished':
-      return {
-        className: 'bg-tm-true-maroon text-white border-tm-true-maroon',
-        label: 'Distinguished',
-      }
-    default:
-      return {
-        className: 'bg-gray-100 text-gray-600 border-gray-300',
-        label: 'Not Distinguished',
-      }
-  }
 }
 
 /**
@@ -168,24 +119,9 @@ export const AreaPerformanceRow: React.FC<AreaPerformanceRowProps> = ({
     area.distinguishedClubs
   )
 
-  // Check if visits gate the recognition (#325)
-  const visitsComplete =
-    area.firstRoundVisits.completed >= area.firstRoundVisits.required &&
-    area.secondRoundVisits.completed >= area.secondRoundVisits.required
-  const isDistinguishedLevel = gapAnalysis.currentLevel !== 'none'
-  const isProvisional = isDistinguishedLevel && !visitsComplete
-
-  // Get recognition badge
-  const baseBadge = getRecognitionBadge(
-    gapAnalysis.currentLevel,
-    gapAnalysis.meetsNoNetLossRequirement
-  )
-  const badge = isProvisional
-    ? {
-        className: 'bg-amber-100 text-amber-800 border-amber-300',
-        label: `${baseBadge.label} (Provisional)`,
-      }
-    : baseBadge
+  // Source-of-truth recognition badge — deadline-aware visit gate lives in
+  // `deriveAreaRecognitionState`. This component is a pure presenter (#832).
+  const badge = renderRecognitionBadge(area.recognitionState)
 
   return (
     <tr className="hover:bg-gray-50 transition-colors">
@@ -256,6 +192,7 @@ export const AreaPerformanceRow: React.FC<AreaPerformanceRowProps> = ({
         <span
           className={`px-2 py-1 text-xs font-medium rounded-full border ${badge.className}`}
           aria-label={`Recognition status: ${badge.label}`}
+          title={badge.tooltip}
         >
           {badge.label}
         </span>

--- a/frontend/src/components/AreaPerformanceTable.tsx
+++ b/frontend/src/components/AreaPerformanceTable.tsx
@@ -4,8 +4,8 @@ import {
   calculateAreaGapAnalysis,
   calculatePaidClubsPercentage,
   calculateDistinguishedPercentage,
-  RecognitionLevel,
 } from '../utils/areaGapAnalysis'
+import { renderRecognitionBadge } from '../utils/areaRecognitionBadge'
 
 /**
  * Props for the AreaPerformanceTable component
@@ -13,55 +13,6 @@ import {
 interface AreaPerformanceTableProps {
   /** Array of area performance data to display */
   areas: AreaPerformance[]
-}
-
-/**
- * Get recognition badge styling and label based on recognition level
- *
- * Uses Toastmasters brand colors for status indicators:
- * - President's Distinguished: TM Happy Yellow background
- * - Select Distinguished: TM Cool Gray background
- * - Distinguished: TM True Maroon background
- * - Not Distinguished: Gray background
- * - Net Loss: Red background (special indicator)
- *
- * Requirements: 9.5
- */
-const getRecognitionBadge = (
-  level: RecognitionLevel,
-  meetsNoNetLossRequirement: boolean
-): { className: string; label: string } => {
-  // If no net loss requirement not met, show special indicator
-  if (!meetsNoNetLossRequirement) {
-    return {
-      className: 'bg-red-100 text-red-800 border-red-300',
-      label: 'Net Loss',
-    }
-  }
-
-  switch (level) {
-    case 'presidents':
-      return {
-        className:
-          'bg-tm-happy-yellow text-gray-900 border-yellow-500 font-semibold',
-        label: "President's Distinguished",
-      }
-    case 'select':
-      return {
-        className: 'bg-tm-cool-gray text-gray-900 border-gray-400',
-        label: 'Select Distinguished',
-      }
-    case 'distinguished':
-      return {
-        className: 'bg-tm-true-maroon text-white border-tm-true-maroon',
-        label: 'Distinguished',
-      }
-    default:
-      return {
-        className: 'bg-gray-100 text-gray-600 border-gray-300',
-        label: 'Not Distinguished',
-      }
-  }
 }
 
 /**
@@ -346,11 +297,9 @@ export const AreaPerformanceTable: React.FC<AreaPerformanceTableProps> = ({
               area.distinguishedClubs
             )
 
-            // Get recognition badge
-            const badge = getRecognitionBadge(
-              gapAnalysis.currentLevel,
-              gapAnalysis.meetsNoNetLossRequirement
-            )
+            // Source-of-truth recognition badge (#832) — visit-deadline gate
+            // lives in `deriveAreaRecognitionState`; this is a pure presenter.
+            const badge = renderRecognitionBadge(area.recognitionState)
 
             return (
               <tr
@@ -425,6 +374,7 @@ export const AreaPerformanceTable: React.FC<AreaPerformanceTableProps> = ({
                   <span
                     className={`px-2 py-1 text-xs font-medium rounded-full border ${badge.className}`}
                     aria-label={`Recognition status: ${badge.label}`}
+                    title={badge.tooltip}
                   >
                     {badge.label}
                   </span>

--- a/frontend/src/components/DivisionAreaProgressSummary.tsx
+++ b/frontend/src/components/DivisionAreaProgressSummary.tsx
@@ -31,10 +31,8 @@
 
 import React, { useMemo } from 'react'
 import { DivisionPerformance, AreaPerformance } from '../utils/divisionStatus'
-import {
-  calculateAreaGapAnalysis,
-  RecognitionLevel,
-} from '../utils/areaGapAnalysis'
+import { calculateAreaGapAnalysis } from '../utils/areaGapAnalysis'
+import { renderRecognitionBadge } from '../utils/areaRecognitionBadge'
 import {
   generateAreaProgressText,
   AreaProgressText,
@@ -96,32 +94,6 @@ interface DivisionGroup {
 }
 
 /**
- * Get badge styling for area recognition level
- * Uses Toastmasters brand colors
- *
- * Requirements: 7.1, 7.2
- */
-const getRecognitionBadgeClass = (
-  level: RecognitionLevel,
-  meetsNoNetLossRequirement: boolean
-): string => {
-  if (!meetsNoNetLossRequirement) {
-    return 'bg-red-100 text-red-800 border-red-300'
-  }
-
-  switch (level) {
-    case 'presidents':
-      return 'bg-tm-happy-yellow text-gray-900 border-yellow-500 font-semibold'
-    case 'select':
-      return 'bg-tm-cool-gray text-gray-900 border-gray-400'
-    case 'distinguished':
-      return 'bg-tm-true-maroon text-white border-tm-true-maroon'
-    default:
-      return 'bg-gray-100 text-gray-600 border-gray-300'
-  }
-}
-
-/**
  * Get badge styling for division recognition level
  * Uses Toastmasters brand colors with visual distinction from area badges
  *
@@ -144,29 +116,6 @@ const getDivisionRecognitionBadgeClass = (
       return 'bg-tm-true-maroon text-white border-tm-true-maroon'
     default:
       return 'bg-gray-100 text-gray-600 border-gray-300'
-  }
-}
-
-/**
- * Get display label for recognition level
- */
-const getRecognitionLabel = (
-  level: RecognitionLevel,
-  meetsNoNetLossRequirement: boolean
-): string => {
-  if (!meetsNoNetLossRequirement) {
-    return 'Net Loss'
-  }
-
-  switch (level) {
-    case 'presidents':
-      return "President's Distinguished"
-    case 'select':
-      return 'Select Distinguished'
-    case 'distinguished':
-      return 'Distinguished'
-    default:
-      return 'Not Distinguished'
   }
 }
 
@@ -451,37 +400,10 @@ export const DivisionAreaProgressSummary: React.FC<
               {/* Area Articles - Requirements: 11.3 */}
               <div className="space-y-4">
                 {group.areas.map(({ area, progressText }) => {
-                  const gapAnalysis = calculateAreaGapAnalysis({
-                    clubBase: area.clubBase,
-                    paidClubs: area.paidClubs,
-                    distinguishedClubs: area.distinguishedClubs,
-                  })
-
-                  // Check if visits gate the recognition (#325)
-                  const visitsComplete =
-                    area.firstRoundVisits.completed >=
-                      area.firstRoundVisits.required &&
-                    area.secondRoundVisits.completed >=
-                      area.secondRoundVisits.required
-                  const isDistinguishedLevel =
-                    progressText.currentLevel !== 'none'
-                  const isProvisionalArea =
-                    isDistinguishedLevel && !visitsComplete
-
-                  const badgeClass = isProvisionalArea
-                    ? 'bg-amber-100 text-amber-800 border-amber-300'
-                    : getRecognitionBadgeClass(
-                        progressText.currentLevel,
-                        gapAnalysis.meetsNoNetLossRequirement
-                      )
-
-                  const baseLabel = getRecognitionLabel(
-                    progressText.currentLevel,
-                    gapAnalysis.meetsNoNetLossRequirement
-                  )
-                  const badgeLabel = isProvisionalArea
-                    ? `${baseLabel} (Provisional)`
-                    : baseLabel
+                  // Source-of-truth recognition badge (#832) — deadline-aware
+                  // visit gate lives in `deriveAreaRecognitionState`; this is
+                  // a pure presenter.
+                  const badge = renderRecognitionBadge(area.recognitionState)
 
                   return (
                     <article
@@ -498,10 +420,11 @@ export const DivisionAreaProgressSummary: React.FC<
                           Area {area.areaId}
                         </h5>
                         <span
-                          className={`px-2 py-1 text-xs font-medium rounded-full border ${badgeClass}`}
-                          aria-label={`Recognition status: ${badgeLabel}`}
+                          className={`px-2 py-1 text-xs font-medium rounded-full border ${badge.className}`}
+                          aria-label={`Recognition status: ${badge.label}`}
+                          title={badge.tooltip}
                         >
-                          {badgeLabel}
+                          {badge.label}
                         </span>
                       </div>
 

--- a/frontend/src/components/DivisionPerformanceCards.tsx
+++ b/frontend/src/components/DivisionPerformanceCards.tsx
@@ -67,12 +67,12 @@ export const DivisionPerformanceCards: React.FC<
       return []
     }
     try {
-      return extractDivisionPerformance(districtSnapshot)
+      return extractDivisionPerformance(districtSnapshot, snapshotTimestamp)
     } catch (error) {
       logger.error('Error extracting division performance:', error)
       return []
     }
-  }, [districtSnapshot, isLoading])
+  }, [districtSnapshot, isLoading, snapshotTimestamp])
 
   // Loading state
   if (isLoading) {

--- a/frontend/src/components/__tests__/AreaPerformanceRow.test.tsx
+++ b/frontend/src/components/__tests__/AreaPerformanceRow.test.tsx
@@ -2,33 +2,52 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { AreaPerformanceRow } from '../AreaPerformanceRow'
 import { AreaPerformance } from '../../utils/divisionStatus'
+import { deriveAreaRecognitionState } from '../../utils/areaRecognitionState'
 
 describe('AreaPerformanceRow', () => {
   const createMockArea = (
     overrides: Partial<AreaPerformance> = {}
-  ): AreaPerformance => ({
-    areaId: 'A1',
-    status: 'distinguished',
-    clubBase: 10,
-    paidClubs: 10,
-    netGrowth: 0,
-    distinguishedClubs: 5,
-    requiredDistinguishedClubs: 5,
-    firstRoundVisits: {
-      completed: 8,
-      required: 8,
-      percentage: 80,
-      meetsThreshold: true,
-    },
-    secondRoundVisits: {
-      completed: 8,
-      required: 8,
-      percentage: 80,
-      meetsThreshold: true,
-    },
-    isQualified: true,
-    ...overrides,
-  })
+  ): AreaPerformance => {
+    const base: Omit<AreaPerformance, 'recognitionState'> = {
+      areaId: 'A1',
+      status: 'distinguished',
+      clubBase: 10,
+      paidClubs: 10,
+      netGrowth: 0,
+      distinguishedClubs: 5,
+      requiredDistinguishedClubs: 5,
+      firstRoundVisits: {
+        completed: 8,
+        required: 8,
+        percentage: 80,
+        meetsThreshold: true,
+      },
+      secondRoundVisits: {
+        completed: 8,
+        required: 8,
+        percentage: 80,
+        meetsThreshold: true,
+      },
+      isQualified: true,
+      ...overrides,
+    }
+    return {
+      ...base,
+      recognitionState: deriveAreaRecognitionState({
+        clubBase: base.clubBase,
+        paidClubs: base.paidClubs,
+        distinguishedClubs: base.distinguishedClubs,
+        firstRoundVisitMet: base.firstRoundVisits.meetsThreshold,
+        secondRoundVisitMet: base.secondRoundVisits.meetsThreshold,
+        // Mid-PY snapshot — R1 deadline has passed, R2 has not. An R2-unmet
+        // case yields Provisional (label still contains the tier name), so
+        // pre-gate assertions like `toContain("President's Distinguished")`
+        // remain valid. Visits-met cases are Confirmed regardless of date.
+        snapshotDate: '2026-03-15',
+      }),
+      ...overrides,
+    }
+  }
 
   describe('Requirement 9.1: Column Order - Area Identifier Display', () => {
     it('should display the area identifier in the first column', () => {
@@ -577,7 +596,7 @@ describe('AreaPerformanceRow', () => {
 
   describe('Data Integrity', () => {
     it('should display all input values in the rendered output', () => {
-      const area: AreaPerformance = {
+      const area = createMockArea({
         areaId: 'D7',
         status: 'not-qualified',
         clubBase: 8,
@@ -598,7 +617,7 @@ describe('AreaPerformanceRow', () => {
           meetsThreshold: false,
         },
         isQualified: false,
-      }
+      })
 
       const { container } = render(
         <table>

--- a/frontend/src/components/__tests__/AreaPerformanceTable.test.tsx
+++ b/frontend/src/components/__tests__/AreaPerformanceTable.test.tsx
@@ -2,6 +2,28 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { AreaPerformanceTable } from '../AreaPerformanceTable'
 import { AreaPerformance } from '../../utils/divisionStatus'
+import { deriveAreaRecognitionState } from '../../utils/areaRecognitionState'
+
+/**
+ * Add a derived `recognitionState` to a partially-constructed AreaPerformance
+ * fixture. Year-end snapshot keeps legacy "visits met → confirmed" assertions
+ * valid; the deadline-aware gate is verified in `areaRecognitionState.test.ts`.
+ */
+function withState(
+  fixture: Omit<AreaPerformance, 'recognitionState'>
+): AreaPerformance {
+  return {
+    ...fixture,
+    recognitionState: deriveAreaRecognitionState({
+      clubBase: fixture.clubBase,
+      paidClubs: fixture.paidClubs,
+      distinguishedClubs: fixture.distinguishedClubs,
+      firstRoundVisitMet: fixture.firstRoundVisits.meetsThreshold,
+      secondRoundVisitMet: fixture.secondRoundVisits.meetsThreshold,
+      snapshotDate: '2026-06-15',
+    }),
+  }
+}
 
 /**
  * Unit tests for AreaPerformanceTable component
@@ -19,7 +41,7 @@ import { AreaPerformance } from '../../utils/divisionStatus'
  * - Requirement 9.6: Gap columns show number of additional distinguished clubs needed
  */
 describe('AreaPerformanceTable', () => {
-  const mockArea1: AreaPerformance = {
+  const mockArea1: AreaPerformance = withState({
     areaId: 'A1',
     status: 'distinguished',
     clubBase: 10,
@@ -40,9 +62,9 @@ describe('AreaPerformanceTable', () => {
       meetsThreshold: true,
     },
     isQualified: true,
-  }
+  })
 
-  const mockArea2: AreaPerformance = {
+  const mockArea2: AreaPerformance = withState({
     areaId: 'A2',
     status: 'not-qualified',
     clubBase: 8,
@@ -63,9 +85,9 @@ describe('AreaPerformanceTable', () => {
       meetsThreshold: false,
     },
     isQualified: false,
-  }
+  })
 
-  const mockArea3: AreaPerformance = {
+  const mockArea3: AreaPerformance = withState({
     areaId: 'B1',
     status: 'presidents-distinguished',
     clubBase: 12,
@@ -86,7 +108,7 @@ describe('AreaPerformanceTable', () => {
       meetsThreshold: true,
     },
     isQualified: true,
-  }
+  })
 
   describe('Requirement 6.1: Display one row for each area', () => {
     it('should render one row for each area in the areas array', () => {
@@ -433,13 +455,13 @@ describe('AreaPerformanceTable', () => {
     it('should display Select Distinguished badge when criteria met', () => {
       // Create area that meets Select Distinguished criteria
       // paidClubs >= clubBase AND distinguishedClubs >= 50% of clubBase + 1
-      const selectArea: AreaPerformance = {
+      const selectArea: AreaPerformance = withState({
         ...mockArea1,
         areaId: 'S1',
         clubBase: 10,
         paidClubs: 10, // >= clubBase (10) but not clubBase + 1
         distinguishedClubs: 6, // >= 50% of 10 + 1 = 6
-      }
+      })
       render(<AreaPerformanceTable areas={[selectArea]} />)
 
       const badge = screen.getByLabelText(
@@ -452,13 +474,13 @@ describe('AreaPerformanceTable', () => {
     it('should display Distinguished badge when criteria met', () => {
       // Create area that meets Distinguished criteria
       // paidClubs >= clubBase AND distinguishedClubs >= 50% of clubBase
-      const distinguishedArea: AreaPerformance = {
+      const distinguishedArea: AreaPerformance = withState({
         ...mockArea1,
         areaId: 'D1',
         clubBase: 10,
         paidClubs: 10, // >= clubBase (10)
         distinguishedClubs: 5, // >= 50% of 10 = 5
-      }
+      })
       render(<AreaPerformanceTable areas={[distinguishedArea]} />)
 
       const badge = screen.getByLabelText(/Recognition status: Distinguished/i)
@@ -471,13 +493,13 @@ describe('AreaPerformanceTable', () => {
 
     it('should display Not Distinguished badge when no criteria met', () => {
       // Create area that doesn't meet any criteria
-      const notDistinguishedArea: AreaPerformance = {
+      const notDistinguishedArea: AreaPerformance = withState({
         ...mockArea1,
         areaId: 'N1',
         clubBase: 10,
         paidClubs: 10, // >= clubBase (10)
         distinguishedClubs: 4, // < 50% of 10 = 5
-      }
+      })
       render(<AreaPerformanceTable areas={[notDistinguishedArea]} />)
 
       const badge = screen.getByLabelText(

--- a/frontend/src/components/__tests__/AreaProgressSummary.test.tsx
+++ b/frontend/src/components/__tests__/AreaProgressSummary.test.tsx
@@ -33,34 +33,50 @@ import type {
   DivisionPerformance,
   AreaPerformance,
 } from '../../utils/divisionStatus'
+import { deriveAreaRecognitionState } from '../../utils/areaRecognitionState'
 /**
  * Test data factory for creating area data
  */
 const createArea = (
   overrides: Partial<AreaPerformance> = {}
-): AreaPerformance => ({
-  areaId: 'A1',
-  clubBase: 4,
-  paidClubs: 4,
-  distinguishedClubs: 2,
-  netGrowth: 0,
-  requiredDistinguishedClubs: 2,
-  firstRoundVisits: {
-    completed: 4,
-    required: 3,
-    percentage: 100,
-    meetsThreshold: true,
-  },
-  secondRoundVisits: {
-    completed: 2,
-    required: 3,
-    percentage: 50,
-    meetsThreshold: false,
-  },
-  status: 'distinguished',
-  isQualified: true,
-  ...overrides,
-})
+): AreaPerformance => {
+  const base: Omit<AreaPerformance, 'recognitionState'> = {
+    areaId: 'A1',
+    clubBase: 4,
+    paidClubs: 4,
+    distinguishedClubs: 2,
+    netGrowth: 0,
+    requiredDistinguishedClubs: 2,
+    firstRoundVisits: {
+      completed: 4,
+      required: 3,
+      percentage: 100,
+      meetsThreshold: true,
+    },
+    secondRoundVisits: {
+      completed: 2,
+      required: 3,
+      percentage: 50,
+      meetsThreshold: false,
+    },
+    status: 'distinguished',
+    isQualified: true,
+    ...overrides,
+  }
+  return {
+    ...base,
+    recognitionState: deriveAreaRecognitionState({
+      clubBase: base.clubBase,
+      paidClubs: base.paidClubs,
+      distinguishedClubs: base.distinguishedClubs,
+      firstRoundVisitMet: base.firstRoundVisits.meetsThreshold,
+      secondRoundVisitMet: base.secondRoundVisits.meetsThreshold,
+      // Mid-year snapshot: R1 deadline already passed, R2 still pending.
+      snapshotDate: '2026-03-15',
+    }),
+    ...overrides,
+  }
+}
 
 /**
  * Helper to group flat area data into DivisionPerformance[] format.

--- a/frontend/src/components/__tests__/DivisionAreaPerformance.accessibility.test.tsx
+++ b/frontend/src/components/__tests__/DivisionAreaPerformance.accessibility.test.tsx
@@ -34,6 +34,23 @@ import type {
   DivisionPerformance,
   AreaPerformance,
 } from '../../types/performance'
+import { deriveAreaRecognitionState } from '../../utils/areaRecognitionState'
+
+function withState(
+  fixture: Omit<AreaPerformance, 'recognitionState'>
+): AreaPerformance {
+  return {
+    ...fixture,
+    recognitionState: deriveAreaRecognitionState({
+      clubBase: fixture.clubBase,
+      paidClubs: fixture.paidClubs,
+      distinguishedClubs: fixture.distinguishedClubs,
+      firstRoundVisitMet: fixture.firstRoundVisits.meetsThreshold,
+      secondRoundVisitMet: fixture.secondRoundVisits.meetsThreshold,
+      snapshotDate: '2026-06-15',
+    }),
+  }
+}
 
 // Extend expect with jest-axe matchers
 // @ts-expect-error - jest-axe types are not perfectly compatible with vitest expect
@@ -132,7 +149,7 @@ const createMockDivisionPerformance = (): DivisionPerformance => ({
   distinguishedClubs: 6,
   requiredDistinguishedClubs: 5,
   areas: [
-    {
+    withState({
       areaId: 'A1',
       status: 'presidents-distinguished',
       clubBase: 5,
@@ -153,8 +170,8 @@ const createMockDivisionPerformance = (): DivisionPerformance => ({
         meetsThreshold: true,
       },
       isQualified: true,
-    },
-    {
+    }),
+    withState({
       areaId: 'A2',
       status: 'distinguished',
       clubBase: 5,
@@ -175,32 +192,33 @@ const createMockDivisionPerformance = (): DivisionPerformance => ({
         meetsThreshold: false,
       },
       isQualified: false,
-    },
+    }),
   ],
 })
 
-const createMockAreaPerformance = (): AreaPerformance => ({
-  areaId: 'A1',
-  status: 'presidents-distinguished',
-  clubBase: 5,
-  paidClubs: 6,
-  netGrowth: 1,
-  distinguishedClubs: 3,
-  requiredDistinguishedClubs: 3,
-  firstRoundVisits: {
-    completed: 4,
-    required: 4,
-    percentage: 80,
-    meetsThreshold: true,
-  },
-  secondRoundVisits: {
-    completed: 4,
-    required: 4,
-    percentage: 80,
-    meetsThreshold: true,
-  },
-  isQualified: true,
-})
+const createMockAreaPerformance = (): AreaPerformance =>
+  withState({
+    areaId: 'A1',
+    status: 'presidents-distinguished',
+    clubBase: 5,
+    paidClubs: 6,
+    netGrowth: 1,
+    distinguishedClubs: 3,
+    requiredDistinguishedClubs: 3,
+    firstRoundVisits: {
+      completed: 4,
+      required: 4,
+      percentage: 80,
+      meetsThreshold: true,
+    },
+    secondRoundVisits: {
+      completed: 4,
+      required: 4,
+      percentage: 80,
+      meetsThreshold: true,
+    },
+    isQualified: true,
+  })
 
 describe('Division and Area Performance Components - Accessibility Audit', () => {
   describe('DivisionPerformanceCards - axe-core validation', () => {

--- a/frontend/src/components/__tests__/DivisionAreaRecognitionPanel.test.tsx
+++ b/frontend/src/components/__tests__/DivisionAreaRecognitionPanel.test.tsx
@@ -38,6 +38,7 @@ const cleanupAllResources = () => cleanup()
 import '@testing-library/jest-dom'
 import { DivisionAreaRecognitionPanel } from '../DivisionAreaRecognitionPanel'
 import { DivisionPerformance } from '../../utils/divisionStatus'
+import { withRecognitionState } from '../../test-utils/areaFixture'
 /**
  * Test data factory for creating division performance data
  */
@@ -46,7 +47,7 @@ const createDivision = (
 ): DivisionPerformance => ({
   divisionId: 'A',
   areas: [
-    {
+    withRecognitionState({
       areaId: 'A1',
       clubBase: 4,
       paidClubs: 3,
@@ -67,7 +68,7 @@ const createDivision = (
       },
       status: 'distinguished',
       isQualified: true,
-    },
+    }),
   ],
   clubBase: 4,
   paidClubs: 3,
@@ -86,28 +87,30 @@ const createDivisionWithAreas = (
   areaIds: string[]
 ): DivisionPerformance => ({
   divisionId,
-  areas: areaIds.map(areaId => ({
-    areaId,
-    clubBase: 4,
-    paidClubs: 3,
-    distinguishedClubs: 2,
-    netGrowth: 0,
-    requiredDistinguishedClubs: 2,
-    firstRoundVisits: {
-      completed: 4,
-      required: 3,
-      percentage: 100,
-      meetsThreshold: true,
-    },
-    secondRoundVisits: {
-      completed: 2,
-      required: 3,
-      percentage: 50,
-      meetsThreshold: false,
-    },
-    status: 'distinguished' as const,
-    isQualified: true,
-  })),
+  areas: areaIds.map(areaId =>
+    withRecognitionState({
+      areaId,
+      clubBase: 4,
+      paidClubs: 3,
+      distinguishedClubs: 2,
+      netGrowth: 0,
+      requiredDistinguishedClubs: 2,
+      firstRoundVisits: {
+        completed: 4,
+        required: 3,
+        percentage: 100,
+        meetsThreshold: true,
+      },
+      secondRoundVisits: {
+        completed: 2,
+        required: 3,
+        percentage: 50,
+        meetsThreshold: false,
+      },
+      status: 'distinguished' as const,
+      isQualified: true,
+    })
+  ),
   clubBase: 4 * areaIds.length,
   paidClubs: 3 * areaIds.length,
   distinguishedClubs: 2 * areaIds.length,
@@ -599,7 +602,7 @@ describe('DivisionAreaRecognitionPanel', () => {
           ...createDivision(),
           divisionId: 'A',
           areas: [
-            {
+            withRecognitionState({
               areaId: 'A1',
               clubBase: 5,
               paidClubs: 4,
@@ -620,7 +623,7 @@ describe('DivisionAreaRecognitionPanel', () => {
               },
               status: 'select-distinguished' as const,
               isQualified: true,
-            },
+            }),
           ],
         },
       ]
@@ -734,7 +737,7 @@ describe('DivisionAreaRecognitionPanel', () => {
           ...createDivision(),
           divisionId: 'A',
           areas: [
-            {
+            withRecognitionState({
               areaId: 'A1',
               clubBase: 4,
               paidClubs: 4,
@@ -755,7 +758,7 @@ describe('DivisionAreaRecognitionPanel', () => {
               },
               status: 'distinguished' as const,
               isQualified: true,
-            },
+            }),
           ],
         },
       ]
@@ -827,7 +830,7 @@ describe('DivisionAreaRecognitionPanel', () => {
           divisionId: 'A',
           areas: [
             // Distinguished area
-            {
+            withRecognitionState({
               areaId: 'A1',
               clubBase: 4,
               paidClubs: 4,
@@ -848,7 +851,7 @@ describe('DivisionAreaRecognitionPanel', () => {
               },
               status: 'distinguished' as const,
               isQualified: true,
-            },
+            }),
           ],
         },
       ]

--- a/frontend/src/components/__tests__/DivisionPerformanceCard.test.tsx
+++ b/frontend/src/components/__tests__/DivisionPerformanceCard.test.tsx
@@ -12,6 +12,7 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { DivisionPerformanceCard } from '../DivisionPerformanceCard'
 import type { DivisionPerformance } from '../../utils/divisionStatus'
+import { withRecognitionState } from '../../test-utils/areaFixture'
 
 describe('DivisionPerformanceCard', () => {
   const mockDivision: DivisionPerformance = {
@@ -23,7 +24,7 @@ describe('DivisionPerformanceCard', () => {
     distinguishedClubs: 26,
     requiredDistinguishedClubs: 25,
     areas: [
-      {
+      withRecognitionState({
         areaId: 'A1',
         status: 'distinguished',
         clubBase: 10,
@@ -44,8 +45,8 @@ describe('DivisionPerformanceCard', () => {
           meetsThreshold: true,
         },
         isQualified: true,
-      },
-      {
+      }),
+      withRecognitionState({
         areaId: 'A2',
         status: 'not-qualified',
         clubBase: 8,
@@ -66,7 +67,7 @@ describe('DivisionPerformanceCard', () => {
           meetsThreshold: true,
         },
         isQualified: false,
-      },
+      }),
     ],
   }
 

--- a/frontend/src/components/__tests__/DivisionPerformanceCards.test.tsx
+++ b/frontend/src/components/__tests__/DivisionPerformanceCards.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../../utils/dateFormatting', () => ({
 
 import { extractDivisionPerformance } from '../../utils/extractDivisionPerformance'
 import type { DivisionPerformance } from '../../utils/divisionStatus'
+import { withRecognitionState } from '../../test-utils/areaFixture'
 
 describe('DivisionPerformanceCards', () => {
   const mockDivisions: DivisionPerformance[] = [
@@ -44,7 +45,7 @@ describe('DivisionPerformanceCards', () => {
       distinguishedClubs: 26,
       requiredDistinguishedClubs: 25,
       areas: [
-        {
+        withRecognitionState({
           areaId: 'A1',
           status: 'distinguished',
           clubBase: 10,
@@ -65,7 +66,7 @@ describe('DivisionPerformanceCards', () => {
             meetsThreshold: true,
           },
           isQualified: true,
-        },
+        }),
       ],
     },
     {
@@ -77,7 +78,7 @@ describe('DivisionPerformanceCards', () => {
       distinguishedClubs: 21,
       requiredDistinguishedClubs: 20,
       areas: [
-        {
+        withRecognitionState({
           areaId: 'B1',
           status: 'select-distinguished',
           clubBase: 8,
@@ -98,7 +99,7 @@ describe('DivisionPerformanceCards', () => {
             meetsThreshold: true,
           },
           isQualified: true,
-        },
+        }),
       ],
     },
   ]
@@ -328,7 +329,13 @@ describe('DivisionPerformanceCards', () => {
         />
       )
 
-      expect(extractDivisionPerformance).toHaveBeenCalledWith(mockSnapshot)
+      // Snapshot date is forwarded so the source-of-truth gate is
+      // snapshot-relative, not wall-clock (#832). Undefined when no
+      // `snapshotTimestamp` prop is provided.
+      expect(extractDivisionPerformance).toHaveBeenCalledWith(
+        mockSnapshot,
+        undefined
+      )
       expect(extractDivisionPerformance).toHaveBeenCalledTimes(1)
     })
   })

--- a/frontend/src/pages/DistrictDivisionsPage.tsx
+++ b/frontend/src/pages/DistrictDivisionsPage.tsx
@@ -153,7 +153,10 @@ const DistrictDivisionsPage: React.FC = () => {
 
             {districtStatistics ? (
               <DivisionAreaRecognitionPanel
-                divisions={extractDivisionPerformance(districtStatistics)}
+                divisions={extractDivisionPerformance(
+                  districtStatistics,
+                  districtStatistics.asOfDate
+                )}
                 isLoading={isLoadingStatistics}
               />
             ) : (

--- a/frontend/src/test-utils/areaFixture.ts
+++ b/frontend/src/test-utils/areaFixture.ts
@@ -1,0 +1,29 @@
+/**
+ * Test helper: derive `recognitionState` for a partial `AreaPerformance` fixture.
+ *
+ * The component tests don't care about the snapshot-date-aware gate (that's
+ * exhaustively tested in `areaRecognitionState.test.ts`). They just need the
+ * required field present so the presenter can render. Default snapshot date
+ * is mid-PY (`2026-03-15`): R1 deadline has passed but R2 hasn't, so a
+ * single-round-unmet fixture yields Provisional rather than hard-fail —
+ * preserving pre-#832 "tier name appears in badge" assertions.
+ */
+import type { AreaPerformance } from '../utils/divisionStatus'
+import { deriveAreaRecognitionState } from '../utils/areaRecognitionState'
+
+export function withRecognitionState(
+  fixture: Omit<AreaPerformance, 'recognitionState'>,
+  snapshotDate = '2026-03-15'
+): AreaPerformance {
+  return {
+    ...fixture,
+    recognitionState: deriveAreaRecognitionState({
+      clubBase: fixture.clubBase,
+      paidClubs: fixture.paidClubs,
+      distinguishedClubs: fixture.distinguishedClubs,
+      firstRoundVisitMet: fixture.firstRoundVisits.meetsThreshold,
+      secondRoundVisitMet: fixture.secondRoundVisits.meetsThreshold,
+      snapshotDate,
+    }),
+  }
+}

--- a/frontend/src/test-utils/generators/divisionPerformance.ts
+++ b/frontend/src/test-utils/generators/divisionPerformance.ts
@@ -28,6 +28,7 @@ import type {
   AreaPerformance,
   VisitStatus,
 } from '../../utils/divisionStatus'
+import { deriveAreaRecognitionState } from '../../utils/areaRecognitionState'
 
 /**
  * Generator for division identifiers (A-Z, AA-ZZ)
@@ -264,6 +265,16 @@ export const areaPerformanceArb = (options?: {
             firstRoundVisits,
             secondRoundVisits,
             isQualified,
+            recognitionState: deriveAreaRecognitionState({
+              clubBase,
+              paidClubs,
+              distinguishedClubs,
+              firstRoundVisitMet: firstRoundVisits.meetsThreshold,
+              secondRoundVisitMet: secondRoundVisits.meetsThreshold,
+              // Mid-year snapshot so the generator yields a stable mix of
+              // confirmed/provisional/not-distinguished states.
+              snapshotDate: '2026-03-15',
+            }),
           }
         })
     })

--- a/frontend/src/utils/__tests__/areaRecognitionState.test.ts
+++ b/frontend/src/utils/__tests__/areaRecognitionState.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for snapshot-date-aware area recognition gating (#832).
+ *
+ * Source-of-truth for area Distinguished/Select/President's recognition
+ * with the qualifying club-visit requirement enforced as either:
+ *   - Confirmed       (visits met)
+ *   - Provisional     (visits unmet but deadline has not passed)
+ *   - Not Distinguished (visits unmet AND deadline has passed → hard fail)
+ *
+ * Deadlines per Toastmasters District Recognition Program manual (item 1490 p.10):
+ *   - R1: ≥75% of area's club base visited by Nov 30 of the program year start
+ *   - R2: ≥75% by May 31 of the program year end
+ *
+ * Reference date is the snapshot's `asOfDate`, not wall-clock (so historical
+ * snapshots gate correctly).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  deriveAreaRecognitionState,
+  getAreaVisitDeadlines,
+  type AreaRecognitionInput,
+} from '../areaRecognitionState'
+
+function input(
+  overrides: Partial<AreaRecognitionInput> = {}
+): AreaRecognitionInput {
+  return {
+    // Default: an area that earns Distinguished on metrics (50% of 10 = 5)
+    clubBase: 10,
+    paidClubs: 10,
+    distinguishedClubs: 5,
+    firstRoundVisitMet: true,
+    secondRoundVisitMet: true,
+    snapshotDate: '2026-06-15', // post both deadlines
+    ...overrides,
+  }
+}
+
+describe('getAreaVisitDeadlines (program-year anchoring)', () => {
+  it('anchors deadlines to the snapshot date program year (Aug 2026 → PY 2026-2027)', () => {
+    expect(getAreaVisitDeadlines('2026-08-15')).toEqual({
+      r1: '2026-11-30',
+      r2: '2027-05-31',
+    })
+  })
+
+  it('anchors deadlines correctly for Jan snapshot (PY 2025-2026 still active)', () => {
+    expect(getAreaVisitDeadlines('2026-01-15')).toEqual({
+      r1: '2025-11-30',
+      r2: '2026-05-31',
+    })
+  })
+
+  it('handles July 1 program-year boundary (Jul 1 = new PY start)', () => {
+    expect(getAreaVisitDeadlines('2026-07-01')).toEqual({
+      r1: '2026-11-30',
+      r2: '2027-05-31',
+    })
+  })
+
+  it('handles June 30 as last day of prior PY', () => {
+    expect(getAreaVisitDeadlines('2026-06-30')).toEqual({
+      r1: '2025-11-30',
+      r2: '2026-05-31',
+    })
+  })
+})
+
+describe('deriveAreaRecognitionState — earned tier × deadline-aware visits', () => {
+  describe('CONFIRMED (both rounds met)', () => {
+    it("confirms Distinguished when both rounds met at year's end", () => {
+      const s = deriveAreaRecognitionState(input({ snapshotDate: '2026-06-15' }))
+      expect(s.level).toBe('distinguished')
+      expect(s.status).toBe('confirmed')
+      expect(s.pendingRounds).toEqual([])
+      expect(s.failureReason).toBeNull()
+    })
+
+    it('confirms Select Distinguished tier when earned + both rounds met', () => {
+      const s = deriveAreaRecognitionState(
+        input({ distinguishedClubs: 6, snapshotDate: '2026-06-15' })
+      )
+      expect(s.level).toBe('select')
+      expect(s.status).toBe('confirmed')
+    })
+
+    it("confirms President's Distinguished tier when earned + both rounds met", () => {
+      const s = deriveAreaRecognitionState(
+        input({
+          paidClubs: 11,
+          distinguishedClubs: 6,
+          snapshotDate: '2026-06-15',
+        })
+      )
+      expect(s.level).toBe('presidents')
+      expect(s.status).toBe('confirmed')
+    })
+  })
+
+  describe('PROVISIONAL (unmet round whose deadline has not passed)', () => {
+    it('flags Provisional in October when R1 unmet (R1 not yet due)', () => {
+      const s = deriveAreaRecognitionState(
+        input({
+          firstRoundVisitMet: false,
+          secondRoundVisitMet: false,
+          snapshotDate: '2026-10-15',
+        })
+      )
+      expect(s.level).toBe('distinguished')
+      expect(s.status).toBe('provisional')
+      expect(s.pendingRounds).toEqual([
+        { round: 1, deadline: '2026-11-30' },
+        { round: 2, deadline: '2027-05-31' },
+      ])
+      expect(s.failureReason).toBeNull()
+    })
+
+    it('flags Provisional in March when R1 met but R2 unmet (R2 not yet due)', () => {
+      const s = deriveAreaRecognitionState(
+        input({
+          firstRoundVisitMet: true,
+          secondRoundVisitMet: false,
+          snapshotDate: '2026-03-10',
+        })
+      )
+      expect(s.status).toBe('provisional')
+      expect(s.pendingRounds).toEqual([{ round: 2, deadline: '2026-05-31' }])
+    })
+
+    it('flags Provisional on Nov 30 itself (deadline day not yet PAST)', () => {
+      // Operator rule: passed(R) = snapshotDate > deadline(R) (strict >).
+      const s = deriveAreaRecognitionState(
+        input({
+          firstRoundVisitMet: false,
+          secondRoundVisitMet: false,
+          snapshotDate: '2026-11-30',
+        })
+      )
+      expect(s.status).toBe('provisional')
+    })
+  })
+
+  describe('NOT DISTINGUISHED — hard fail (deadline passed unmet)', () => {
+    it('hard-fails Distinguished in December when R1 still unmet', () => {
+      const s = deriveAreaRecognitionState(
+        input({
+          firstRoundVisitMet: false,
+          secondRoundVisitMet: true,
+          snapshotDate: '2026-12-05',
+        })
+      )
+      expect(s.level).toBe('none')
+      expect(s.status).toBe('not-distinguished')
+      expect(s.pendingRounds).toEqual([])
+      expect(s.failureReason).toBe('missed-deadline')
+    })
+
+    it('hard-fails in June when R2 deadline passed unmet (even if R1 was met)', () => {
+      const s = deriveAreaRecognitionState(
+        input({
+          firstRoundVisitMet: true,
+          secondRoundVisitMet: false,
+          snapshotDate: '2026-06-15',
+        })
+      )
+      expect(s.status).toBe('not-distinguished')
+      expect(s.failureReason).toBe('missed-deadline')
+    })
+
+    it('hard-fails when BOTH deadlines passed unmet', () => {
+      const s = deriveAreaRecognitionState(
+        input({
+          firstRoundVisitMet: false,
+          secondRoundVisitMet: false,
+          snapshotDate: '2026-06-15',
+        })
+      )
+      expect(s.status).toBe('not-distinguished')
+      expect(s.failureReason).toBe('missed-deadline')
+    })
+
+    it('hard-fail on Dec 1 (Nov 30 strictly passed)', () => {
+      const s = deriveAreaRecognitionState(
+        input({
+          firstRoundVisitMet: false,
+          secondRoundVisitMet: true,
+          snapshotDate: '2026-12-01',
+        })
+      )
+      expect(s.status).toBe('not-distinguished')
+      expect(s.failureReason).toBe('missed-deadline')
+    })
+  })
+
+  describe('Earned-tier gate (does not earn tier on metrics)', () => {
+    it('returns Not Distinguished when distinguished < 50% regardless of visits', () => {
+      const s = deriveAreaRecognitionState(
+        input({ distinguishedClubs: 4, snapshotDate: '2026-06-15' })
+      )
+      expect(s.level).toBe('none')
+      expect(s.status).toBe('not-distinguished')
+      expect(s.failureReason).toBe('insufficient-distinguished')
+    })
+
+    it('flags Net Loss reason when paid < base (separate from visit gate)', () => {
+      const s = deriveAreaRecognitionState(
+        input({ paidClubs: 8, snapshotDate: '2026-06-15' })
+      )
+      expect(s.level).toBe('none')
+      expect(s.status).toBe('not-distinguished')
+      expect(s.failureReason).toBe('net-loss')
+    })
+
+    it('net-loss takes precedence over missed-deadline as the displayed reason', () => {
+      const s = deriveAreaRecognitionState(
+        input({
+          paidClubs: 8, // net loss
+          firstRoundVisitMet: false, // and visits missed
+          snapshotDate: '2026-12-15',
+        })
+      )
+      expect(s.failureReason).toBe('net-loss')
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('handles zero clubBase as Not Distinguished', () => {
+      const s = deriveAreaRecognitionState(
+        input({
+          clubBase: 0,
+          paidClubs: 0,
+          distinguishedClubs: 0,
+          snapshotDate: '2026-06-15',
+        })
+      )
+      expect(s.level).toBe('none')
+      expect(s.status).toBe('not-distinguished')
+    })
+
+    it('handles snapshot before any deadline (early August)', () => {
+      const s = deriveAreaRecognitionState(
+        input({
+          firstRoundVisitMet: false,
+          secondRoundVisitMet: false,
+          snapshotDate: '2026-08-05',
+        })
+      )
+      expect(s.status).toBe('provisional')
+      expect(s.pendingRounds).toHaveLength(2)
+    })
+  })
+})

--- a/frontend/src/utils/__tests__/areaRecognitionState.test.ts
+++ b/frontend/src/utils/__tests__/areaRecognitionState.test.ts
@@ -69,7 +69,9 @@ describe('getAreaVisitDeadlines (program-year anchoring)', () => {
 describe('deriveAreaRecognitionState — earned tier × deadline-aware visits', () => {
   describe('CONFIRMED (both rounds met)', () => {
     it("confirms Distinguished when both rounds met at year's end", () => {
-      const s = deriveAreaRecognitionState(input({ snapshotDate: '2026-06-15' }))
+      const s = deriveAreaRecognitionState(
+        input({ snapshotDate: '2026-06-15' })
+      )
       expect(s.level).toBe('distinguished')
       expect(s.status).toBe('confirmed')
       expect(s.pendingRounds).toEqual([])

--- a/frontend/src/utils/__tests__/areaRecognitionState.test.ts
+++ b/frontend/src/utils/__tests__/areaRecognitionState.test.ts
@@ -225,6 +225,30 @@ describe('deriveAreaRecognitionState — earned tier × deadline-aware visits', 
     })
   })
 
+  describe('Snapshot date format normalisation', () => {
+    it('treats an ISO timestamp on the deadline day as still-pending (not hard-fail)', () => {
+      // Without normalisation, `'2026-11-30T15:00:00Z' > '2026-11-30'` is
+      // lexically true and the area would hard-fail mid-deadline-day.
+      const s = deriveAreaRecognitionState(
+        input({
+          firstRoundVisitMet: false,
+          secondRoundVisitMet: false,
+          snapshotDate: '2026-11-30T15:00:00Z',
+        })
+      )
+      expect(s.status).toBe('provisional')
+      expect(s.failureReason).toBeNull()
+    })
+
+    it('anchors the PY correctly for an ISO timestamp around the Jul 1 boundary', () => {
+      // '2026-07-01T05:00:00Z' must anchor to PY 2026-2027, not 2025-2026.
+      expect(getAreaVisitDeadlines('2026-07-01T05:00:00Z')).toEqual({
+        r1: '2026-11-30',
+        r2: '2027-05-31',
+      })
+    })
+  })
+
   describe('Edge cases', () => {
     it('handles zero clubBase as Not Distinguished', () => {
       const s = deriveAreaRecognitionState(

--- a/frontend/src/utils/areaRecognitionBadge.ts
+++ b/frontend/src/utils/areaRecognitionBadge.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure presenter for the area-recognition badge (#832).
+ *
+ * Maps an `AreaRecognitionState` (the source-of-truth gate) to badge
+ * label + Tailwind classes + tooltip copy. The deadline-aware gating
+ * lives in `deriveAreaRecognitionState`; this module is cosmetic only.
+ */
+import type {
+  AreaRecognitionState,
+  PendingRound,
+} from './areaRecognitionState'
+
+export interface BadgePresentation {
+  label: string
+  className: string
+  tooltip?: string
+}
+
+const TIER_LABEL: Record<'presidents' | 'select' | 'distinguished', string> = {
+  presidents: "President's Distinguished",
+  select: 'Select Distinguished',
+  distinguished: 'Distinguished',
+}
+
+const CONFIRMED_CLASS: Record<
+  'presidents' | 'select' | 'distinguished',
+  string
+> = {
+  presidents:
+    'bg-tm-happy-yellow text-gray-900 border-yellow-500 font-semibold',
+  select: 'bg-tm-cool-gray text-gray-900 border-gray-400',
+  distinguished: 'bg-tm-true-maroon text-white border-tm-true-maroon',
+}
+
+const PROVISIONAL_CLASS = 'bg-amber-100 text-amber-800 border-amber-300'
+const NOT_DISTINGUISHED_CLASS = 'bg-gray-100 text-gray-600 border-gray-300'
+const NET_LOSS_CLASS = 'bg-red-100 text-red-800 border-red-300'
+
+function formatDeadline(deadline: string): string {
+  // YYYY-MM-DD → "MMM D" (e.g. "Nov 30", "May 31"). Parse as UTC so the
+  // month doesn't shift in timezones west of UTC.
+  const [, mm, dd] = deadline.split('-').map(s => Number.parseInt(s, 10))
+  const date = new Date(Date.UTC(2000, (mm ?? 1) - 1, dd ?? 1))
+  const month = date.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })
+  return `${month} ${dd}`
+}
+
+export function pendingRoundsTooltip(rounds: PendingRound[]): string {
+  if (rounds.length === 0) return ''
+  const labels = rounds.map(({ round, deadline }) => {
+    const ordinal = round === 1 ? '1st' : '2nd'
+    return `${ordinal}-round visits due ${formatDeadline(deadline)}`
+  })
+  return `Pending: ${labels.join('; ')}`
+}
+
+/**
+ * Render a recognition badge from the source-of-truth state.
+ *
+ * @param state - The gated recognition state from `deriveAreaRecognitionState`.
+ */
+export function renderRecognitionBadge(
+  state: AreaRecognitionState
+): BadgePresentation {
+  if (state.status === 'confirmed' && state.level !== 'none') {
+    return {
+      label: TIER_LABEL[state.level],
+      className: CONFIRMED_CLASS[state.level],
+    }
+  }
+
+  if (state.status === 'provisional' && state.level !== 'none') {
+    return {
+      label: `${TIER_LABEL[state.level]} (Provisional)`,
+      className: PROVISIONAL_CLASS,
+      tooltip: pendingRoundsTooltip(state.pendingRounds),
+    }
+  }
+
+  // not-distinguished
+  if (state.failureReason === 'net-loss') {
+    return { label: 'Net Loss', className: NET_LOSS_CLASS }
+  }
+  return { label: 'Not Distinguished', className: NOT_DISTINGUISHED_CLASS }
+}

--- a/frontend/src/utils/areaRecognitionBadge.ts
+++ b/frontend/src/utils/areaRecognitionBadge.ts
@@ -6,6 +6,7 @@
  * lives in `deriveAreaRecognitionState`; this module is cosmetic only.
  */
 import type { AreaRecognitionState, PendingRound } from './areaRecognitionState'
+import { formatShortDate } from './dateFormatting'
 
 export interface BadgePresentation {
   label: string
@@ -33,23 +34,11 @@ const PROVISIONAL_CLASS = 'bg-amber-100 text-amber-800 border-amber-300'
 const NOT_DISTINGUISHED_CLASS = 'bg-gray-100 text-gray-600 border-gray-300'
 const NET_LOSS_CLASS = 'bg-red-100 text-red-800 border-red-300'
 
-function formatDeadline(deadline: string): string {
-  // YYYY-MM-DD → "MMM D" (e.g. "Nov 30", "May 31"). Parse as UTC so the
-  // month doesn't shift in timezones west of UTC.
-  const [, mm, dd] = deadline.split('-').map(s => Number.parseInt(s, 10))
-  const date = new Date(Date.UTC(2000, (mm ?? 1) - 1, dd ?? 1))
-  const month = date.toLocaleString('en-US', {
-    month: 'short',
-    timeZone: 'UTC',
-  })
-  return `${month} ${dd}`
-}
-
 export function pendingRoundsTooltip(rounds: PendingRound[]): string {
   if (rounds.length === 0) return ''
   const labels = rounds.map(({ round, deadline }) => {
     const ordinal = round === 1 ? '1st' : '2nd'
-    return `${ordinal}-round visits due ${formatDeadline(deadline)}`
+    return `${ordinal}-round visits due ${formatShortDate(deadline)}`
   })
   return `Pending: ${labels.join('; ')}`
 }

--- a/frontend/src/utils/areaRecognitionBadge.ts
+++ b/frontend/src/utils/areaRecognitionBadge.ts
@@ -5,10 +5,7 @@
  * label + Tailwind classes + tooltip copy. The deadline-aware gating
  * lives in `deriveAreaRecognitionState`; this module is cosmetic only.
  */
-import type {
-  AreaRecognitionState,
-  PendingRound,
-} from './areaRecognitionState'
+import type { AreaRecognitionState, PendingRound } from './areaRecognitionState'
 
 export interface BadgePresentation {
   label: string
@@ -41,7 +38,10 @@ function formatDeadline(deadline: string): string {
   // month doesn't shift in timezones west of UTC.
   const [, mm, dd] = deadline.split('-').map(s => Number.parseInt(s, 10))
   const date = new Date(Date.UTC(2000, (mm ?? 1) - 1, dd ?? 1))
-  const month = date.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })
+  const month = date.toLocaleString('en-US', {
+    month: 'short',
+    timeZone: 'UTC',
+  })
   return `${month} ${dd}`
 }
 

--- a/frontend/src/utils/areaRecognitionState.ts
+++ b/frontend/src/utils/areaRecognitionState.ts
@@ -66,13 +66,29 @@ export interface AreaRecognitionInput {
 }
 
 /**
+ * Normalise any ISO-shaped input to `YYYY-MM-DD`. Date-only strings pass
+ * through; full ISO timestamps (`'2025-11-30T15:00:00Z'`) get sliced so
+ * the lexical `snapshotDate > deadline` comparison below holds the
+ * "deadline day itself is not yet passed" invariant — without the slice,
+ * any time-of-day suffix lexically sorts after the bare date and flips
+ * the comparison on the deadline day itself.
+ */
+function toIsoDate(dateStr: string): string {
+  return dateStr.slice(0, 10)
+}
+
+/**
  * Program-year anchor: Jul 1 starts a new PY.
  * Returns the 4-digit start year for the PY containing `dateStr`.
+ *
+ * String-slice parsing is intentional — `new Date(yyyy-mm-dd).getFullYear()`
+ * is timezone-sensitive (UTC midnight in `Date` parses to the prior local
+ * day west of UTC), so we side-step the JS `Date` constructor entirely.
  */
 function programYearStartYear(dateStr: string): number {
-  // Parse YYYY-MM-DD without timezone drift — string slice is sufficient.
-  const year = Number.parseInt(dateStr.slice(0, 4), 10)
-  const month = Number.parseInt(dateStr.slice(5, 7), 10)
+  const iso = toIsoDate(dateStr)
+  const year = Number.parseInt(iso.slice(0, 4), 10)
+  const month = Number.parseInt(iso.slice(5, 7), 10)
   return month >= 7 ? year : year - 1
 }
 
@@ -133,9 +149,12 @@ export function deriveAreaRecognitionState(
   }
 
   const { r1, r2 } = getAreaVisitDeadlines(snapshotDate)
-  // Strict `>` per the operator spec: the deadline day itself is still "not yet passed".
-  const r1Passed = snapshotDate > r1
-  const r2Passed = snapshotDate > r2
+  // Strict `>` on date-only strings. Normalising via `toIsoDate` guards
+  // against ISO-timestamp callers (`'2025-11-30T15:00:00Z' > '2025-11-30'`
+  // would otherwise be true and silently flip the deadline-day case).
+  const isoSnapshot = toIsoDate(snapshotDate)
+  const r1Passed = isoSnapshot > r1
+  const r2Passed = isoSnapshot > r2
 
   const hardFailR1 = r1Passed && !firstRoundVisitMet
   const hardFailR2 = r2Passed && !secondRoundVisitMet

--- a/frontend/src/utils/areaRecognitionState.ts
+++ b/frontend/src/utils/areaRecognitionState.ts
@@ -1,0 +1,170 @@
+/**
+ * Area Recognition Gate — snapshot-date-aware (#832).
+ *
+ * Source-of-truth that enforces the Distinguished Area Program qualifying
+ * club-visit requirement (item 1490, p.10 of the Toastmasters District
+ * Recognition Program manual):
+ *
+ *   - R1: ≥75% of the area's club base visited by **Nov 30**
+ *         of the program-year start year
+ *   - R2: ≥75% by **May 31** of the program-year end year
+ *
+ * For an area that earns Distinguished/Select/President's on club metrics
+ * (50% / 50%+1 / 50%+1+growth), this gate returns:
+ *
+ *   - 'confirmed'           — all rounds met
+ *   - 'provisional'         — a round is unmet but its deadline has NOT passed
+ *   - 'not-distinguished'   — a round's deadline has passed unmet (hard fail)
+ *
+ * Reference date is the snapshot's `asOfDate` (not wall-clock) so historical
+ * snapshots gate correctly.
+ *
+ * `AreaPerformanceRow` is a pure presenter that reads this state — it must
+ * NOT re-derive deadline-blind provisional logic locally. See #832.
+ */
+
+import {
+  determineRecognitionLevel,
+  type RecognitionLevel,
+} from './areaGapAnalysis'
+
+export type AreaRecognitionLevel = RecognitionLevel
+export type AreaRecognitionStatus =
+  | 'confirmed'
+  | 'provisional'
+  | 'not-distinguished'
+
+export type AreaRecognitionFailureReason =
+  | 'net-loss'
+  | 'missed-deadline'
+  | 'insufficient-distinguished'
+  | null
+
+export interface PendingRound {
+  round: 1 | 2
+  /** Deadline as an ISO `YYYY-MM-DD` string (Nov 30 or May 31). */
+  deadline: string
+}
+
+export interface AreaRecognitionState {
+  /** Earned tier on club metrics, OR `'none'` if visit gate hard-failed. */
+  level: AreaRecognitionLevel
+  status: AreaRecognitionStatus
+  /** Visit rounds still pending (only populated for `'provisional'`). */
+  pendingRounds: PendingRound[]
+  failureReason: AreaRecognitionFailureReason
+}
+
+export interface AreaRecognitionInput {
+  clubBase: number
+  paidClubs: number
+  distinguishedClubs: number
+  firstRoundVisitMet: boolean
+  secondRoundVisitMet: boolean
+  /** Snapshot/as-of date in `YYYY-MM-DD` form. */
+  snapshotDate: string
+}
+
+/**
+ * Program-year anchor: Jul 1 starts a new PY.
+ * Returns the 4-digit start year for the PY containing `dateStr`.
+ */
+function programYearStartYear(dateStr: string): number {
+  // Parse YYYY-MM-DD without timezone drift — string slice is sufficient.
+  const year = Number.parseInt(dateStr.slice(0, 4), 10)
+  const month = Number.parseInt(dateStr.slice(5, 7), 10)
+  return month >= 7 ? year : year - 1
+}
+
+/**
+ * Returns the R1 and R2 deadlines for the program year containing `snapshotDate`.
+ */
+export function getAreaVisitDeadlines(snapshotDate: string): {
+  r1: string
+  r2: string
+} {
+  const start = programYearStartYear(snapshotDate)
+  return {
+    r1: `${start}-11-30`,
+    r2: `${start + 1}-05-31`,
+  }
+}
+
+/**
+ * Derive area recognition state, gated on the visit requirement with
+ * snapshot-date deadline awareness.
+ */
+export function deriveAreaRecognitionState(
+  input: AreaRecognitionInput
+): AreaRecognitionState {
+  const {
+    clubBase,
+    paidClubs,
+    distinguishedClubs,
+    firstRoundVisitMet,
+    secondRoundVisitMet,
+    snapshotDate,
+  } = input
+
+  // Net loss is reported as the failure reason even when visit deadlines have
+  // also passed unmet — operators care more about the club-loss signal.
+  if (clubBase > 0 && paidClubs < clubBase) {
+    return {
+      level: 'none',
+      status: 'not-distinguished',
+      pendingRounds: [],
+      failureReason: 'net-loss',
+    }
+  }
+
+  const earnedLevel = determineRecognitionLevel({
+    clubBase,
+    paidClubs,
+    distinguishedClubs,
+  })
+
+  if (earnedLevel === 'none') {
+    return {
+      level: 'none',
+      status: 'not-distinguished',
+      pendingRounds: [],
+      failureReason: clubBase === 0 ? null : 'insufficient-distinguished',
+    }
+  }
+
+  const { r1, r2 } = getAreaVisitDeadlines(snapshotDate)
+  // Strict `>` per the operator spec: the deadline day itself is still "not yet passed".
+  const r1Passed = snapshotDate > r1
+  const r2Passed = snapshotDate > r2
+
+  const hardFailR1 = r1Passed && !firstRoundVisitMet
+  const hardFailR2 = r2Passed && !secondRoundVisitMet
+  if (hardFailR1 || hardFailR2) {
+    return {
+      level: 'none',
+      status: 'not-distinguished',
+      pendingRounds: [],
+      failureReason: 'missed-deadline',
+    }
+  }
+
+  if (firstRoundVisitMet && secondRoundVisitMet) {
+    return {
+      level: earnedLevel,
+      status: 'confirmed',
+      pendingRounds: [],
+      failureReason: null,
+    }
+  }
+
+  const pendingRounds: PendingRound[] = []
+  if (!firstRoundVisitMet) pendingRounds.push({ round: 1, deadline: r1 })
+  if (!secondRoundVisitMet) pendingRounds.push({ round: 2, deadline: r2 })
+
+  return {
+    level: earnedLevel,
+    status: 'provisional',
+    pendingRounds,
+    failureReason: null,
+  }
+}

--- a/frontend/src/utils/divisionStatus.ts
+++ b/frontend/src/utils/divisionStatus.ts
@@ -9,6 +9,7 @@
  */
 
 import { determineDivisionRecognitionLevel } from './divisionGapAnalysis'
+import type { AreaRecognitionState } from './areaRecognitionState'
 
 /**
  * Distinguished status levels for divisions and areas
@@ -77,6 +78,13 @@ export interface AreaPerformance {
   secondRoundVisits: VisitStatus
   /** Whether the area meets all qualifying requirements */
   isQualified: boolean
+  /**
+   * Snapshot-date-aware recognition state — the source of truth for the
+   * area's recognition badge. See `deriveAreaRecognitionState` (#832).
+   * Components MUST read this rather than re-deriving deadline-blind
+   * provisional logic locally.
+   */
+  recognitionState: AreaRecognitionState
 }
 
 /**

--- a/frontend/src/utils/extractDivisionPerformance.ts
+++ b/frontend/src/utils/extractDivisionPerformance.ts
@@ -22,7 +22,18 @@ import {
   checkAreaQualifying,
 } from './divisionStatus.js'
 import { calculateDivisionDistinguishedRequirement } from './divisionGapAnalysis.js'
+import { deriveAreaRecognitionState } from './areaRecognitionState.js'
 import { logger } from './logger'
+
+/**
+ * Fallback snapshot date when none is provided by the caller. Today's date
+ * preserves the legacy wall-clock behaviour for unwired callers (tests,
+ * stories), while wired callers (DistrictDivisionsPage) MUST pass
+ * `districtStatistics.asOfDate` so historical snapshots gate correctly.
+ */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10)
+}
 
 /**
  * Determines the distinguished level for a club based on DCP criteria
@@ -382,8 +393,11 @@ export function extractVisitData(
  * Requirements: 1.1, 1.3, 1.4, 6.8
  */
 export function extractDivisionPerformance(
-  districtSnapshot: unknown
+  districtSnapshot: unknown,
+  snapshotDate?: string
 ): DivisionPerformance[] {
+  const effectiveSnapshotDate = snapshotDate ?? todayIso()
+
   // Type guard: ensure districtSnapshot is an object
   if (typeof districtSnapshot !== 'object' || districtSnapshot === null) {
     return []
@@ -552,7 +566,8 @@ export function extractDivisionPerformance(
     const areas = extractAreasForDivision(
       divisionId,
       clubDataRaw,
-      clubPerformanceMap
+      clubPerformanceMap,
+      effectiveSnapshotDate
     )
 
     // Add division to results
@@ -585,7 +600,8 @@ export function extractDivisionPerformance(
 function extractAreasForDivision(
   divisionId: string,
   clubData: unknown[],
-  clubPerformanceMap: Map<string, Record<string, unknown>>
+  clubPerformanceMap: Map<string, Record<string, unknown>>,
+  snapshotDate: string
 ): AreaPerformance[] {
   // Group clubs by area
   const areaMap = new Map<string, unknown[]>()
@@ -730,6 +746,17 @@ function extractAreasForDivision(
       netGrowth
     )
 
+    // Source-of-truth recognition state (snapshot-date-aware, gated on
+    // qualifying visit deadlines — #832).
+    const recognitionState = deriveAreaRecognitionState({
+      clubBase,
+      paidClubs,
+      distinguishedClubs,
+      firstRoundVisitMet: firstRound.meetsThreshold,
+      secondRoundVisitMet: secondRound.meetsThreshold,
+      snapshotDate,
+    })
+
     // Add area to results
     areas.push({
       areaId,
@@ -742,6 +769,7 @@ function extractAreasForDivision(
       firstRoundVisits: firstRound,
       secondRoundVisits: secondRound,
       isQualified,
+      recognitionState,
     })
   }
 

--- a/tasks/lessons/119-when-removing-a-bandaid-grep-for-its-shape-not-just-its-named-site.md
+++ b/tasks/lessons/119-when-removing-a-bandaid-grep-for-its-shape-not-just-its-named-site.md
@@ -1,0 +1,82 @@
+---
+id: '119'
+category: lesson
+tags: [frontend, scope, refactor, dcp]
+auto_load: true
+date: 2026-05-28
+issues: [832, 833]
+---
+
+# Lesson 119 — When removing a UI bandaid, grep for its _shape_, not just its named site
+
+**Date:** 2026-05-28
+**Issue:** #832 (epic #833)
+
+## What happened
+
+#832's body named one bug site: `AreaPerformanceRow.tsx:172` —
+
+```ts
+const visitsComplete =
+  area.firstRoundVisits.completed >= area.firstRoundVisits.required &&
+  area.secondRoundVisits.completed >= area.secondRoundVisits.required
+const isDistinguishedLevel = gapAnalysis.currentLevel !== 'none'
+const isProvisional = isDistinguishedLevel && !visitsComplete
+```
+
+The fix was to delete that deadline-blind gate and route the badge through a
+snapshot-date-aware source-of-truth state instead. Easy enough — except a quick
+`grep "isProvisional\|visitsComplete"` across the frontend turned up the same
+five-line shape, character-for-character, in `AreaPerformanceTable.tsx` and
+`DivisionAreaProgressSummary.tsx`. Same comment (`// Check if visits gate the
+recognition (#325)`), same variable names, same `&& !visitsComplete` semantics.
+Fixing only the named site would have shipped two un-gated surfaces under a PR
+titled "fix area recognition" — and three months later someone else would be
+filing #832 again from a screenshot of either of them.
+
+## The principle
+
+When the ticket names a bug site, the named site is a sample, not the
+population. A copy-pasted UI bandaid lives in every surface that needs the
+same lie — because the author who copy-pasted it had the same blind spot in
+every surface, in the same week. Before declaring the source-gate refactor
+complete, grep the codebase for the _shape_ of the deleted logic:
+
+```
+rg -F "isDistinguishedLevel && !visitsComplete"
+rg -nF "firstRoundVisits.completed >= area.firstRoundVisits.required"
+```
+
+The hits are the rest of the population. Either fix them all in the same PR
+(they share one cause), or open follow-up issues with the same root cause
+linked — never silently leave them.
+
+## How to apply
+
+- After deleting a UI-level bandaid the ticket named, grep for its
+  literal expression (5–10 chars of the conditional) across the
+  same layer (components/, pages/). Hits in sibling files are co-equal
+  sites of the same bug.
+- Same prompt for the inverse: when adding a source-of-truth value the
+  presenters should consume, grep for every presenter that currently
+  re-derives it locally — convert all of them in one PR (they're already
+  out-of-sync risks; converting just one creates a new asymmetry).
+- The presenter / source-of-truth split has the same drift surface as
+  the cross-package formula trap ([[076-shared-formula-helper-eliminates-the-two-copies-trap]]),
+  one layer up: two views that re-derive the same gate are two copies of
+  the rule. Replace all, not the named one.
+
+## Related
+
+- [[076-shared-formula-helper-eliminates-the-two-copies-trap]] — the same
+  "duplicated-formula drift surface" pattern at the analytics layer; this
+  is the UI variant.
+- [[061-fix-the-formula-everywhere-not-just-the-one-in-the-bug-report]] —
+  the predecessor lesson at the data-pipeline layer (PR #538 fixed only
+  one of two `% Distinguished` implementations).
+- [[117-a-delegate-to-x-ticket-is-a-trap-when-the-two-impls-have-diverged-in-output]]
+  — adjacent: when the ticket names a refactor, prove output equivalence
+  before delegating.
+- `tasks/rules.md` R6 ("Trace the actual call graph before refactoring")
+  applies symmetrically to bandaid removal — _audit the actual presenter
+  population before declaring the gate centralised._

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -85,6 +85,7 @@
 - **118** [data-pipeline, analytics, collector-cli, find-a-club] — "Missing from Find-A-Club" is a registry-visibility signal, not a data gap (#490, #757)
 - **119** [automation, sprint-runner, prompts, process] — An issue's cited doc may be uncommitted in the operator's main checkout, not missing (#809, #813)
 - **119** [ci, tests, seo, frontend, verification, performance] — Before gating a Lighthouse SEO audit at `error`, verify which audits survive the localhost/preview host (#778, #785)
+- **119** [frontend, scope, refactor, dcp] — When removing a UI bandaid, grep for its _shape_, not just its named site (#832, #833)
 - **120** [css, frontend, scope, router, architecture] — A CSS class named like "a page" may be shared chrome for a whole route family (#810, #813)
 - **120** [frontend, react, refactor, tests, tanstack] — Reproduce a hand-rolled comparator's tiebreak + undefined rules with a headless table's native options, not a negation-fighting comparator (#835, #821)
 - **120** [tests, vitest, flaky, react, frontend] — `await waitFor` for an already-flushed effect leaks a deferred render into the next test (#780, #785)


### PR DESCRIPTION
## Summary

Areas were being shown Distinguished / Select / President's whenever they met
the distinguished-club % + paid requirement, **without enforcing the qualifying
Area Director Club Visit Report requirement** (item 1490, p.10). The only
existing visit-gate was a deadline-blind UI patch in `AreaPerformanceRow.tsx`
(`isProvisional = isDistinguishedLevel && !visitsComplete`) that never
hard-failed — so an area that missed Nov 30 still showed "(Provisional)"
indefinitely. The same shape was duplicated in `AreaPerformanceTable.tsx` and
`DivisionAreaProgressSummary.tsx`.

This PR introduces a **snapshot-date-aware source-of-truth gate** and makes
those three components pure presenters.

- New `frontend/src/utils/areaRecognitionState.ts` — `deriveAreaRecognitionState`
  returns `{ level, status: 'confirmed' | 'provisional' | 'not-distinguished',
  pendingRounds, failureReason }` driven by the snapshot's `asOfDate`
  (not wall-clock).
- New `frontend/src/utils/areaRecognitionBadge.ts` — pure presenter that
  maps the state to badge label + Tailwind classes + tooltip copy.
- `AreaPerformance.recognitionState` is now a required field on the type
  (`divisionStatus.ts`); `extractDivisionPerformance(snapshot, snapshotDate?)`
  populates it per area; `DistrictDivisionsPage` and `DivisionPerformanceCards`
  thread `asOfDate` through.
- `AreaPerformanceRow.tsx`, `AreaPerformanceTable.tsx`, and
  `DivisionAreaProgressSummary.tsx` now render via `renderRecognitionBadge(area.recognitionState)`
  — the deadline-blind `isProvisional` is gone from all three.

## Operator rules implemented (per #832 Finalised Decisions)

- R1 deadline = **Nov 30** of program-year start year
- R2 deadline = **May 31** of program-year end year
- `passed(R) = snapshotDate > deadline(R)` (strict `>` — the deadline day itself is "not yet passed")
- **Hard fail:** any round with `passed && !met` → status `'not-distinguished'`, failureReason `'missed-deadline'`
- **Confirmed:** both rounds met → status `'confirmed'` at the earned tier
- **Provisional:** unmet round whose deadline has not yet passed → status `'provisional'` at the earned tier, tooltip lists the pending round + deadline
- **Net Loss** (paid < base) takes precedence over `missed-deadline` as `failureReason`
- **Area thresholds** were already corrected to 50% / 50%+1 / 50%+1+growth in `areaGapAnalysis.ts` (#799) — no change here.
- **Division recognition unchanged** — `divisionGapAnalysis.ts` is untouched.

## Test plan

- [x] **19 new unit tests** for `deriveAreaRecognitionState` covering
      `{tier earned} × {R1/R2 met/unmet} × {snapshot vs Nov-30/May-31}` →
      Confirmed / Provisional / Not Distinguished
- [x] Edge cases: PY boundary (Jul 1 / Jun 30), strict `>` on the deadline
      day itself, ISO-timestamp snapshotDate normalisation, net-loss precedence,
      zero clubBase, insufficient-distinguished
- [x] Frontend full suite: 2967/2968 (1 pre-existing flaky journey test, passes solo — Lesson 53/78)
- [x] analytics-core full suite: 791/791 (no regressions — division logic untouched)
- [x] Typecheck clean
- [x] Prettier clean
- [x] Fresh-context `/code-review high` — 2 findings applied (snapshotDate normalisation + reuse `formatShortDate`); 4 deferred with reasons in the commit.
- [ ] PR-preview Playwright smoke (chromium + webkit)

## Acceptance criteria

- [x] Failing tests first, covering the case matrix (snapshot-date driven, not wall-clock)
- [x] `recognitionState` (source of truth) reflects the gate — no `ineligible` + `Distinguished` contradiction
- [x] Provisional badge + tooltip render; hard-fail shows Not Distinguished; no color-alone
- [x] **Division recognition unchanged** (regression test: analytics-core 791/791)
- [x] Deadlines cited to the 1490 manual; program-year anchoring correct across PY boundary
- [x] Existing recognition tests pass/updated w/ justification; no assertion pinning
- [x] The deadline-blind `isProvisional` logic in `AreaPerformanceRow` is **removed**, not left alongside the gated value (also removed from `AreaPerformanceTable` + `DivisionAreaProgressSummary`)
- [x] `AreaPerformanceRow` is a pure presenter (no `visitsComplete` recomputation, no deadline/PY math) — same for the other two surfaces

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)