### PR TITLE
fix(district): use canonical countdown for Distinguished tiles (#840)

### DIFF
--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -1,4 +1,8 @@
 import React, { useState } from 'react'
+import {
+  deriveRemainingToTier,
+  type RemainingInputs,
+} from '../utils/distinguishedCountdown'
 
 export type DistinguishedDistrictTier =
   | 'NotDistinguished'
@@ -21,12 +25,8 @@ export interface DistinguishedDistrictGap {
   clubGrowthGap: number
   distinguishedPercentGap: number
   netClubGrowthGap: number
-  /**
-   * Program-year baseline values used to derive concrete unit counts
-   * from the gap percentages (#555). Optional during the rollout —
-   * downstream callers that don't populate them simply omit the
-   * secondary "~N units" line.
-   */
+  /** Program-year baselines, used as fallback inputs when canonical
+      `*Remaining` fields are absent (#840 / lesson 104). */
   paidClubBase?: number
   paymentBase?: number
 }
@@ -37,10 +37,21 @@ export interface DistinguishedDistrictStatus {
   allPrerequisitesMet: boolean
   prerequisites: DistinguishedDistrictPrerequisites
   nextTierGap: DistinguishedDistrictGap | null
+  /** Canonical absolute counts remaining to the minimum (Distinguished)
+      tier (#686). When `nextTierGap.tier === 'Distinguished'` these are
+      the same integers the region row consumes — preferred over any
+      ranking-row derivation. */
+  paidClubsRemaining?: number
+  paymentsRemaining?: number
+  distinguishedClubsRemaining?: number
 }
 
 interface DistinguishedDistrictTrophyCaseProps {
   status: DistinguishedDistrictStatus | null
+  /** Optional rankings row used to derive the absolute remaining counts
+      when the canonical fields are absent or the next tier is above
+      Distinguished. Matches the region page's data source. */
+  ranking?: RemainingInputs | null
   clubStrengthQualifies?: boolean | undefined
   clubStrengthGrowth?: number | null | undefined
   leadershipExcellenceQualifies?: boolean | undefined
@@ -91,27 +102,26 @@ const PREREQUISITE_KEYS = Object.keys(PREREQUISITE_LABELS) as Array<
 
 interface GapTileSpec {
   label: string
-  /** Headline gap value, in percent. */
-  gap: number
-  /**
-   * Concrete unit count derived from `gap × base`. `null` skips the
-   * secondary line (older snapshots without base values).
-   */
-  concreteCount: number | null
-  /** Unit noun used singular when concreteCount === 1. */
+  /** Canonical integer count remaining to the next tier. `null` skips
+      the headline integer (no canonical field, no rankings row). */
+  count: number | null
+  /** Sub-item: the same gap expressed as a percentage. */
+  gapPercent: number
   unitSingular: string
   unitPlural: string
 }
 
 const GapTile: React.FC<GapTileSpec> = ({
   label,
-  gap,
-  concreteCount,
+  count,
+  gapPercent,
   unitSingular,
   unitPlural,
 }) => {
-  const closed = gap === 0
-  const showConcrete = !closed && concreteCount != null && concreteCount > 0
+  // `count === 0` is the canonical "met" signal (lesson 103); only the
+  // un-evaluable case (no canonical, no ranking) leaves the headline blank.
+  const closed = count === 0
+  const noun = count === 1 ? unitSingular : unitPlural
   return (
     <div className="rounded-md border border-gray-200 theme-dark:border-gray-700 px-3 py-2">
       <div
@@ -128,37 +138,25 @@ const GapTile: React.FC<GapTileSpec> = ({
             : 'text-gray-900 theme-dark:text-gray-100'
         }`}
       >
-        {closed ? '✓' : `+${gap.toFixed(1)}%`}
+        {closed ? '✓' : count != null ? `${count} ${noun}` : '—'}
       </div>
-      {showConcrete && (
+      {!closed && count != null && (
         <div
-          data-testid="gap-tile-units"
+          data-testid="gap-tile-subitem"
           className="mt-0.5 text-[11px] text-gray-600 theme-dark:text-gray-400 font-tm-body tabular-nums"
         >
-          ~{concreteCount} {concreteCount === 1 ? unitSingular : unitPlural}
+          +{gapPercent.toFixed(1)}%
         </div>
       )}
     </div>
   )
 }
 
-/**
- * Convert a growth-percentage gap to a concrete unit count using the
- * program-year baseline. Returns `null` when base is unavailable so
- * the tile can omit the secondary line gracefully.
- */
-function concreteUnitsFromGap(
-  gapPercent: number,
-  base: number | undefined
-): number | null {
-  if (gapPercent <= 0 || base == null || base <= 0) return null
-  return Math.max(1, Math.round((base * gapPercent) / 100))
-}
-
 export const DistinguishedDistrictTrophyCase: React.FC<
   DistinguishedDistrictTrophyCaseProps
 > = ({
   status,
+  ranking,
   clubStrengthQualifies,
   clubStrengthGrowth,
   leadershipExcellenceQualifies,
@@ -184,6 +182,35 @@ export const DistinguishedDistrictTrophyCase: React.FC<
     leadershipExcellenceQualifies ||
     educationTrainingQualifies ||
     clubGrowthQualifies
+
+  /* Resolve the three headline integers via the SAME helper the region
+     row uses. Canonical analytics fields (#686) win when the target is
+     the Distinguished gate; otherwise (Select / Presidents / Smedley)
+     we derive from the rankings row against the appropriate tier
+     thresholds. (#840 / lessons 103, 104) */
+  let paidClubsCount: number | null = null
+  let paymentsCount: number | null = null
+  let distinguishedClubsCount: number | null = null
+  if (nextTierGap) {
+    if (nextTierGap.tier === 'Distinguished') {
+      paidClubsCount = status.paidClubsRemaining ?? null
+      paymentsCount = status.paymentsRemaining ?? null
+      distinguishedClubsCount = status.distinguishedClubsRemaining ?? null
+    }
+    if (
+      (paidClubsCount === null ||
+        paymentsCount === null ||
+        distinguishedClubsCount === null) &&
+      ranking &&
+      nextTierGap.tier !== 'NotDistinguished'
+    ) {
+      const derived = deriveRemainingToTier(nextTierGap.tier, ranking)
+      paidClubsCount = paidClubsCount ?? derived.paidClubsRemaining
+      paymentsCount = paymentsCount ?? derived.paymentsRemaining
+      distinguishedClubsCount =
+        distinguishedClubsCount ?? derived.distinguishedClubsRemaining
+    }
+  }
 
   return (
     <div className="redesign-panel">
@@ -281,36 +308,28 @@ export const DistinguishedDistrictTrophyCase: React.FC<
             data-testid="distinguished-gap-tiles"
             className="grid grid-cols-1 md:grid-cols-3 gap-2"
           >
-            {/* Order: Club growth → Payment growth → % Distinguished (#556).
-                Net Club Growth tile dropped — Club Growth % conveys the same
-                fact as the absolute count for any positive growth. */}
+            {/* Headline integer is the canonical countdown to the next tier,
+                matching the region row's "Remaining to Distinguished" cells.
+                Percentage demoted to a sub-item. Labels mirror the region
+                page exactly. (#840 / lesson 103) */}
             <GapTile
-              label="Club growth"
-              gap={nextTierGap.clubGrowthGap}
-              concreteCount={concreteUnitsFromGap(
-                nextTierGap.clubGrowthGap,
-                nextTierGap.paidClubBase
-              )}
+              label="Paid Clubs"
+              count={paidClubsCount}
+              gapPercent={nextTierGap.clubGrowthGap}
               unitSingular="club"
               unitPlural="clubs"
             />
             <GapTile
-              label="Payment growth"
-              gap={nextTierGap.paymentGrowthGap}
-              concreteCount={concreteUnitsFromGap(
-                nextTierGap.paymentGrowthGap,
-                nextTierGap.paymentBase
-              )}
+              label="Payments"
+              count={paymentsCount}
+              gapPercent={nextTierGap.paymentGrowthGap}
               unitSingular="payment"
               unitPlural="payments"
             />
             <GapTile
-              label="% Distinguished"
-              gap={nextTierGap.distinguishedPercentGap}
-              concreteCount={concreteUnitsFromGap(
-                nextTierGap.distinguishedPercentGap,
-                nextTierGap.paidClubBase
-              )}
+              label="Distinguished Clubs"
+              count={distinguishedClubsCount}
+              gapPercent={nextTierGap.distinguishedPercentGap}
               unitSingular="club"
               unitPlural="clubs"
             />

--- a/frontend/src/components/__tests__/DistinguishedDistrictTrophyCase.test.tsx
+++ b/frontend/src/components/__tests__/DistinguishedDistrictTrophyCase.test.tsx
@@ -6,6 +6,7 @@ import {
   DistinguishedDistrictTrophyCase,
   type DistinguishedDistrictStatus,
 } from '../DistinguishedDistrictTrophyCase'
+import type { RemainingInputs } from '../../utils/distinguishedCountdown'
 
 afterEach(() => cleanup())
 
@@ -26,10 +27,22 @@ const baseStatus: DistinguishedDistrictStatus = {
     clubGrowthGap: 5.5,
     distinguishedPercentGap: 13.6,
     netClubGrowthGap: 7,
-    // #555 — base values used to derive concrete-unit secondary lines.
     paidClubBase: 161,
     paymentBase: 5605,
   },
+  // #840 — canonical absolute counts to the Distinguished gate. Match
+  // the integers a region row would show; same shape as RegionPage.
+  paidClubsRemaining: 11,
+  paymentsRemaining: 169,
+  distinguishedClubsRemaining: 20,
+}
+
+const baseRanking: RemainingInputs = {
+  paidClubBase: 161,
+  paidClubs: 152,
+  paymentBase: 5605,
+  totalPayments: 5493,
+  distinguishedClubs: 53,
 }
 
 describe('DistinguishedDistrictTrophyCase', () => {
@@ -104,78 +117,159 @@ describe('DistinguishedDistrictTrophyCase', () => {
     })
   })
 
-  describe('gap to next tier — inline tile row (#555, #556)', () => {
-    it('renders three tiles in Club Growth → Payment Growth → % Distinguished order', () => {
-      render(<DistinguishedDistrictTrophyCase status={baseStatus} />)
+  describe('gap to next tier — canonical countdown tiles (#840)', () => {
+    /* The district tiles must consume the SAME integers the region row's
+       "Remaining to Distinguished" cells consume — never a value derived
+       from TI's pre-rounded gap %. Integer is the headline; percentage is
+       the sub-item. Labels match the region page exactly. Lesson 103/104. */
+
+    it('renders three tiles in Paid Clubs → Payments → Distinguished Clubs order with region-page labels', () => {
+      render(
+        <DistinguishedDistrictTrophyCase
+          status={baseStatus}
+          ranking={baseRanking}
+        />
+      )
       const tiles = screen.getByTestId('distinguished-gap-tiles')
       const labels = within(tiles).getAllByTestId('gap-tile-label')
       expect(labels.map(l => l.textContent)).toEqual([
-        'Club growth',
-        'Payment growth',
-        '% Distinguished',
+        'Paid Clubs',
+        'Payments',
+        'Distinguished Clubs',
       ])
-      // Net Club Growth tile is gone (#556)
-      expect(screen.queryByText(/Net club growth/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Club growth/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Payment growth/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/% Distinguished/i)).not.toBeInTheDocument()
     })
 
-    it('renders both the percentage and the concrete unit count per tile (#555)', () => {
-      render(<DistinguishedDistrictTrophyCase status={baseStatus} />)
+    it('renders the canonical integer as the headline and the percentage as a sub-item (no ~)', () => {
+      render(
+        <DistinguishedDistrictTrophyCase
+          status={baseStatus}
+          ranking={baseRanking}
+        />
+      )
       const tiles = screen.getByTestId('distinguished-gap-tiles')
       const values = within(tiles).getAllByTestId('gap-tile-value')
-      const units = within(tiles).getAllByTestId('gap-tile-units')
+      const subitems = within(tiles).getAllByTestId('gap-tile-subitem')
 
-      // Order: Club growth, Payment growth, % Distinguished
-      expect(values[0]).toHaveTextContent('+5.5%')
-      // 161 × 5.5% = 8.855 → ~9 clubs
-      expect(units[0]).toHaveTextContent('~9 clubs')
+      // Headlines — exact canonical counts. Distinguished-Clubs is 20,
+      // not 19 (the rounded-% derivation bug).
+      expect(values[0]).toHaveTextContent(/^11 clubs?$/)
+      expect(values[1]).toHaveTextContent(/^169 payments$/)
+      expect(values[2]).toHaveTextContent(/^20 clubs$/)
 
-      expect(values[1]).toHaveTextContent('+2.0%')
-      // 5605 × 2% = 112.1 → ~112 payments
-      expect(units[1]).toHaveTextContent('~112 payments')
+      // Percentages are demoted to the sub-item, no "~" prefix on either.
+      expect(subitems[0]).toHaveTextContent(/^\+5\.5%$/)
+      expect(subitems[1]).toHaveTextContent(/^\+2\.0%$/)
+      expect(subitems[2]).toHaveTextContent(/^\+13\.6%$/)
 
-      expect(values[2]).toHaveTextContent('+13.6%')
-      // 161 × 13.6 / 100 = 21.896 → ~22 clubs (Distinguished clubs)
-      expect(units[2]).toHaveTextContent('~22 clubs')
+      // The "~" approximation marker is gone — the integer is exact now.
+      values.forEach(v => expect(v.textContent).not.toMatch(/~/))
+      subitems.forEach(s => expect(s.textContent).not.toMatch(/~/))
     })
 
-    it('singularises units when count is exactly 1', () => {
-      const tinyGap: DistinguishedDistrictStatus = {
+    it('prefers the canonical status field over a derivation from the rankings row', () => {
+      // status carries 20 (canonical); rankings derivation would give 20 too,
+      // but if they disagreed the canonical field wins.
+      const drifted = {
         ...baseStatus,
+        distinguishedClubsRemaining: 22, // deliberately != derivation
+      }
+      render(
+        <DistinguishedDistrictTrophyCase
+          status={drifted}
+          ranking={baseRanking}
+        />
+      )
+      const values = screen.getAllByTestId('gap-tile-value')
+      expect(values[2]).toHaveTextContent(/^22 clubs$/)
+    })
+
+    it('derives counts from the rankings row when the canonical fields are absent', () => {
+      const noCanonical: DistinguishedDistrictStatus = {
+        ...baseStatus,
+      }
+      delete (noCanonical as Partial<DistinguishedDistrictStatus>)
+        .paidClubsRemaining
+      delete (noCanonical as Partial<DistinguishedDistrictStatus>)
+        .paymentsRemaining
+      delete (noCanonical as Partial<DistinguishedDistrictStatus>)
+        .distinguishedClubsRemaining
+
+      render(
+        <DistinguishedDistrictTrophyCase
+          status={noCanonical}
+          ranking={baseRanking}
+        />
+      )
+      const values = screen.getAllByTestId('gap-tile-value')
+      // Same headline integers via derivation: 11 / 169 / 20.
+      expect(values[0]).toHaveTextContent(/^11 clubs?$/)
+      expect(values[1]).toHaveTextContent(/^169 payments$/)
+      expect(values[2]).toHaveTextContent(/^20 clubs$/)
+    })
+
+    it('uses the next-tier thresholds for districts already at Distinguished', () => {
+      // Already at Distinguished, counting down to Select (+3% growth,
+      // 50% distinguished, plus-one): from baseRanking →
+      // paid: ceil(161 × 1.03) − 152 = 14; payments: ceil(5605 × 1.03) − 5493 = 281;
+      // dist: ceil(161 × 0.50) − 53 = 28.
+      const atDistinguished: DistinguishedDistrictStatus = {
+        ...baseStatus,
+        currentTier: 'Distinguished',
         nextTierGap: {
-          tier: 'Distinguished',
-          paymentGrowthGap: 0.018, // 5605 × 0.00018 = 1.01 → 1 payment
-          clubGrowthGap: 0.62, // 161 × 0.0062 = 1.0 → 1 club
-          distinguishedPercentGap: 0.62, // 161 × 0.62/100 = 1.0 → 1 club
-          netClubGrowthGap: 1,
-          paidClubBase: 161,
-          paymentBase: 5605,
+          ...baseStatus.nextTierGap!,
+          tier: 'Select',
         },
       }
-      render(<DistinguishedDistrictTrophyCase status={tinyGap} />)
-      const units = screen.getAllByTestId('gap-tile-units')
-      expect(units[0]).toHaveTextContent('~1 club')
-      expect(units[1]).toHaveTextContent('~1 payment')
-      expect(units[2]).toHaveTextContent('~1 club')
+      // Remove canonical Distinguished-tier counts — they're for the wrong
+      // gate when the next target is Select.
+      delete (atDistinguished as Partial<DistinguishedDistrictStatus>)
+        .paidClubsRemaining
+      delete (atDistinguished as Partial<DistinguishedDistrictStatus>)
+        .paymentsRemaining
+      delete (atDistinguished as Partial<DistinguishedDistrictStatus>)
+        .distinguishedClubsRemaining
+
+      render(
+        <DistinguishedDistrictTrophyCase
+          status={atDistinguished}
+          ranking={baseRanking}
+        />
+      )
+      const values = screen.getAllByTestId('gap-tile-value')
+      expect(values[0]).toHaveTextContent(/^14 clubs$/)
+      expect(values[1]).toHaveTextContent(/^281 payments$/)
+      expect(values[2]).toHaveTextContent(/^28 clubs$/)
     })
 
-    it('renders a ✓ with no concrete-unit line when a gap is zero', () => {
+    it('singularises the unit noun when the count is exactly 1', () => {
+      const oneEach: DistinguishedDistrictStatus = {
+        ...baseStatus,
+        paidClubsRemaining: 1,
+        paymentsRemaining: 1,
+        distinguishedClubsRemaining: 1,
+      }
+      render(<DistinguishedDistrictTrophyCase status={oneEach} />)
+      const values = screen.getAllByTestId('gap-tile-value')
+      expect(values[0]).toHaveTextContent(/^1 club$/)
+      expect(values[1]).toHaveTextContent(/^1 payment$/)
+      expect(values[2]).toHaveTextContent(/^1 club$/)
+    })
+
+    it('renders ✓ when a metric minimum is met (canonical remaining = 0)', () => {
       const closed: DistinguishedDistrictStatus = {
         ...baseStatus,
-        nextTierGap: {
-          tier: 'Distinguished',
-          paymentGrowthGap: 0,
-          clubGrowthGap: 0,
-          distinguishedPercentGap: 0,
-          netClubGrowthGap: 0,
-          paidClubBase: 161,
-          paymentBase: 5605,
-        },
+        paidClubsRemaining: 0,
+        paymentsRemaining: 0,
+        distinguishedClubsRemaining: 0,
       }
       render(<DistinguishedDistrictTrophyCase status={closed} />)
       const values = screen.getAllByTestId('gap-tile-value')
       values.forEach(v => expect(v).toHaveTextContent('✓'))
-      // No "gap-tile-units" rendered when the gap is closed
-      expect(screen.queryByTestId('gap-tile-units')).not.toBeInTheDocument()
+      // No sub-item rendered when the gate is met.
+      expect(screen.queryByTestId('gap-tile-subitem')).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -27,6 +27,7 @@ import { NotableDatesSection } from '../components/NotableDatesSection'
 import { LongestServingClubsLeaderboard } from '../components/LongestServingClubsLeaderboard'
 import { DistinguishedDistrictTrophyCase } from '../components/DistinguishedDistrictTrophyCase'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
+import { useDistrictRanking } from '../hooks/useDistrictRanking'
 
 import {
   DistrictKpiStrip,
@@ -249,6 +250,21 @@ const DistrictDetailPageInner: React.FC = () => {
     if (!districtId || !competitiveAwards?.distinguishedDistrict) return null
     return competitiveAwards.distinguishedDistrict[districtId] ?? null
   }, [districtId, competitiveAwards])
+
+  // Rankings row supplies the raw integer counts used to derive the
+  // trophy-case tile integers when the canonical `*Remaining` fields
+  // are absent or the target tier is above Distinguished (#840).
+  const { ranking: districtRanking } = useDistrictRanking(districtId)
+  const distinguishedRankingInputs = React.useMemo(() => {
+    if (!districtRanking) return null
+    return {
+      paidClubBase: districtRanking.paidClubBase,
+      paymentBase: districtRanking.paymentBase,
+      paidClubs: districtRanking.paidClubs,
+      totalPayments: districtRanking.totalPayments,
+      distinguishedClubs: districtRanking.distinguishedClubs,
+    }
+  }, [districtRanking])
 
   // Extract threshold + officer award results for this district (#333)
   const clubStrengthResult = React.useMemo(() => {
@@ -497,6 +513,7 @@ const DistrictDetailPageInner: React.FC = () => {
                 {/* Distinguished District Trophy Case (#332) */}
                 <DistinguishedDistrictTrophyCase
                   status={distinguishedDistrictStatus}
+                  ranking={distinguishedRankingInputs}
                   clubStrengthQualifies={clubStrengthResult?.qualifies}
                   clubStrengthGrowth={clubStrengthResult?.growthPercent}
                   leadershipExcellenceQualifies={

--- a/frontend/src/utils/__tests__/distinguishedCountdown.test.ts
+++ b/frontend/src/utils/__tests__/distinguishedCountdown.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   getDistinguishedCountdown,
   deriveRemainingToMinimum,
+  deriveRemainingToTier,
   type DistinguishedCountdown,
   type RemainingInputs,
 } from '../distinguishedCountdown'
@@ -116,6 +117,90 @@ describe('deriveRemainingToMinimum — matches the canonical analytics field (#6
   it('clamps to 0 when a metric minimum is already met or exceeded', () => {
     expect(
       deriveRemainingToMinimum({
+        paidClubBase: 100,
+        paidClubs: 120,
+        paymentBase: 5000,
+        totalPayments: 6000,
+        distinguishedClubs: 60,
+      })
+    ).toEqual({
+      paidClubsRemaining: 0,
+      paymentsRemaining: 0,
+      distinguishedClubsRemaining: 0,
+    })
+  })
+})
+
+describe('deriveRemainingToTier — same gate, any tier (#840)', () => {
+  /* Generalises deriveRemainingToMinimum to all four tiers above
+     NotDistinguished. Targets/denominators must match the analytics-core
+     TIER_THRESHOLDS row exactly — same gate the tier badge counts down
+     to. Lesson 103. */
+
+  // paidClubBase 161, paidClubs 152, paymentBase 5605, totalPayments 5493,
+  // distinguishedClubs 53 — D61-ish synthetic where the bug renders 19 and
+  // the canonical computation renders 20 distinguished clubs to go.
+  const D61: RemainingInputs = {
+    paidClubBase: 161,
+    paidClubs: 152,
+    paymentBase: 5605,
+    totalPayments: 5493,
+    distinguishedClubs: 53,
+  }
+
+  it('matches deriveRemainingToMinimum when tier is Distinguished', () => {
+    expect(deriveRemainingToTier('Distinguished', D61)).toEqual(
+      deriveRemainingToMinimum(D61)
+    )
+  })
+
+  it('counts down to the Distinguished gate (+1% growth, 45% distinguished)', () => {
+    // paid:    ceil(161 × 1.01) − 152 = 163 − 152 = 11
+    // payments: ceil(5605 × 1.01) − 5493 = 5662 − 5493 = 169
+    // dist:    ceil(161 × 0.45) − 53 = 73 − 53 = 20  ← the canonical 20, not the rounded-% 19.
+    expect(deriveRemainingToTier('Distinguished', D61)).toEqual({
+      paidClubsRemaining: 11,
+      paymentsRemaining: 169,
+      distinguishedClubsRemaining: 20,
+    })
+  })
+
+  it('counts down to the Select gate (+3% growth, 50% distinguished, plus-one)', () => {
+    // paid:    ceil(161 × 1.03) − 152 = 166 − 152 = 14
+    // payments: ceil(5605 × 1.03) − 5493 = 5774 − 5493 = 281
+    // dist:    ceil(161 × 0.50) − 53 = 81 − 53 = 28
+    expect(deriveRemainingToTier('Select', D61)).toEqual({
+      paidClubsRemaining: 14,
+      paymentsRemaining: 281,
+      distinguishedClubsRemaining: 28,
+    })
+  })
+
+  it('counts down to the Presidents gate (+5% growth, 55% distinguished)', () => {
+    // paid:    ceil(161 × 1.05) − 152 = 170 − 152 = 18
+    // payments: ceil(5605 × 1.05) − 5493 = 5886 − 5493 = 393
+    // dist:    ceil(161 × 0.55) − 53 = 89 − 53 = 36
+    expect(deriveRemainingToTier('Presidents', D61)).toEqual({
+      paidClubsRemaining: 18,
+      paymentsRemaining: 393,
+      distinguishedClubsRemaining: 36,
+    })
+  })
+
+  it('counts down to the Smedley gate (+8% growth, 60% distinguished)', () => {
+    // paid:    ceil(161 × 1.08) − 152 = 174 − 152 = 22
+    // payments: ceil(5605 × 1.08) − 5493 = 6054 − 5493 = 561
+    // dist:    ceil(161 × 0.60) − 53 = 97 − 53 = 44
+    expect(deriveRemainingToTier('Smedley', D61)).toEqual({
+      paidClubsRemaining: 22,
+      paymentsRemaining: 561,
+      distinguishedClubsRemaining: 44,
+    })
+  })
+
+  it('clamps to 0 once the tier-specific minimum is met', () => {
+    expect(
+      deriveRemainingToTier('Distinguished', {
         paidClubBase: 100,
         paidClubs: 120,
         paymentBase: 5000,

--- a/frontend/src/utils/distinguishedCountdown.ts
+++ b/frontend/src/utils/distinguishedCountdown.ts
@@ -1,4 +1,7 @@
-import type { CompetitiveAwardStandings } from '../services/cdn'
+import type {
+  CompetitiveAwardStandings,
+  DistinguishedDistrictTier,
+} from '../services/cdn'
 
 /* Per-district countdown to the *minimum* Distinguished District tier.
    Folds three absolute "remaining" counts (paid clubs, payments,
@@ -35,23 +38,48 @@ export interface DistinguishedCountdown {
   clubGrowth: CountdownCell
 }
 
-/* The MINIMUM (Distinguished) tier thresholds. These MUST stay in lockstep
-   with the Distinguished entry of `TIER_THRESHOLDS` in
-   packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts —
-   they are the gate this countdown counts down to. If the program rules
-   change, update both (lesson 103). The equivalence test pins the derived
-   counts to the canonical analytics values for several real districts. */
-const MIN_DISTINGUISHED = {
-  /** +1% net payment growth vs program-year base. */
-  paymentGrowthMin: 1,
-  /** +1% net paid-club growth vs program-year base. */
-  clubGrowthMin: 1,
-  /** ≥45% of paid-club BASE are Distinguished (denominator is the base,
-      not active clubs — lesson 60). */
-  distinguishedPercentMin: 45,
-} as const
+/* Tier thresholds — frontend twin of the analytics-core
+   TIER_THRESHOLDS in
+   packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts.
+   These MUST stay in lockstep with the calculator: they are the gates the
+   countdown counts down to. If the program rules change, update both
+   (lesson 103). The equivalence test pins the derived counts to the
+   canonical analytics values for several real districts. */
+export type DistinguishedTier = Exclude<
+  DistinguishedDistrictTier,
+  'NotDistinguished'
+>
 
-/** Inputs needed to derive the remaining-to-minimum counts from a
+interface TierThreshold {
+  paymentGrowthMin: number
+  clubGrowthMin: number
+  distinguishedPercentMin: number
+}
+
+const TIER_THRESHOLDS: Record<DistinguishedTier, TierThreshold> = {
+  Distinguished: {
+    paymentGrowthMin: 1,
+    clubGrowthMin: 1,
+    distinguishedPercentMin: 45,
+  },
+  Select: {
+    paymentGrowthMin: 3,
+    clubGrowthMin: 3,
+    distinguishedPercentMin: 50,
+  },
+  Presidents: {
+    paymentGrowthMin: 5,
+    clubGrowthMin: 5,
+    distinguishedPercentMin: 55,
+  },
+  Smedley: {
+    paymentGrowthMin: 8,
+    clubGrowthMin: 8,
+    distinguishedPercentMin: 60,
+  },
+}
+
+/** Inputs needed to derive the remaining-to-tier counts from a
     rankings row, when the canonical analytics fields are absent. */
 export interface RemainingInputs {
   paidClubBase: number
@@ -61,22 +89,24 @@ export interface RemainingInputs {
   distinguishedClubs: number
 }
 
-/* Frontend twin of DistinguishedDistrictCalculator.computeRemainingToMinimum
-   (#686). Same targets, same denominators, same clamp — so the derived
-   value equals the canonical `*Remaining` field for any snapshot. */
-export function deriveRemainingToMinimum(r: RemainingInputs): {
+/* Frontend twin of the analytics-core countdown formula. Same targets,
+   same denominators, same clamp — so the derived value equals the
+   canonical `*Remaining` field for any snapshot. Generalised over tier
+   so the district trophy case can count down to whichever tier the
+   district is targeting next (#840). */
+export function deriveRemainingToTier(
+  tier: DistinguishedTier,
+  r: RemainingInputs
+): {
   paidClubsRemaining: number
   paymentsRemaining: number
   distinguishedClubsRemaining: number
 } {
-  const paymentTarget = Math.ceil(
-    r.paymentBase * (1 + MIN_DISTINGUISHED.paymentGrowthMin / 100)
-  )
-  const paidClubTarget = Math.ceil(
-    r.paidClubBase * (1 + MIN_DISTINGUISHED.clubGrowthMin / 100)
-  )
+  const t = TIER_THRESHOLDS[tier]
+  const paymentTarget = Math.ceil(r.paymentBase * (1 + t.paymentGrowthMin / 100))
+  const paidClubTarget = Math.ceil(r.paidClubBase * (1 + t.clubGrowthMin / 100))
   const distinguishedTarget = Math.ceil(
-    r.paidClubBase * (MIN_DISTINGUISHED.distinguishedPercentMin / 100)
+    r.paidClubBase * (t.distinguishedPercentMin / 100)
   )
   return {
     paidClubsRemaining: Math.max(0, paidClubTarget - r.paidClubs),
@@ -86,6 +116,17 @@ export function deriveRemainingToMinimum(r: RemainingInputs): {
       distinguishedTarget - r.distinguishedClubs
     ),
   }
+}
+
+/** Count down to the minimum (Distinguished) tier. Kept as a thin
+    wrapper so the region-table path and its equivalence-pinned tests
+    stay unchanged. */
+export function deriveRemainingToMinimum(r: RemainingInputs): {
+  paidClubsRemaining: number
+  paymentsRemaining: number
+  distinguishedClubsRemaining: number
+} {
+  return deriveRemainingToTier('Distinguished', r)
 }
 
 const countCell = (value: number): CountdownCell =>

--- a/frontend/src/utils/distinguishedCountdown.ts
+++ b/frontend/src/utils/distinguishedCountdown.ts
@@ -103,7 +103,9 @@ export function deriveRemainingToTier(
   distinguishedClubsRemaining: number
 } {
   const t = TIER_THRESHOLDS[tier]
-  const paymentTarget = Math.ceil(r.paymentBase * (1 + t.paymentGrowthMin / 100))
+  const paymentTarget = Math.ceil(
+    r.paymentBase * (1 + t.paymentGrowthMin / 100)
+  )
   const paidClubTarget = Math.ceil(r.paidClubBase * (1 + t.clubGrowthMin / 100))
   const distinguishedTarget = Math.ceil(
     r.paidClubBase * (t.distinguishedPercentMin / 100)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       }
     },
     "frontend": {
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.0",


### PR DESCRIPTION
## Summary

Resolves the cross-surface disagreement in #840 / epic #841: the district page's "Gap to Distinguished District" tiles derived integers from rounded percentages (`~19 clubs`) and didn't match the region page's exact value (`20`). They now consume the **same canonical countdown** as the region row.

## What changed

- `frontend/src/utils/distinguishedCountdown.ts` — generalises `deriveRemainingToMinimum` → `deriveRemainingToTier(tier, inputs)` over all four tiers (Distinguished / Select / Presidents / Smedley). `deriveRemainingToMinimum` is preserved as a thin wrapper so the region table path and its equivalence-pinned tests stay intact.
- `frontend/src/components/DistinguishedDistrictTrophyCase.tsx` —
  - **Integer is the headline**, percentage demoted to a sub-item.
  - Prefers `status.{paid,payments,distinguished}Remaining` (#686) when the target is Distinguished — same integers the region row shows.
  - Falls back to `deriveRemainingToTier(nextTierGap.tier, ranking)` when the canonical fields are absent OR the next tier is above Distinguished.
  - **Drops the `~` approximation marker** — the value is now exact.
  - **Relabels to region-page vocabulary**: Paid Clubs / Payments / Distinguished Clubs.
  - Deletes `concreteUnitsFromGap` (the rounded-percentage derivation that caused the ±1 drift — lesson 104).
- `frontend/src/pages/DistrictDetailPage.tsx` — passes `useDistrictRanking(districtId)` into the trophy case as the derivation source.

## Why this matters

- Cross-surface trust bug: a district page reading `~19` while the region page reads `20` for the same district is the same disagree-with-itself class as lessons 60 / 102 / 103, one surface over.
- TI publishes growth percentages **pre-rounded to 1 decimal place**; multiplying them back by a base re-inflates the rounding into a ±1 count error, which on a "remaining" countdown can flip met/not-met (lesson 104).

## Acceptance criteria

- [x] Failing test first: D61 distinguished-clubs tile reads **20** (not 19); region-page parity asserted via the canonical `*Remaining` fields the region row already consumes.
- [x] No `Math.round((base * gapPercent) / 100)` derivations remain; `concreteUnitsFromGap` deleted.
- [x] Integer is the headline; percentage is a sub-item; `~` removed; labels are **Paid Clubs / Payments / Distinguished Clubs**.
- [x] Districts already at Distinguished count down to the next tier via `deriveRemainingToTier(nextTierGap.tier, ranking)` — covered by a Select-target test.
- [x] Full local test suite: **4,641 passed across 299 files** (frontend 2,979 / analytics-core 791 / collector-cli 737 / shared-contracts 134). Quality gate (typecheck + lint + yaml-lint + format-check) green.

## Test plan

- [ ] Preview deploys via `pr-preview.yml`
- [ ] Live verify on the preview channel at 375 / 768 / 1280 / 1600 + dark mode (Playwright smoke: Chromium **and** WebKit per Lesson 107)
- [ ] D61 distinguished-clubs tile reads **20 clubs** (not ~19), label "Distinguished Clubs"
- [ ] All three tiles render integer prominently with percentage as a sub-item; no `~` anywhere in the section
- [ ] No regressions on the region page (it consumes `getDistinguishedCountdown` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)