### PR TITLE
feat(district): cap upcoming renewals to Next 3 on mobile with 'Show all →' (#869)

### DIFF
--- a/frontend/src/components/UpcomingAnniversariesPanel.tsx
+++ b/frontend/src/components/UpcomingAnniversariesPanel.tsx
@@ -7,6 +7,7 @@ import {
   type ClubAnniversary,
 } from '../utils/clubAnniversary'
 import { ordinalSuffix } from '../utils/ordinal'
+import { useIsMobile } from '../hooks/useIsMobile'
 
 /* UpcomingAnniversariesPanel (#446 / #511) — district-level recognition
    planner. Tight, dense rows of clubs whose next anniversary is within
@@ -14,6 +15,10 @@ import { ordinalSuffix } from '../utils/ordinal'
 
 export const UPCOMING_WINDOW_DAYS = 60
 const DEFAULT_ROW_LIMIT = 5
+// Below 768px the full list runs ~6 viewports (audit §Epic B), so mobile
+// caps to the Next 3 with a "Show all →" disclosure (#869). Desktop keeps
+// DEFAULT_ROW_LIMIT unchanged.
+const MOBILE_ROW_LIMIT = 3
 
 export interface UpcomingAnniversariesPanelProps {
   clubs: ClubTrend[]
@@ -69,6 +74,7 @@ export const UpcomingAnniversariesPanel: React.FC<
   initialRowLimit = DEFAULT_ROW_LIMIT,
 }) => {
   const [expanded, setExpanded] = useState(false)
+  const isMobile = useIsMobile(768)
 
   const { upcoming, nextBeyondWindow } = useMemo(() => {
     const all = buildRows(clubs, referenceDate)
@@ -120,7 +126,8 @@ export const UpcomingAnniversariesPanel: React.FC<
     )
   }
 
-  const visible = expanded ? upcoming : upcoming.slice(0, initialRowLimit)
+  const effectiveLimit = isMobile ? MOBILE_ROW_LIMIT : initialRowLimit
+  const visible = expanded ? upcoming : upcoming.slice(0, effectiveLimit)
   const hidden = upcoming.length - visible.length
 
   return (
@@ -204,7 +211,13 @@ export const UpcomingAnniversariesPanel: React.FC<
           onClick={() => setExpanded(true)}
           className="mt-2 text-xs font-semibold text-tm-loyal-blue hover:underline font-tm-body"
         >
-          Show all ({upcoming.length})
+          {isMobile ? (
+            <>
+              Show all <span aria-hidden="true">→</span>
+            </>
+          ) : (
+            `Show all (${upcoming.length})`
+          )}
         </button>
       )}
     </section>

--- a/frontend/src/components/__tests__/UpcomingAnniversariesPanel.mobileCap.test.tsx
+++ b/frontend/src/components/__tests__/UpcomingAnniversariesPanel.mobileCap.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import '@testing-library/jest-dom'
+import { UpcomingAnniversariesPanel } from '../UpcomingAnniversariesPanel'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+/* #869 — below the 768px mobile breakpoint the upcoming-renewals list runs
+   ~6 viewports, so it caps to the Next 3 followed by a "Show all →" link.
+   Desktop (≥768px) keeps the default 5-row cap and "Show all (N)" label
+   unchanged. matchMedia is stubbed the same way the #867/#868 fold tests do
+   it. */
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+const stubViewport = (mobile: boolean) => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: mobile,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  )
+}
+
+const REF = new Date('2026-05-15T12:00:00Z')
+
+const mkClub = (overrides: Partial<ClubTrend>): ClubTrend => ({
+  clubId: '0',
+  clubName: 'Test Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '01',
+  areaName: 'Area 01',
+  membershipTrend: [],
+  dcpGoalsTrend: [],
+  currentStatus: 'thriving',
+  riskFactors: [],
+  distinguishedLevel: 'NotDistinguished',
+  ...overrides,
+})
+
+// 6 clubs all within the 60-day window, spread 5–30 days out from REF.
+const sixClubs = () =>
+  Array.from({ length: 6 }, (_, i) =>
+    mkClub({
+      clubId: String(i + 1),
+      clubName: `Club ${i + 1}`,
+      charterDate: new Date(REF.getTime() + (5 + i * 5) * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10),
+    })
+  )
+
+const renderPanel = (clubs: ClubTrend[]) =>
+  render(
+    <MemoryRouter>
+      <UpcomingAnniversariesPanel
+        clubs={clubs}
+        referenceDate={REF}
+        districtId="61"
+      />
+    </MemoryRouter>
+  )
+
+describe('UpcomingAnniversariesPanel mobile cap (#869)', () => {
+  it('caps the visible list to 3 rows below the mobile breakpoint', () => {
+    stubViewport(true)
+    renderPanel(sixClubs())
+    expect(screen.getAllByTestId('upcoming-anniversary-row')).toHaveLength(3)
+  })
+
+  it('shows a "Show all →" link on mobile that reveals the full list', () => {
+    stubViewport(true)
+    renderPanel(sixClubs())
+    const button = screen.getByRole('button', { name: /show all/i })
+    expect(button).toHaveTextContent('→')
+    fireEvent.click(button)
+    expect(screen.getAllByTestId('upcoming-anniversary-row')).toHaveLength(6)
+  })
+
+  it('keeps the default 5-row cap and "Show all (N)" label on desktop', () => {
+    stubViewport(false)
+    renderPanel(sixClubs())
+    expect(screen.getAllByTestId('upcoming-anniversary-row')).toHaveLength(5)
+    expect(
+      screen.getByRole('button', { name: /show all \(6\)/i })
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What

Epic #870 Sprint 4 (mobile UX audit §Epic B). Below the 768px mobile breakpoint, `UpcomingAnniversariesPanel` (the district overview's "upcoming renewals" list, ~6 viewports tall on a phone) now caps to the **Next 3** rows followed by a **"Show all →"** disclosure. Desktop (≥768px) is unchanged: 5-row cap + "Show all (N)".

Refs #870, #869.

## How

- `useIsMobile(768)` (the established breakpoint hook used by the #867/#868 folds) selects an `effectiveLimit` of `MOBILE_ROW_LIMIT` (3) on mobile, `initialRowLimit` (5) on desktop.
- The existing "Show all" button renders "Show all →" on mobile (arrow `aria-hidden`), keeps "Show all (N)" on desktop.
- Pure JS breakpoint — no shared CSS class touched (Lesson 131). Button reuses the existing `text-tm-loyal-blue` utility — no `var()` token-fallback risk (Lesson 132).

## Tests

- New `UpcomingAnniversariesPanel.mobileCap.test.tsx`: mobile caps to 3, "Show all →" reveals full list, desktop keeps 5 + "Show all (6)". RED-then-GREEN.
- Existing `UpcomingAnniversariesPanel.test.tsx` (5 tests) unchanged and passing — desktop path is genuinely untouched (`useIsMobile` returns false in JSDOM).
- Full frontend suite: 3035 passed, 0 regressions.

## Acceptance criteria

- [x] Mobile shows 3 + link.
- [x] Desktop full list unchanged.
- [ ] 375px Chromium + WebKit smoke on preview (pending CI/preview deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)