### PR TITLE
chore(runner): launch spawned sprint sessions at ultracode effort (#909)

### DIFF
--- a/scripts/sprint-runner.sh
+++ b/scripts/sprint-runner.sh
@@ -749,10 +749,18 @@ mode_run() {
   local session_name="sprint-runner-$target_issue"
   log "Launching detached screen session $session_name (Sprint $target_n of epic #$EPIC, work #$target_issue)"
 
+  # Spawned sprint sessions run at ultracode (effortLevel "ultracode" = xhigh
+  # reasoning + standing dynamic workflow orchestration). Passed per-launch via
+  # --settings (an *additional* settings overlay) so it scopes to the runner's
+  # sessions ONLY — the operator's own interactive `claude` keeps its configured
+  # effortLevel. "ultracode" is not a valid --effort flag choice; it must come
+  # through settings. Single-quoted so the inner bash passes the JSON literally.
+  local ultracode_settings='{"effortLevel":"ultracode"}'
+
   # `screen -dmS` allocates a PTY so claude's interactive UI works.
   screen -dmS "$session_name" bash -c "
     cd '$worktree' && \
-    claude --remote-control 'sprint-$target_issue' \"\$(cat '$PROMPT_FILE')\";
+    claude --settings '$ultracode_settings' --remote-control 'sprint-$target_issue' \"\$(cat '$PROMPT_FILE')\";
     EXIT_CODE=\$?;
     rm -f '$PROMPT_FILE';
     echo \"[sprint-runner] claude exited with code \$EXIT_CODE — session ending.\"


### PR DESCRIPTION
Closes #909.

## What
Spawned autonomous sprint sessions now launch at **ultracode** effort (xhigh reasoning + standing dynamic workflow orchestration).

`scripts/sprint-runner.sh` adds `--settings '{"effortLevel":"ultracode"}'` to the `claude --remote-control` launch command.

## Why --settings, not --effort
`ultracode` is an `effortLevel` *settings* value — confirmed from the compiled CLI binary (`"Enable ultracode for the session: xhigh effort plus standing dynamic workflow orchestration"`). It is intentionally **not** a valid `--effort` flag choice (low/medium/high/xhigh/max), so it must come through settings.

Passing it as a per-launch `--settings` overlay scopes it to the runner's spawned sessions only — the operator's own interactive `claude` keeps its configured effortLevel.

## Verification
- `bash -n scripts/sprint-runner.sh` passes.
- Probe confirmed the real CLI accepts `--settings '{"effortLevel":"ultracode"}'` (clean run, exit 0).
- Single-quoted JSON so the inner `bash -c` passes it literally.

## Trade-off
Every spawned sprint now runs at xhigh and authors workflows by default — more tokens and longer wall-clock per sprint, in exchange for deeper, more thorough autonomous work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)