### PR TITLE
feat(charts): sparkline-then-expand wrapper for mobile (#874)

### DIFF
--- a/frontend/src/components/ChartExpandSheet.tsx
+++ b/frontend/src/components/ChartExpandSheet.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+
+export interface ChartExpandSheetProps {
+  isOpen: boolean
+  onClose: () => void
+  /** Heading shown in the sheet header. */
+  title: string
+  children: React.ReactNode
+}
+
+/**
+ * A full-screen modal sheet that hosts the desktop chart on mobile, opened
+ * from the collapsed sparkline by `ChartSparklineExpand`.
+ *
+ * Dismissible three ways (close button, Esc, backdrop click) and focus-trapped
+ * while open — the same modal-dialog contract as the clubs `FiltersPanel`
+ * (#816). Portalled to `document.body` so it escapes any clipped/overflow
+ * ancestor and reliably covers the viewport. Semantic tokens only, so dark mode
+ * comes for free at the CSS layer (R10).
+ */
+export const ChartExpandSheet: React.FC<ChartExpandSheetProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+}) => {
+  const sheetRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  // Esc-to-close (document-level, so it works before focus lands inside).
+  useEffect(() => {
+    if (!isOpen) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [isOpen, onClose])
+
+  // Move focus into the sheet on open; keep Tab inside it while open.
+  useEffect(() => {
+    if (!isOpen) return
+    closeButtonRef.current?.focus()
+
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !sheetRef.current) return
+      const focusables = sheetRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      if (!first || !last) return
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    const sheet = sheetRef.current
+    sheet?.addEventListener('keydown', handleTab)
+    return () => sheet?.removeEventListener('keydown', handleTab)
+  }, [isOpen])
+
+  // Lock background scroll while the sheet is open.
+  useEffect(() => {
+    if (!isOpen) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  return createPortal(
+    <div className="chart-expand-sheet-overlay">
+      <div
+        className="chart-expand-sheet-backdrop"
+        data-testid="chart-expand-sheet-backdrop"
+        onClick={onClose}
+      />
+      <div
+        ref={sheetRef}
+        className="chart-expand-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        <div className="chart-expand-sheet__header">
+          <h2 className="chart-expand-sheet__title">{title}</h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="chart-expand-sheet__close"
+            aria-label="Close chart"
+            onClick={onClose}
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M5 5l10 10M15 5L5 15"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="chart-expand-sheet__body">{children}</div>
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+export default ChartExpandSheet

--- a/frontend/src/components/ChartExpandSheet.tsx
+++ b/frontend/src/components/ChartExpandSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useId, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
 export interface ChartExpandSheetProps {
@@ -27,6 +27,7 @@ export const ChartExpandSheet: React.FC<ChartExpandSheetProps> = ({
 }) => {
   const sheetRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const titleId = useId()
 
   // Esc-to-close (document-level, so it works before focus lands inside).
   useEffect(() => {
@@ -38,9 +39,11 @@ export const ChartExpandSheet: React.FC<ChartExpandSheetProps> = ({
     return () => document.removeEventListener('keydown', onKeyDown)
   }, [isOpen, onClose])
 
-  // Move focus into the sheet on open; keep Tab inside it while open.
+  // Move focus into the sheet on open; restore it to the opener on close so
+  // keyboard/AT users return to the trigger, not the document top.
   useEffect(() => {
     if (!isOpen) return
+    const opener = document.activeElement as HTMLElement | null
     closeButtonRef.current?.focus()
 
     const handleTab = (e: KeyboardEvent) => {
@@ -61,7 +64,10 @@ export const ChartExpandSheet: React.FC<ChartExpandSheetProps> = ({
     }
     const sheet = sheetRef.current
     sheet?.addEventListener('keydown', handleTab)
-    return () => sheet?.removeEventListener('keydown', handleTab)
+    return () => {
+      sheet?.removeEventListener('keydown', handleTab)
+      opener?.focus?.()
+    }
   }, [isOpen])
 
   // Lock background scroll while the sheet is open.
@@ -88,10 +94,12 @@ export const ChartExpandSheet: React.FC<ChartExpandSheetProps> = ({
         className="chart-expand-sheet"
         role="dialog"
         aria-modal="true"
-        aria-label={title}
+        aria-labelledby={titleId}
       >
         <div className="chart-expand-sheet__header">
-          <h2 className="chart-expand-sheet__title">{title}</h2>
+          <h2 id={titleId} className="chart-expand-sheet__title">
+            {title}
+          </h2>
           <button
             ref={closeButtonRef}
             type="button"

--- a/frontend/src/components/ChartSparklineExpand.tsx
+++ b/frontend/src/components/ChartSparklineExpand.tsx
@@ -18,8 +18,6 @@ export interface ChartSparklineExpandProps {
   expandLabel?: string
   /** Class on the collapsed-mobile wrapper (Lesson 077 — override, no variant). */
   className?: string
-  /** Class on the <svg> sparkline. */
-  sparklineClassName?: string
 }
 
 /**
@@ -45,7 +43,6 @@ export const ChartSparklineExpand: React.FC<ChartSparklineExpandProps> = ({
   breakpoint = 768,
   expandLabel,
   className,
-  sparklineClassName,
 }) => {
   const isMobile = useIsMobile(breakpoint)
   const [isOpen, setIsOpen] = useState(false)
@@ -65,7 +62,7 @@ export const ChartSparklineExpand: React.FC<ChartSparklineExpandProps> = ({
         <Sparkline
           data={sparklineData}
           ariaLabel={`${title} sparkline`}
-          className={sparklineClassName ?? 'chart-spark__sparkline'}
+          className="chart-spark__sparkline"
         />
         <span className="chart-spark__hint" aria-hidden="true">
           Tap to expand

--- a/frontend/src/components/ChartSparklineExpand.tsx
+++ b/frontend/src/components/ChartSparklineExpand.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react'
+import { useIsMobile } from '../hooks/useIsMobile'
+import { Sparkline } from './Sparkline'
+import { ChartExpandSheet } from './ChartExpandSheet'
+
+export interface ChartSparklineExpandProps {
+  /** Chart name — sheet heading, sparkline aria-label, default expand label. */
+  title: string
+  /** Series for the collapsed mobile sparkline. */
+  sparklineData: number[]
+  /** Headline numbers rendered above the sparkline (the chart's key figures). */
+  headline: React.ReactNode
+  /** The desktop chart: rendered directly on desktop, inside the sheet on mobile. */
+  children: React.ReactNode
+  /** Viewport width (px) below which the chart collapses. Default 768. */
+  breakpoint?: number
+  /** Accessible label for the expand trigger. Default `Expand <title> chart`. */
+  expandLabel?: string
+  /** Class on the collapsed-mobile wrapper (Lesson 077 — override, no variant). */
+  className?: string
+  /** Class on the <svg> sparkline. */
+  sparklineClassName?: string
+}
+
+/**
+ * Sparkline-then-expand wrapper (epic #876 / CC-3). At and above `breakpoint`
+ * the desktop chart renders directly — zero added chrome, so desktop layout is
+ * untouched. Below it, the multi-series chart (unreadable at 375px) collapses
+ * to its headline numbers + a sparkline behind a tap target; tapping opens a
+ * full-screen `ChartExpandSheet` with the full desktop chart.
+ *
+ * The collapse is width-driven (`useIsMobile` → matchMedia), NOT scroll/visibility
+ * gated, so the collapsed view is present on mount in every context including
+ * non-scroll capture (Lesson 113). In JSDOM `useIsMobile` resolves to false, so
+ * desktop tests and existing consumers see the bare chart unchanged.
+ *
+ * This sprint (#874) ships only the reusable wrapper; #875 applies it to the
+ * District Trends, Club detail, Rankings Progression and Awards charts.
+ */
+export const ChartSparklineExpand: React.FC<ChartSparklineExpandProps> = ({
+  title,
+  sparklineData,
+  headline,
+  children,
+  breakpoint = 768,
+  expandLabel,
+  className,
+  sparklineClassName,
+}) => {
+  const isMobile = useIsMobile(breakpoint)
+  const [isOpen, setIsOpen] = useState(false)
+
+  if (!isMobile) return <>{children}</>
+
+  return (
+    <div className={className ?? 'chart-spark'}>
+      <button
+        type="button"
+        className="chart-spark__trigger"
+        aria-haspopup="dialog"
+        aria-label={expandLabel ?? `Expand ${title} chart`}
+        onClick={() => setIsOpen(true)}
+      >
+        <span className="chart-spark__headline">{headline}</span>
+        <Sparkline
+          data={sparklineData}
+          ariaLabel={`${title} sparkline`}
+          className={sparklineClassName ?? 'chart-spark__sparkline'}
+        />
+        <span className="chart-spark__hint" aria-hidden="true">
+          Tap to expand
+        </span>
+      </button>
+
+      <ChartExpandSheet
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title={title}
+      >
+        {children}
+      </ChartExpandSheet>
+    </div>
+  )
+}
+
+export default ChartSparklineExpand

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+
+export interface SparklineProps {
+  /** The series to plot. Each value is one point, evenly spaced on x. */
+  data: number[]
+  /** SVG viewBox width in px (intrinsic; scales via CSS). Default 96. */
+  width?: number
+  /** SVG viewBox height in px. Default 28. */
+  height?: number
+  /** Accessible label for the graphic. Falls back to a generic one. */
+  ariaLabel?: string
+  /** Class on the root <svg> (Lesson 077 — override, don't add a variant). */
+  className?: string
+}
+
+/**
+ * A minimal, dependency-free SVG sparkline — a single polyline, no axes,
+ * ticks, or tooltip. Used as the collapsed mobile representation of a
+ * multi-series chart by `ChartSparklineExpand`.
+ *
+ * Recharts is deliberately NOT used here: a sparkline has none of the chrome
+ * recharts provides, and the inner charts it represents are already its only
+ * recharts consumers. A flat polyline keeps the collapsed view cheap and
+ * synchronous (no lazy chunk, no `ResponsiveContainer` measure pass), which
+ * matters because it must render immediately on mobile mount — not gated on
+ * scroll/visibility (Lesson 113).
+ */
+export const Sparkline: React.FC<SparklineProps> = ({
+  data,
+  width = 96,
+  height = 28,
+  ariaLabel,
+  className,
+}) => {
+  // Inset the stroke so the rounded caps aren't clipped at the edges.
+  const pad = 2
+  const innerW = width - pad * 2
+  const innerH = height - pad * 2
+
+  const points = (() => {
+    if (data.length === 0) return ''
+    const min = Math.min(...data)
+    const max = Math.max(...data)
+    const range = max - min
+    // Flat series (range 0) sits on the vertical midline — never divide by
+    // zero, never invert the axis (CLAUDE.md y-axis tripwire).
+    const denom = data.length > 1 ? data.length - 1 : 1
+    return data
+      .map((value, i) => {
+        const x = pad + (i / denom) * innerW
+        const yFrac = range === 0 ? 0.5 : (value - min) / range
+        // SVG y grows downward; a higher value should sit higher.
+        const y = pad + (1 - yFrac) * innerH
+        return `${x.toFixed(2)},${y.toFixed(2)}`
+      })
+      .join(' ')
+  })()
+
+  return (
+    <svg
+      className={className ?? 'sparkline'}
+      role="img"
+      aria-label={ariaLabel ?? 'Trend sparkline'}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+    >
+      {points && (
+        <polyline
+          className="sparkline__line"
+          points={points}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+    </svg>
+  )
+}
+
+export default Sparkline

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 export interface SparklineProps {
   /** The series to plot. Each value is one point, evenly spaced on x. */
@@ -34,11 +34,10 @@ export const Sparkline: React.FC<SparklineProps> = ({
 }) => {
   // Inset the stroke so the rounded caps aren't clipped at the edges.
   const pad = 2
-  const innerW = width - pad * 2
-  const innerH = height - pad * 2
-
-  const points = (() => {
+  const points = useMemo(() => {
     if (data.length === 0) return ''
+    const innerW = width - pad * 2
+    const innerH = height - pad * 2
     const min = Math.min(...data)
     const max = Math.max(...data)
     const range = max - min
@@ -54,7 +53,7 @@ export const Sparkline: React.FC<SparklineProps> = ({
         return `${x.toFixed(2)},${y.toFixed(2)}`
       })
       .join(' ')
-  })()
+  }, [data, width, height])
 
   return (
     <svg

--- a/frontend/src/components/__tests__/ChartExpandSheet.test.tsx
+++ b/frontend/src/components/__tests__/ChartExpandSheet.test.tsx
@@ -60,4 +60,53 @@ describe('ChartExpandSheet', () => {
     fireEvent.click(screen.getByTestId('chart-expand-sheet-backdrop'))
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  it('labels the dialog by its visible heading (aria-labelledby)', () => {
+    render(
+      <ChartExpandSheet isOpen onClose={() => {}} title="Membership trend">
+        <div>chart</div>
+      </ChartExpandSheet>
+    )
+    const dialog = screen.getByRole('dialog')
+    const labelledBy = dialog.getAttribute('aria-labelledby')
+    expect(labelledBy).toBeTruthy()
+    const heading = screen.getByText('Membership trend')
+    expect(heading.id).toBe(labelledBy)
+    // accessible name comes from the heading, not a competing aria-label
+    expect(dialog.getAttribute('aria-label')).toBeNull()
+  })
+
+  it('moves focus to the close button on open', () => {
+    render(
+      <ChartExpandSheet isOpen onClose={() => {}} title="X">
+        <div>chart</div>
+      </ChartExpandSheet>
+    )
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: /close/i })
+    )
+  })
+
+  it('restores focus to the opener when it closes', () => {
+    const opener = document.createElement('button')
+    document.body.appendChild(opener)
+    opener.focus()
+    expect(document.activeElement).toBe(opener)
+
+    const { rerender } = render(
+      <ChartExpandSheet isOpen onClose={() => {}} title="X">
+        <div>chart</div>
+      </ChartExpandSheet>
+    )
+    // focus moved into the sheet
+    expect(document.activeElement).not.toBe(opener)
+
+    rerender(
+      <ChartExpandSheet isOpen={false} onClose={() => {}} title="X">
+        <div>chart</div>
+      </ChartExpandSheet>
+    )
+    expect(document.activeElement).toBe(opener)
+    opener.remove()
+  })
 })

--- a/frontend/src/components/__tests__/ChartExpandSheet.test.tsx
+++ b/frontend/src/components/__tests__/ChartExpandSheet.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+import { ChartExpandSheet } from '../ChartExpandSheet'
+
+afterEach(cleanup)
+
+describe('ChartExpandSheet', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <ChartExpandSheet isOpen={false} onClose={() => {}} title="Membership">
+        <div data-testid="chart-body">chart</div>
+      </ChartExpandSheet>
+    )
+    expect(screen.queryByTestId('chart-body')).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('renders a modal dialog with the title and children when open', () => {
+    render(
+      <ChartExpandSheet isOpen onClose={() => {}} title="Membership trend">
+        <div data-testid="chart-body">chart</div>
+      </ChartExpandSheet>
+    )
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    expect(screen.getByTestId('chart-body')).toBeTruthy()
+    expect(screen.getByText('Membership trend')).toBeTruthy()
+  })
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <ChartExpandSheet isOpen onClose={onClose} title="X">
+        <div>chart</div>
+      </ChartExpandSheet>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    render(
+      <ChartExpandSheet isOpen onClose={onClose} title="X">
+        <div>chart</div>
+      </ChartExpandSheet>
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <ChartExpandSheet isOpen onClose={onClose} title="X">
+        <div>chart</div>
+      </ChartExpandSheet>
+    )
+    fireEvent.click(screen.getByTestId('chart-expand-sheet-backdrop'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/__tests__/ChartSparklineExpand.test.tsx
+++ b/frontend/src/components/__tests__/ChartSparklineExpand.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+import { ChartSparklineExpand } from '../ChartSparklineExpand'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+/** Stub matchMedia so useIsMobile(768) resolves to the given viewport. */
+const stubViewport = (mobile: boolean) => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: mobile,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  )
+}
+
+const renderWrapper = () =>
+  render(
+    <ChartSparklineExpand
+      title="Membership trend"
+      sparklineData={[1, 3, 2, 5]}
+      headline={<span data-testid="headline">1,234 members</span>}
+    >
+      <div data-testid="desktop-chart">desktop chart</div>
+    </ChartSparklineExpand>
+  )
+
+describe('ChartSparklineExpand', () => {
+  it('on desktop renders the chart directly with no sparkline trigger', () => {
+    stubViewport(false)
+    renderWrapper()
+    expect(screen.getByTestId('desktop-chart')).toBeTruthy()
+    expect(screen.queryByTestId('headline')).toBeNull()
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(document.querySelector('svg')).toBeNull()
+  })
+
+  it('on mobile renders headline + sparkline behind a trigger, chart hidden until tapped', () => {
+    stubViewport(true)
+    renderWrapper()
+    // collapsed state: headline visible, sparkline svg present, chart not yet
+    expect(screen.getByTestId('headline')).toBeTruthy()
+    expect(document.querySelector('svg')).not.toBeNull()
+    expect(screen.queryByTestId('desktop-chart')).toBeNull()
+    // a single trigger control to expand
+    expect(screen.getByRole('button')).toBeTruthy()
+  })
+
+  it('on mobile, tapping the trigger opens the full-screen sheet with the chart', () => {
+    stubViewport(true)
+    renderWrapper()
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByTestId('desktop-chart')).toBeTruthy()
+  })
+
+  it('does not gate the collapsed view on scroll/IntersectionObserver (Lesson 113)', () => {
+    // No IntersectionObserver involvement: the sparkline must be present
+    // immediately on mobile mount, not after an intersection callback.
+    stubViewport(true)
+    renderWrapper()
+    expect(document.querySelector('svg')).not.toBeNull()
+  })
+})

--- a/frontend/src/components/__tests__/Sparkline.test.tsx
+++ b/frontend/src/components/__tests__/Sparkline.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+import { Sparkline } from '../Sparkline'
+
+afterEach(cleanup)
+
+describe('Sparkline', () => {
+  it('renders an accessible svg with a polyline of N points', () => {
+    const { container } = render(
+      <Sparkline data={[1, 5, 2, 8, 3]} ariaLabel="Membership sparkline" />
+    )
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg?.getAttribute('role')).toBe('img')
+    expect(svg?.getAttribute('aria-label')).toBe('Membership sparkline')
+
+    const poly = container.querySelector('polyline')
+    expect(poly).not.toBeNull()
+    // 5 data points → 5 "x,y" coordinate pairs
+    const points = poly?.getAttribute('points')?.trim().split(/\s+/) ?? []
+    expect(points).toHaveLength(5)
+  })
+
+  it('does not produce NaN coordinates when all values are equal (range 0)', () => {
+    const { container } = render(<Sparkline data={[4, 4, 4]} />)
+    const points = container.querySelector('polyline')?.getAttribute('points')
+    expect(points).toBeTruthy()
+    expect(points).not.toMatch(/NaN/)
+  })
+
+  it('renders nothing meaningful for empty data (no polyline)', () => {
+    const { container } = render(<Sparkline data={[]} />)
+    expect(container.querySelector('polyline')).toBeNull()
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,6 +41,7 @@
 @import './styles/components/status-indicators.css';
 @import './styles/components/alerts.css';
 @import './styles/components/app-shell.css';
+@import './styles/components/chart-sparkline-expand.css';
 @import './styles/components/district-narrative.css';
 @import './styles/components/district-subnav.css';
 @import './styles/components/district-changes.css';

--- a/frontend/src/styles/components/chart-sparkline-expand.css
+++ b/frontend/src/styles/components/chart-sparkline-expand.css
@@ -1,0 +1,146 @@
+/* chart-sparkline-expand.css (#874, epic #876 Epic D / CC-3)
+   The mobile sparkline-then-expand pattern: a collapsed headline + sparkline
+   trigger, and the full-screen sheet it opens. Desktop renders the raw chart
+   (no chrome from this file). Semantic tokens only → dark mode at the CSS
+   layer for free (R10). */
+
+@layer components {
+  /* ---- Collapsed mobile trigger -------------------------------------- */
+  .chart-spark {
+    width: 100%;
+  }
+
+  .chart-spark__trigger {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    /* ≥44px touch target (WCAG 2.5.5). */
+    min-height: 44px;
+    border: 1px solid var(--line);
+    border-radius: 0.625rem;
+    background-color: var(--surface);
+    color: var(--ink);
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .chart-spark__trigger:hover {
+    background-color: var(--surface-2);
+  }
+
+  .chart-spark__trigger:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+  }
+
+  .chart-spark__headline {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem 0.75rem;
+    font-weight: 600;
+    color: var(--ink);
+  }
+
+  .chart-spark__sparkline {
+    display: block;
+    width: 100%;
+    height: 32px;
+    /* The polyline strokes `currentColor`; tint it with the product accent. */
+    color: var(--rt-stats, #d4873f);
+  }
+
+  .chart-spark__hint {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--ink-2);
+  }
+
+  /* ---- Full-screen sheet --------------------------------------------- */
+  .chart-expand-sheet-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 80;
+    display: flex;
+  }
+
+  .chart-expand-sheet-backdrop {
+    position: absolute;
+    inset: 0;
+    background-color: rgba(15, 23, 42, 0.55);
+  }
+
+  .chart-expand-sheet {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    background-color: var(--surface);
+    animation: chart-expand-sheet-in 180ms ease-out;
+  }
+
+  @keyframes chart-expand-sheet-in {
+    from {
+      opacity: 0;
+      transform: translateY(2%);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .chart-expand-sheet {
+      animation: none;
+    }
+  }
+
+  .chart-expand-sheet__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .chart-expand-sheet__title {
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: 1.0625rem;
+    font-weight: 700;
+  }
+
+  /* 44px touch target (WCAG 2.5.5). */
+  .chart-expand-sheet__close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 0.5rem;
+    color: var(--ink-2);
+    cursor: pointer;
+  }
+
+  .chart-expand-sheet__close:hover {
+    background-color: var(--surface-2);
+    color: var(--ink);
+  }
+
+  .chart-expand-sheet__close:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+  }
+
+  .chart-expand-sheet__body {
+    flex: 1;
+    min-height: 0;
+    padding: 1rem;
+    overflow: auto;
+  }
+}


### PR DESCRIPTION
## What

Sprint 1 of epic #876 (Mobile UX audit — Epic D, kill CC-3: charts unreadable at 375px). Builds the **reusable sparkline-then-expand wrapper**. This sprint ships the pattern only; **#875** (Sprint 2) wires it into District Trends, Club detail, Rankings Progression and Awards.

Three net-new, cohesive components (no existing module touched):

- **`Sparkline`** — dependency-free SVG polyline (no recharts; a sparkline has no axes/tooltip). `role="img"`, range-0 guard (no NaN / no axis inversion — CLAUDE.md tripwire), points memoized.
- **`ChartExpandSheet`** — full-screen modal via `createPortal`. Dismiss by close button / Esc / backdrop; focus trap; focus moved in on open and **restored to the opener on close**; `aria-modal` + `aria-labelledby` heading; body-scroll lock; semantic tokens (R10 → dark mode free).
- **`ChartSparklineExpand`** — desktop (≥768px) passes `children` through unchanged (**no desktop regression**); mobile collapses to headline numbers + sparkline behind a 44px tap target that opens the sheet. Width-driven via `useIsMobile`, **not** scroll/IntersectionObserver-gated (Lesson 113). className override prop, no variant taxonomy (Lesson 077).

## Acceptance criteria

- [x] Reusable wrapper takes the desktop chart as `children` + sparkline data.
- [x] Full-screen sheet on tap; dismiss with close + Esc (+ backdrop).
- [x] Headline numbers render above the sparkline.

## Testing

- TDD: red → green → refactor → review-fix. 15 new unit tests (Sparkline, sheet dismiss/focus/labelledby, wrapper desktop-passthrough vs mobile-collapse).
- Full frontend suite: **3078/3078 pass**, zero regressions. Lint + prettier + typecheck clean.
- Live 375px Chromium + WebKit verification on the PR preview to follow per the sprint protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)