### PR TITLE
test(flake): eradicate contention & isolation root causes (#914)

### DIFF
--- a/docs/investigations/flake-baseline-2026-05-28.md
+++ b/docs/investigations/flake-baseline-2026-05-28.md
@@ -82,9 +82,20 @@ record it under §4.
 The clean, calibrated number — `flake-detection` job, suspect set ×8 on a
 dedicated `ubuntu-latest` runner:
 
-| Date       | Commit     | Flake rate | p50    | p95    | Source                      |
-| ---------- | ---------- | ---------- | ------ | ------ | --------------------------- |
-| 2026-05-29 | `8a672b7b` | **0.0%**   | 31.4 s | 31.9 s | PR #919 flake-detection job |
+| Date       | Commit     | Flake rate                                                              | p50    | p95    | Source                      |
+| ---------- | ---------- | ----------------------------------------------------------------------- | ------ | ------ | --------------------------- |
+| 2026-05-29 | `8a672b7b` | **0.0%**                                                                | 31.4 s | 31.9 s | PR #919 flake-detection job |
+| 2026-05-29 | (S3 PR)    | _(record from the S3 PR's `flake-detection` job — `--maxWorkers=100%`)_ |        |        |                             |
+
+> **Sprint 3 (#914) note.** The harness now pins `--maxWorkers=100%`
+> (`buildVitestArgs`) so the DETECTOR keeps running one-fork-per-core — the
+> §2.3 amplifier — _decoupled_ from the gate. The BLOCKING CI `test` job is now
+> capped at **50% of cores** (`resolveMaxWorkers` in `vitest.shared.mjs`, V8).
+> So the detector row above and the gate are deliberately measuring different
+> configurations: the detector at 100% should stay ~0% on a clean runner (same
+> as #919) and spike on an oversubscribed one (early-warning), while the capped
+> gate stays stable even when the runner is busy. Record the S3 detector row
+> from the PR's `flake-detection` job once it runs.
 
 **Reading:** on a clean, non-oversubscribed CI runner the suspect set is **not
 flaky** (0/8) and its duration is tight (31.3–31.9 s, p95/p50 ≈ 1.02 — no

--- a/frontend/src/__tests__/accessibility/DistrictDetailPage.axe.test.tsx
+++ b/frontend/src/__tests__/accessibility/DistrictDetailPage.axe.test.tsx
@@ -35,23 +35,36 @@ expect.extend(toHaveNoViolations)
 vi.setConfig({ testTimeout: 15000 })
 
 // IntersectionObserver mock (lazy children need to flush). Mirrors the
-// shape from DistrictDetailPage.AnalyticsTab.test.tsx — note Lesson 72:
-// callbacks consuming `entry.target` must guard with `?.`.
+// shape from DistrictDetailPage.AnalyticsTab.test.tsx and the global
+// setup.ts mock — fires from observe() with a real `target` (Lesson 72).
 class MockIntersectionObserver implements IntersectionObserver {
   readonly root: Element | null = null
   readonly rootMargin: string = ''
   readonly thresholds: ReadonlyArray<number> = []
+  private readonly callback: (
+    entries: IntersectionObserverEntry[],
+    observer: IntersectionObserver
+  ) => void
   constructor(
     callback: (
       entries: IntersectionObserverEntry[],
       observer: IntersectionObserver
     ) => void
   ) {
+    this.callback = callback
+  }
+  // Fire from observe() (deferred, so lazy children still flush) WITH the
+  // observed `target` — conforming to the global setup.ts mock's shape. The
+  // old version fired from the constructor with no target, so any callback
+  // reading `entry.target` would throw asynchronously (Lesson 72 / V3, #914).
+  observe(target: Element): void {
     setTimeout(() => {
-      callback([{ isIntersecting: true } as IntersectionObserverEntry], this)
+      this.callback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        this
+      )
     }, 0)
   }
-  observe(): void {}
   unobserve(): void {}
   disconnect(): void {}
   takeRecords(): IntersectionObserverEntry[] {

--- a/frontend/src/__tests__/config/globalMockReset.guard.test.ts
+++ b/frontend/src/__tests__/config/globalMockReset.guard.test.ts
@@ -1,0 +1,30 @@
+/**
+ * V5 guard (#914, epic #917 S3) — setup.ts must reset mock call-history between
+ * EVERY test globally, so a file that forgets its own `vi.clearAllMocks()` can't
+ * leak a mock's call/return state into the next test.
+ *
+ * The Sprint 1 deep-dive (V5) found `setup.ts` cleared localStorage in a global
+ * `beforeEach` but had no global mock reset — every file had to remember its own.
+ * A missed reset is exactly the kind of cross-test contamination that makes a
+ * `mockReturnValueOnce`-consuming test fail "for no reason" two tests away (L120).
+ *
+ * This guard is the falsifying test: `leakyMock` is module-scoped and nothing in
+ * THIS file clears it, so whether its call history survives from one test into
+ * the next depends solely on the global safety net.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+const leakyMock = vi.fn()
+
+describe('global mock-reset safety net (V5, #914)', () => {
+  it('A — records a call on a module-scoped mock that this file never clears', () => {
+    leakyMock()
+    expect(leakyMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('B — sees a clean mock; the global afterEach wiped A’s call history', () => {
+    // Without a global afterEach(vi.clearAllMocks()) in setup.ts this is 1
+    // (A’s call leaked in). The whole point of V5 is that it is 0.
+    expect(leakyMock).toHaveBeenCalledTimes(0)
+  })
+})

--- a/frontend/src/__tests__/config/maxWorkers.guard.test.ts
+++ b/frontend/src/__tests__/config/maxWorkers.guard.test.ts
@@ -16,12 +16,9 @@ import { resolveMaxWorkers } from '../../../vitest.shared.mjs'
 
 describe('resolveMaxWorkers — CI worker cap (V8, #914)', () => {
   it('caps workers under CI (never unbounded)', () => {
-    const ci = resolveMaxWorkers({ CI: 'true' })
     // The bug was `undefined` in CI (= one fork per core). The cap must be a
-    // concrete, bounded value — a percentage of cores or a fixed N.
-    expect(ci).toBeDefined()
-    expect(ci).not.toBeUndefined()
-    expect(ci).toBe('50%')
+    // concrete, bounded value — `toBe('50%')` also proves it isn't undefined.
+    expect(resolveMaxWorkers({ CI: 'true' })).toBe('50%')
   })
 
   it('keeps the fixed local cap when not in CI', () => {

--- a/frontend/src/__tests__/config/maxWorkers.guard.test.ts
+++ b/frontend/src/__tests__/config/maxWorkers.guard.test.ts
@@ -1,0 +1,31 @@
+/**
+ * V8 guard (#914, epic #917 S3) — the BLOCKING CI test invocation must run with
+ * a CAPPED worker count, never unbounded.
+ *
+ * The Sprint 1 deep-dive named the unbounded-worker CI config the single
+ * highest-leverage flake amplifier: `maxWorkers: process.env.CI ? undefined : 3`
+ * left CI free to spawn one fork per core, so the moment a runner was
+ * oversubscribed the suite's fast tests blew the 5s timeout (contention, not a
+ * regression). Local dev was already protected by a fixed 3-fork cap; CI was
+ * not. This guard sources the worker policy from the SAME helper the real
+ * vitest config uses (`resolveMaxWorkers`), so it can't drift from the gate it
+ * claims to protect (R20 spirit: assert against the tool's own resolution).
+ */
+import { describe, it, expect } from 'vitest'
+import { resolveMaxWorkers } from '../../../vitest.shared.mjs'
+
+describe('resolveMaxWorkers — CI worker cap (V8, #914)', () => {
+  it('caps workers under CI (never unbounded)', () => {
+    const ci = resolveMaxWorkers({ CI: 'true' })
+    // The bug was `undefined` in CI (= one fork per core). The cap must be a
+    // concrete, bounded value — a percentage of cores or a fixed N.
+    expect(ci).toBeDefined()
+    expect(ci).not.toBeUndefined()
+    expect(ci).toBe('50%')
+  })
+
+  it('keeps the fixed local cap when not in CI', () => {
+    expect(resolveMaxWorkers({})).toBe(3)
+    expect(resolveMaxWorkers({ CI: '' })).toBe(3)
+  })
+})

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import 'jest-axe/extend-expect'
-import { beforeEach, vi } from 'vitest'
+import { afterEach, beforeEach, vi } from 'vitest'
 
 // Import brand CSS to make design tokens available in tests
 import '../styles/brand.css'
@@ -89,4 +89,17 @@ Object.defineProperty(window, 'localStorage', {
 // localStorage on the Districts page.
 beforeEach(() => {
   Object.keys(store).forEach(k => delete store[k])
+})
+
+// Global mock-reset safety net (V5, #914, epic #917 S3). Clear every mock's
+// call/instance/return history after each test so a file that forgets its own
+// `vi.clearAllMocks()` can't leak a mock's state into the next test — the
+// cross-test contamination behind the `mockReturnValueOnce`-consumed-two-tests-
+// away failures (L120). `clearAllMocks` (not `resetAllMocks`) is deliberate: it
+// wipes call history but PRESERVES implementations, so a stray/leaked render
+// landing after a test ends still hits a valid mock impl instead of `undefined`
+// (the `undefined.dates` footgun, V2) — and a file's `vi.mock(...)` factories
+// stay intact across the suite.
+afterEach(() => {
+  vi.clearAllMocks()
 })

--- a/frontend/src/components/__tests__/DateSelector.integration.test.tsx
+++ b/frontend/src/components/__tests__/DateSelector.integration.test.tsx
@@ -47,13 +47,24 @@ const createEmptyCdnDatesResponse = () => ({
   generatedAt: '2024-02-10T10:00:00Z',
 })
 
-// Create a wrapper with QueryClientProvider for testing
-// Note: retry: false ensures errors are immediately propagated without retries
+// Create a wrapper with QueryClientProvider for testing.
+//
+// `retryDelay: 0` (V2, #914): DateSelector's query hardcodes `retry: 2`
+// (Requirement 3.4), which OVERRIDES this wrapper's `retry: false`. With the
+// default exponential backoff that means the rejection-path tests sit through
+// ~1s + ~2s of retry waits before settling to the error state — which both
+// pushes them toward the 5s test timeout under contention (the baseline §3
+// "Test timed out in 5000ms" flake signature) and widens the window in which a
+// deferred retry/render can leak into the next test and hit the reset mock's
+// `undefined.dates` (L120). Zeroing the delay keeps the retry COUNT (the
+// retry-limit test still asserts ≤3 calls) but collapses the multi-second
+// window — a test-only timing fix, no production behaviour change.
 const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
         retry: false,
+        retryDelay: 0,
         gcTime: 0,
         staleTime: 0,
       },

--- a/frontend/src/pages/__tests__/DistrictDetailPage.AnalyticsTab.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.AnalyticsTab.test.tsx
@@ -21,18 +21,32 @@ class MockIntersectionObserver implements IntersectionObserver {
   readonly rootMargin: string = ''
   readonly thresholds: ReadonlyArray<number> = []
 
+  private readonly callback: (
+    entries: IntersectionObserverEntry[],
+    observer: IntersectionObserver
+  ) => void
+
   constructor(
     callback: (
       entries: IntersectionObserverEntry[],
       observer: IntersectionObserver
     ) => void
   ) {
-    setTimeout(() => {
-      callback([{ isIntersecting: true } as IntersectionObserverEntry], this)
-    }, 0)
+    this.callback = callback
   }
 
-  observe(): void {}
+  // Fire from observe() (deferred, so lazy children still flush) WITH the
+  // observed `target` — conforming to the global setup.ts mock's shape. The
+  // old version fired from the constructor with no target, so any callback
+  // reading `entry.target` would throw asynchronously (Lesson 72 / V3, #914).
+  observe(target: Element): void {
+    setTimeout(() => {
+      this.callback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        this
+      )
+    }, 0)
+  }
   unobserve(): void {}
   disconnect(): void {}
   takeRecords(): IntersectionObserverEntry[] {

--- a/frontend/src/pages/__tests__/DistrictDetailPage.leanHub.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.leanHub.test.tsx
@@ -45,17 +45,30 @@ class MockIntersectionObserver implements IntersectionObserver {
   readonly root: Element | null = null
   readonly rootMargin: string = ''
   readonly thresholds: ReadonlyArray<number> = []
+  private readonly callback: (
+    entries: IntersectionObserverEntry[],
+    observer: IntersectionObserver
+  ) => void
   constructor(
     callback: (
       entries: IntersectionObserverEntry[],
       observer: IntersectionObserver
     ) => void
   ) {
+    this.callback = callback
+  }
+  // Fire from observe() (deferred, so lazy children still flush) WITH the
+  // observed `target` — conforming to the global setup.ts mock's shape. The
+  // old version fired from the constructor with no target, so any callback
+  // reading `entry.target` would throw asynchronously (Lesson 72 / V3, #914).
+  observe(target: Element): void {
     setTimeout(() => {
-      callback([{ isIntersecting: true } as IntersectionObserverEntry], this)
+      this.callback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        this
+      )
     }, 0)
   }
-  observe(): void {}
   unobserve(): void {}
   disconnect(): void {}
   takeRecords(): IntersectionObserverEntry[] {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
-import { integrationGlobs, baseExclude } from './vitest.shared.mjs'
+import {
+  integrationGlobs,
+  baseExclude,
+  resolveMaxWorkers,
+} from './vitest.shared.mjs'
 
 // Test config is split into two first-class projects (#482):
 //   - `unit`        — fast (~18-20s, well under the 30s pre-push budget),
@@ -25,17 +29,14 @@ export default defineConfig({
     // Set aggressive timeout limits for fast test execution
     testTimeout: 5000, // 5 seconds max per test
     hookTimeout: 5000, // 5 seconds max for setup/teardown hooks
-    // Cap local worker forks at 3. The default (one fork per core) saturates
-    // a busy dev machine — when something else is eating CPU (a background OS
-    // update/reindex, a persistent VM like Rancher Desktop, another build),
-    // forks starve each other and fast tests blow the 5s timeout, failing the
-    // pre-push gate for reasons unrelated to the code (worker-saturation
-    // flakiness, #473 / Lesson 53). A 50% cap still left ~4 timeouts on a
-    // heavily-contended machine; a fixed 3 forks gives each enough headroom
-    // to finish in time. CI runners are small and not oversubscribed, so they
-    // keep the default for full throughput.
+    // Worker-count policy lives in vitest.shared.mjs so the guard test can't
+    // drift from it (V8, #914). Local: fixed 3 forks (a busy dev machine
+    // saturates at one-fork-per-core and blows the 5s timeout — #473 / Lesson
+    // 53). CI: capped at 50% of cores so an oversubscribed runner can't convert
+    // contention into red builds (previously `undefined` = unbounded, the
+    // Sprint 1 deep-dive's single highest-leverage flake amplifier).
     // eslint-disable-next-line no-undef
-    maxWorkers: process.env.CI ? undefined : 3,
+    maxWorkers: resolveMaxWorkers(process.env),
     exclude: baseExclude,
     coverage: {
       exclude: [...baseExclude],

--- a/frontend/vitest.shared.mjs
+++ b/frontend/vitest.shared.mjs
@@ -24,6 +24,28 @@ import { dirname, join } from 'node:path'
 // file lands in neither project, so a mis-placed test is caught in CI
 // rather than silently dropping out of both gates.
 
+// V8 (#914, epic #917 S3) — the worker-count policy, sourced once so the real
+// vitest config and its guard test (src/__tests__/config/maxWorkers.guard.test.ts)
+// can never disagree.
+//
+// The Sprint 1 deep-dive named `maxWorkers: CI ? undefined : 3` the single
+// highest-leverage flake amplifier: `undefined` lets CI spawn one fork per core,
+// so an oversubscribed runner converts ambient timing-sensitivity into 5s-timeout
+// failures (contention, not a regression). Local dev was already capped at a
+// fixed 3 forks; CI was unbounded. We now cap CI at 50% of cores — half the box
+// stays free for the main thread + v8 coverage instrumentation, which is exactly
+// the headroom that keeps fast tests under the 5s timeout. The calibrated CI
+// baseline was already 0% at unbounded on a clean runner; the cap is the durable
+// guard against a future oversubscribed/larger runner drifting toward the
+// workstation stress ceiling (100% flake, 30.9→171.9s spread).
+//
+// NOTE: the non-gating flake-detection harness (scripts/run-flake-detection.ts)
+// deliberately OVERRIDES this with `--maxWorkers=100%` so the DETECTOR stays
+// maximally sensitive while the GATE stays capped/stable.
+export function resolveMaxWorkers(env) {
+  return env && env.CI ? '50%' : 3
+}
+
 export const integrationGlobs = [
   'src/__tests__/integration/**/*.test.{ts,tsx}',
   'src/__tests__/accessibility/**/*.test.{ts,tsx}',

--- a/scripts/lib/__tests__/flakeMetrics.test.ts
+++ b/scripts/lib/__tests__/flakeMetrics.test.ts
@@ -174,4 +174,13 @@ describe('buildVitestArgs', () => {
     expect(args).toContain('--coverage.thresholds.branches=0')
     expect(args).toContain('--coverage.thresholds.statements=0')
   })
+
+  it('pins --maxWorkers=100% so the DETECTOR stays maximally sensitive after the gate was capped (V8, #914)', () => {
+    // Sprint 3 capped the BLOCKING CI test invocation at 50% of cores
+    // (resolveMaxWorkers). The flake DETECTOR must NOT inherit that cap, or it
+    // would only ever measure the safe configuration and could never surface a
+    // contention regression. Pinning 100% keeps it running one-fork-per-core —
+    // the original §2.3 amplifier — decoupled from the gate's stability cap.
+    expect(args).toContain('--maxWorkers=100%')
+  })
 })

--- a/scripts/lib/flakeMetrics.ts
+++ b/scripts/lib/flakeMetrics.ts
@@ -94,6 +94,14 @@ export function resolveHarnessConfig(
  * misread as a 100% flake rate (all tests can pass and the run still "fails").
  * Zeroing every threshold makes the exit code reflect TEST pass/fail only —
  * which is what the flake metric is measuring.
+ *
+ * `--maxWorkers=100%` (V8, #914): Sprint 3 capped the BLOCKING CI test
+ * invocation at 50% of cores (`resolveMaxWorkers` in vitest.shared.mjs) to keep
+ * an oversubscribed runner from converting contention into red builds. The flake
+ * DETECTOR must NOT inherit that cap — a detector that only ever runs the safe
+ * configuration can never surface a contention regression. Pinning 100% keeps it
+ * running one-fork-per-core (the original §2.3 amplifier), decoupled from the
+ * gate's stability cap: gate = capped/stable, detector = unbounded/sensitive.
  */
 export function buildVitestArgs(targets: string[]): string[] {
   return [
@@ -104,6 +112,7 @@ export function buildVitestArgs(targets: string[]): string[] {
     '--coverage.thresholds.functions=0',
     '--coverage.thresholds.branches=0',
     '--coverage.thresholds.statements=0',
+    '--maxWorkers=100%',
     '--reporter=dot',
   ]
 }

--- a/scripts/run-flake-detection.ts
+++ b/scripts/run-flake-detection.ts
@@ -1,11 +1,17 @@
 /**
  * Flake-detection harness — IO orchestrator (#913, epic #917 S2).
  *
- * Runs a target test set N× under the REAL CI invocation (`CI=true vitest run
- * --coverage`, unbounded workers — the §2.3 amplifier) from the frontend
- * workspace, captures per-run pass/fail + wall-clock duration, and computes the
- * variance-aware flake metric. Writes a JSON artifact and, when running in CI,
- * a markdown summary to $GITHUB_STEP_SUMMARY.
+ * Runs a target test set N× under the CI invocation (`CI=true vitest run
+ * --coverage`) from the frontend workspace, captures per-run pass/fail +
+ * wall-clock duration, and computes the variance-aware flake metric. Writes a
+ * JSON artifact and, when running in CI, a markdown summary to
+ * $GITHUB_STEP_SUMMARY.
+ *
+ * Worker policy (V8, #914): the BLOCKING CI test job is now capped at 50% of
+ * cores (`resolveMaxWorkers`), but this DETECTOR pins `--maxWorkers=100%`
+ * (buildVitestArgs) so it keeps running one-fork-per-core — the original §2.3
+ * amplifier — and stays sensitive to a contention regression the capped gate
+ * would mask.
  *
  *   npm run test:flake                    # suspect set ×DEFAULT_REPEATS
  *   FLAKE_REPEATS=20 npm run test:flake   # more samples
@@ -40,7 +46,9 @@ function runOnce(targets: string[], i: number, total: number): RunResult {
   const start = Date.now()
   const res = spawnSync('npx', ['vitest', ...buildVitestArgs(targets)], {
     cwd: FRONTEND_DIR,
-    // CI=true removes the local 3-worker cap → the real, contended invocation.
+    // CI=true + the explicit --maxWorkers=100% in buildVitestArgs keep this the
+    // unbounded, contended invocation (the §2.3 amplifier) even though the
+    // blocking CI gate is now capped at 50% (V8, #914).
     env: { ...process.env, CI: 'true' },
     encoding: 'utf8',
     stdio: ['ignore', 'inherit', 'inherit'],

--- a/tasks/lessons/136-a-flake-detector-must-not-inherit-the-stability-cap-it-measures.md
+++ b/tasks/lessons/136-a-flake-detector-must-not-inherit-the-stability-cap-it-measures.md
@@ -1,0 +1,73 @@
+---
+id: '136'
+category: principle
+tags: [tests, flaky, vitest, ci, contention]
+auto_load: true
+date: 2026-05-29
+issues: [914, 917]
+---
+
+# Lesson 136 — A flake detector must not inherit the stability cap it measures; cap the gate, pin the detector to max parallelism
+
+**Date:** 2026-05-29
+**Issue:** #914 (epic #917 Sprint 3 — eradicate contention & isolation root causes)
+**PR:** _(record on merge)_
+
+## What happened
+
+The Sprint 1 deep-dive named the unbounded-worker CI config
+(`maxWorkers: process.env.CI ? undefined : 3`) the single highest-leverage flake
+amplifier: an oversubscribed runner spawns one fork per core and fast tests blow
+the 5s timeout (contention, not a regression). Sprint 3's fix capped the
+**blocking** CI test job at 50% of cores. But the repo also has a non-gating
+**flake-detection harness** (Sprint 2, #913) that runs the suspect set N× under
+`CI=true vitest run --coverage` and reports a pass/fail + variance metric — and
+it picked up the CI worker policy from the same vitest config.
+
+If the detector inherits the cap, it only ever runs the _safe_ configuration. A
+detector that can't reproduce contention can never surface a contention
+regression — it would report a reassuring 0% forever while the very failure mode
+it exists to catch drifts back in. The cap that stabilizes the gate _blinds_ the
+detector.
+
+## The transferable principle
+
+**An instrument that measures stability must not be subject to the same
+stabilization it measures.** When you add a guard that suppresses a failure
+class (a worker cap, a retry, a timeout, a serialization lock), check whether
+your _detector_ for that class shares the config — and decouple it if so. Here:
+the gate is capped (`resolveMaxWorkers` → 50% in CI, the durable stability
+guard); the detector explicitly pins `--maxWorkers=100%` in `buildVitestArgs`
+(one fork per core, the original amplifier) so it stays maximally sensitive.
+Gate = capped/stable; detector = unbounded/sensitive. Same idea as keeping
+coverage _instrumentation_ but zeroing the _threshold_ in the harness ([[135-a-coverage-gate-fails-a-filtered-subset-run-zero-thresholds-in-a-flake-harness]]):
+preserve the contention load, neutralize only the gate that would mask the
+signal.
+
+## How to apply
+
+- Sourcing a worker/retry/timeout policy from shared config? Ask "does my flake
+  detector read this too?" If yes, give the detector an explicit override so a
+  future tightening of the gate doesn't silently desensitize it.
+- A detector reporting a _tight_ 0% (no duration spread) right after you added a
+  stabilizer is suspect — confirm it's still running the _stressful_
+  configuration, not the safe one. Variance is the signal (L53); its absence in
+  a detector can mean the detector went blind, not that the flake is gone.
+
+## Adjacent gotcha from the same sprint (V2)
+
+A React Query hook that hardcodes `retry: N` at the **query** level overrides a
+test wrapper's `retry: false` **default** — so rejection-path tests sit through
+the full exponential backoff (~1s + 2s …) before settling, pushing them toward
+the 5s timeout under load. Fix in the test wrapper with `retryDelay: 0`: it keeps
+the retry _count_ (any "bounded retries" assertion still holds) but collapses the
+multi-second window. In #914 this dropped one file's test time 27.4s → 0.18s.
+
+## Related
+
+- [[135-a-coverage-gate-fails-a-filtered-subset-run-zero-thresholds-in-a-flake-harness]]
+  — sibling: neutralize the gate, keep the load.
+- [[053-renderwithproviders-bloat-as-contention-amplifier]] — variance is the
+  contention signal; this lesson is why a detector must stay able to produce it.
+- `frontend/vitest.shared.mjs` (`resolveMaxWorkers`), `scripts/lib/flakeMetrics.ts`
+  (`buildVitestArgs` `--maxWorkers=100%`).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -104,3 +104,4 @@
 - **133** [verification, playwright, frontend, cls, tests] — To measure a before/after UX delta locally, proxy the prod CDN and give each git state its own served dir (#864, #865)
 - **134** [css, frontend, responsive, mobile, tables, verification, playwright] — Chipping a status cell doesn't fix mobile truncation while the table still overflows; de-table the row, and verify "unclipped" by bounding box, not `toBeVisible` (#871, #873)
 - **135** [tests, flaky, vitest, ci, coverage, verification] — A global coverage threshold deterministically fails a filtered subset run; a flake harness must keep instrumentation but zero thresholds (#913, #917)
+- **136** [tests, flaky, vitest, ci, contention] — A flake detector must not inherit the stability cap it measures; cap the gate, pin the detector to max parallelism (#914, #917)


### PR DESCRIPTION
Epic #917 (eradicate load-related test flakiness) **Sprint 3 (#914)**. Implements the four contention/isolation vectors the [Sprint 1 deep-dive §6 S3](docs/investigations/test-flakiness-deep-dive-2026-05-28.md) prioritized. Doc-only Sprints 1–2 shipped the audit + harness; this is the first source pass.

## What changed (TDD, each vector its own commit)

**V8 — cap the CI worker amplifier (highest leverage).** `maxWorkers: CI ? undefined : 3` let an oversubscribed runner spawn one fork per core and blow the 5s timeout — the deep-dive's single highest-leverage flake amplifier. Extracted the policy to `resolveMaxWorkers(env)` in `vitest.shared.mjs` (the source the partition module already owns, so the guard test can't drift) and capped CI at **50% of cores**. The non-gating flake **detector** explicitly pins `--maxWorkers=100%` (`buildVitestArgs`) so it stays maximally sensitive — gate = capped/stable, detector = unbounded/sensitive (see [Lesson 136](tasks/lessons/136-a-flake-detector-must-not-inherit-the-stability-cap-it-measures.md)).

**V5 — global mock-reset safety net.** `setup.ts` cleared localStorage globally but not mocks. Added `afterEach(vi.clearAllMocks())` (clears call history, **preserves** implementations — so a leaked render hits a valid impl, not `undefined`). Falsifying guard test included.

**V3 — conform per-file IntersectionObserver mocks (L72).** Three `DistrictDetailPage` test files fired their IO mock from the constructor with **no `target`** (a latent async-throw footgun). Conformed all three to fire from `observe(target)` (deferred preserved) with a real target — the global `setup.ts` shape.

**V2 — collapse the DateSelector retry-backoff window (L120).** The component query hardcodes `retry: 2`, overriding the test wrapper's `retry: false`, so rejection-path tests sat through ~1s+2s of backoff → toward the 5s timeout under contention. `retryDelay: 0` keeps the retry **count** (retry-limit test still asserts ≤3) but collapses the window: **27.43s → 0.18s** for that file's tests.

## Evidence
- Full frontend suite **238 files / 3055 tests green**; scripts **192 green**; 4/4 new guard tests green.
- V2 before/after: DateSelector file test time 27.43s → 0.18s (single-file run via `--environment jsdom`).
- **Flake-rate metric:** the calibrated row comes from this PR's `flake-detection` CI job (detector pinned to `--maxWorkers=100%`) — recorded in `flake-baseline-2026-05-28.md §4` once it runs. Quarantine list is already empty (nothing to shrink).
- `/simplify` + fresh-context `/review` (verdict: APPROVE, no high/medium findings) run pre-push.

## Scope notes
- **Deferred (own follow-up):** V1 §4.1 page-mount consolidation (test-effectiveness debt; contention now bounded by the V8 cap — lower regression risk to leave). V4/V12 tripwires + §4.2 false-confidence tests are Sprint 5 (lock-in).
- **`/review` low nit (not blocking):** adding `retryDelay: 0` to the two shared test QueryClient factories would future-proof the class, but it's a no-op for current `retry:false` tests and doesn't dedup the DateSelector local wrapper — left for the S5 lock-in pass.
- No `packages/*/src` touched → no dist rebuild needed (R16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)