### PR TITLE
fix(region): RegionPage gets the wide --page-max-wide cap (#848)

### DIFF
--- a/docs/architecture-decisions/006-data-table-page-layout-and-column-model.md
+++ b/docs/architecture-decisions/006-data-table-page-layout-and-column-model.md
@@ -39,11 +39,28 @@ the B/C epics) apply it.
 Data-table pages use a wider cap; prose pages stay narrow.
 
 - **`--page-max-wide: 1600px`** — the new token. Applied to the data-table page
-  containers (`.districts-page`, `.district-detail-page`, and the club table
-  page) in Sprint 2 (#810).
+  containers in Sprint 2 (#810) and patched to cover the region landing in
+  #848.
 - **Prose / narrative pages keep `max-width: 1280px`** (the existing default).
   The 1280 cap is a readability rule for text columns and stays there; it is not
   the right cap for a data grid.
+
+**Wide-cap pages — the explicit list (amended 2026-05-28, #848).** The
+original Sprint 2 prose named two classes; per lesson 120 a `.foo-page` class
+may be shared chrome for a whole route family, so the contract is enumerated
+by surface, not by class, to keep the policy auditable as new pages land:
+
+| Surface                                     | Wrapper class           | Rationale                                                              |
+| ------------------------------------------- | ----------------------- | ---------------------------------------------------------------------- |
+| District landing (`DistrictsPage`)          | `.districts-page`       | 13+ column rankings table.                                             |
+| Region landing (`RegionPage`)               | `.districts-page`       | 19-column region rankings table (#848). Reuses the districts chrome.   |
+| District-detail family (7 sub-routes)       | `.district-detail-page` | Shared chrome per lesson 120: clubs/rankings/divisions/trends/changes/analytics/overview. |
+
+The empty-state branch of `RegionPage` (no districts found in a region) stays
+on `.app-shell__page` — it is prose, not a data grid.
+
+Any future page added to this list **must** be guarded by
+`frontend/src/styles/__tests__/page-width-tokens.test.ts` so it cannot drift.
 
 A wider **capped** width was chosen over fluid/edge-to-edge (see Alternatives):
 1600px holds the club table's full column set without horizontal scroll on a

--- a/docs/architecture-decisions/006-data-table-page-layout-and-column-model.md
+++ b/docs/architecture-decisions/006-data-table-page-layout-and-column-model.md
@@ -50,11 +50,11 @@ original Sprint 2 prose named two classes; per lesson 120 a `.foo-page` class
 may be shared chrome for a whole route family, so the contract is enumerated
 by surface, not by class, to keep the policy auditable as new pages land:
 
-| Surface                                     | Wrapper class           | Rationale                                                              |
-| ------------------------------------------- | ----------------------- | ---------------------------------------------------------------------- |
-| District landing (`DistrictsPage`)          | `.districts-page`       | 13+ column rankings table.                                             |
-| Region landing (`RegionPage`)               | `.districts-page`       | 19-column region rankings table (#848). Reuses the districts chrome.   |
-| District-detail family (7 sub-routes)       | `.district-detail-page` | Shared chrome per lesson 120: clubs/rankings/divisions/trends/changes/analytics/overview. |
+| Surface                               | Wrapper class           | Rationale                                                                                 |
+| ------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------- |
+| District landing (`DistrictsPage`)    | `.districts-page`       | 13+ column rankings table.                                                                |
+| Region landing (`RegionPage`)         | `.districts-page`       | 19-column region rankings table (#848). Reuses the districts chrome.                      |
+| District-detail family (7 sub-routes) | `.district-detail-page` | Shared chrome per lesson 120: clubs/rankings/divisions/trends/changes/analytics/overview. |
 
 The empty-state branch of `RegionPage` (no districts found in a region) stays
 on `.app-shell__page` — it is prose, not a data grid.

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -319,7 +319,11 @@ const RegionPage: React.FC = () => {
   )
 
   return (
-    <div className="app-shell__page">
+    // #848 — data-grid surface (19-column rankings table); uses the wide
+    // --page-max-wide cap, same policy as .districts-page /
+    // .district-detail-page (ADR-006 §1). The empty-state branch above
+    // stays on .app-shell__page since it's prose, not a data grid.
+    <div className="districts-page">
       <header className="districts-page-header">
         <div className="districts-page-header__intro">
           <p className="districts-page-header__eyebrow">

--- a/frontend/src/styles/__tests__/page-width-tokens.test.ts
+++ b/frontend/src/styles/__tests__/page-width-tokens.test.ts
@@ -21,9 +21,11 @@ import { dirname, resolve } from 'node:path'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const redesignTokensPath = resolve(__dirname, '../tokens/redesign.css')
 const appShellPath = resolve(__dirname, '../components/app-shell.css')
+const regionPagePath = resolve(__dirname, '../../pages/RegionPage.tsx')
 
 const redesignCss = readFileSync(redesignTokensPath, 'utf-8')
 const appShellCss = readFileSync(appShellPath, 'utf-8')
+const regionPageTsx = readFileSync(regionPagePath, 'utf-8')
 
 describe('full-width data-table page policy (#810, ADR-006 §1)', () => {
   it('redesign.css declares --page-max-wide: 1600px in :root', () => {
@@ -41,6 +43,18 @@ describe('full-width data-table page policy (#810, ADR-006 §1)', () => {
   it('the district-detail (clubs) page uses the wide token', () => {
     expect(appShellCss).toMatch(
       /\.district-detail-page\s*\{[^}]*max-width:\s*var\(--page-max-wide\)/
+    )
+  })
+
+  it('the region landing page (RegionPage) uses the wide token (#848)', () => {
+    // #848 — the region rankings page renders a 19-column table; the
+    // 1280 prose cap forces horizontal scroll on every standard desktop.
+    // The data-grid wrapper around the rankings table must consume
+    // `--page-max-wide` (same policy as `.districts-page` /
+    // `.district-detail-page`). The empty-state branch (no districts in
+    // region) is prose and may keep the narrow cap.
+    expect(regionPageTsx).toMatch(
+      /<div className="(?:districts-page|district-detail-page|region-page)">\s*\n\s*<header className="districts-page-header">/
     )
   })
 


### PR DESCRIPTION
Tracks #848 (epic #849 Sprint 1). _The sprint-runner closes #848 explicitly after epic-tick — do NOT auto-close from this PR (lesson 106)._

## What

ADR-006 §1 introduced `--page-max-wide: 1600px` for data-table pages and Sprint 2 (#810) wired it to `.districts-page` + `.district-detail-page`. The **region landing** (`RegionPage`, `/region/:n`) — same 19-column rankings table family — was missed because it used the generic prose wrapper `.app-shell__page` (1280 cap).

This sprint:

- Switches `RegionPage`'s data-grid branch from `.app-shell__page` → `.districts-page` (same chrome family it already uses for header/KPI strip/rankings).
- Extends `frontend/src/styles/__tests__/page-width-tokens.test.ts` with a guard that fails if the RegionPage wrapper drifts back to a non-wide-cap class.
- Amends ADR-006 to enumerate wide-cap pages **by surface, not class** (per lesson 120 — a `.foo-page` class can be shared chrome for a whole route family), and adds `RegionPage` to that list.

The empty-state branch (no districts found in region) intentionally stays on `.app-shell__page` — it is prose, not a data grid.

## Tests

- `npx vitest --run` (full frontend suite): 2982 / 2982 passing.
- `npm run pre-commit` (typecheck + lint + yaml lint): green.

## Verification

Live verification on the PR preview channel (375 / 768 / 1280 / 1600 + dark mode + CLS guard ≤ 0.1) to follow per Full DoD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)