### PR TITLE
test(landing): mobile scroll-length regression guard (#864)

### DIFF
--- a/frontend/e2e/landing-mobile-scroll.smoke.ts
+++ b/frontend/e2e/landing-mobile-scroll.smoke.ts
@@ -1,0 +1,66 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/* Landing-page mobile scroll-length guard (#864, epic #865 "mobile UX audit").
+ *
+ * Epic A turned `/` from a ~28-viewport scroll into a "find my district" page
+ * via three sprints: hoist the picker + demote the KPI strip (#861), defer the
+ * Awards Race behind a link (#862), and cap the districts list to the top
+ * MOBILE_RANKINGS_CAP with a "Show all" disclosure on mobile (#863).
+ *
+ * Sprint 4 (#864) verified the cumulative win empirically: at 375px / 414px the
+ * full-page scrollHeight dropped from a measured 19,529–22,176px baseline
+ * (pre-#861, commit de7cf5e3) to ~5,046–5,433px — a 73.8–75.9% reduction in
+ * both Chromium and WebKit, well past the epic's ≥60% target.
+ *
+ * This guard locks that win in. The mobile caps are render-time gates fed by a
+ * separately-resolving rankings query (the Lesson 79 / 107 CLS shape): a future
+ * change that un-defers the Awards Race or un-caps the list would silently
+ * restore the multi-screen scroll. An 8,000px ceiling sits ~47% above the
+ * current ~5.4k px ship (so ordinary content growth won't flake it) yet
+ * guarantees a ≥59% reduction against the lowest measured baseline (19,529px) —
+ * any regression toward the old uncapped page (the un-capped list alone adds
+ * ~14k px) breaches it loudly. Runs in BOTH engines via playwright.config
+ * (smoke=Chromium, webkit=Safari) because the mobile state is width-driven
+ * (useIsMobile -> matchMedia), not touch-driven. */
+
+const SCROLL_BUDGET_PX = 8000
+
+const VIEWPORTS = [
+  { name: '375', width: 375, height: 812 }, // iPhone-class portrait
+  { name: '414', width: 414, height: 896 }, // larger phone portrait
+]
+
+async function landingScrollHeight(page: Page): Promise<number> {
+  await page.goto('/', { waitUntil: 'networkidle', timeout: 60_000 })
+
+  // Wait for the rankings table to render so we measure the populated page,
+  // not a loading skeleton (a skeleton is short and would falsely pass).
+  await page
+    .locator('table[aria-label="District rankings"]')
+    .waitFor({ state: 'visible', timeout: 30_000 })
+
+  // The mobile top-N cap must be active — this is the state whose scroll length
+  // the epic shrank. If it isn't visible we'd be measuring the desktop fallback
+  // and the budget would be meaningless.
+  await expect(
+    page.locator('[data-testid="mobile-show-all-districts"]')
+  ).toBeVisible({ timeout: 10_000 })
+
+  // Let any secondary, separately-resolving section settle before measuring.
+  await page.waitForTimeout(1_000)
+
+  return page.evaluate(() => document.documentElement.scrollHeight)
+}
+
+for (const vp of VIEWPORTS) {
+  test(`landing / stays under scroll budget at ${vp.name}px`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: vp.width, height: vp.height })
+    const scrollHeight = await landingScrollHeight(page)
+    expect(
+      scrollHeight,
+      `landing / scrollHeight ${scrollHeight}px exceeds the ${SCROLL_BUDGET_PX}px mobile budget at ${vp.width}px — the #861-#863 mobile caps may have regressed`
+    ).toBeLessThan(SCROLL_BUDGET_PX)
+  })
+}

