### PR TITLE
feat(district): fold Milestones + Longest-Serving Clubs on mobile (#867)

### DIFF
--- a/frontend/src/components/MobileDisclosure.tsx
+++ b/frontend/src/components/MobileDisclosure.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { useIsMobile } from '../hooks/useIsMobile'
+
+export interface MobileDisclosureProps {
+  /** Label shown on the collapsed summary row (mobile only). */
+  summaryLabel: string
+  /** Viewport width (px) below which the content folds. Default 768. */
+  breakpoint?: number
+  children: React.ReactNode
+}
+
+/**
+ * Folds its children behind a collapsed-by-default native `<details>`
+ * disclosure below `breakpoint`; at or above it the children render
+ * directly, so the desktop layout is untouched (#867).
+ *
+ * Native `<details>`/`<summary>` gives keyboard operability and the
+ * disclosure ARIA semantics for free — the same progressive-enhancement
+ * pattern as the DistrictsPage "Show all" fold (#863). The
+ * `useIsMobile` gate (rather than CSS alone) is what keeps the desktop
+ * tree free of disclosure chrome; in JSDOM it resolves to `false`, so
+ * existing desktop tests see the bare children unchanged.
+ */
+export const MobileDisclosure: React.FC<MobileDisclosureProps> = ({
+  summaryLabel,
+  breakpoint = 768,
+  children,
+}) => {
+  const isMobile = useIsMobile(breakpoint)
+
+  if (!isMobile) return <>{children}</>
+
+  return (
+    <details className="mobile-disclosure">
+      <summary className="mobile-disclosure__summary">{summaryLabel}</summary>
+      <div className="mobile-disclosure__content">{children}</div>
+    </details>
+  )
+}
+
+export default MobileDisclosure

--- a/frontend/src/components/NotableDatesSection.tsx
+++ b/frontend/src/components/NotableDatesSection.tsx
@@ -12,6 +12,7 @@ import {
   MilestonesCallout,
   hasProgramYearMilestones,
 } from './MilestonesCallout'
+import { MobileDisclosure } from './MobileDisclosure'
 
 export interface NotableDatesSectionProps {
   clubs: ClubTrend[]
@@ -90,6 +91,15 @@ export const NotableDatesSection: React.FC<NotableDatesSectionProps> = ({
 
   const sideBySide = upcomingPresent && milestonesPresent
 
+  // The Milestones list is a low "what do I do next" panel on a phone, so
+  // it folds behind a disclosure below 768 px (audit §Epic B). The label
+  // mirrors the panel's own "Milestones · PY …" header. On desktop
+  // MobileDisclosure renders the panel directly, so the side-by-side grid
+  // is unchanged. Upcoming anniversaries stays unfolded (#867).
+  const milestonesPyLabel = formatProgramYearShort(
+    programYearStart ?? getCurrentProgramYear().year
+  )
+
   return (
     <div
       className={
@@ -100,7 +110,9 @@ export const NotableDatesSection: React.FC<NotableDatesSectionProps> = ({
         <UpcomingAnniversariesPanel clubs={clubs} {...upcomingProps} />
       )}
       {milestonesPresent && (
-        <MilestonesCallout clubs={clubs} {...milestoneProps} />
+        <MobileDisclosure summaryLabel={`Milestones · PY ${milestonesPyLabel}`}>
+          <MilestonesCallout clubs={clubs} {...milestoneProps} />
+        </MobileDisclosure>
       )}
     </div>
   )

--- a/frontend/src/components/__tests__/LongestServingClubsLeaderboard.fold.test.tsx
+++ b/frontend/src/components/__tests__/LongestServingClubsLeaderboard.fold.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import '@testing-library/jest-dom'
+
+import { LongestServingClubsLeaderboard } from '../LongestServingClubsLeaderboard'
+import { MobileDisclosure } from '../MobileDisclosure'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+/* #867 — DistrictDetailPage folds the longest-serving leaderboard behind a
+   disclosure below 768 px. This locks the exact composition the page uses
+   (summary label + the real leaderboard component) without paying the cost
+   of mounting the full page (kept light per the redesign-test note). */
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+const stubViewport = (mobile: boolean) => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: mobile,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  )
+}
+
+const mkClub = (overrides: Partial<ClubTrend>): ClubTrend => ({
+  clubId: '0',
+  clubName: 'Test Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '01',
+  areaName: 'Area 01',
+  membershipTrend: [],
+  dcpGoalsTrend: [],
+  currentStatus: 'thriving',
+  riskFactors: [],
+  distinguishedLevel: 'NotDistinguished',
+  ...overrides,
+})
+
+// As wired in DistrictDetailPage.tsx.
+const renderFolded = () =>
+  render(
+    <MemoryRouter>
+      <MobileDisclosure summaryLabel="Longest-serving clubs">
+        <LongestServingClubsLeaderboard
+          clubs={[mkClub({ clubId: '1', charterDate: '1990-01-01' })]}
+          districtId="61"
+        />
+      </MobileDisclosure>
+    </MemoryRouter>
+  )
+
+describe('Longest-serving clubs mobile fold (#867)', () => {
+  it('folds the leaderboard behind a collapsed disclosure on mobile', () => {
+    stubViewport(true)
+    renderFolded()
+
+    const summary = screen.getByText('Longest-serving clubs', {
+      selector: 'summary',
+    })
+    const details = summary.closest('details')
+    expect(details).not.toBeNull()
+    expect(details?.hasAttribute('open')).toBe(false)
+  })
+
+  it('renders the leaderboard directly with no disclosure on desktop', () => {
+    stubViewport(false)
+    const { container } = renderFolded()
+
+    expect(container.querySelector('details')).toBeNull()
+    expect(
+      screen.getByRole('heading', { name: /Longest-serving clubs/i })
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/MobileDisclosure.test.tsx
+++ b/frontend/src/components/__tests__/MobileDisclosure.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+import { MobileDisclosure } from '../MobileDisclosure'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+/** Stub matchMedia so useIsMobile(768) resolves to the given viewport. */
+const stubViewport = (mobile: boolean) => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: mobile,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  )
+}
+
+describe('MobileDisclosure (#867)', () => {
+  it('renders children directly with no disclosure chrome on desktop', () => {
+    stubViewport(false)
+    const { container } = render(
+      <MobileDisclosure summaryLabel="Milestones · PY 25–26">
+        <p data-testid="payload">contents</p>
+      </MobileDisclosure>
+    )
+
+    // Desktop must be byte-for-byte the bare children — no <details>/<summary>.
+    expect(container.querySelector('details')).toBeNull()
+    expect(container.querySelector('summary')).toBeNull()
+    expect(screen.getByTestId('payload')).toBeInTheDocument()
+  })
+
+  it('folds children behind a collapsed-by-default disclosure on mobile', () => {
+    stubViewport(true)
+    const { container } = render(
+      <MobileDisclosure summaryLabel="Longest-serving clubs">
+        <p data-testid="payload">contents</p>
+      </MobileDisclosure>
+    )
+
+    const details = container.querySelector('details')
+    expect(details).not.toBeNull()
+    // Collapsed by default — the whole point of the fold.
+    expect(details?.hasAttribute('open')).toBe(false)
+    // The summary carries the label so the user knows what they're expanding.
+    expect(
+      screen.getByText('Longest-serving clubs').tagName.toLowerCase()
+    ).toBe('summary')
+    // Children stay mounted (native <details> keeps content in the DOM).
+    expect(screen.getByTestId('payload')).toBeInTheDocument()
+  })
+
+  it('honors a custom breakpoint', () => {
+    // 1024px viewport is "mobile" relative to a 1280 breakpoint.
+    stubViewport(true)
+    const { container } = render(
+      <MobileDisclosure summaryLabel="Wide fold" breakpoint={1280}>
+        <span>x</span>
+      </MobileDisclosure>
+    )
+    expect(container.querySelector('details')).not.toBeNull()
+  })
+})

--- a/frontend/src/components/__tests__/NotableDatesSection.test.tsx
+++ b/frontend/src/components/__tests__/NotableDatesSection.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
@@ -92,6 +92,51 @@ describe('NotableDatesSection (#551)', () => {
     expect(
       screen.queryByRole('heading', { name: /Upcoming anniversaries/i })
     ).not.toBeInTheDocument()
+  })
+
+  it('folds the milestones panel behind a collapsed disclosure on mobile (#867)', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+    )
+    const clubs = [
+      mkClub({
+        clubId: '1',
+        clubName: 'Anniversary Club',
+        charterDate: UPCOMING_CHARTER,
+      }),
+      mkClub({
+        clubId: '2',
+        clubName: 'Decade Club',
+        charterDate: MILESTONE_CHARTER,
+      }),
+    ]
+    const { container } = renderSection(clubs)
+
+    // Milestones is folded: a collapsed <details> whose <summary> labels it.
+    const summary = screen.getByText(/Milestones/i, { selector: 'summary' })
+    const details = summary.closest('details')
+    expect(details).not.toBeNull()
+    expect(details?.hasAttribute('open')).toBe(false)
+
+    // Upcoming anniversaries stays visible — only Milestones folds (audit
+    // §Epic B names the Milestones list, not anniversaries).
+    expect(
+      screen.getByRole('heading', { name: /Upcoming anniversaries/i })
+    ).toBeInTheDocument()
+    // Anniversaries is not itself wrapped in a disclosure.
+    expect(container.querySelectorAll('details')).toHaveLength(1)
+
+    vi.unstubAllGlobals()
   })
 
   it('renders both panels side-by-side when both have data', () => {

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -25,6 +25,7 @@ import {
 import { DistrictOverview } from '../components/DistrictOverview'
 import { NotableDatesSection } from '../components/NotableDatesSection'
 import { LongestServingClubsLeaderboard } from '../components/LongestServingClubsLeaderboard'
+import { MobileDisclosure } from '../components/MobileDisclosure'
 import { DistinguishedDistrictTrophyCase } from '../components/DistinguishedDistrictTrophyCase'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
 import { useDistrictRanking } from '../hooks/useDistrictRanking'
@@ -539,11 +540,15 @@ const DistrictDetailPageInner: React.FC = () => {
                   })}
                 />
 
-                {/* Longest-serving clubs leaderboard (#449) */}
-                <LongestServingClubsLeaderboard
-                  clubs={allClubs}
-                  {...(districtId !== undefined && { districtId })}
-                />
+                {/* Longest-serving clubs — secondary detail, folded behind a
+                    disclosure below 768 px (audit §Epic B, #867). On desktop
+                    MobileDisclosure renders the leaderboard directly. */}
+                <MobileDisclosure summaryLabel="Longest-serving clubs">
+                  <LongestServingClubsLeaderboard
+                    clubs={allClubs}
+                    {...(districtId !== undefined && { districtId })}
+                  />
+                </MobileDisclosure>
               </section>
             )}
 

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -3165,6 +3165,48 @@
     color: var(--ink);
   }
 
+  /* MobileDisclosure (#867) — folds a secondary district-overview panel
+     behind a collapsed-by-default native <details> on mobile. The wrapper
+     stays chrome-less because the folded child already carries its own
+     .redesign-panel surface; the <summary> is the visible collapsed state,
+     so it gets the panel-card look + a >=44px touch target. */
+  .mobile-disclosure {
+    margin: 0;
+  }
+
+  .mobile-disclosure__summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 44px;
+    padding: 12px 18px;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-md);
+    box-shadow: var(--rds-shadow-sm);
+    cursor: pointer;
+    user-select: none;
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: -0.005em;
+    color: var(--ink);
+  }
+
+  .mobile-disclosure__summary:hover {
+    color: var(--link);
+  }
+
+  /* The native marker triangle is the affordance the audit asked for
+     ("Milestones (PY 25–26) ▾"); keep it, push the label off it. */
+  .mobile-disclosure__summary::-webkit-details-marker {
+    order: 1;
+  }
+
+  .mobile-disclosure[open] > .mobile-disclosure__content {
+    margin-top: 8px;
+  }
+
   /* Clubs table single-scroll container (#667, epic #665). Pagination was
      removed; the full sorted+filtered set renders in one capped-height
      container so the header stays in view while the body scrolls. The

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       }
     },
     "frontend": {
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.0",


### PR DESCRIPTION
## Summary

Epic #870 Sprint 2 (#867). Makes `/district/:id` glanceable on mobile by folding two secondary overview panels behind collapsed-by-default disclosures below 768 px (mobile-ux-audit §Epic B). Desktop is unchanged.

- **New** `MobileDisclosure` — reusable native `<details>` wrapper that collapses children below a breakpoint (default 768) and renders them directly at/above it, reusing the #863 `useIsMobile` + `<details>` progressive-enhancement pattern.
- **Milestones** (`MilestonesCallout`, inside `NotableDatesSection`) folds under "Milestones · PY 25–26". Upcoming anniversaries stays unfolded — the audit names only the Milestones list.
- **Longest-serving clubs** (`LongestServingClubsLeaderboard`, in `DistrictDetailPage`) folds under "Longest-serving clubs".

## Acceptance criteria

- [x] Both sections collapsed by default on mobile; expand on tap (native `<details>`).
- [x] Desktop unchanged (`useIsMobile` resolves false → bare children; JSDOM defaults desktop so all existing tests stay green).
- [x] Disclosure pattern reused via one shared `MobileDisclosure`, not re-implemented per section.

## Testing

- TDD: `MobileDisclosure.test.tsx` (desktop passthrough / mobile fold / custom breakpoint), `NotableDatesSection` mobile-fold case, `LongestServingClubsLeaderboard.fold.test.tsx`.
- Full frontend suite: **3015 passed**.
- Live verification on the PR preview channel (Chromium + WebKit, 375 px) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)