### PR TITLE
feat(landing): hoist 'Find your district' picker above the fold; demote KPI strip to a single tile on mobile (#861)

### DIFF
--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -469,14 +469,21 @@ const DistrictsPage: React.FC = () => {
             </p>
           </div>
         </div>
+        {/* #861 — reserve the mobile-hoisted hero-search slot so the
+            skeleton/error → loaded swap is shift-free (CLS, #826/#488,
+            Lesson 125). Rendered only <768px via CSS. */}
+        <div className="districts-hero-search-skeleton" aria-hidden="true" />
         <div className="districts-kpi-strip" aria-hidden="true">
           {[
             'Paid Clubs · Global',
             'Total Payments',
             'Distinguished Clubs',
             'Districts Tracked',
-          ].map(label => (
-            <div key={label} className="districts-kpi-card">
+          ].map((label, i) => (
+            <div
+              key={label}
+              className={`districts-kpi-card${i > 0 ? ' districts-kpi-card--secondary' : ''}`}
+            >
               <p className="districts-kpi-card__label">{label}</p>
               <div
                 className="districts-kpi-card__value animate-pulse bg-gray-200 rounded-sm"
@@ -761,237 +768,244 @@ const DistrictsPage: React.FC = () => {
           </div>
         </div>
 
-        {/* Global KPI strip (#356, tooltips per #413) */}
-        <div className="districts-kpi-strip">
-          <div className="districts-kpi-card">
-            <p className="districts-kpi-card__label">
-              Paid Clubs · Global
-              <InfoTooltip text="Sum of paid clubs across every tracked district worldwide. A 'paid club' has met its renewal obligations for the program year." />
-            </p>
-            <div
-              className="districts-kpi-card__value"
-              data-testid="kpi-paid-clubs"
-            >
-              {kpiTotals.paidClubs.toLocaleString()}
+        {/* #861 — Mobile hero zone: wraps KPI strip → hero search in a flex
+            stack so the "Find your district" search can hoist above the fold
+            (order:-1) below 768px. At ≥768px the natural source order is kept,
+            so desktop is visually unchanged. */}
+        <div className="districts-hero-stack">
+          {/* Global KPI strip (#356, tooltips per #413) */}
+          <div className="districts-kpi-strip">
+            <div className="districts-kpi-card">
+              <p className="districts-kpi-card__label">
+                Paid Clubs · Global
+                <InfoTooltip text="Sum of paid clubs across every tracked district worldwide. A 'paid club' has met its renewal obligations for the program year." />
+              </p>
+              <div
+                className="districts-kpi-card__value"
+                data-testid="kpi-paid-clubs"
+              >
+                {kpiTotals.paidClubs.toLocaleString()}
+              </div>
+            </div>
+            <div className="districts-kpi-card districts-kpi-card--secondary">
+              <p className="districts-kpi-card__label">
+                Total Payments
+                <InfoTooltip text="Year-to-date membership payment count summed across every tracked district. Members typically pay twice/year so this approximately doubles total membership over a full program year." />
+              </p>
+              <div
+                className="districts-kpi-card__value"
+                data-testid="kpi-total-payments"
+              >
+                {kpiTotals.totalPayments.toLocaleString()}
+              </div>
+            </div>
+            <div className="districts-kpi-card districts-kpi-card--secondary">
+              <p className="districts-kpi-card__label">
+                Distinguished Clubs
+                <InfoTooltip text="Clubs at Distinguished tier or higher (Distinguished / Select / President's / Smedley). See How it works for tier definitions." />
+              </p>
+              <div
+                className="districts-kpi-card__value"
+                data-testid="kpi-distinguished-clubs"
+              >
+                {kpiTotals.distinguishedClubs.toLocaleString()}
+              </div>
+            </div>
+            <div className="districts-kpi-card districts-kpi-card--secondary">
+              <p className="districts-kpi-card__label">
+                Districts Tracked
+                <InfoTooltip text="Number of districts in the current snapshot. Toastmasters has 117 districts worldwide; this counts those with usable data in the most recent rankings file." />
+              </p>
+              <div
+                className="districts-kpi-card__value"
+                data-testid="kpi-districts-tracked"
+              >
+                {kpiTotals.tracked.toLocaleString()}
+              </div>
             </div>
           </div>
-          <div className="districts-kpi-card">
-            <p className="districts-kpi-card__label">
-              Total Payments
-              <InfoTooltip text="Year-to-date membership payment count summed across every tracked district. Members typically pay twice/year so this approximately doubles total membership over a full program year." />
-            </p>
-            <div
-              className="districts-kpi-card__value"
-              data-testid="kpi-total-payments"
-            >
-              {kpiTotals.totalPayments.toLocaleString()}
-            </div>
-          </div>
-          <div className="districts-kpi-card">
-            <p className="districts-kpi-card__label">
-              Distinguished Clubs
-              <InfoTooltip text="Clubs at Distinguished tier or higher (Distinguished / Select / President's / Smedley). See How it works for tier definitions." />
-            </p>
-            <div
-              className="districts-kpi-card__value"
-              data-testid="kpi-distinguished-clubs"
-            >
-              {kpiTotals.distinguishedClubs.toLocaleString()}
-            </div>
-          </div>
-          <div className="districts-kpi-card">
-            <p className="districts-kpi-card__label">
-              Districts Tracked
-              <InfoTooltip text="Number of districts in the current snapshot. Toastmasters has 117 districts worldwide; this counts those with usable data in the most recent rankings file." />
-            </p>
-            <div
-              className="districts-kpi-card__value"
-              data-testid="kpi-districts-tracked"
-            >
-              {kpiTotals.tracked.toLocaleString()}
-            </div>
-          </div>
-        </div>
 
-        {/* Awards Race — competitive district awards (#331) */}
-        <AwardsRaceSection
-          standings={competitiveAwards ?? null}
-          isLoading={isLoadingAwards}
-        />
+          {/* Awards Race — competitive district awards (#331) */}
+          <AwardsRaceSection
+            standings={competitiveAwards ?? null}
+            isLoading={isLoadingAwards}
+          />
 
-        {/* Region Filter Toolbar — compact (#83). The dedicated "Sort by:"
+          {/* Region Filter Toolbar — compact (#83). The dedicated "Sort by:"
             button row was retired in #851: sort now lives on the table
             column headers (click to toggle, URL-synced). */}
-        <div className="districts-toolbar">
-          {/* Region Filter — solo-select pill bar (#434).
+          <div className="districts-toolbar">
+            {/* Region Filter — solo-select pill bar (#434).
               Plain click = solo that region; click again = back to all.
               Shift-click = additive toggle. The "All" pill explicitly
               selects every region and is the active state when no
               filtering is happening. */}
-          {(() => {
-            const isAllActive =
-              regions.length > 0 &&
-              (selectedRegions.length === 0 ||
-                selectedRegions.length === regions.length)
-            const handleRegionClick = (region: string, shiftKey: boolean) => {
-              if (shiftKey) {
-                setSelectedRegions(
-                  selectedRegions.includes(region)
-                    ? selectedRegions.filter(r => r !== region)
-                    : [...selectedRegions, region]
-                )
-                return
-              }
-              const isSoloActive =
-                selectedRegions.length === 1 && selectedRegions[0] === region
-              setSelectedRegions(isSoloActive ? regions : [region])
-            }
-            const stateLabel = isAllActive
-              ? 'Showing all regions'
-              : selectedRegions.length === 1
-                ? `Showing region ${selectedRegions[0]} only`
-                : `Showing ${selectedRegions.length} of ${regions.length} regions`
-            return (
-              <div className="districts-toolbar__row">
-                <span className="districts-toolbar__label">Regions:</span>
-                <button
-                  type="button"
-                  onClick={() => setSelectedRegions(regions)}
-                  className={`districts-toolbar__region-chip${isAllActive ? ' districts-toolbar__region-chip--active' : ''}`}
-                  aria-pressed={isAllActive}
-                >
-                  All
-                </button>
-                {regions.map(region => {
-                  const isActive = selectedRegions.includes(region)
-                  return (
-                    <button
-                      key={region}
-                      type="button"
-                      onClick={e => handleRegionClick(region, e.shiftKey)}
-                      className={`districts-toolbar__region-chip${isActive && !isAllActive ? ' districts-toolbar__region-chip--active' : ''}`}
-                      aria-pressed={isActive && !isAllActive}
-                      aria-label={`Region ${region}`}
-                      title="Click to isolate · shift-click to add"
-                    >
-                      {region}
-                    </button>
+            {(() => {
+              const isAllActive =
+                regions.length > 0 &&
+                (selectedRegions.length === 0 ||
+                  selectedRegions.length === regions.length)
+              const handleRegionClick = (region: string, shiftKey: boolean) => {
+                if (shiftKey) {
+                  setSelectedRegions(
+                    selectedRegions.includes(region)
+                      ? selectedRegions.filter(r => r !== region)
+                      : [...selectedRegions, region]
                   )
-                })}
-                <span
-                  className="districts-toolbar__region-state"
-                  style={{
-                    fontSize: 12,
-                    color: 'var(--ink-3)',
-                    marginLeft: 4,
-                  }}
-                >
-                  {stateLabel}
-                </span>
-              </div>
-            )
-          })()}
-        </div>
-
-        {/* Search Bar — promoted to hero prominence (#435). Larger input,
-            type-ahead suggestions, '/' keyboard shortcut. */}
-        <div
-          className="districts-toolbar__search districts-toolbar__search--hero"
-          style={{ marginBottom: 12 }}
-        >
-          <div className="districts-toolbar__search-icon">
-            <svg
-              width="20"
-              height="20"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
+                  return
+                }
+                const isSoloActive =
+                  selectedRegions.length === 1 && selectedRegions[0] === region
+                setSelectedRegions(isSoloActive ? regions : [region])
+              }
+              const stateLabel = isAllActive
+                ? 'Showing all regions'
+                : selectedRegions.length === 1
+                  ? `Showing region ${selectedRegions[0]} only`
+                  : `Showing ${selectedRegions.length} of ${regions.length} regions`
+              return (
+                <div className="districts-toolbar__row">
+                  <span className="districts-toolbar__label">Regions:</span>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedRegions(regions)}
+                    className={`districts-toolbar__region-chip${isAllActive ? ' districts-toolbar__region-chip--active' : ''}`}
+                    aria-pressed={isAllActive}
+                  >
+                    All
+                  </button>
+                  {regions.map(region => {
+                    const isActive = selectedRegions.includes(region)
+                    return (
+                      <button
+                        key={region}
+                        type="button"
+                        onClick={e => handleRegionClick(region, e.shiftKey)}
+                        className={`districts-toolbar__region-chip${isActive && !isAllActive ? ' districts-toolbar__region-chip--active' : ''}`}
+                        aria-pressed={isActive && !isAllActive}
+                        aria-label={`Region ${region}`}
+                        title="Click to isolate · shift-click to add"
+                      >
+                        {region}
+                      </button>
+                    )
+                  })}
+                  <span
+                    className="districts-toolbar__region-state"
+                    style={{
+                      fontSize: 12,
+                      color: 'var(--ink-3)',
+                      marginLeft: 4,
+                    }}
+                  >
+                    {stateLabel}
+                  </span>
+                </div>
+              )
+            })()}
           </div>
-          <input
-            ref={searchInputRef}
-            type="text"
-            value={searchQuery}
-            onChange={e => setSearchQuery(e.target.value)}
-            onFocus={() => setSearchFocused(true)}
-            onBlur={() => {
-              // Delay so click on a suggestion can register before blur hides
-              window.setTimeout(() => setSearchFocused(false), 150)
-            }}
-            placeholder="Search by district number or name… (press /)"
-            aria-label="Search districts by number or name"
-            aria-controls="district-search-suggestions"
-            aria-expanded={searchFocused && searchSuggestions.length > 0}
-            className="districts-toolbar__search-input"
-          />
-          {searchQuery && (
-            <button
-              type="button"
-              aria-label="Clear search"
-              onClick={() => setSearchQuery('')}
-              style={{
-                position: 'absolute',
-                right: 12,
-                top: '50%',
-                transform: 'translateY(-50%)',
-                background: 'transparent',
-                border: 0,
-                color: 'var(--ink-3)',
-                cursor: 'pointer',
-              }}
-            >
+
+          {/* Search Bar — promoted to hero prominence (#435). Larger input,
+            type-ahead suggestions, '/' keyboard shortcut. */}
+          <div
+            className="districts-toolbar__search districts-toolbar__search--hero"
+            style={{ marginBottom: 12 }}
+          >
+            <div className="districts-toolbar__search-icon">
               <svg
-                className="w-5 h-5"
+                width="20"
+                height="20"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
                 />
               </svg>
-            </button>
-          )}
-          {searchFocused && searchSuggestions.length > 0 && (
-            <ul
-              id="district-search-suggestions"
-              role="listbox"
-              aria-label="District search suggestions"
-              className="districts-toolbar__search-suggestions"
-            >
-              {searchSuggestions.map(s => (
-                <li key={s.districtId} role="option" aria-selected={false}>
-                  <Link
-                    to={`/district/${s.districtId}`}
-                    role="option"
-                    aria-selected={false}
-                    className="districts-toolbar__search-suggestion"
-                  >
-                    <DistrictChipAndName
-                      districtId={s.districtId}
-                      name={s.districtName}
-                      chipClassName="districts-toolbar__search-suggestion-num"
-                      nameClassName="districts-toolbar__search-suggestion-name"
-                    />
-                    <span className="districts-toolbar__search-suggestion-rank">
-                      #{s.displayRank}
-                    </span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          )}
+            </div>
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              onFocus={() => setSearchFocused(true)}
+              onBlur={() => {
+                // Delay so click on a suggestion can register before blur hides
+                window.setTimeout(() => setSearchFocused(false), 150)
+              }}
+              placeholder="Search by district number or name… (press /)"
+              aria-label="Search districts by number or name"
+              aria-controls="district-search-suggestions"
+              aria-expanded={searchFocused && searchSuggestions.length > 0}
+              className="districts-toolbar__search-input"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                aria-label="Clear search"
+                onClick={() => setSearchQuery('')}
+                style={{
+                  position: 'absolute',
+                  right: 12,
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  background: 'transparent',
+                  border: 0,
+                  color: 'var(--ink-3)',
+                  cursor: 'pointer',
+                }}
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            )}
+            {searchFocused && searchSuggestions.length > 0 && (
+              <ul
+                id="district-search-suggestions"
+                role="listbox"
+                aria-label="District search suggestions"
+                className="districts-toolbar__search-suggestions"
+              >
+                {searchSuggestions.map(s => (
+                  <li key={s.districtId} role="option" aria-selected={false}>
+                    <Link
+                      to={`/district/${s.districtId}`}
+                      role="option"
+                      aria-selected={false}
+                      className="districts-toolbar__search-suggestion"
+                    >
+                      <DistrictChipAndName
+                        districtId={s.districtId}
+                        name={s.districtName}
+                        chipClassName="districts-toolbar__search-suggestion-num"
+                        nameClassName="districts-toolbar__search-suggestion-name"
+                      />
+                      <span className="districts-toolbar__search-suggestion-rank">
+                        #{s.displayRank}
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          {/* /.districts-hero-stack (#861) */}
         </div>
 
         {/* Comparison Panel (#93) */}

--- a/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
@@ -178,3 +178,81 @@ describe('DistrictsPage rankings table — responsive + sticky (#811)', () => {
     expect(badge.textContent?.trim()).toBe('1')
   })
 })
+
+/**
+ * Landing hero hoist + KPI demotion (#861, epic #865 Sprint 1).
+ *
+ * Mobile-first triage: the "Find your district" hero search must sit above the
+ * fold at 375px, and the 4-card global KPI strip collapses to a single
+ * headline tile (Paid Clubs · Global) below 768px, restoring the full strip at
+ * ≥768px. jsdom has no layout/media queries (Lesson 66), so these assert the
+ * structural hooks the CSS keys off; the live per-breakpoint position + the
+ * single-visible-tile are proven on the PR preview channel (both engines).
+ *
+ * CLS guard (#826/#488, Lesson 125): the loaded state hoists the search above
+ * the KPI strip, so the shared shell (loading + both error states) must reserve
+ * the same slot, or the KPI strip shifts down on data-load and re-opens the
+ * ~0.2 CLS that lessons 79/107/125 closed.
+ */
+describe('DistrictsPage landing hero hoist + KPI demotion (#861)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps Paid Clubs · Global as the primary tile and marks the other three secondary (hidden <768px)', async () => {
+    setupSingleRow()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    const primary = screen
+      .getByTestId('kpi-paid-clubs')
+      .closest('.districts-kpi-card') as HTMLElement
+    expect(primary.className).not.toMatch(/districts-kpi-card--secondary/)
+
+    for (const tid of [
+      'kpi-total-payments',
+      'kpi-distinguished-clubs',
+      'kpi-districts-tracked',
+    ]) {
+      const card = screen
+        .getByTestId(tid)
+        .closest('.districts-kpi-card') as HTMLElement
+      expect(card.className).toMatch(/districts-kpi-card--secondary/)
+    }
+  })
+
+  it('wraps the hero search and the KPI strip in one reorder stack so the search can hoist on mobile', async () => {
+    setupSingleRow()
+    const { container } = renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    const stack = container.querySelector('.districts-hero-stack')
+    expect(stack).not.toBeNull()
+    expect(
+      stack!.querySelector('.districts-toolbar__search--hero')
+    ).not.toBeNull()
+    expect(stack!.querySelector('.districts-kpi-strip')).not.toBeNull()
+  })
+
+  it('reserves the hoisted-search slot in the loading shell, before the KPI strip (CLS-stable swap)', async () => {
+    // Pending fetch → component stays in the isLoading shell.
+    mockedFetchCdnRankings.mockReturnValue(new Promise(() => {}) as never)
+    const { container } = renderWithProviders(<DistrictsPage />)
+    await screen.findByRole('status', { name: /loading district rankings/i })
+
+    const skel = container.querySelector('.districts-hero-search-skeleton')
+    const strip = container.querySelector('.districts-kpi-strip')
+    expect(skel).not.toBeNull()
+    expect(strip).not.toBeNull()
+    // Placeholder must precede the KPI strip in DOM so it sits above it on mobile.
+    expect(
+      skel!.compareDocumentPosition(strip!) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+
+    // Lesson 125: the KPI demotion must apply to the loading state too.
+    const secondary = container.querySelectorAll(
+      '.districts-kpi-card--secondary'
+    )
+    expect(secondary.length).toBe(3)
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -575,10 +575,7 @@
     margin-bottom: 20px;
   }
 
-  /* #861 — the 2-col step starts at 768px (was 640) so the mobile single-tile
-     demotion below 768 renders the lone headline tile full-width, and the
-     "full strip" returns exactly at the 768 demotion boundary (AC #2). */
-  @media (min-width: 768px) {
+  @media (min-width: 640px) {
     .districts-kpi-strip {
       grid-template-columns: repeat(2, 1fr);
     }
@@ -643,6 +640,17 @@
      Clubs · Global) on mobile. */
   .districts-kpi-card--secondary {
     display: none;
+  }
+
+  /* The lone visible tile must span full width. `.districts-kpi-strip` is
+     SHARED with RegionPage (Lesson 120), which keeps all 4 cards and relies on
+     its 2-col step at 640px — so scope this re-collapse to the landing stack:
+     in the 640–767 band only the landing strip (where 3 cards are --secondary)
+     drops back to a single column. The full strip returns at 768px (AC #2). */
+  @media (min-width: 640px) and (max-width: 767px) {
+    .districts-hero-stack .districts-kpi-strip {
+      grid-template-columns: 1fr;
+    }
   }
 
   /* Reserved slot for the hoisted search in the loading/error shell, so the

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -575,7 +575,10 @@
     margin-bottom: 20px;
   }
 
-  @media (min-width: 640px) {
+  /* #861 — the 2-col step starts at 768px (was 640) so the mobile single-tile
+     demotion below 768 renders the lone headline tile full-width, and the
+     "full strip" returns exactly at the 768 demotion boundary (AC #2). */
+  @media (min-width: 768px) {
     .districts-kpi-strip {
       grid-template-columns: repeat(2, 1fr);
     }
@@ -616,41 +619,56 @@
 
   /* #861 — Mobile hero zone. The KPI strip → AwardsRace → toolbar → hero
      search live in a flex stack so the "Find your district" search can hoist
-     above the fold on small screens via `order`, without reordering the DOM
-     (keeps desktop source order, so desktop is visually unchanged). */
+     above the fold on small screens via `order`. Mobile-first: the hoist + KPI
+     demotion + reserved slot are the BASE state; the ≥768px block below
+     restores the desktop layout, so desktop stays visually byte-identical.
+
+     WCAG 2.4.3 note: the hoist is visual-only (DOM order is unchanged), so on
+     mobile keyboard focus reaches the search after the single KPI tile + region
+     toolbar. Deliberate responsive-reflow tradeoff — it keeps the desktop
+     surface unchanged (AC: "no desktop regression"); the reordered items are
+     non-sequential and the search stays operable + reachable via the '/'
+     shortcut. */
   .districts-hero-stack {
     display: flex;
     flex-direction: column;
   }
 
-  /* Reserved slot for the hoisted search in the loading/error shell, so the
-     skeleton/error → loaded swap doesn't shift the KPI strip down (CLS,
-     #826/#488, Lesson 125). Hidden at ≥768px, where there is no hoist. */
-  .districts-hero-search-skeleton {
+  /* AC #1 — hoist the hero search to the top of the stack (above the fold). */
+  .districts-hero-stack .districts-toolbar__search--hero {
+    order: -1;
+  }
+
+  /* AC #2 — demote the global KPI strip to a single headline tile (Paid
+     Clubs · Global) on mobile. */
+  .districts-kpi-card--secondary {
     display: none;
   }
 
-  @media (max-width: 767px) {
-    /* AC #2 — demote the global KPI strip to a single headline tile (Paid
-       Clubs · Global); the full strip returns at ≥768px. */
-    .districts-kpi-card--secondary {
-      display: none;
-    }
+  /* Reserved slot for the hoisted search in the loading/error shell, so the
+     skeleton/error → loaded swap doesn't shift the KPI strip down (CLS,
+     #826/#488, Lesson 125). Height matches the rendered hero input
+     (14px padding ×2 + ~24px line box + 2px border ×2, border-box). */
+  .districts-hero-search-skeleton {
+    display: block;
+    height: 56px;
+    margin-bottom: 12px;
+    background-color: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-sm);
+  }
 
-    /* AC #1 — hoist the hero search to the top of the stack (above the fold). */
+  /* ≥768px — restore the full desktop layout: full KPI strip, search back in
+     source order, no reserved slot. */
+  @media (min-width: 768px) {
     .districts-hero-stack .districts-toolbar__search--hero {
-      order: -1;
+      order: 0;
     }
-
-    /* Match the hoisted hero-search footprint (≈50px input + 12px gap) so the
-       shell reserves the same space the loaded search lands in. */
-    .districts-hero-search-skeleton {
+    .districts-kpi-card--secondary {
       display: block;
-      height: 50px;
-      margin-bottom: 12px;
-      background-color: var(--surface-2);
-      border: 1px solid var(--line);
-      border-radius: var(--rds-radius-sm);
+    }
+    .districts-hero-search-skeleton {
+      display: none;
     }
   }
 

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -614,6 +614,46 @@
     color: var(--ink);
   }
 
+  /* #861 — Mobile hero zone. The KPI strip → AwardsRace → toolbar → hero
+     search live in a flex stack so the "Find your district" search can hoist
+     above the fold on small screens via `order`, without reordering the DOM
+     (keeps desktop source order, so desktop is visually unchanged). */
+  .districts-hero-stack {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Reserved slot for the hoisted search in the loading/error shell, so the
+     skeleton/error → loaded swap doesn't shift the KPI strip down (CLS,
+     #826/#488, Lesson 125). Hidden at ≥768px, where there is no hoist. */
+  .districts-hero-search-skeleton {
+    display: none;
+  }
+
+  @media (max-width: 767px) {
+    /* AC #2 — demote the global KPI strip to a single headline tile (Paid
+       Clubs · Global); the full strip returns at ≥768px. */
+    .districts-kpi-card--secondary {
+      display: none;
+    }
+
+    /* AC #1 — hoist the hero search to the top of the stack (above the fold). */
+    .districts-hero-stack .districts-toolbar__search--hero {
+      order: -1;
+    }
+
+    /* Match the hoisted hero-search footprint (≈50px input + 12px gap) so the
+       shell reserves the same space the loaded search lands in. */
+    .districts-hero-search-skeleton {
+      display: block;
+      height: 50px;
+      margin-bottom: 12px;
+      background-color: var(--surface-2);
+      border: 1px solid var(--line);
+      border-radius: var(--rds-radius-sm);
+    }
+  }
+
   /* Methodology callout */
   .districts-methodology-callout {
     margin-top: 24px;

--- a/tasks/lessons/131-the-class-cardinality-check-must-cover-every-shared-class-the-diff-touches.md
+++ b/tasks/lessons/131-the-class-cardinality-check-must-cover-every-shared-class-the-diff-touches.md
@@ -1,0 +1,72 @@
+---
+id: '131'
+category: lesson
+tags: [css, frontend, scope, responsive, architecture]
+auto_load: true
+date: 2026-05-28
+issues: [861, 865]
+---
+
+# Lesson 131 — The class-cardinality check must cover EVERY shared class your CSS diff touches, not just the headline one
+
+**Date:** 2026-05-28
+**Issue:** #861 (epic #865 Sprint 1 — landing mobile hoist) — surfaced by the
+fresh-context review before push.
+
+## What happened
+
+The sprint hoisted the landing hero search and demoted the KPI strip to one
+tile on mobile. Lesson 120 was top of mind, so I deliberately did **not** touch
+`.districts-page` (the known route-family-shared chrome) and instead introduced
+a new landing-only `.districts-hero-stack` wrapper. Good.
+
+But the same diff also nudged a breakpoint on `.districts-kpi-strip`
+(`min-width: 640px` → `768px`) so the lone demoted tile wouldn't sit in a
+half-width 2-col grid cell. `.districts-kpi-strip` is **also shared** — RegionPage
+(`pages/RegionPage.tsx`) renders a 4-card strip with the same class and no
+`--secondary` demotion. So the "landing" breakpoint change silently reflowed
+RegionPage's strip from 2-col to 1-col in the 640–767 band: an out-of-scope
+visual regression on a page the sprint never meant to touch, untested (its
+responsive test only covers the table), and invisible in jsdom (Lesson 66).
+
+The fix: revert the shared rule and scope the re-collapse to
+`.districts-hero-stack .districts-kpi-strip` so only the landing strip is
+affected.
+
+## The transferable point
+
+**Applying the Lesson-120 cardinality check to the _obvious_ class is not
+enough — run it on every class-scoped rule the diff edits.** I cleared the
+headline class (`.districts-page`) and felt safe, but a secondary helper class
+(`.districts-kpi-strip`) edited later in the same diff carried the identical
+"looks page-local, is actually shared" trap. The blind spot moves to whichever
+shared class you _didn't_ consciously vet.
+
+Concretely: for each selector your CSS diff changes, run
+`grep -rl 'className="<class>"' src/pages src/components` (or `<class>` for
+template usages). >1 page hit = the change is route-family-wide. Do this for the
+grid/strip/row helper classes too, not just the `*-page` wrapper — helpers are
+the ones that look incidental and get shared the most.
+
+## How to apply
+
+- Before pushing a CSS diff, list every class selector it touches and confirm
+  each one's consumer count. A breakpoint tweak on a "strip"/"grid"/"row" helper
+  is as scope-sensitive as a change to the page wrapper.
+- When a shared class needs page-specific behaviour, scope via an
+  ancestor-qualified selector keyed off a page-local wrapper
+  (`.districts-hero-stack .districts-kpi-strip`), never by editing the shared
+  rule.
+- A fresh-context review caught this where the author's "I already handled the
+  sharing" confidence hid it — exactly the [[120-a-css-class-named-as-a-page-may-be-shared-chrome-for-a-whole-route-family]]
+  blind spot, one class deeper.
+
+## Related
+
+- [[120-a-css-class-named-as-a-page-may-be-shared-chrome-for-a-whole-route-family]]
+  — the parent lesson (verify class→page cardinality before a class-scoped CSS
+  edit). This one adds: do it for _every_ class in the diff, not just the named
+  page class.
+- [[066-jsdom-style-assertions-do-not-catch-positioning-bugs]] — why the
+  RegionPage reflow was invisible to the unit suite and only a live/visual check
+  (or counting consumers) would surface it.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -99,3 +99,4 @@
 - **128** [accessibility, frontend, react, ux] — A filter control is `aria-pressed`, not `role="tab"` — tabs promise a panel switch (#815, #818)
 - **129** [react, frontend, hooks, tests, verification] — A render-phase prop-sync that compares by REFERENCE clobbers local edits when the parent rebuilds the prop each render (#816, #818)
 - **130** [react, frontend, hooks, debounce, router] — A debounced outward-push must gate on the debounce having SETTLED, or an external clear races the stale value back out (#817, #818)
+- **131** [css, frontend, scope, responsive, architecture] — The class-cardinality check must cover EVERY shared class your CSS diff touches, not just the headline one (#861, #865)


### PR DESCRIPTION
## What & why (#861, epic #865 Sprint 1)

Mobile-UX triage for the landing page (`/`) per `docs/design/mobile-ux-audit-2026-05-28.md` §Epic A: turn the front door from a ~28-viewport KPI scroll into a "find my district" page.

- **Hoist** the existing "Find your district" hero search above the fold on mobile.
- **Demote** the 4-card global KPI strip to a single headline tile (**Paid Clubs · Global**) below 768px; the full strip returns at ≥768px.

## How

- New **landing-only** `.districts-hero-stack` flex wrapper around `[KPI strip → AwardsRace → toolbar → hero search]`. On mobile, CSS `order:-1` hoists the search above the fold; at ≥768px source order is restored, so **desktop is visually byte-identical**.
- `districts-kpi-card--secondary` modifier on the 3 non-headline cards → `display:none` below 768px. Applied in the loaded state **and** the loading skeleton.
- CLS-neutral swap: a `.districts-hero-search-skeleton` reserved slot added to `renderShell` so the **loading + both error states** reserve the hoisted-search space (preserves the #826/#488 header+KPI invariant; lessons 79/107/125).
- The single tile renders **full-width** in the 640–767 band via a landing-scoped grid override — `.districts-kpi-strip` is **shared with RegionPage** (Lesson 120), so the shared 640 breakpoint is left untouched.

## Verification

- TDD: RED structural-hook tests → GREEN → /simplify → fresh-context review (one Medium found & fixed: the shared-class breakpoint leak to RegionPage).
- jsdom can't evaluate media queries (Lesson 66) — structural hooks are unit-tested; **live 375px behaviour (both engines) + CLS verified on the PR preview channel** below.
- Full frontend suite green (2996 tests); typecheck clean.

## Notes / tradeoffs

- **WCAG 2.4.3**: the mobile hoist is visual-only (`order`), so keyboard focus reaches the search after the single KPI tile + toolbar. Deliberate responsive-reflow choice to keep desktop unchanged; reordered items are non-sequential and the input stays reachable via the `/` shortcut. Documented at the CSS site.
- Awards Race deferral and districts-list capping are **Sprint 2/3** (this PR leaves them in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
