### PR TITLE
feat(landing): cap districts list to top-20 on mobile with 'Show all' disclosure (#863)

### DIFF
--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -28,6 +28,17 @@ import {
 } from '../utils/programYear'
 import { DistrictRanking } from '../types/districts'
 import { arrayToCSV, downloadCSV } from '../utils/csvExport'
+import { useIsMobile } from '../hooks/useIsMobile'
+
+// On mobile (<768px) the rankings render only the top slice by default,
+// followed by a "Show all <n>" disclosure. The user landed on `/` to find
+// THEIR district, not to read a 138-row leaderboard on a phone (mobile-ux-audit
+// 2026-05-28 §Epic A, #863). 20 keeps the strongest performers — plus any
+// pinned "my district", which displayRankings hoists to the top — visible in a
+// thumb-scroll or two before the disclosure. Desktop is unaffected: it always
+// renders the full list. The cap also yields off when a search is active, so a
+// query never hides its own matches.
+const MOBILE_RANKINGS_CAP = 20
 
 const DistrictsPage: React.FC = () => {
   const navigate = useNavigate()
@@ -336,6 +347,26 @@ const DistrictsPage: React.FC = () => {
     )
     return [myRow, ...rest]
   }, [filteredRankingsBySearch, myDistrictId])
+
+  // Mobile top-N cap (#863). Below 768px, default to the top
+  // MOBILE_RANKINGS_CAP rows and reveal the rest behind a disclosure. Held off
+  // while a search is active (the result set is already narrowed and capping it
+  // would hide matches) and when the list is already at/under the cap.
+  const isMobile = useIsMobile(768)
+  const [showAllMobile, setShowAllMobile] = useState(false)
+  const isSearching = searchQuery.trim().length > 0
+  const mobileCapActive =
+    isMobile &&
+    !showAllMobile &&
+    !isSearching &&
+    displayRankings.length > MOBILE_RANKINGS_CAP
+  const visibleRankings = mobileCapActive
+    ? displayRankings.slice(0, MOBILE_RANKINGS_CAP)
+    : displayRankings
+  // The disclosure toggle is mobile-only and only when there's something to
+  // reveal; in the expanded state it offers a way back to the capped view.
+  const showMobileDisclosure =
+    isMobile && !isSearching && displayRankings.length > MOBILE_RANKINGS_CAP
 
   // Type-ahead suggestions for the search bar (#435). Top 5 matches.
   const searchSuggestions = React.useMemo(() => {
@@ -1118,7 +1149,7 @@ const DistrictsPage: React.FC = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {displayRankings.map(district => {
+                  {visibleRankings.map(district => {
                     const rank = district.displayRank
                     const isPinned = pinnedDistrictIds.has(district.districtId)
                     const pinDisabled =
@@ -1413,6 +1444,23 @@ const DistrictsPage: React.FC = () => {
               aria-hidden="true"
             />
           </div>
+          {/* Mobile-only top-N disclosure (#863). Sits outside the horizontal
+              scroller so it spans the full width and its focus ring is visible
+              (Lesson 58). Hidden on desktop and while searching via the
+              showMobileDisclosure gate above. */}
+          {showMobileDisclosure && (
+            <button
+              type="button"
+              data-testid="mobile-show-all-districts"
+              className="districts-rankings-table__show-all"
+              aria-expanded={showAllMobile}
+              onClick={() => setShowAllMobile(v => !v)}
+            >
+              {showAllMobile
+                ? `Show top ${MOBILE_RANKINGS_CAP}`
+                : `Show all ${displayRankings.length} districts`}
+            </button>
+          )}
         </div>
 
         {/* Historical Rank Progression — collapsed by default (#83) */}

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -355,18 +355,17 @@ const DistrictsPage: React.FC = () => {
   const isMobile = useIsMobile(768)
   const [showAllMobile, setShowAllMobile] = useState(false)
   const isSearching = searchQuery.trim().length > 0
-  const mobileCapActive =
-    isMobile &&
-    !showAllMobile &&
-    !isSearching &&
-    displayRankings.length > MOBILE_RANKINGS_CAP
+  // The cap features (the disclosure toggle and the row-slice) both apply only
+  // on mobile, off-search, and when there are more rows than the cap.
+  const mobileCapEligible =
+    isMobile && !isSearching && displayRankings.length > MOBILE_RANKINGS_CAP
+  // The slice is active until the user expands; the disclosure stays visible in
+  // the expanded state so it offers a way back to the capped view.
+  const mobileCapActive = mobileCapEligible && !showAllMobile
   const visibleRankings = mobileCapActive
     ? displayRankings.slice(0, MOBILE_RANKINGS_CAP)
     : displayRankings
-  // The disclosure toggle is mobile-only and only when there's something to
-  // reveal; in the expanded state it offers a way back to the capped view.
-  const showMobileDisclosure =
-    isMobile && !isSearching && displayRankings.length > MOBILE_RANKINGS_CAP
+  const showMobileDisclosure = mobileCapEligible
 
   // Type-ahead suggestions for the search bar (#435). Top 5 matches.
   const searchSuggestions = React.useMemo(() => {

--- a/frontend/src/pages/__tests__/DistrictsPage.mobileCap.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.mobileCap.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * DistrictsPage landing rankings — cap the list to top-N on mobile with a
+ * "Show all <count>" disclosure (#863, epic #865 Sprint 3).
+ *
+ * Mobile-first triage (mobile-ux-audit-2026-05-28 §Epic A): the user landed on
+ * `/` to find THEIR district, not to read a 138-row leaderboard on a phone. So
+ * below 768px the rankings render only the top MOBILE_RANKINGS_CAP rows by
+ * default, followed by a "Show all <n> districts" disclosure that reveals the
+ * rest. Desktop (≥768px) is unchanged — it shows the full list and never sees
+ * the disclosure.
+ *
+ * jsdom has no real media queries, so useIsMobile reads from a stubbed
+ * window.matchMedia (Lesson 66 — live per-breakpoint layout is proven on the
+ * PR preview channel in both engines). matches:true ⇒ mobile, matches:false ⇒
+ * desktop.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DistrictsPage from '../DistrictsPage'
+import { fetchCdnRankings } from '../../services/cdn'
+import { renderWithProviders } from '../../__tests__/test-utils'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: [],
+    count: 0,
+    generatedAt: '2025-01-01T00:00:00Z',
+  }),
+  fetchCdnSnapshotIndex: vi.fn().mockResolvedValue({}),
+  fetchCdnRankings: vi.fn(),
+  fetchCdnManifest: vi.fn().mockResolvedValue({
+    latestSnapshotDate: '2025-11-22',
+    generatedAt: '2025-01-01T00:00:00Z',
+  }),
+  cdnAnalyticsUrl: vi.fn().mockReturnValue('https://cdn.taverns.red/test'),
+  fetchFromCdn: vi.fn(),
+}))
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: () => ({
+    data: { districts: [] },
+    isLoading: false,
+    isError: false,
+  }),
+}))
+
+const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)
+
+const makeRow = (i: number) => ({
+  districtId: String(i),
+  districtName: `District ${i}`,
+  region: String((i % 14) + 1),
+  paidClubs: 200 - i,
+  paidClubBase: 190 - i,
+  clubGrowthPercent: 5,
+  totalPayments: 5000 - i,
+  paymentBase: 4500,
+  paymentGrowthPercent: 5,
+  activeClubs: 200 - i,
+  distinguishedClubs: 50,
+  selectDistinguished: 20,
+  presidentsDistinguished: 10,
+  distinguishedPercent: 25,
+  clubsRank: i,
+  paymentsRank: i,
+  distinguishedRank: i,
+  aggregateScore: 1000 - i,
+  overallRank: i,
+})
+
+/** Resolve the rankings fetch with `n` districts (ids 1..n). */
+const setupRows = (n: number) => {
+  mockedFetchCdnRankings.mockResolvedValue({
+    rankings: Array.from({ length: n }, (_, idx) => makeRow(idx + 1)),
+    date: '2025-11-22',
+  } as never)
+}
+
+/** Stub matchMedia so useIsMobile(768) resolves to the given viewport. */
+const stubViewport = (mobile: boolean) => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: mobile,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  )
+}
+
+const rowCount = () => screen.getAllByTestId(/^district-row-/).length
+
+describe('DistrictsPage mobile top-N cap + disclosure (#863)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('caps the list to the top 20 on mobile and shows a "Show all 25 districts" disclosure', async () => {
+    stubViewport(true)
+    setupRows(25)
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 1')
+
+    expect(rowCount()).toBe(20)
+
+    const showAll = screen.getByTestId('mobile-show-all-districts')
+    expect(showAll).toHaveTextContent(/show all 25 districts/i)
+    expect(showAll).toHaveAttribute('aria-expanded', 'false')
+    // Rows beyond the cap are not in the DOM yet.
+    expect(screen.queryByTestId('district-row-25')).toBeNull()
+  })
+
+  it('reveals the full list when the disclosure is tapped, and toggles its label/aria', async () => {
+    stubViewport(true)
+    setupRows(25)
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 1')
+
+    await userEvent.click(screen.getByTestId('mobile-show-all-districts'))
+
+    expect(rowCount()).toBe(25)
+    expect(screen.getByTestId('district-row-25')).toBeInTheDocument()
+    const showAll = screen.getByTestId('mobile-show-all-districts')
+    expect(showAll).toHaveAttribute('aria-expanded', 'true')
+    expect(showAll).toHaveTextContent(/show top 20/i)
+  })
+
+  it('shows the full list and no disclosure on desktop', async () => {
+    stubViewport(false)
+    setupRows(25)
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 1')
+
+    expect(rowCount()).toBe(25)
+    expect(screen.queryByTestId('mobile-show-all-districts')).toBeNull()
+  })
+
+  it('does not cap when the list is already at or below the cap on mobile', async () => {
+    stubViewport(true)
+    setupRows(12)
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 1')
+
+    expect(rowCount()).toBe(12)
+    expect(screen.queryByTestId('mobile-show-all-districts')).toBeNull()
+  })
+
+  it('does not cap an active search on mobile (search must not hide matches)', async () => {
+    stubViewport(true)
+    setupRows(25)
+    renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 1')
+
+    // "District" matches every row by name → 25 results, all shown, no cap.
+    const search = screen.getByRole('textbox', { name: /search districts/i })
+    await userEvent.type(search, 'District')
+
+    expect(rowCount()).toBe(25)
+    expect(screen.queryByTestId('mobile-show-all-districts')).toBeNull()
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -1093,10 +1093,13 @@
     min-height: 44px;
     margin-top: 0.5rem;
     padding: 0.625rem 1rem;
-    border: 1px solid var(--border, #d1d5db);
+    border: 1px solid var(--line, #e5e7eb);
     border-radius: 0.5rem;
-    background: var(--surface, #fff);
-    color: var(--rt-stats, #d4873f);
+    background: var(--surface, #ffffff);
+    /* Label is primary ink (AA on --surface in both themes); the --rt-stats
+       amber accent is reserved for the hover border so the label never falls
+       below 4.5:1 (amber-on-white is ~2.4:1 — Lesson 112). */
+    color: var(--ink, #0f1720);
     font-size: 0.875rem;
     font-weight: 600;
     cursor: pointer;

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -1083,6 +1083,32 @@
     opacity: 1;
   }
 
+  /* Mobile-only top-N disclosure (#863). Full-width, ≥44px touch target
+     (Lesson 111). Gated to mobile by React (showMobileDisclosure), so no media
+     query is needed here — it simply isn't rendered on desktop. Themed tokens
+     so it remaps in dark (Lesson 116 — no hardcoded literals). */
+  .districts-rankings-table__show-all {
+    display: block;
+    width: 100%;
+    min-height: 44px;
+    margin-top: 0.5rem;
+    padding: 0.625rem 1rem;
+    border: 1px solid var(--border, #d1d5db);
+    border-radius: 0.5rem;
+    background: var(--surface, #fff);
+    color: var(--rt-stats, #d4873f);
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+  .districts-rankings-table__show-all:hover {
+    background: var(--surface-2, #f9fafb);
+    border-color: var(--rt-stats, #d4873f);
+  }
+
   /* Region rankings: intentional, documented horizontal scroll (#689, epic
      #683). The 19-column table can't fit a phone and a regional leaderboard
      exists to compare districts across rows, so card-collapse is wrong here


### PR DESCRIPTION
## Summary

Sprint 3 of epic #865 (mobile UX audit Epic A). On mobile (<768px) the landing-page district rankings now render only the **top 20** by default, followed by a **"Show all <count> districts"** disclosure that reveals the rest. Desktop is unchanged — it always renders the full list and never sees the disclosure. The user came to `/` to find *their* district, not to read a 138-row leaderboard on a phone (mobile-ux-audit-2026-05-28 §Epic A).

Part of #863.

## What changed
- `DistrictsPage.tsx` — `MOBILE_RANKINGS_CAP = 20` (module constant + comment naming the choice); `useIsMobile(768)` + `showAllMobile` state gate a `visibleRankings` slice and a disclosure button. Cap yields off while a search is active (a query never hides its own matches) and when the list is already ≤ cap.
- `app-shell.css` — `.districts-rankings-table__show-all`: full-width, ≥44px touch target (Lesson 111), themed tokens (`--ink` label / `--surface` / `--line` / `--rt-stats` hover accent) so it remaps in dark and the label clears AA contrast (Lesson 112).

## Design notes
- Leaderboard intent preserved (Lesson 105): this caps **rows**, it does not card-collapse — the table + non-trap horizontal scroll stay intact.
- `displayRankings` hoists a pinned "my district" to index 0, so the top-20 slice always includes it.
- Row capping is JS-driven (CSS can't cleanly limit DOM row *count*, and the toggle needs state); column-hiding stays CSS-media-driven as before.

## Testing
- New TDD test `DistrictsPage.mobileCap.test.tsx` (red→green): caps to 20 + discloses full count on mobile; tap reveals all + toggles label/aria; desktop shows full list, no button; no cap at/under cap; no cap during search. Mobile exercised via stubbed `matchMedia` (jsdom has no media queries — Lesson 66).
- Full frontend suite green: **3005 passed**.
- 375px Chromium + WebKit live smoke on the PR preview channel to follow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)