### PR TITLE
docs: sprint-runner 7-day timeline & starvation analysis (#924)

### DIFF
--- a/docs/investigations/sprint-runner-timeline-2026-05-29.md
+++ b/docs/investigations/sprint-runner-timeline-2026-05-29.md
@@ -1,0 +1,224 @@
+# Sprint-runner session timeline & gap analysis
+
+Source: `~/.toast-stats-sprint-runner.log` · span Fri 05-22 07:50 → Fri 05-29 07:17 2026
+Launches: 128 · unique work items: 109
+
+## A. Per-sprint (collapsed by work issue, chronological)
+
+RL = relaunches (stuck/restarted). Span = first launch → last reap (incl. ≤5m reap latency).
+
+|   # | Work | Sp  | Epic | First launch    | Last reap       | Span  | RL  |
+| --: | ---- | :-: | ---- | --------------- | --------------- | ----- | :-: |
+|   1 | #2   |  ?  | ?    | Fri 05-22 07:50 | OPEN ⚠          | —     |     |
+|   2 | #3   |  ?  | ?    | Fri 05-22 10:26 | Fri 05-22 11:47 | 1h21m |     |
+|   3 | #4   |  ?  | ?    | Fri 05-22 11:47 | Fri 05-22 15:54 | 4h07m |  5  |
+|   4 | #5   |  ?  | ?    | Fri 05-22 15:54 | Fri 05-22 17:17 | 1h23m |     |
+|   5 | #6   |  ?  | ?    | Fri 05-22 17:17 | Fri 05-22 18:17 | 60m   |     |
+|   6 | #7   |  ?  | ?    | Fri 05-22 18:17 | Fri 05-22 19:17 | 60m   |  1  |
+|   7 | #8   |  ?  | ?    | Fri 05-22 19:17 | Fri 05-22 19:47 | 30m   |     |
+|   8 | #9   |  ?  | ?    | Fri 05-22 19:47 | Fri 05-22 21:17 | 1h30m |  3  |
+|   9 | #11  |  ?  | ?    | Fri 05-22 21:47 | Fri 05-22 22:17 | 30m   |  1  |
+|  10 | #16  |  ?  | ?    | Fri 05-22 22:17 | Fri 05-22 22:47 | 30m   |     |
+|  11 | #17  |  ?  | ?    | Fri 05-22 22:47 | Fri 05-22 23:17 | 30m   |     |
+|  12 | #18  |  ?  | ?    | Fri 05-22 23:17 | Sat 05-23 01:17 | 1h60m |  1  |
+|  13 | #19  |  ?  | ?    | Sat 05-23 01:17 | Sat 05-23 02:17 | 60m   |     |
+|  14 | #20  |  ?  | ?    | Sat 05-23 02:17 | Sat 05-23 03:22 | 1h06m |     |
+|  15 | #1   |  ?  | ?    | Sat 05-23 11:17 | Sat 05-23 11:47 | 30m   |  2  |
+|  16 | #482 |  1  | 616  | Sat 05-23 13:17 | OPEN ⚠          | —     |     |
+|  17 | #619 |  2  | 617  | Sat 05-23 16:17 | Sat 05-23 18:02 | 1h45m |     |
+|  18 | #620 |  3  | 617  | Sat 05-23 18:02 | Sat 05-23 20:17 | 2h15m |     |
+|  19 | #621 |  4  | 617  | Sat 05-23 20:17 | Sat 05-23 21:47 | 1h30m |     |
+|  20 | #608 | 12  | 574  | Sat 05-23 22:32 | Sat 05-23 23:17 | 45m   |     |
+|  21 | #609 | 13  | 574  | Sat 05-23 23:17 | Sun 05-24 00:17 | 60m   |     |
+|  22 | #610 | 14  | 574  | Sun 05-24 00:17 | Sun 05-24 01:02 | 45m   |     |
+|  23 | #611 | 15  | 574  | Sun 05-24 01:02 | Sun 05-24 01:47 | 45m   |     |
+|  24 | #651 |  0  | 647  | Sun 05-24 01:47 | Sun 05-24 02:32 | 45m   |     |
+|  25 | #648 |  1  | 647  | Sun 05-24 02:32 | Sun 05-24 12:02 | 9h30m |  1  |
+|  26 | #580 |  1  | 657  | Sun 05-24 10:32 | Sun 05-24 11:17 | 45m   |     |
+|  27 | #649 |  2  | 647  | Sun 05-24 12:02 | Sun 05-24 12:32 | 30m   |     |
+|  28 | #650 |  3  | 647  | Sun 05-24 12:32 | Sun 05-24 13:02 | 30m   |     |
+|  29 | #612 |  1  | 597  | Sun 05-24 13:02 | Sun 05-24 13:47 | 45m   |     |
+|  30 | #613 |  2  | 597  | Sun 05-24 13:47 | Sun 05-24 15:02 | 1h15m |     |
+|  31 | #614 |  3  | 597  | Sun 05-24 15:02 | Sun 05-24 15:47 | 45m   |     |
+|  32 | #685 |  2  | 683  | Sun 05-24 16:47 | Sun 05-24 18:17 | 1h30m |     |
+|  33 | #686 |  3  | 683  | Sun 05-24 18:17 | Sun 05-24 19:32 | 1h15m |     |
+|  34 | #687 |  4  | 683  | Sun 05-24 19:32 | Sun 05-24 20:32 | 60m   |     |
+|  35 | #688 |  5  | 683  | Sun 05-24 20:32 | Sun 05-24 21:32 | 60m   |     |
+|  36 | #689 |  6  | 683  | Sun 05-24 21:32 | Sun 05-24 22:17 | 45m   |     |
+|  37 | #699 |  7  | 683  | Sun 05-24 22:17 | Sun 05-24 23:02 | 45m   |     |
+|  38 | #710 |  8  | 683  | Sun 05-24 23:02 | Mon 05-25 00:32 | 1h30m |     |
+|  39 | #700 |  1  | 701  | Mon 05-25 00:32 | Mon 05-25 07:02 | 6h30m |     |
+|  40 | #708 |  1  | 709  | Mon 05-25 07:02 | Mon 05-25 07:17 | 15m   |     |
+|  41 | #707 |  2  | 709  | Mon 05-25 07:17 | Mon 05-25 13:17 | 6h00m |     |
+|  42 | #713 |  3  | 709  | Mon 05-25 13:17 | Mon 05-25 15:17 | 1h60m |     |
+|  43 | #720 |  4  | 709  | Mon 05-25 15:17 | Mon 05-25 16:17 | 1h00m |     |
+|  44 | #667 |  1  | 665  | Mon 05-25 16:17 | Mon 05-25 17:17 | 59m   |     |
+|  45 | #668 |  2  | 665  | Mon 05-25 17:17 | OPEN ⚠          | —     |     |
+|  46 | #669 |  3  | 665  | Mon 05-25 18:17 | Mon 05-25 19:02 | 45m   |     |
+|  47 | #670 |  4  | 665  | Mon 05-25 19:02 | Mon 05-25 20:02 | 60m   |     |
+|  48 | #671 |  5  | 665  | Mon 05-25 20:02 | Mon 05-25 20:56 | 55m   |     |
+|  49 | #672 |  6  | 665  | Mon 05-25 20:56 | Mon 05-25 21:42 | 45m   |     |
+|  50 | #675 |  1  | 674  | Mon 05-25 21:42 | Mon 05-25 22:45 | 1h03m |     |
+|  51 | #676 |  2  | 674  | Mon 05-25 22:46 | Tue 05-26 00:15 | 1h29m |     |
+|  52 | #677 |  3  | 674  | Tue 05-26 00:16 | Tue 05-26 00:26 | 10m   |     |
+|  53 | #678 |  4  | 674  | Tue 05-26 00:26 | Tue 05-26 01:11 | 45m   |     |
+|  54 | #679 |  5  | 674  | Tue 05-26 01:11 | Tue 05-26 01:52 | 40m   |     |
+|  55 | #680 |  6  | 674  | Tue 05-26 01:52 | Tue 05-26 02:32 | 40m   |     |
+|  56 | #681 |  7  | 674  | Tue 05-26 02:32 | Tue 05-26 03:07 | 35m   |     |
+|  57 | #682 |  8  | 674  | Tue 05-26 03:07 | Tue 05-26 04:03 | 55m   |     |
+|  58 | #306 |  1  | 757  | Tue 05-26 08:39 | Tue 05-26 10:12 | 1h33m |     |
+|  59 | #753 |  2  | 757  | Tue 05-26 10:12 | Tue 05-26 10:42 | 30m   |     |
+|  60 | #490 |  3  | 757  | Tue 05-26 10:43 | Tue 05-26 11:28 | 45m   |     |
+|  61 | #735 |  1  | 756  | Tue 05-26 11:28 | Tue 05-26 12:08 | 40m   |     |
+|  62 | #750 |  2  | 756  | Tue 05-26 12:08 | Tue 05-26 12:44 | 35m   |     |
+|  63 | #715 |  3  | 756  | Tue 05-26 12:44 | Tue 05-26 13:29 | 45m   |     |
+|  64 | #754 |  1  | 758  | Tue 05-26 13:29 | Tue 05-26 13:44 | 15m   |     |
+|  65 | #755 |  2  | 758  | Tue 05-26 13:44 | Tue 05-26 14:20 | 35m   |     |
+|  66 | #772 |  1  | 659  | Tue 05-26 15:15 | Tue 05-26 15:45 | 30m   |     |
+|  67 | #778 |  1  | 785  | Tue 05-26 22:32 | Tue 05-26 23:17 | 45m   |     |
+|  68 | #779 |  2  | 785  | Tue 05-26 23:17 | Tue 05-26 23:43 | 25m   |     |
+|  69 | #780 |  3  | 785  | Tue 05-26 23:43 | Wed 05-27 00:33 | 51m   |     |
+|  70 | #782 |  4  | 785  | Wed 05-27 00:33 | Wed 05-27 01:04 | 30m   |     |
+|  71 | #783 |  5  | 785  | Wed 05-27 01:04 | Wed 05-27 02:04 | 1h01m |     |
+|  72 | #793 |  1  | 797  | Wed 05-27 08:56 | OPEN ⚠          | —     |     |
+|  73 | #798 |  1  | 800  | Wed 05-27 10:01 | Wed 05-27 10:47 | 45m   |     |
+|  74 | #799 |  2  | 800  | Wed 05-27 11:07 | Wed 05-27 12:07 | 1h00m |     |
+|  75 | #794 |  2  | 797  | Wed 05-27 12:07 | Wed 05-27 13:38 | 1h31m |     |
+|  76 | #795 |  3  | 821  | Wed 05-27 13:38 | Wed 05-27 23:27 | 9h48m |  2  |
+|  77 | #809 |  1  | 813  | Wed 05-27 14:19 | Wed 05-27 14:29 | 10m   |     |
+|  78 | #810 |  2  | 813  | Wed 05-27 14:29 | Wed 05-27 15:04 | 35m   |     |
+|  79 | #811 |  3  | 813  | Wed 05-27 15:04 | Wed 05-27 16:00 | 55m   |     |
+|  80 | #812 |  4  | 813  | Wed 05-27 16:00 | Wed 05-27 16:49 | 50m   |     |
+|  81 | #814 |  1  | 818  | Wed 05-27 16:49 | Wed 05-27 17:35 | 45m   |     |
+|  82 | #815 |  2  | 818  | Wed 05-27 17:35 | Wed 05-27 18:20 | 45m   |     |
+|  83 | #816 |  3  | 818  | Wed 05-27 18:21 | Wed 05-27 19:16 | 56m   |     |
+|  84 | #817 |  4  | 818  | Wed 05-27 19:16 | Wed 05-27 20:20 | 1h04m |     |
+|  85 | #819 |  2  | 821  | Wed 05-27 20:20 | Wed 05-27 22:51 | 2h31m |  1  |
+|  86 | #835 |  1  | 821  | Wed 05-27 21:11 | Wed 05-27 22:11 | 1h01m |     |
+|  87 | #832 |  1  | 833  | Wed 05-27 23:27 | Thu 05-28 00:58 | 1h31m |     |
+|  88 | #840 |  1  | 841  | Thu 05-28 07:05 | Thu 05-28 08:31 | 1h26m |  1  |
+|  89 | #826 |  1  | 842  | Thu 05-28 08:31 | Thu 05-28 09:21 | 50m   |     |
+|  90 | #804 |  1  | 843  | Thu 05-28 09:22 | Thu 05-28 09:47 | 25m   |     |
+|  91 | #848 |  1  | 849  | Thu 05-28 10:07 | Thu 05-28 10:42 | 35m   |     |
+|  92 | #851 |  1  | 852  | Thu 05-28 11:33 | Thu 05-28 12:53 | 1h21m |     |
+|  93 | #853 |  1  | 854  | Thu 05-28 12:53 | Thu 05-28 13:03 | 10m   |     |
+|  94 | #855 |  1  | 856  | Thu 05-28 13:04 | Thu 05-28 14:04 | 1h00m |     |
+|  95 | #861 |  1  | 865  | Thu 05-28 14:54 | Thu 05-28 15:50 | 55m   |     |
+|  96 | #862 |  2  | 865  | Thu 05-28 15:50 | Thu 05-28 16:15 | 25m   |     |
+|  97 | #863 |  3  | 865  | Thu 05-28 16:15 | Thu 05-28 16:45 | 30m   |     |
+|  98 | #864 |  4  | 865  | Thu 05-28 16:45 | Thu 05-28 17:26 | 40m   |     |
+|  99 | #866 |  1  | 870  | Thu 05-28 17:26 | Thu 05-28 17:51 | 25m   |     |
+| 100 | #867 |  2  | 870  | Thu 05-28 17:51 | Thu 05-28 18:16 | 25m   |     |
+| 101 | #868 |  3  | 870  | Thu 05-28 18:16 | Thu 05-28 18:47 | 30m   |     |
+| 102 | #869 |  4  | 870  | Thu 05-28 18:47 | Thu 05-28 19:29 | 42m   |     |
+| 103 | #871 |  1  | 873  | Thu 05-28 19:29 | Thu 05-28 21:00 | 1h31m |  1  |
+| 104 | #872 |  2  | 873  | Thu 05-28 21:00 | Thu 05-28 22:40 | 1h41m |     |
+| 105 | #912 |  1  | 917  | Thu 05-28 22:41 | Thu 05-28 23:51 | 1h11m |     |
+| 106 | #913 |  2  | 917  | Thu 05-28 23:52 | Fri 05-29 01:23 | 1h31m |     |
+| 107 | #914 |  3  | 917  | Fri 05-29 01:23 | Fri 05-29 02:29 | 1h06m |     |
+| 108 | #915 |  4  | 917  | Fri 05-29 02:29 | Fri 05-29 03:50 | 1h21m |     |
+| 109 | #916 |  5  | 917  | Fri 05-29 03:50 | OPEN ⚠          | —     |     |
+
+## B. "Nothing available" idle windows (runner ticked but had no work to launch)
+
+Clustered consecutive no-work ticks (≤10m apart). Count = number of 5-min ticks idle.
+
+|   # | From            | To              | Idle  | Ticks | Reason                                                                                    |
+| --: | --------------- | --------------- | ----- | :---: | ----------------------------------------------------------------------------------------- |
+|   1 | Sat 05-23 10:47 | Sat 05-23 10:47 | 0m    |   1   | queue drained (roadmap complete)                                                          |
+|   2 | Sat 05-23 12:17 | Sat 05-23 12:17 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|   3 | Sat 05-23 21:47 | Sat 05-23 21:47 | 0m    |   2   | epic done, auto-advancing, gate FAIL: missing sprint-verified                             |
+|   4 | Sat 05-23 22:17 | Sat 05-23 22:17 | 0m    |   1   | gate FAIL: missing sprint-verified                                                        |
+|   5 | Sun 05-24 01:47 | Sun 05-24 01:47 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|   6 | Sun 05-24 11:17 | Sun 05-24 11:17 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|   7 | Sun 05-24 13:02 | Sun 05-24 13:02 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|   8 | Sun 05-24 15:47 | Sun 05-24 15:47 | 0m    |   5   | epic done, auto-advancing, queue drained (roadmap complete)                               |
+|   9 | Sun 05-24 16:02 | Sun 05-24 16:02 | 0m    |   1   | paused (runner-paused label)                                                              |
+|  10 | Mon 05-25 00:32 | Mon 05-25 00:32 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  11 | Mon 05-25 07:02 | Mon 05-25 07:02 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  12 | Mon 05-25 16:17 | Mon 05-25 16:17 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  13 | Mon 05-25 18:02 | Mon 05-25 18:02 | 0m    |   1   | paused (runner-paused label)                                                              |
+|  14 | Mon 05-25 21:42 | Mon 05-25 21:42 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  15 | Tue 05-26 04:03 | Tue 05-26 08:34 | 4h31m |  56   | queue drained (roadmap complete), epic done, auto-advancing                               |
+|  16 | Tue 05-26 11:28 | Tue 05-26 11:28 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  17 | Tue 05-26 13:29 | Tue 05-26 13:34 | 5m    |   2   | epic done, auto-advancing, paused (runner-paused label)                                   |
+|  18 | Tue 05-26 14:20 | Tue 05-26 15:10 | 50m   |  13   | queue drained (roadmap complete), epic done, auto-advancing, paused (runner-paused label) |
+|  19 | Tue 05-26 15:45 | Tue 05-26 19:01 | 3h16m |  40   | queue drained (roadmap complete), blocked: needs-product-review                           |
+|  20 | Tue 05-26 19:21 | Tue 05-26 22:27 | 3h06m |  38   | queue drained (roadmap complete)                                                          |
+|  21 | Wed 05-27 02:04 | Wed 05-27 08:11 | 6h06m |  75   | queue drained (roadmap complete), epic done, auto-advancing                               |
+|  22 | Wed 05-27 08:36 | Wed 05-27 08:51 | 15m   |   4   | queue drained (roadmap complete)                                                          |
+|  23 | Wed 05-27 10:47 | Wed 05-27 11:02 | 15m   |   4   | blocked: needs-product-review                                                             |
+|  24 | Wed 05-27 12:07 | Wed 05-27 12:07 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  25 | Wed 05-27 14:14 | Wed 05-27 14:19 | 5m    |   2   | paused (runner-paused label), epic done, auto-advancing                                   |
+|  26 | Wed 05-27 16:49 | Wed 05-27 16:49 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  27 | Wed 05-27 20:20 | Wed 05-27 20:20 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  28 | Wed 05-27 21:01 | Wed 05-27 21:06 | 5m    |   2   | paused (runner-paused label)                                                              |
+|  29 | Wed 05-27 23:27 | Wed 05-27 23:27 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  30 | Thu 05-28 00:58 | Thu 05-28 07:00 | 6h02m |  74   | queue drained (roadmap complete), epic done, auto-advancing                               |
+|  31 | Thu 05-28 08:31 | Thu 05-28 08:31 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  32 | Thu 05-28 09:21 | Thu 05-28 09:21 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  33 | Thu 05-28 09:47 | Thu 05-28 10:02 | 15m   |   5   | queue drained (roadmap complete), epic done, auto-advancing                               |
+|  34 | Thu 05-28 10:42 | Thu 05-28 11:28 | 45m   |  11   | queue drained (roadmap complete), epic done, auto-advancing                               |
+|  35 | Thu 05-28 12:53 | Thu 05-28 12:53 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  36 | Thu 05-28 13:03 | Thu 05-28 13:03 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  37 | Thu 05-28 14:04 | Thu 05-28 14:49 | 45m   |  11   | queue drained (roadmap complete), epic done, auto-advancing                               |
+|  38 | Thu 05-28 17:26 | Thu 05-28 17:26 | 0m    |   1   | epic done, auto-advancing                                                                 |
+|  39 | Thu 05-28 19:29 | Thu 05-28 19:29 | 0m    |   1   | epic done, auto-advancing                                                                 |
+
+## C. Summary
+
+- Log span **167.4h** (~7.0 days)
+- Sprint span: min 10m · median 51m · max 9h48m (n=104)
+- Relaunched (stuck/restarted) work items: **11**
+- Sessions OPEN at log end: **9**
+- "Nothing available" windows: **39** · total idle **26h22m (16% of span)**
+- Idle window: median 0m · max 6h06m · windows >1h: **5**
+- Idle time by dominant reason:
+  - queue drained (roadmap complete): 25h52m
+  - blocked: needs-product-review: 15m
+  - paused (runner-paused label): 10m
+  - epic done, auto-advancing: 5m
+  - gate FAIL: missing sprint-verified: 0m
+
+## D. Starvation deep-dive (the 16%)
+
+**26h22m idle / 167.4h span = 16%.** Essentially all of it (25h52m) is the queue
+being _empty_ — the runner ticked, found "roadmap complete / no unchecked sprints,"
+and had nothing to launch. Process blocks were trivial (needs-review 15m, paused 10m).
+
+### When it happens — overnight starvation
+
+- **62% of idle (16h21m) falls in 22:00–08:00**; only 38% in working hours.
+- Idle peaks **04:00–07:00 (~3h each)** — the runner drains whatever was queued the
+  evening before, then sits until the operator (you) queues more in the morning.
+- The two longest windows (6h06m on 05-27, 6h02m on 05-28) are both pure overnight
+  drains ending right around 07:00–08:00.
+
+### Idle by day
+
+| Day       | Idle   |
+| --------- | ------ |
+| Sat 05-23 | 0m     |
+| Sun 05-24 | 0m     |
+| Mon 05-25 | 0m     |
+| Tue 05-26 | 11h48m |
+| Wed 05-27 | 6h47m  |
+| Thu 05-28 | 7h48m  |
+
+Zero starvation 05-23→05-25 (deep, multi-sprint epics were queued — dark-mode,
+club redesign, etc., kept the runner saturated). Starvation appears **05-26 onward**,
+exactly when the queue shifted to **shorter, single-sprint epics and review-only
+epics** that drain in <1h each. The runner consumes them faster than they're refilled.
+
+### Why it's a refill problem, not a runner problem
+
+Every starvation window is bounded by _new work being queued_, never by the runner
+failing to pick up available work. The cadence is healthy (5-min ticks, picks the
+first unchecked sprint immediately). The constraint is **upstream queue depth**: the
+runner can clear ~1 sprint/hour (median 51m) but the META_EPIC isn't kept that deep.
+
+### Levers (informational — not actioned per operator)
+
+- Keep a deeper backlog of _ready_ (no needs-product-review) sprints queued before EOD.
+- Auto-refill: a scheduled "planner" routine that tops up the META_EPIC when depth < N.
+- Batch larger multi-sprint epics (the 05-23→25 pattern) rather than many 1-sprint epics.


### PR DESCRIPTION
Closes #924.

Analysis of `~/.toast-stats-sprint-runner.log` (2026-05-22 → 05-29) feeding the **ops#53** sprint-runner extraction-readiness assessment.

Report: `docs/investigations/sprint-runner-timeline-2026-05-29.md` — per-sprint durations, stuck/relaunched sessions, and "nothing available" idle windows.

## Key findings
- ~95 sprints over 7 days; median span **51m**, max 9h48m.
- **16% idle**, 98% of which is **queue starvation** (empty roadmap), **62% overnight** (peaks 04:00–07:00).
- Starvation is a refill/queue-depth issue, not a runner defect — every window is bounded by new work being queued.
- 11 relaunched/stuck work items; 9 sessions open at log tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)