### PR TITLE
feat(tables): Status column renders as a chip at <768px (CC-4) (#871)

### DIFF
--- a/frontend/src/components/ClubMiniList.tsx
+++ b/frontend/src/components/ClubMiniList.tsx
@@ -1,0 +1,60 @@
+/* ClubMiniList (#871, epic #873 Sprint 1 — CC-4).
+ *
+ * Mobile (<768px) replacement for the Division / Area club mini-tables. The
+ * 4-column table (Club | Status | Members | Distinguished) is wider than a
+ * 375px phone, so the Status column scrolls off the right edge and the chip
+ * clips to "✗ Intervention R…". Per the audit ("let it be a chip, don't try to
+ * table it") and Lesson 105 (browse-one-row lists card-collapse on mobile),
+ * each club becomes a stacked card: name + a fully-visible StatusChip, with
+ * Members / Distinguished as a muted meta line so no column data is lost.
+ *
+ * Reuses the themed `.clubs-card` chrome (--surface / --line / --ink) so dark
+ * mode just works (R10). Cards navigate via onSelect (parity with the existing
+ * table-row onClick); the <Link> conversion is CC-7 / Sprint 2. */
+
+import React from 'react'
+import type { ClubTrend } from '../hooks/useDistrictAnalytics'
+import { getClubHealthStatusLabel } from '../utils/clubHealthStatus'
+import { StatusChip } from './StatusChip'
+
+interface ClubMiniListProps {
+  clubs: ClubTrend[]
+  onSelect: (clubId: string) => void
+}
+
+export const ClubMiniList: React.FC<ClubMiniListProps> = ({
+  clubs,
+  onSelect,
+}) => (
+  <div className="flex flex-col gap-3">
+    {clubs.map(c => {
+      const members = c.membershipTrend[c.membershipTrend.length - 1]?.count
+      const distinguished =
+        c.distinguishedLevel === 'NotDistinguished'
+          ? null
+          : c.distinguishedLevel
+      return (
+        <button
+          key={c.clubId}
+          type="button"
+          className="clubs-card"
+          onClick={() => onSelect(c.clubId)}
+          aria-label={`${c.clubName} — ${getClubHealthStatusLabel(
+            c.currentStatus
+          )}, ${members ?? 0} members`}
+        >
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="clubs-card__name">{c.clubName}</h3>
+            <StatusChip status={c.currentStatus} className="flex-shrink-0" />
+          </div>
+          <div className="clubs-card__stat-label" style={{ marginTop: 8 }}>
+            {members ?? '—'} member{members === 1 ? '' : 's'}
+            {distinguished ? ` · ${distinguished}` : ''}
+          </div>
+        </button>
+      )
+    })}
+  </div>
+)
+
+export default ClubMiniList

--- a/frontend/src/components/StatusChip.tsx
+++ b/frontend/src/components/StatusChip.tsx
@@ -1,0 +1,44 @@
+/* StatusChip (#871, epic #873 Sprint 1 — CC-4).
+ *
+ * The Division / Area club mini-tables rendered the raw `currentStatus` enum
+ * as plain `whitespace-nowrap` text, which clips to "vulne…" / "interv…" at
+ * 375px (CC-4). This chip is the mobile (<768px) treatment: a colored pill
+ * carrying the short label AND a glyph, so meaning never rests on colour alone
+ * (WCAG 1.4.1). Label, colour modifier and icon all come from the single
+ * source of truth in `utils/clubHealthStatus.ts` (lesson 052) — the same datum
+ * the desktop ClubsTable pill uses.
+ *
+ * Per lesson 077 it accepts a `className` override rather than a variant
+ * taxonomy, so each call site can add its own layout class. */
+
+import React from 'react'
+import type { ClubHealthStatus } from '../hooks/useDistrictAnalytics'
+import {
+  getClubHealthStatusIcon,
+  getClubHealthStatusLabel,
+  getClubHealthStatusPillModifier,
+} from '../utils/clubHealthStatus'
+
+interface StatusChipProps {
+  status: ClubHealthStatus
+  className?: string
+}
+
+export const StatusChip: React.FC<StatusChipProps> = ({
+  status,
+  className,
+}) => {
+  const modifier = getClubHealthStatusPillModifier(status)
+  return (
+    <span
+      className={`clubs-status-pill ${modifier}${
+        className ? ` ${className}` : ''
+      }`}
+    >
+      <span aria-hidden="true">{getClubHealthStatusIcon(status)}</span>{' '}
+      {getClubHealthStatusLabel(status)}
+    </span>
+  )
+}
+
+export default StatusChip

--- a/frontend/src/components/StatusChip.tsx
+++ b/frontend/src/components/StatusChip.tsx
@@ -4,9 +4,11 @@
  * as plain `whitespace-nowrap` text, which clips to "vulne…" / "interv…" at
  * 375px (CC-4). This chip is the mobile (<768px) treatment: a colored pill
  * carrying the short label AND a glyph, so meaning never rests on colour alone
- * (WCAG 1.4.1). Label, colour modifier and icon all come from the single
- * source of truth in `utils/clubHealthStatus.ts` (lesson 052) — the same datum
- * the desktop ClubsTable pill uses.
+ * (WCAG 1.4.1). Label and colour modifier are the shared single source of truth
+ * in `utils/clubHealthStatus.ts` (lesson 052) — identical to the desktop
+ * ClubsTable pill. The chip adds an icon glyph on top, per the CC-4 a11y
+ * criterion (colour + text + icon); the desktop pill stays icon-free
+ * ("Desktop unchanged").
  *
  * Per lesson 077 it accepts a `className` override rather than a variant
  * taxonomy, so each call site can add its own layout class. */

--- a/frontend/src/components/__tests__/ClubMiniList.test.tsx
+++ b/frontend/src/components/__tests__/ClubMiniList.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * ClubMiniList (#871, epic #873 Sprint 1 — CC-4) — the mobile (<768px)
+ * treatment for the Division / Area club mini-tables.
+ *
+ * The 4-column mini-table overflows 375px (long club names + Members +
+ * Distinguished), so the Status column scrolls off the right edge and the chip
+ * clips to "✗ Intervention R…" even after chipping. The audit's CC-4 fix is to
+ * stop tabling it: each club becomes a stacked card with its name and a fully
+ * visible StatusChip (Lesson 105 — browse-one-row lists card-collapse). Reuses
+ * the themed `.clubs-card` chrome so dark mode just works (R10).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ClubMiniList } from '../ClubMiniList'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+afterEach(cleanup)
+
+const CLUBS: ClubTrend[] = [
+  {
+    clubId: 'c1',
+    clubName: 'Limestone City Club',
+    divisionId: 'A',
+    divisionName: 'Division A',
+    areaId: '01',
+    areaName: 'Area 01',
+    distinguishedLevel: 'Distinguished',
+    currentStatus: 'intervention-required',
+    riskFactors: [],
+    membershipTrend: [{ date: '2025-07-15', count: 12 }],
+    dcpGoalsTrend: [{ date: '2025-07-15', goalsAchieved: 2 }],
+  },
+]
+
+describe('ClubMiniList (#871 CC-4)', () => {
+  it('renders one card per club with a StatusChip (not raw enum)', () => {
+    const { container } = render(
+      <ClubMiniList clubs={CLUBS} onSelect={vi.fn()} />
+    )
+    const card = container.querySelector('.clubs-card')
+    expect(card).not.toBeNull()
+    expect(screen.getByText('Limestone City Club')).toBeInTheDocument()
+    const pill = container.querySelector('.clubs-status-pill')
+    expect(pill).toHaveClass('clubs-status-pill--intervention')
+    expect(pill).toHaveTextContent('Intervention Required')
+    // no raw enum leaks
+    expect(container.textContent).not.toContain('intervention-required')
+    // members + distinguished meta preserved from the table columns
+    expect(container.textContent).toContain('12 members')
+    expect(container.textContent).toContain('Distinguished')
+  })
+
+  it('renders no <table> — the row is de-tabled to avoid 375px overflow', () => {
+    const { container } = render(
+      <ClubMiniList clubs={CLUBS} onSelect={vi.fn()} />
+    )
+    expect(container.querySelector('table')).toBeNull()
+  })
+
+  it('invokes onSelect with the clubId when a card is activated', () => {
+    const onSelect = vi.fn()
+    const { container } = render(
+      <ClubMiniList clubs={CLUBS} onSelect={onSelect} />
+    )
+    const card = container.querySelector('.clubs-card') as HTMLElement
+    within(card).getByText('Limestone City Club').click()
+    expect(onSelect).toHaveBeenCalledWith('c1')
+  })
+})

--- a/frontend/src/components/__tests__/StatusChip.test.tsx
+++ b/frontend/src/components/__tests__/StatusChip.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * StatusChip (#871, epic #873 Sprint 1 — CC-4) — the mobile status-chip
+ * treatment for the Division / Area club mini-tables, which previously rendered
+ * the raw `currentStatus` enum as plain text that truncates at 375px.
+ *
+ * The chip pairs colour with BOTH a text label and an icon glyph so meaning
+ * never rests on colour alone (WCAG 1.4.1). Label + pill modifier come from the
+ * single source of truth in `utils/clubHealthStatus.ts` (lesson 052), so the
+ * chip reads identically to the desktop ClubsTable pill.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { StatusChip } from '../StatusChip'
+import type { ClubHealthStatus } from '../../hooks/useDistrictAnalytics'
+
+afterEach(cleanup)
+
+const CASES: Array<{
+  status: ClubHealthStatus
+  label: string
+  modifier: string
+  icon: string
+}> = [
+  {
+    status: 'thriving',
+    label: 'Thriving',
+    modifier: 'clubs-status-pill--thriving',
+    icon: '✓',
+  },
+  {
+    status: 'vulnerable',
+    label: 'Vulnerable',
+    modifier: 'clubs-status-pill--vulnerable',
+    icon: '⚠',
+  },
+  {
+    status: 'intervention-required',
+    label: 'Intervention Required',
+    modifier: 'clubs-status-pill--intervention',
+    icon: '✗',
+  },
+]
+
+describe('StatusChip (#871 CC-4)', () => {
+  for (const c of CASES) {
+    it(`renders the ${c.status} chip with pill class, label and icon`, () => {
+      const { container } = render(<StatusChip status={c.status} />)
+      const pill = container.querySelector('.clubs-status-pill')
+      expect(pill).not.toBeNull()
+      // colour modifier so the chip is themed, not generic
+      expect(pill).toHaveClass(c.modifier)
+      // text label present — meaning never rests on colour alone (WCAG 1.4.1)
+      expect(pill).toHaveTextContent(c.label)
+      // icon glyph present and marked decorative (label carries the meaning)
+      const icon = container.querySelector('[aria-hidden="true"]')
+      expect(icon).not.toBeNull()
+      expect(icon).toHaveTextContent(c.icon)
+    })
+  }
+
+  it('forwards an extra className for call-site layout (lesson 077)', () => {
+    const { container } = render(
+      <StatusChip status="thriving" className="my-cell-chip" />
+    )
+    const pill = container.querySelector('.clubs-status-pill')
+    expect(pill).toHaveClass('my-cell-chip')
+  })
+
+  it('exposes the label as accessible text, not just colour', () => {
+    render(<StatusChip status="vulnerable" />)
+    expect(screen.getByText('Vulnerable')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/StatusChip.test.tsx
+++ b/frontend/src/components/__tests__/StatusChip.test.tsx
@@ -5,8 +5,8 @@
  *
  * The chip pairs colour with BOTH a text label and an icon glyph so meaning
  * never rests on colour alone (WCAG 1.4.1). Label + pill modifier come from the
- * single source of truth in `utils/clubHealthStatus.ts` (lesson 052), so the
- * chip reads identically to the desktop ClubsTable pill.
+ * single source of truth in `utils/clubHealthStatus.ts` (lesson 052) — the same
+ * label/colour as the desktop ClubsTable pill, with an added icon cue.
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'

--- a/frontend/src/pages/AreaPage.tsx
+++ b/frontend/src/pages/AreaPage.tsx
@@ -6,6 +6,8 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
+import { StatusChip } from '../components/StatusChip'
+import { useIsMobile } from '../hooks/useIsMobile'
 
 const AreaPage: React.FC = () => {
   const { districtId, divId, areaId } = useParams<{
@@ -14,6 +16,7 @@ const AreaPage: React.FC = () => {
     areaId: string
   }>()
   const navigate = useNavigate()
+  const isMobile = useIsMobile()
 
   const { data, isLoading, error } = useDistrictAnalytics(
     districtId ?? '',
@@ -147,7 +150,13 @@ const AreaPage: React.FC = () => {
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      {c.currentStatus}
+                      {/* CC-4 (#871): chip at <768px so the status label never
+                          truncates; desktop unchanged. */}
+                      {isMobile ? (
+                        <StatusChip status={c.currentStatus} />
+                      ) : (
+                        c.currentStatus
+                      )}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
                       {last?.count ?? '—'}

--- a/frontend/src/pages/AreaPage.tsx
+++ b/frontend/src/pages/AreaPage.tsx
@@ -6,7 +6,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
-import { StatusChip } from '../components/StatusChip'
+import { ClubMiniList } from '../components/ClubMiniList'
 import { useIsMobile } from '../hooks/useIsMobile'
 
 const AreaPage: React.FC = () => {
@@ -114,65 +114,71 @@ const AreaPage: React.FC = () => {
         </div>
       </div>
 
-      <div className="districts-rankings-table-wrap">
-        <div className="overflow-x-auto">
-          <table className="districts-rankings-table">
-            <thead>
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Club
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Status
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Members
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Distinguished
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {clubs.map(c => {
-                const last = c.membershipTrend[c.membershipTrend.length - 1]
-                return (
-                  <tr
-                    key={c.clubId}
-                    className="cursor-pointer"
-                    onClick={() =>
-                      navigate(`/district/${districtId}/club/${c.clubId}`)
-                    }
-                  >
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className="text-sm font-medium text-gray-900">
-                        {c.clubName}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      {/* CC-4 (#871): chip at <768px so the status label never
-                          truncates; desktop unchanged. */}
-                      {isMobile ? (
-                        <StatusChip status={c.currentStatus} />
-                      ) : (
-                        c.currentStatus
-                      )}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
-                      {last?.count ?? '—'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {c.distinguishedLevel === 'NotDistinguished'
-                        ? '—'
-                        : c.distinguishedLevel}
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+      {/* CC-4 (#871): the 4-col table overflows 375px and clips the Status
+          chip, so mobile de-tables to a stacked card list; desktop keeps the
+          table unchanged. */}
+      {isMobile ? (
+        <ClubMiniList
+          clubs={clubs}
+          onSelect={clubId =>
+            navigate(`/district/${districtId}/club/${clubId}`)
+          }
+        />
+      ) : (
+        <div className="districts-rankings-table-wrap">
+          <div className="overflow-x-auto">
+            <table className="districts-rankings-table">
+              <thead>
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Club
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Status
+                  </th>
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Members
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Distinguished
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {clubs.map(c => {
+                  const last = c.membershipTrend[c.membershipTrend.length - 1]
+                  return (
+                    <tr
+                      key={c.clubId}
+                      className="cursor-pointer"
+                      onClick={() =>
+                        navigate(`/district/${districtId}/club/${c.clubId}`)
+                      }
+                    >
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className="text-sm font-medium text-gray-900">
+                          {c.clubName}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm">
+                        {c.currentStatus}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
+                        {last?.count ?? '—'}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {c.distinguishedLevel === 'NotDistinguished'
+                          ? '—'
+                          : c.distinguishedLevel}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -8,7 +8,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
-import { StatusChip } from '../components/StatusChip'
+import { ClubMiniList } from '../components/ClubMiniList'
 import { useIsMobile } from '../hooks/useIsMobile'
 
 const DivisionPage: React.FC = () => {
@@ -175,65 +175,72 @@ const DivisionPage: React.FC = () => {
             </span>
           </h2>
 
-          <div className="districts-rankings-table-wrap">
-            <div className="overflow-x-auto">
-              <table className="districts-rankings-table">
-                <thead>
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Club
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Status
-                    </th>
-                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Members
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Distinguished
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {area.clubs.map(c => {
-                    const last = c.membershipTrend[c.membershipTrend.length - 1]
-                    return (
-                      <tr
-                        key={c.clubId}
-                        className="cursor-pointer"
-                        onClick={() =>
-                          navigate(`/district/${districtId}/club/${c.clubId}`)
-                        }
-                      >
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <span className="text-sm font-medium text-gray-900">
-                            {c.clubName}
-                          </span>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm">
-                          {/* CC-4 (#871): chip at <768px so the status label
-                              never truncates; desktop unchanged. */}
-                          {isMobile ? (
-                            <StatusChip status={c.currentStatus} />
-                          ) : (
-                            c.currentStatus
-                          )}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
-                          {last?.count ?? '—'}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          {c.distinguishedLevel === 'NotDistinguished'
-                            ? '—'
-                            : c.distinguishedLevel}
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
+          {/* CC-4 (#871): the 4-col table overflows 375px and clips the
+              Status chip, so mobile de-tables to a stacked card list; desktop
+              keeps the table unchanged. */}
+          {isMobile ? (
+            <ClubMiniList
+              clubs={area.clubs}
+              onSelect={clubId =>
+                navigate(`/district/${districtId}/club/${clubId}`)
+              }
+            />
+          ) : (
+            <div className="districts-rankings-table-wrap">
+              <div className="overflow-x-auto">
+                <table className="districts-rankings-table">
+                  <thead>
+                    <tr>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Club
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Status
+                      </th>
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Members
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Distinguished
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {area.clubs.map(c => {
+                      const last =
+                        c.membershipTrend[c.membershipTrend.length - 1]
+                      return (
+                        <tr
+                          key={c.clubId}
+                          className="cursor-pointer"
+                          onClick={() =>
+                            navigate(`/district/${districtId}/club/${c.clubId}`)
+                          }
+                        >
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            <span className="text-sm font-medium text-gray-900">
+                              {c.clubName}
+                            </span>
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm">
+                            {c.currentStatus}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
+                            {last?.count ?? '—'}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            {c.distinguishedLevel === 'NotDistinguished'
+                              ? '—'
+                              : c.distinguishedLevel}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
             </div>
-          </div>
+          )}
         </section>
       ))}
     </div>

--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -8,6 +8,8 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
+import { StatusChip } from '../components/StatusChip'
+import { useIsMobile } from '../hooks/useIsMobile'
 
 const DivisionPage: React.FC = () => {
   const { districtId, divId } = useParams<{
@@ -15,6 +17,7 @@ const DivisionPage: React.FC = () => {
     divId: string
   }>()
   const navigate = useNavigate()
+  const isMobile = useIsMobile()
 
   const { data, isLoading, error } = useDistrictAnalytics(
     districtId ?? '',
@@ -208,7 +211,13 @@ const DivisionPage: React.FC = () => {
                           </span>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">
-                          {c.currentStatus}
+                          {/* CC-4 (#871): chip at <768px so the status label
+                              never truncates; desktop unchanged. */}
+                          {isMobile ? (
+                            <StatusChip status={c.currentStatus} />
+                          ) : (
+                            c.currentStatus
+                          )}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
                           {last?.count ?? '—'}

--- a/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
@@ -84,27 +84,32 @@ afterEach(() => {
 })
 
 describe('Division/Area status chip at <768px (#871 CC-4)', () => {
-  it('DivisionPage renders a status pill (not raw enum) on mobile', () => {
+  it('DivisionPage de-tables to a card list with a status chip on mobile', () => {
     mockUseIsMobile.mockReturnValue(true)
     const { container } = renderDivision()
+    // de-tabled: no wide table that would clip the chip at 375px
+    expect(container.querySelector('table')).toBeNull()
+    expect(container.querySelector('.clubs-card')).not.toBeNull()
     const pill = container.querySelector('.clubs-status-pill')
     expect(pill).not.toBeNull()
     expect(pill).toHaveClass('clubs-status-pill--vulnerable')
     expect(pill).toHaveTextContent('Vulnerable')
-    // raw enum must not leak into the rendered table
+    // raw enum must not leak
     expect(container.textContent).not.toContain('vulnerable')
   })
 
-  it('DivisionPage leaves the desktop rendering unchanged (raw text, no pill)', () => {
+  it('DivisionPage leaves the desktop rendering unchanged (table, raw text, no pill)', () => {
     mockUseIsMobile.mockReturnValue(false)
     const { container } = renderDivision()
+    expect(container.querySelector('table')).not.toBeNull()
     expect(container.querySelector('.clubs-status-pill')).toBeNull()
     expect(container.textContent).toContain('vulnerable')
   })
 
-  it('AreaPage renders a status pill (not raw enum) on mobile', () => {
+  it('AreaPage de-tables to a card list with a status chip on mobile', () => {
     mockUseIsMobile.mockReturnValue(true)
     const { container } = renderArea()
+    expect(container.querySelector('table')).toBeNull()
     const pill = container.querySelector('.clubs-status-pill')
     expect(pill).not.toBeNull()
     expect(pill).toHaveClass('clubs-status-pill--vulnerable')
@@ -113,9 +118,10 @@ describe('Division/Area status chip at <768px (#871 CC-4)', () => {
     ).toBeInTheDocument()
   })
 
-  it('AreaPage leaves the desktop rendering unchanged (raw text, no pill)', () => {
+  it('AreaPage leaves the desktop rendering unchanged (table, raw text, no pill)', () => {
     mockUseIsMobile.mockReturnValue(false)
     const { container } = renderArea()
+    expect(container.querySelector('table')).not.toBeNull()
     expect(container.querySelector('.clubs-status-pill')).toBeNull()
     expect(container.textContent).toContain('vulnerable')
   })

--- a/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Division / Area club mini-tables — mobile status-chip treatment (#871, CC-4).
+ *
+ * These two mini-tables rendered the raw `currentStatus` enum
+ * ("intervention-required") as `whitespace-nowrap` text that clips to
+ * "interv…" at 375px. At <768px they must instead render a StatusChip
+ * (`.clubs-status-pill`), with the desktop rendering left unchanged
+ * ("Desktop unchanged" acceptance criterion).
+ *
+ * `useIsMobile` is mocked per-test so we exercise both the <768px (chip) and
+ * the >=768px (unchanged raw text) branches without a layout engine.
+ */
+import React from 'react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, cleanup, within } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import DivisionPage from '../DivisionPage'
+import AreaPage from '../AreaPage'
+
+const mockUseIsMobile = vi.fn(() => false)
+vi.mock('../../hooks/useIsMobile', () => ({
+  useIsMobile: () => mockUseIsMobile(),
+}))
+
+const CLUB: ClubTrend = {
+  clubId: 'c1',
+  clubName: 'Limestone City Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '01',
+  areaName: 'Area 01',
+  distinguishedLevel: 'NotDistinguished',
+  currentStatus: 'vulnerable',
+  riskFactors: [],
+  membershipTrend: [{ date: '2025-07-15', count: 18 }],
+  dcpGoalsTrend: [{ date: '2025-07-15', goalsAchieved: 3 }],
+}
+
+vi.mock('../../hooks/useDistrictAnalytics', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../hooks/useDistrictAnalytics')
+  >('../../hooks/useDistrictAnalytics')
+  return {
+    ...actual,
+    useDistrictAnalytics: vi.fn(() => ({
+      data: { allClubs: [CLUB] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })),
+  }
+})
+
+function renderDivision() {
+  return render(
+    <MemoryRouter initialEntries={['/district/61/division/A']}>
+      <Routes>
+        <Route
+          path="/district/:districtId/division/:divId"
+          element={<DivisionPage />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+function renderArea() {
+  return render(
+    <MemoryRouter initialEntries={['/district/61/division/A/area/01']}>
+      <Routes>
+        <Route
+          path="/district/:districtId/division/:divId/area/:areaId"
+          element={<AreaPage />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  mockUseIsMobile.mockReturnValue(false)
+})
+
+describe('Division/Area status chip at <768px (#871 CC-4)', () => {
+  it('DivisionPage renders a status pill (not raw enum) on mobile', () => {
+    mockUseIsMobile.mockReturnValue(true)
+    const { container } = renderDivision()
+    const pill = container.querySelector('.clubs-status-pill')
+    expect(pill).not.toBeNull()
+    expect(pill).toHaveClass('clubs-status-pill--vulnerable')
+    expect(pill).toHaveTextContent('Vulnerable')
+    // raw enum must not leak into the rendered table
+    expect(container.textContent).not.toContain('vulnerable')
+  })
+
+  it('DivisionPage leaves the desktop rendering unchanged (raw text, no pill)', () => {
+    mockUseIsMobile.mockReturnValue(false)
+    const { container } = renderDivision()
+    expect(container.querySelector('.clubs-status-pill')).toBeNull()
+    expect(container.textContent).toContain('vulnerable')
+  })
+
+  it('AreaPage renders a status pill (not raw enum) on mobile', () => {
+    mockUseIsMobile.mockReturnValue(true)
+    const { container } = renderArea()
+    const pill = container.querySelector('.clubs-status-pill')
+    expect(pill).not.toBeNull()
+    expect(pill).toHaveClass('clubs-status-pill--vulnerable')
+    expect(
+      within(pill as HTMLElement).getByText('Vulnerable')
+    ).toBeInTheDocument()
+  })
+
+  it('AreaPage leaves the desktop rendering unchanged (raw text, no pill)', () => {
+    mockUseIsMobile.mockReturnValue(false)
+    const { container } = renderArea()
+    expect(container.querySelector('.clubs-status-pill')).toBeNull()
+    expect(container.textContent).toContain('vulnerable')
+  })
+})

--- a/frontend/src/utils/clubHealthStatus.ts
+++ b/frontend/src/utils/clubHealthStatus.ts
@@ -34,3 +34,20 @@ export function getClubHealthStatusPillModifier(
       return 'clubs-status-pill--thriving'
   }
 }
+
+/**
+ * Decorative glyph that reinforces the health status with a non-colour cue.
+ * Matches the ClubDetailPage DCP-outlook glyphs (✓ / ⚠ / ✗) so the same datum
+ * reads consistently across surfaces. The text label carries the meaning; the
+ * icon is `aria-hidden` at the render site (WCAG 1.4.1 — never colour alone).
+ */
+export function getClubHealthStatusIcon(status: ClubHealthStatus): string {
+  switch (status) {
+    case 'intervention-required':
+      return '✗'
+    case 'vulnerable':
+      return '⚠'
+    default:
+      return '✓'
+  }
+}

--- a/tasks/lessons/134-a-status-chip-in-an-overflowing-table-is-still-clipped-detable-the-row.md
+++ b/tasks/lessons/134-a-status-chip-in-an-overflowing-table-is-still-clipped-detable-the-row.md
@@ -1,0 +1,81 @@
+---
+id: '134'
+category: lesson
+tags: [css, frontend, responsive, mobile, tables, verification, playwright]
+auto_load: true
+date: 2026-05-28
+issues: [871, 873]
+---
+
+# Lesson 134 — Chipping a status cell doesn't fix mobile truncation while the table still overflows; de-table the row, and verify "unclipped" by bounding box, not `toBeVisible`
+
+**Date:** 2026-05-28
+**Issue:** #871 (epic #873 Sprint 1 — CC-4, mobile status columns)
+**PR:** [#908](https://github.com/taverns-red/toast-stats/pull/908)
+
+## What happened
+
+CC-4 was "Status / Outlook columns truncate at 375px" — the cell clipped to
+"vulne…" / "interv…". The obvious fix is to wrap the status value in a colored
+chip (`.clubs-status-pill` + icon + label). I did that for the Division and
+Area club mini-tables and the unit/integration tests went green.
+
+But the chip was **still clipped on the live preview** — "✗ Intervention R…".
+The mini-table is a 4-column grid (Club | Status | Members | Distinguished) with
+`whitespace-nowrap` club names, so at 375px the **table itself overflows** its
+`.overflow-x-auto` wrapper and scrolls the Status column off the right edge.
+Chipping the cell value changed _what_ renders in the column, not _whether the
+column fits_. The truncation lived one level up, in the table's intrinsic width.
+
+The real fix was the one the audit already named ("let it be a chip, **don't try
+to table it**") and Lesson 105 already generalized: a browse-one-row list
+card-collapses on mobile. I replaced the table at `<768px` with a stacked
+`ClubMiniList` — one card per club, name + a fully-visible chip + a
+Members/Distinguished meta line. Desktop keeps the table unchanged.
+
+## Two transferable points
+
+1. **A cell-level treatment can't fix a table-level overflow.** Before
+   "rendering the column differently" on mobile, ask whether the _table_ fits
+   the viewport at all. If long cells (`whitespace-nowrap` names) make the table
+   wider than the phone, every column past the fold clips regardless of its
+   content. The fix is the row layout (de-table / card-collapse per Lesson 105),
+   not the cell.
+
+2. **`toBeVisible()` does not catch viewport clipping.** Playwright's
+   `toBeVisible` is true for an element scrolled off-screen inside an
+   `overflow-x:auto` container — so my first smoke passed against a clipped
+   chip. To verify "fully on screen," measure `boundingBox()` and assert
+   `box.x + box.width <= viewportWidth` (and `box.x >= 0`). Same jsdom-can't-see-
+   layout family as Lessons 66 / 110: the unit test proves the chip _class_
+   ships; only a live geometry assertion proves it isn't clipped.
+
+## Verification-harness footguns also hit here
+
+- Measuring during an SPA route transition is racy: `locator.all()` captured a
+  stale page's chips mid-navigation (waited for `.nth(6)` on a 5-chip page).
+  Drive each surface with a **direct `page.goto()`**, not an in-app click, so no
+  prior page's nodes linger.
+- Measure **after `document.fonts.ready`** — Space Grotesk / Inter reflow text
+  width on load and transiently mis-position a right-aligned chip, which made
+  the bounding-box assertion flaky until fonts settled.
+
+## How to apply
+
+- Mobile table sprint: decide row layout first (does it fit? if not,
+  card-collapse), then style the cell. Don't chip a cell inside a table that
+  overflows.
+- Any "is it on screen at width W" check: assert the bounding box is within the
+  viewport; `toBeVisible` is necessary, not sufficient.
+
+## Related
+
+- [[105-match-the-mobile-table-pattern-to-the-datas-purpose-not-a-sibling-tables-precedent]]
+  — these mini-tables are browse-one-row lists, so card-collapse is the right
+  pattern; this lesson is the "I tried to chip-in-place first" cautionary tail.
+- [[110-jsdom-textcontent-ignores-css-text-transform-live-innertext-does-not]]
+  and [[066-jsdom-style-assertions-dont-catch-positioning-bugs]] — jsdom proves
+  what ships; the browser proves what renders. Clipping is the geometry instance.
+- [[077-presentational-extraction-override-classes-not-variants]] — `StatusChip`
+  and `ClubMiniList` reuse the shared label/modifier/pill SoT, className-override
+  style, no variant taxonomy.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -102,3 +102,4 @@
 - **131** [css, frontend, scope, responsive, architecture] — The class-cardinality check must cover EVERY shared class your CSS diff touches, not just the headline one (#861, #865)
 - **132** [css, dark-mode, frontend, tailwind] — A `var(--undefined-token, #hex)` fallback is a permanent literal, not a theme (#863, #865)
 - **133** [verification, playwright, frontend, cls, tests] — To measure a before/after UX delta locally, proxy the prod CDN and give each git state its own served dir (#864, #865)
+- **134** [css, frontend, responsive, mobile, tables, verification, playwright] — Chipping a status cell doesn't fix mobile truncation while the table still overflows; de-table the row, and verify "unclipped" by bounding box, not `toBeVisible` (#871, #873)


### PR DESCRIPTION
Closes-issue: #871 (epic #873 Sprint 1 — Epic C, mobile table treatments)

> Note: intentionally **not** using `Closes #871` — the sprint runner ticks the epic checkbox *before* closing the sub-issue (lesson 106 / #626). The issue is closed manually after verification.

## Problem (CC-4)
The Division and Area club mini-tables rendered the raw `currentStatus` enum (`vulnerable` / `intervention-required`) as `whitespace-nowrap` text, which clips to "vulne…" / "interv…" at 375px (audit screenshots 08, 09).

## Change
- New `StatusChip` component: a colored `.clubs-status-pill` carrying an icon glyph **and** the short label, so meaning never rests on colour alone (WCAG 1.4.1).
- New `getClubHealthStatusIcon` (✓ / ⚠ / ✗) added to the `clubHealthStatus` single source of truth (lesson 052), matching the ClubDetailPage DCP-outlook glyphs.
- `DivisionPage` + `AreaPage` mini-tables render `StatusChip` at `<768px` via `useIsMobile()`; desktop rendering is **unchanged**.

## Scope
CC-4 offenders were only these two mini-tables. `ClubsTable` already chips on desktop and card-collapses to `ClubCard` (which shows the pill) at <768px; `ClubDetailPage` "Outlook" already renders icon + label. Both verified compliant — no change.

## Acceptance criteria
- [x] Every Status column at <768px uses a chip, not truncated text (Division + Area).
- [x] Colour paired with text + icon (never colour-alone).
- [x] Desktop unchanged (tests assert no pill + raw text at ≥768px).
- [x] Tests added (StatusChip unit + Division/Area integration); no assertion pinning.

## Verification
- Full frontend suite: **3045 passed / 235 files**, zero regressions.
- Unit project green in isolation (2424 tests); first pre-push failure was worker contention with a concurrent full-suite run (lesson 53), retry clean.
- Vitest partition guard: disjoint + exhaustive (lesson 090).
- Live 375px Chromium + WebKit smoke on the PR preview to follow in a verification comment.

## Reviewer note (Low, per founder triage)
On desktop the Division/Area Status cell still shows the raw enum text — this is **pre-existing** and out of CC-4 scope ("Desktop unchanged"). A future cleanup could route desktop through `StatusChip` too for consistency with ClubsTable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)