--- a/tasks/lessons/133-measure-a-multi-sprint-ux-delta-with-a-cors-proxy-and-per-build-served-dirs.md
+++ b/tasks/lessons/133-measure-a-multi-sprint-ux-delta-with-a-cors-proxy-and-per-build-served-dirs.md
@@ -1,0 +1,55 @@
+---
+id: '133'
+category: lesson
+tags: [verification, playwright, frontend, cls, tests]
+auto_load: true
+date: 2026-05-28
+issues: [864, 865]
+---
+
+# Lesson 133 — To measure a before/after UX delta locally, proxy the prod CDN and give each git state its own served dir
+
+**Date:** 2026-05-28
+**Issue:** #864 (epic #865 Sprint 4 — verify the landing-page scroll-length drop)
+**PR:** [#898](https://github.com/taverns-red/toast-stats/pull/898)
+
+## What happened
+
+Sprint 4 was a pure verification gate: prove the landing page `/` scroll length
+dropped ≥60% at 375/414px in Chromium **and** WebKit after three earlier
+sprints capped it. There is no deployed "before" — the baseline is a commit
+(`de7cf5e3`, pre-#861). Two obstacles, both with reusable fixes:
+
+1. **CORS blocks a local build from the prod CDN.** `vite preview` of a local
+   build defaults `VITE_CDN_BASE_URL` to `https://cdn.taverns.red`, which
+   returns 200 but **no `Access-Control-Allow-Origin`** for a `localhost`
+   origin — so the SPA renders "Error Loading Rankings / Failed to fetch" and
+   the page is ~1 viewport tall (a false "huge drop"). Fix: a ~20-line node
+   `http` proxy that refetches the CDN path and adds `access-control-allow-origin: *`,
+   then build **both** states with `VITE_CDN_BASE_URL=http://localhost:8899`.
+   Same real prod data on both sides → apples-to-apples.
+
+2. **`vite preview` serves `frontend/dist` live from disk.** Two preview
+   servers on different ports both serve `frontend/dist`. Building the second
+   git state (`npm run build:frontend`) **overwrites the dist the first server
+   is still serving** — so the "after" server silently starts serving the
+   "baseline" bundle. The tell was a Playwright run that showed 128 uncapped
+   rows / 22,176px against the port I thought held the capped build. Fix: build
+   each state into its **own** output dir (or re-measure each state immediately
+   after its own build, before touching the other).
+
+A third confound to rule out first: at a narrow viewport the desktop layout can
+still render if `useIsMobile` (matchMedia `max-width:767`) resolves false. Here
+it was a red herring — the "desktop at 375px" screenshots were just the
+baseline bundle (which predates the mobile cap), not a media-query miss.
+
+## The takeaway
+
+A "verify the win" sprint on a CDN-backed SPA needs a measurement harness, not
+just a smoke: **proxy the CDN for CORS, pin both git states to it, and isolate
+each build's served files.** Then the durable artifact is a budget guard gated
+on the capped state being active —
+the caps are fed by a separately-resolving query, so a future un-cap silently
+reverts the win unless a test holds the line. (See lessons
+[107](107-a-deferred-async-insert-cls-source-reactivates-when-its-data-lands.md)
+and [079](079-suspense-fallback-for-null-component-is-pure-cls.md).)

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -101,3 +101,4 @@
 - **130** [react, frontend, hooks, debounce, router] — A debounced outward-push must gate on the debounce having SETTLED, or an external clear races the stale value back out (#817, #818)
 - **131** [css, frontend, scope, responsive, architecture] — The class-cardinality check must cover EVERY shared class your CSS diff touches, not just the headline one (#861, #865)
 - **132** [css, dark-mode, frontend, tailwind] — A `var(--undefined-token, #hex)` fallback is a permanent literal, not a theme (#863, #865)
+- **133** [verification, playwright, frontend, cls, tests] — To measure a before/after UX delta locally, proxy the prod CDN and give each git state its own served dir (#864, #865)


### PR DESCRIPTION
## Sprint 4 of epic #865 (Mobile UX audit — Epic A) — verification

Epic A reshaped the landing page `/` across three sprints: hoist the picker + demote the KPI strip (#861), defer the Awards Race behind a link (#862), cap the districts list to top-N with a "Show all" disclosure on mobile (#863). Sprint 4 (#864) is the **verification gate**: confirm the cumulative scroll-length drop is ≥60% at 375px / 414px in Chromium **and** WebKit.

### Measured result (apples-to-apples, prod-CDN data via local CORS proxy)

| engine / viewport | baseline (de7cf5e3, pre-#861) | after (origin/main) | drop |
|---|---|---|---|
| Chromium 375 | 22,176px | 5,433px | **75.5%** |
| Chromium 414 | 22,072px | 5,330px | **75.9%** |
| WebKit 375 | 19,633px | 5,149px | **73.8%** |
| WebKit 414 | 19,529px | 5,046px | **74.2%** |

Min drop **73.8%** — clears the ≥60% target on every combination. The ~22k px baseline matches the audit's "≈28-viewport scroll" framing.

### What ships

A dual-engine Playwright smoke (`frontend/e2e/landing-mobile-scroll.smoke.ts`) that asserts `/` stays under an **8,000px** scroll budget while the mobile top-N cap is active. The caps are render-time gates fed by a separately-resolving rankings query (the Lesson 79/107 CLS shape) — a future un-defer/un-cap would silently restore the multi-screen scroll. The guard catches that loudly.

- **Red:** the budget assertion fails against the baseline build (received 22,176px > 8000) in both engines.
- **Green:** passes against `origin/main` (≤5,433px) in both engines.
- 8,000px sits ~47% above the current ~5.4k ship (no flake on content growth) yet guarantees ≥59% reduction vs the lowest baseline.

No production code change — verification + regression guard only. Full frontend suite: 3005 tests pass.

Closes nothing automatically — sub-issue close + epic tick handled by the runner ordering (#626).