### PR TITLE
feat(landing): defer Awards Race behind a 'See Awards →' link on mobile (#862)

### DIFF
--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -825,11 +825,22 @@ const DistrictsPage: React.FC = () => {
             </div>
           </div>
 
-          {/* Awards Race — competitive district awards (#331) */}
+          {/* Awards Race — competitive district awards (#331).
+              #862 — at <768px the heavy 3-card section is deferred behind a
+              compact "See Awards →" link to its canonical home (/awards); the
+              full section returns at ≥768px. Both stay mounted — the toggle is
+              pure CSS `display` (see .awards-race / .awards-race-mobile-link),
+              so the desktop render path and the #750 reserved-skeleton CLS
+              contract are untouched, and the mobile section never expands to
+              shift the page. */}
           <AwardsRaceSection
             standings={competitiveAwards ?? null}
             isLoading={isLoadingAwards}
           />
+          <Link to="/awards" className="awards-race-mobile-link">
+            See Awards
+            <span aria-hidden="true"> →</span>
+          </Link>
 
           {/* Region Filter Toolbar — compact (#83). The dedicated "Sort by:"
             button row was retired in #851: sort now lives on the table

--- a/frontend/src/pages/__tests__/DistrictsPage.awardsDefer.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.awardsDefer.test.tsx
@@ -69,8 +69,13 @@ const mockStandings: CompetitiveAwardStandings = {
   byDistrict: {},
 }
 
+// Mutable per-test result so we can exercise both the loaded and the
+// still-loading branch (the #750 reserved-skeleton path) on mobile.
+const { awardsResult } = vi.hoisted(() => ({
+  awardsResult: { current: null as unknown },
+}))
 vi.mock('../../hooks/useCompetitiveAwards', () => ({
-  useCompetitiveAwards: () => ({ data: mockStandings, isLoading: false }),
+  useCompetitiveAwards: () => awardsResult.current,
 }))
 
 const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)
@@ -107,6 +112,7 @@ const setupSingleRow = () => {
 describe('DistrictsPage — defer Awards Race behind a mobile link (#862)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    awardsResult.current = { data: mockStandings, isLoading: false }
   })
 
   it('renders a "See Awards →" link to /awards carrying the mobile-only class', async () => {
@@ -131,6 +137,24 @@ describe('DistrictsPage — defer Awards Race behind a mobile link (#862)', () =
     expect(section).not.toBeNull()
     expect(
       screen.getByRole('heading', { name: /awards race/i })
+    ).toBeInTheDocument()
+  })
+
+  it('keeps the reserved skeleton mounted while awards load (the #750 CLS slot survives the deferral)', async () => {
+    // The whole point of the deferral is that it does NOT touch the desktop
+    // render path: while the separate competitive-awards query is in flight the
+    // section must still mount its height-matched skeleton (carrying
+    // `.awards-race`), so the desktop slot reservation is intact. On mobile the
+    // CSS hides `.awards-race` outright, so the same skeleton can't shift.
+    awardsResult.current = { data: null, isLoading: true }
+    setupSingleRow()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    expect(screen.getByTestId('awards-race-skeleton')).toBeInTheDocument()
+    // The mobile link is always mounted alongside it.
+    expect(
+      screen.getByRole('link', { name: /see awards/i })
     ).toBeInTheDocument()
   })
 

--- a/frontend/src/pages/__tests__/DistrictsPage.awardsDefer.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.awardsDefer.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Landing Awards-Race mobile deferral (#862, epic #865 Sprint 2).
+ *
+ * Mobile-first triage: at <768px the heavy 3-card Awards Race section is the
+ * single biggest above-the-fold block that isn't "find my district". It already
+ * has a canonical home at `/awards`, so on mobile we replace it with a compact
+ * "See Awards →" link and hide the full section; at ≥768px the section is shown
+ * and the link hidden — desktop is visually unchanged.
+ *
+ * jsdom has no layout/media queries (Lesson 66), so these assert the structural
+ * hooks the CSS keys off (the always-rendered section + always-rendered link,
+ * each carrying the class its `@media` rule toggles `display` on). The live
+ * per-breakpoint show/hide is proven on the PR preview channel in both engines.
+ *
+ * Both surfaces stay mounted in the DOM at every width — the toggle is pure CSS
+ * `display`. That keeps the desktop section render path (and its #750 reserved
+ * skeleton / CLS contract) untouched: this sprint only adds a sibling link and a
+ * media query, it does not change AwardsRaceSection.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import DistrictsPage from '../DistrictsPage'
+import { fetchCdnRankings } from '../../services/cdn'
+import type { CompetitiveAwardStandings } from '../../services/cdn'
+import { renderWithProviders } from '../../__tests__/test-utils'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: [],
+    count: 0,
+    generatedAt: '2025-01-01T00:00:00Z',
+  }),
+  fetchCdnSnapshotIndex: vi.fn().mockResolvedValue({}),
+  fetchCdnRankings: vi.fn(),
+  fetchCdnManifest: vi.fn().mockResolvedValue({
+    latestSnapshotDate: '2025-11-22',
+    generatedAt: '2025-01-01T00:00:00Z',
+  }),
+  cdnAnalyticsUrl: vi.fn().mockReturnValue('https://cdn.taverns.red/test'),
+  fetchFromCdn: vi.fn(),
+}))
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: () => ({
+    data: { districts: [] },
+    isLoading: false,
+    isError: false,
+  }),
+}))
+
+const mockStandings: CompetitiveAwardStandings = {
+  metadata: {
+    snapshotId: '2025-11-22',
+    calculatedAt: '2025-11-22T00:00:00.000Z',
+    totalDistricts: 1,
+  },
+  extensionAward: [
+    {
+      districtId: '7',
+      districtName: 'District 7',
+      region: '7',
+      rank: 1,
+      value: 14,
+      isWinner: false,
+    },
+  ],
+  twentyPlusAward: [],
+  retentionAward: [],
+  byDistrict: {},
+}
+
+vi.mock('../../hooks/useCompetitiveAwards', () => ({
+  useCompetitiveAwards: () => ({ data: mockStandings, isLoading: false }),
+}))
+
+const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)
+
+const setupSingleRow = () => {
+  mockedFetchCdnRankings.mockResolvedValue({
+    rankings: [
+      {
+        districtId: '7',
+        districtName: 'District 7',
+        region: '7',
+        paidClubs: 100,
+        paidClubBase: 90,
+        clubGrowthPercent: 11.1,
+        totalPayments: 5000,
+        paymentBase: 4500,
+        paymentGrowthPercent: 11.1,
+        activeClubs: 100,
+        distinguishedClubs: 50,
+        selectDistinguished: 20,
+        presidentsDistinguished: 10,
+        distinguishedPercent: 50,
+        clubsRank: 1,
+        paymentsRank: 1,
+        distinguishedRank: 1,
+        aggregateScore: 300,
+        overallRank: 1,
+      },
+    ],
+    date: '2025-11-22',
+  } as never)
+}
+
+describe('DistrictsPage — defer Awards Race behind a mobile link (#862)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a "See Awards →" link to /awards carrying the mobile-only class', async () => {
+    setupSingleRow()
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    const link = screen.getByRole('link', { name: /see awards/i })
+    expect(link).toHaveAttribute('href', '/awards')
+    // The class its `@media (min-width: 768px) { display: none }` rule keys off.
+    expect(link.className).toMatch(/awards-race-mobile-link/)
+  })
+
+  it('keeps the full Awards Race section mounted (the ≥768px desktop slot is unchanged)', async () => {
+    setupSingleRow()
+    const { container } = renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    // Section still in DOM at every width; CSS hides it <768px. The render
+    // path (incl. the #750 reserved-skeleton CLS contract) is untouched.
+    const section = container.querySelector('.awards-race')
+    expect(section).not.toBeNull()
+    expect(
+      screen.getByRole('heading', { name: /awards race/i })
+    ).toBeInTheDocument()
+  })
+
+  it('places the mobile link in the hero stack, adjacent to the deferred section', async () => {
+    setupSingleRow()
+    const { container } = renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    const stack = container.querySelector('.districts-hero-stack')
+    expect(stack).not.toBeNull()
+    expect(stack!.querySelector('.awards-race-mobile-link')).not.toBeNull()
+    expect(stack!.querySelector('.awards-race')).not.toBeNull()
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -2602,6 +2602,46 @@
     }
   }
 
+  /* #862 — defer the heavy 3-card Awards Race behind a compact link on mobile.
+     The section already has a canonical home at /awards, so <768px we hide the
+     full section (and its loading skeleton — both carry `.awards-race`) and
+     show the "See Awards →" link instead. At ≥768px the section returns and the
+     link is hidden, leaving desktop visually unchanged. Pure CSS `display`
+     toggle so both stay mounted (#750 reserved-skeleton CLS contract intact;
+     the hidden mobile section can't shift the page on its late data arrival). */
+  .awards-race-mobile-link {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 20px;
+    padding: 14px 16px;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-md);
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--ink);
+    text-decoration: none;
+  }
+
+  .awards-race-mobile-link:hover {
+    border-color: var(--ink-3);
+  }
+
+  @media (min-width: 768px) {
+    .awards-race-mobile-link {
+      display: none;
+    }
+  }
+
+  @media (max-width: 767px) {
+    .awards-race {
+      display: none;
+    }
+  }
+
   .awards-race-card {
     display: flex;
     flex-direction: column;

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -2615,7 +2615,9 @@
     justify-content: space-between;
     gap: 8px;
     margin-bottom: 20px;
-    padding: 14px 16px;
+    /* ≥44px touch target (Lesson 111): 16px vertical padding + 14px line-box
+       clears 44px unambiguously. */
+    padding: 16px;
     background-color: var(--surface);
     border: 1px solid var(--line);
     border-radius: var(--rds-radius-md);


### PR DESCRIPTION
## What & why

Epic #865 Sprint 2 (mobile UX triage). At <768px the heavy 3-card **Awards Race** section is the largest above-the-fold block on `/` that isn't "find my district". It already has a canonical home at `/awards`, so on mobile we replace it with a compact **"See Awards →"** link and hide the full section. At ≥768px the section returns and the link is hidden — **desktop is visually unchanged**.

## Approach

Pure CSS `display` toggle (R10), matching #861's responsive pattern:
- `@media (max-width: 767px) { .awards-race { display: none } }` — hides the section (and its loading skeleton; both carry `.awards-race`).
- `@media (min-width: 768px) { .awards-race-mobile-link { display: none } }` — hides the link on desktop.
- A `<Link to="/awards">` sibling rendered in the hero stack, adjacent to the section.

Both surfaces stay mounted at every width, so the **#750 reserved-skeleton CLS contract is untouched** (the desktop render path of `AwardsRaceSection` is not modified). On mobile the section is `display:none`, so its late competitive-awards data arrival reserves zero height and cannot shift the page.

## Acceptance criteria
- [x] Awards Race section replaced by a single link on mobile.
- [x] Desktop section unchanged (DOM + render path identical).
- [x] Tests added; no assertion pinning.

## Tests
New `DistrictsPage.awardsDefer.test.tsx` (4 tests): link href/class, section stays mounted, hero-stack placement, and the #750 skeleton still mounts while awards load. Full frontend suite green (3000 passed). jsdom has no media queries (Lesson 66) — per-breakpoint show/hide proven on the PR preview channel (375px Chromium + WebKit) per the sprint verification step.

Fresh-context review: APPROVE-WITH-NITS; both nits applied (touch target ≥44px per Lesson 111; loading-state test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)