### PR TITLE
feat(district): 2×2 KPI grid on mobile (#866)

### DIFF
--- a/frontend/src/__tests__/css-migration/district-breakpoints.test.ts
+++ b/frontend/src/__tests__/css-migration/district-breakpoints.test.ts
@@ -30,10 +30,16 @@ describe('District breakpoint reconciliation (#682)', () => {
       expect(narrativeCss).not.toContain('min-width: 768px')
     })
 
-    it('keeps the 640px 2-col intermediate step (#681)', () => {
-      // The 4-card strip steps 1 → 2 (640) → 4 (980); the 640 intermediate
-      // avoids four tall stacked cards on tablet and is intentionally kept.
-      expect(narrativeCss).toContain('min-width: 640px')
+    it('makes 2-col (2×2) the mobile base, no 640px intermediate (#866)', () => {
+      // #866 collapsed the old 1-col mobile base into 2×2 (mobile-ux-audit
+      // §Epic B Sprint 1), so the strip now steps base-2-col → 4-col (980).
+      // The former `min-width: 640px` intermediate is gone — the base already
+      // delivers 2 columns, so the query was redundant. Desktop threshold (980)
+      // is unchanged (asserted above).
+      expect(narrativeCss).not.toContain('min-width: 640px')
+      expect(narrativeCss).toMatch(
+        /\.district-kpi-strip__cards\s*\{[^}]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/
+      )
     })
   })
 

--- a/frontend/src/styles/__tests__/districtNarrative.test.ts
+++ b/frontend/src/styles/__tests__/districtNarrative.test.ts
@@ -48,6 +48,31 @@ describe('district-narrative.css (#572)', () => {
     )
   })
 
+  it('defaults the KPI card grid to 2 columns (2×2) on mobile (#866)', () => {
+    // #866 — at <768px the 4-card strip was a 1×4 vertical stack. The base
+    // grid (no min-width gate) must declare 2 columns so phones get 2×2,
+    // halving the strip's vertical footprint. The 4-across desktop layout is
+    // still gated behind the 980px threshold (asserted below).
+    const baseBlock = css.match(/\.district-kpi-strip__cards\s*\{[^}]*\}/)
+    expect(baseBlock).not.toBeNull()
+    expect(baseBlock?.[0]).toMatch(
+      /grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/
+    )
+  })
+
+  it('keeps the 4-across strip gated at the 980px threshold (#866, no regression)', () => {
+    expect(css).toMatch(
+      /@media\s*\(min-width:\s*980px\)[\s\S]*?\.district-kpi-strip__cards[\s\S]*?grid-template-columns:\s*repeat\(4,\s*minmax\(0,\s*1fr\)\)/
+    )
+  })
+
+  it('gives the collapse toggle a ≥44px touch target (#866, WCAG 2.5.5)', () => {
+    const toggleBlock = css.match(/\.district-kpi-strip__toggle\s*\{[^}]*\}/)
+    expect(toggleBlock).not.toBeNull()
+    expect(toggleBlock?.[0]).toMatch(/width:\s*44px/)
+    expect(toggleBlock?.[0]).toMatch(/height:\s*44px/)
+  })
+
   it('no longer ships the anchor-TOC rail chrome (#679 — rail deleted)', () => {
     // The "On this page" right rail was removed when the hub went lean
     // (ADR-005 §5); DistrictSubnav now owns wayfinding at every width, so

--- a/frontend/src/styles/components/district-narrative.css
+++ b/frontend/src/styles/components/district-narrative.css
@@ -50,22 +50,17 @@
     min-width: 0;
   }
 
+  /* 4 cards (#681, #866): 2-col (2×2) is the mobile base → 4-col (980).
+     #866 dropped the old 1-col base — a 1×4 vertical stack ate ~2 viewports
+     on a phone; 2×2 halves that footprint (mobile-ux-audit §Epic B Sprint 1).
+     A 3-col rule would orphan the 4th card on a second row; 2×2 then
+     4-across reads cleanly. #682: the 4-col threshold is the handoff's 980px
+     2-col-collapse point (HANDOFF §234), reconciled from the original 1024 so
+     the whole district surface shares one breakpoint system. */
   .district-kpi-strip__cards {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 12px;
-  }
-
-  /* 4 cards (#681): 1-col → 2-col (640) → 4-col (980). A 3-col rule would
-     orphan the 4th card on a second row; 2×2 then 4-across reads cleanly.
-     #682: the 4-col threshold is the handoff's 980px 2-col-collapse point
-     (HANDOFF §234), reconciled from the original 1024 so the whole district
-     surface shares one breakpoint system. The 640 intermediate stays — four
-     stacked cards on tablet would be needlessly tall. */
-  @media (min-width: 640px) {
-    .district-kpi-strip__cards {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
   }
 
   @media (min-width: 980px) {
@@ -119,8 +114,12 @@
 
   .district-kpi-strip__toggle {
     flex: 0 0 auto;
-    width: 36px;
-    height: 36px;
+    /* #866 — 44px floor meets the WCAG 2.5.5 / handoff touch-target minimum
+       on the strip's only interactive control. It's a real <button>, so
+       width/height apply directly (no native-control quirk — cf. lesson 111).
+       Hidden ≥980px where the strip is always expanded. */
+    width: 44px;
+    height: 44px;
     border-radius: 8px;
     border: 1px solid var(--line);
     background: transparent;


### PR DESCRIPTION
Sprint 1 of epic #870 (mobile UX audit, §Epic B). Refs #866.

## What
At <980px the district `/district/:id` KPI strip now renders **2×2** instead of a 1×4 vertical stack. The strip's only interactive control (collapse chevron) gets a **44px** touch target.

## Changes
- `district-narrative.css`: `.district-kpi-strip__cards` base grid `1fr` → `repeat(2, minmax(0, 1fr))`. Removed the now-redundant `@media (640px)` 2-col rule (base already 2-col). 4-across desktop layout unchanged at the documented 980px threshold (#682).
- Toggle button `36px` → `44px` (WCAG 2.5.5; it's a real `<button>`, so width/height apply directly — no native-control quirk, cf. lesson 111).

## Breakpoint behaviour
| width | before | after |
|---|---|---|
| 375px | 1×4 stack | **2×2** |
| 640–979px | 2×2 | 2×2 (unchanged) |
| ≥980px | 4-across | 4-across (unchanged) |

No regression at desktop. The "≥768px" in the issue body is loose wording; the repo's authoritative desktop threshold is 980px (#682, guarded by an existing test).

## Tests (TDD)
- New CSS-contract assertions: 2-col base grid, 4-col @980 guard, 44px toggle.
- Moved the #682 breakpoint guard to the new base-2-col scheme (spec changed; not assertion-pinning).
- Full suite green: 3008 passed.

CSS-contract tests are necessary-not-sufficient (lesson 066) — live 375px Chromium + WebKit smoke runs on the PR preview as the load-bearing proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)