### PR TITLE
feat(charts): apply sparkline-then-expand to District Trends, Club detail, Rankings (#875)

### DIFF
--- a/frontend/src/components/GlobalRankingsTab.tsx
+++ b/frontend/src/components/GlobalRankingsTab.tsx
@@ -387,11 +387,7 @@ const GlobalRankingsTab: React.FC<GlobalRankingsTabProps> = ({
       <ChartSparklineExpand
         title="Ranking Progression"
         sparklineData={rankSparkline}
-        headline={
-          <span className="chart-spark__headline-text">
-            {latestRank !== null ? `Rank #${latestRank}` : 'Rank trend'}
-          </span>
-        }
+        headline={latestRank !== null ? `Rank #${latestRank}` : 'Rank trend'}
       >
         <FullYearRankingChart
           data={currentYearHistory}

--- a/frontend/src/components/GlobalRankingsTab.tsx
+++ b/frontend/src/components/GlobalRankingsTab.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import { useUrlState } from '../hooks/useUrlState'
 import EndOfYearRankingsPanel from './EndOfYearRankingsPanel'
 import FullYearRankingChart, { type RankMetric } from './FullYearRankingChart'
+import { ChartSparklineExpand } from './ChartSparklineExpand'
 
 /* #571 — URL contract for the metric toggle. Product-facing token is
    `paid`; the internal RankMetric union still uses `clubs` so the
@@ -268,6 +269,23 @@ const GlobalRankingsTab: React.FC<GlobalRankingsTabProps> = ({
     refetch,
   } = useGlobalRankings(hookParams)
 
+  // #875 (epic #876, CC-3): collapsed-mobile sparkline for the Ranking
+  // Progression chart. Prefer a fully-populated overallRank series; fall back
+  // to aggregateScore (always present) when older snapshots lack overallRank
+  // (mixing the two scales in one line would jump, so don't interleave them).
+  const rankSparkline = useMemo(() => {
+    const pts = currentYearHistory?.history ?? []
+    const ranks = pts
+      .map(p => p.overallRank)
+      .filter((r): r is number => typeof r === 'number')
+    return ranks.length === pts.length && ranks.length > 0
+      ? ranks
+      : pts.map(p => p.aggregateScore)
+  }, [currentYearHistory])
+  const latestRank =
+    currentYearHistory?.history?.[currentYearHistory.history.length - 1]
+      ?.overallRank ?? null
+
   // Determine the effective selected program year (default to most recent)
   const effectiveSelectedYear = useMemo(() => {
     if (selectedProgramYear) return selectedProgramYear
@@ -366,13 +384,23 @@ const GlobalRankingsTab: React.FC<GlobalRankingsTabProps> = ({
       />
 
       {/* Full Year Ranking Chart — loads progressively */}
-      <FullYearRankingChart
-        data={currentYearHistory}
-        selectedMetric={selectedMetric}
-        onMetricChange={handleMetricChange}
-        isLoading={isLoadingChart}
-        programYear={effectiveSelectedYear}
-      />
+      <ChartSparklineExpand
+        title="Ranking Progression"
+        sparklineData={rankSparkline}
+        headline={
+          <span className="chart-spark__headline-text">
+            {latestRank !== null ? `Rank #${latestRank}` : 'Rank trend'}
+          </span>
+        }
+      >
+        <FullYearRankingChart
+          data={currentYearHistory}
+          selectedMetric={selectedMetric}
+          onMetricChange={handleMetricChange}
+          isLoading={isLoadingChart}
+          programYear={effectiveSelectedYear}
+        />
+      </ChartSparklineExpand>
 
       {/* Multi-Year Comparison Table — loads progressively */}
       <MultiYearComparisonTable

--- a/frontend/src/components/__tests__/GlobalRankingsTab.test.tsx
+++ b/frontend/src/components/__tests__/GlobalRankingsTab.test.tsx
@@ -485,7 +485,10 @@ describe('GlobalRankingsTab', () => {
           })
         )
         expect(screen.getByRole('dialog')).toBeInTheDocument()
-        expect(screen.getByText('Ranking Progression')).toBeInTheDocument()
+        // Appears twice once open: the sheet title + the chart's own heading.
+        expect(
+          screen.getAllByText('Ranking Progression').length
+        ).toBeGreaterThanOrEqual(1)
       })
 
       it('renders the chart directly at desktop widths', () => {

--- a/frontend/src/components/__tests__/GlobalRankingsTab.test.tsx
+++ b/frontend/src/components/__tests__/GlobalRankingsTab.test.tsx
@@ -439,6 +439,66 @@ describe('GlobalRankingsTab', () => {
       expect(screen.getByText('Multi-Year Comparison')).toBeInTheDocument()
     })
 
+    // #875 (epic #876 Sprint 2, CC-3): the Ranking Progression chart collapses
+    // to a sparkline-then-expand wrapper below 768px. setup.ts's matchMedia
+    // mock is writable; flip only the max-width query to mobile.
+    describe('mobile chart collapse (#875)', () => {
+      const setMobile = (mobile: boolean) => {
+        ;(window.matchMedia as unknown as ReturnType<typeof vi.fn>) = vi
+          .fn()
+          .mockImplementation((query: string) => ({
+            matches: /max-width/.test(query) ? mobile : false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          }))
+      }
+      afterEach(() => setMobile(false))
+
+      it('collapses Ranking Progression behind an expand trigger', () => {
+        setMobile(true)
+        mockUseGlobalRankings.mockReturnValue(createMockHookResult())
+        renderWithProviders(<GlobalRankingsTab {...baseProps} />)
+        expect(
+          screen.queryByText('Ranking Progression')
+        ).not.toBeInTheDocument()
+        expect(
+          screen.getByRole('button', {
+            name: /expand ranking progression chart/i,
+          })
+        ).toBeInTheDocument()
+        // siblings stay rendered — only the chart collapses
+        expect(screen.getByText('End-of-Year Rankings')).toBeInTheDocument()
+      })
+
+      it('opens the ranking chart in a sheet when tapped', () => {
+        setMobile(true)
+        mockUseGlobalRankings.mockReturnValue(createMockHookResult())
+        renderWithProviders(<GlobalRankingsTab {...baseProps} />)
+        fireEvent.click(
+          screen.getByRole('button', {
+            name: /expand ranking progression chart/i,
+          })
+        )
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+        expect(screen.getByText('Ranking Progression')).toBeInTheDocument()
+      })
+
+      it('renders the chart directly at desktop widths', () => {
+        setMobile(false)
+        mockUseGlobalRankings.mockReturnValue(createMockHookResult())
+        renderWithProviders(<GlobalRankingsTab {...baseProps} />)
+        expect(screen.getByText('Ranking Progression')).toBeInTheDocument()
+        expect(
+          screen.queryByRole('button', { name: /expand .* chart/i })
+        ).not.toBeInTheDocument()
+      })
+    })
+
     it('does not render its own ProgramYearSelector', () => {
       mockUseGlobalRankings.mockReturnValue(createMockHookResult())
 

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -34,6 +34,7 @@ import {
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 import ErrorBoundary from '../components/ErrorBoundary'
+import { ChartSparklineExpand } from '../components/ChartSparklineExpand'
 import { useDistrictStatistics } from '../hooks/useMembershipData'
 import { ClubDCPGoalsPanel } from '../components/ClubDCPGoalsPanel'
 import { useClubGoalTimeline } from '../hooks/useClubGoalTimeline'
@@ -347,6 +348,13 @@ const ClubDetailPage: React.FC = () => {
   const membershipChangePct =
     baseMembership > 0 ? (membershipChange / baseMembership) * 100 : null
 
+  // #875 (epic #876, CC-3): collapsed-mobile sparkline series for the
+  // membership trend — the same counts the hand-rolled .mem-chart plots.
+  const membershipSparkline = useMemo(
+    () => filteredMembershipTrend.map(p => p.count),
+    [filteredMembershipTrend]
+  )
+
   // Membership chart geometry — pixel-mapped to club-reference.html (#619).
   // viewBox 800×260 with PL36/PR14/PT14/PB26 padding → 750×220 plot area.
   const CHART = { W: 800, H: 260, PT: 14, PR: 14, PB: 26, PL: 36 }
@@ -652,150 +660,162 @@ const ClubDetailPage: React.FC = () => {
               </div>
               <div className="club-panel__body">
                 {filteredMembershipTrend.length > 0 ? (
-                  <>
-                    <div className="chart-stats">
-                      <div className="chart-stats__row">
-                        <span className="chart-stats__label">Base</span>
-                        <span className="chart-stats__val">
-                          {baseMembership}
-                        </span>
+                  <ChartSparklineExpand
+                    title="Membership Trend"
+                    sparklineData={membershipSparkline}
+                    headline={
+                      <span className="chart-spark__headline-text">
+                        {latestMembership} members
+                        {membershipChange !== 0 &&
+                          ` (${membershipChange > 0 ? '+' : ''}${membershipChange})`}
+                      </span>
+                    }
+                  >
+                    <>
+                      <div className="chart-stats">
+                        <div className="chart-stats__row">
+                          <span className="chart-stats__label">Base</span>
+                          <span className="chart-stats__val">
+                            {baseMembership}
+                          </span>
+                        </div>
+                        <div className="chart-stats__row">
+                          <span className="chart-stats__label">Current</span>
+                          <span className="chart-stats__val">
+                            {latestMembership}
+                          </span>
+                        </div>
+                        <div className="chart-stats__row">
+                          <span className="chart-stats__label">Change</span>
+                          <span
+                            className={
+                              'chart-stats__val' +
+                              (membershipChange > 0
+                                ? ' chart-stats__val--pos'
+                                : membershipChange < 0
+                                  ? ' chart-stats__val--neg'
+                                  : '')
+                            }
+                          >
+                            {membershipChange >= 0 ? '+' : ''}
+                            {membershipChange}
+                            {membershipChangePct !== null &&
+                              ` (${membershipChangePct >= 0 ? '+' : ''}${membershipChangePct.toFixed(1)}%)`}
+                          </span>
+                        </div>
                       </div>
-                      <div className="chart-stats__row">
-                        <span className="chart-stats__label">Current</span>
-                        <span className="chart-stats__val">
-                          {latestMembership}
-                        </span>
-                      </div>
-                      <div className="chart-stats__row">
-                        <span className="chart-stats__label">Change</span>
-                        <span
-                          className={
-                            'chart-stats__val' +
-                            (membershipChange > 0
-                              ? ' chart-stats__val--pos'
-                              : membershipChange < 0
-                                ? ' chart-stats__val--neg'
-                                : '')
-                          }
-                        >
-                          {membershipChange >= 0 ? '+' : ''}
-                          {membershipChange}
-                          {membershipChangePct !== null &&
-                            ` (${membershipChangePct >= 0 ? '+' : ''}${membershipChangePct.toFixed(1)}%)`}
-                        </span>
-                      </div>
-                    </div>
 
-                    <svg
-                      className="mem-chart"
-                      viewBox={`0 0 ${CHART.W} ${CHART.H}`}
-                      preserveAspectRatio="none"
-                      role="img"
-                      aria-label={`Membership trend for program year ${programYearLabelDisplay}`}
-                    >
-                      {/* Y grid + labels (4 ticks) */}
-                      {[0, 1, 2, 3].map(i => {
-                        const v = yMin + yRange * (i / 3)
-                        const y = yScale(v)
-                        return (
-                          <g key={`grid-${i}`}>
-                            <line
-                              className="grid"
-                              x1={CHART.PL}
-                              y1={y}
-                              x2={CHART.W - CHART.PR}
-                              y2={y}
-                            />
-                            <text
-                              className="axis-text"
-                              x={CHART.PL - 6}
-                              y={y + 4}
-                              textAnchor="end"
-                            >
-                              {Math.round(v)}
-                            </text>
-                          </g>
-                        )
-                      })}
-
-                      {/* Key-date verticals (Jul 1 / Oct 1 / Apr 1 / Jun 30) */}
-                      {keyDates.map(kd => {
-                        const x = xScale(kd.day)
-                        return (
-                          <g key={kd.label}>
-                            <line
-                              className="key-line"
-                              x1={x}
-                              y1={CHART.PT}
-                              x2={x}
-                              y2={CHART.H - CHART.PB}
-                            >
-                              <title>{kd.description}</title>
-                            </line>
-                            <text
-                              className="key-text"
-                              x={x}
-                              y={CHART.H - 10}
-                              textAnchor="middle"
-                            >
-                              {kd.label}
-                            </text>
-                          </g>
-                        )
-                      })}
-
-                      {/* Area fill + line */}
-                      {(() => {
-                        const pts = filteredMembershipTrend
-                          .map(
-                            p =>
-                              `${xScale(calculateProgramYearDay(p.date)).toFixed(1)},${yScale(p.count).toFixed(1)}`
-                          )
-                          .join(' ')
-                        const baseY = (CHART.PT + innerH).toFixed(1)
-                        const firstX = xScale(
-                          calculateProgramYearDay(
-                            filteredMembershipTrend[0]!.date
-                          )
-                        ).toFixed(1)
-                        const lastX = xScale(
-                          calculateProgramYearDay(
-                            filteredMembershipTrend[
-                              filteredMembershipTrend.length - 1
-                            ]!.date
-                          )
-                        ).toFixed(1)
-                        return (
-                          <>
-                            {filteredMembershipTrend.length > 1 && (
-                              <polygon
-                                className="area"
-                                points={`${pts} ${lastX},${baseY} ${firstX},${baseY}`}
+                      <svg
+                        className="mem-chart"
+                        viewBox={`0 0 ${CHART.W} ${CHART.H}`}
+                        preserveAspectRatio="none"
+                        role="img"
+                        aria-label={`Membership trend for program year ${programYearLabelDisplay}`}
+                      >
+                        {/* Y grid + labels (4 ticks) */}
+                        {[0, 1, 2, 3].map(i => {
+                          const v = yMin + yRange * (i / 3)
+                          const y = yScale(v)
+                          return (
+                            <g key={`grid-${i}`}>
+                              <line
+                                className="grid"
+                                x1={CHART.PL}
+                                y1={y}
+                                x2={CHART.W - CHART.PR}
+                                y2={y}
                               />
-                            )}
-                            {filteredMembershipTrend.length > 1 && (
-                              <polyline className="line" points={pts} />
-                            )}
-                          </>
-                        )
-                      })()}
+                              <text
+                                className="axis-text"
+                                x={CHART.PL - 6}
+                                y={y + 4}
+                                textAnchor="end"
+                              >
+                                {Math.round(v)}
+                              </text>
+                            </g>
+                          )
+                        })}
 
-                      {/* Dots + tooltips */}
-                      {filteredMembershipTrend.map((point, index) => (
-                        <circle
-                          key={index}
-                          className="dot"
-                          cx={xScale(calculateProgramYearDay(point.date))}
-                          cy={yScale(point.count)}
-                          r="3"
-                        >
-                          <title>
-                            {formatDate(point.date)}: {point.count} members
-                          </title>
-                        </circle>
-                      ))}
-                    </svg>
-                  </>
+                        {/* Key-date verticals (Jul 1 / Oct 1 / Apr 1 / Jun 30) */}
+                        {keyDates.map(kd => {
+                          const x = xScale(kd.day)
+                          return (
+                            <g key={kd.label}>
+                              <line
+                                className="key-line"
+                                x1={x}
+                                y1={CHART.PT}
+                                x2={x}
+                                y2={CHART.H - CHART.PB}
+                              >
+                                <title>{kd.description}</title>
+                              </line>
+                              <text
+                                className="key-text"
+                                x={x}
+                                y={CHART.H - 10}
+                                textAnchor="middle"
+                              >
+                                {kd.label}
+                              </text>
+                            </g>
+                          )
+                        })}
+
+                        {/* Area fill + line */}
+                        {(() => {
+                          const pts = filteredMembershipTrend
+                            .map(
+                              p =>
+                                `${xScale(calculateProgramYearDay(p.date)).toFixed(1)},${yScale(p.count).toFixed(1)}`
+                            )
+                            .join(' ')
+                          const baseY = (CHART.PT + innerH).toFixed(1)
+                          const firstX = xScale(
+                            calculateProgramYearDay(
+                              filteredMembershipTrend[0]!.date
+                            )
+                          ).toFixed(1)
+                          const lastX = xScale(
+                            calculateProgramYearDay(
+                              filteredMembershipTrend[
+                                filteredMembershipTrend.length - 1
+                              ]!.date
+                            )
+                          ).toFixed(1)
+                          return (
+                            <>
+                              {filteredMembershipTrend.length > 1 && (
+                                <polygon
+                                  className="area"
+                                  points={`${pts} ${lastX},${baseY} ${firstX},${baseY}`}
+                                />
+                              )}
+                              {filteredMembershipTrend.length > 1 && (
+                                <polyline className="line" points={pts} />
+                              )}
+                            </>
+                          )
+                        })()}
+
+                        {/* Dots + tooltips */}
+                        {filteredMembershipTrend.map((point, index) => (
+                          <circle
+                            key={index}
+                            className="dot"
+                            cx={xScale(calculateProgramYearDay(point.date))}
+                            cy={yScale(point.count)}
+                            r="3"
+                          >
+                            <title>
+                              {formatDate(point.date)}: {point.count} members
+                            </title>
+                          </circle>
+                        ))}
+                      </svg>
+                    </>
+                  </ChartSparklineExpand>
                 ) : (
                   <EmptyState
                     title="No Membership Data"

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -664,11 +664,11 @@ const ClubDetailPage: React.FC = () => {
                     title="Membership Trend"
                     sparklineData={membershipSparkline}
                     headline={
-                      <span className="chart-spark__headline-text">
+                      <>
                         {latestMembership} members
                         {membershipChange !== 0 &&
                           ` (${membershipChange > 0 ? '+' : ''}${membershipChange})`}
-                      </span>
+                      </>
                     }
                   >
                     <>

--- a/frontend/src/pages/DistrictTrendsPage.tsx
+++ b/frontend/src/pages/DistrictTrendsPage.tsx
@@ -31,6 +31,7 @@ import {
 } from '../components/LazyCharts'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import ErrorBoundary from '../components/ErrorBoundary'
+import { ChartSparklineExpand } from '../components/ChartSparklineExpand'
 
 /* District Trends Page (#680, epic #674 Sprint 6, ADR-005 §1).
    Dedicated deep-linkable route for the membership / payments / YoY trend
@@ -133,6 +134,33 @@ const DistrictTrendsPage: React.FC = () => {
       performanceTargets ?? null
     )
 
+  // #875 (epic #876, CC-3): the membership/payments charts are multi-series
+  // Recharts that smear at 375px. Derive the collapsed-mobile sparkline series
+  // from the SAME points the charts plot, so the sparkline-then-expand wrapper
+  // (ChartSparklineExpand) previews the real trend. Desktop is untouched — the
+  // wrapper renders its children verbatim at and above the 768px breakpoint.
+  const membershipTrendPoints = useMemo(
+    () =>
+      timeSeries?.years[timeSeries.currentProgramYear]?.dataPoints.map(dp => ({
+        date: dp.date,
+        count: dp.membership,
+      })) ??
+      aggregatedAnalytics?.trends.membership ??
+      [],
+    [timeSeries, aggregatedAnalytics]
+  )
+  const membershipSparkline = useMemo(
+    () => membershipTrendPoints.map(p => p.count),
+    [membershipTrendPoints]
+  )
+  const latestMembership =
+    membershipTrendPoints[membershipTrendPoints.length - 1]?.count ?? null
+  const paymentsSparkline = useMemo(
+    () => (paymentsTrendData?.currentYearTrend ?? []).map(p => p.payments),
+    [paymentsTrendData]
+  )
+  const latestPayments = paymentsSparkline[paymentsSparkline.length - 1] ?? null
+
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
   useDocumentTitle(districtName ? `${districtName} Trends` : null)
@@ -178,37 +206,40 @@ const DistrictTrendsPage: React.FC = () => {
               // #675: charts are React.lazy code-split; reserve space with a
               // fixed-height div but do NOT gate rendering on viewport
               // intersection.
-              <div style={{ minHeight: '400px' }}>
-                <MembershipTrendChart
-                  membershipTrend={
-                    // #170: prefer time-series monthly data over the inline
-                    // 1-point trend.
-                    timeSeries?.years[
-                      timeSeries.currentProgramYear
-                    ]?.dataPoints.map(dp => ({
-                      date: dp.date,
-                      count: dp.membership,
-                    })) ?? aggregatedAnalytics.trends.membership
-                  }
-                  isLoading={isLoadingAggregated}
-                  priorYearTrends={
-                    // #238: overlay prior years for YoY comparison
-                    timeSeries
-                      ? timeSeries.availableYears
-                          .filter(y => y !== timeSeries.currentProgramYear)
-                          .map(y => ({
-                            label: y,
-                            data:
-                              timeSeries.years[y]?.dataPoints.map(dp => ({
-                                date: dp.date,
-                                count: dp.membership,
-                              })) ?? [],
-                          }))
-                          .filter(yt => yt.data.length > 0)
-                      : undefined
-                  }
-                />
-              </div>
+              <ChartSparklineExpand
+                title="Membership trend"
+                sparklineData={membershipSparkline}
+                headline={
+                  <>
+                    {latestMembership !== null
+                      ? `${latestMembership.toLocaleString()} members`
+                      : 'Membership trend'}
+                  </>
+                }
+              >
+                <div style={{ minHeight: '400px' }}>
+                  <MembershipTrendChart
+                    membershipTrend={membershipTrendPoints}
+                    isLoading={isLoadingAggregated}
+                    priorYearTrends={
+                      // #238: overlay prior years for YoY comparison
+                      timeSeries
+                        ? timeSeries.availableYears
+                            .filter(y => y !== timeSeries.currentProgramYear)
+                            .map(y => ({
+                              label: y,
+                              data:
+                                timeSeries.years[y]?.dataPoints.map(dp => ({
+                                  date: dp.date,
+                                  count: dp.membership,
+                                })) ?? [],
+                            }))
+                            .filter(yt => yt.data.length > 0)
+                        : undefined
+                    }
+                  />
+                </div>
+              </ChartSparklineExpand>
             ) : (
               isLoadingAggregated && (
                 <LoadingSkeleton variant="chart" height="400px" />
@@ -217,71 +248,89 @@ const DistrictTrendsPage: React.FC = () => {
 
             {/* Membership Payments Chart (#243) */}
             {paymentsTrendData ? (
-              <div style={{ minHeight: '450px' }}>
-                <MembershipPaymentsChart
-                  paymentsTrend={paymentsTrendData.currentYearTrend}
-                  multiYearData={
-                    // #243: Build multi-year payment data from time-series CDN
-                    // (analytics CDN only has current year payments)
-                    timeSeries
-                      ? ((): MultiYearPaymentData => {
-                          const currentPY = timeSeries.currentProgramYear
-                          const currentData =
-                            timeSeries.years[currentPY]?.dataPoints.map(dp => ({
-                              date: dp.date,
-                              payments: dp.payments,
-                              programYearDay: calculateProgramYearDay(dp.date),
-                            })) ?? []
-                          const previousYears = timeSeries.availableYears
-                            .filter(y => y !== currentPY)
-                            .map(y => ({
-                              label: y,
-                              data:
-                                timeSeries.years[y]?.dataPoints.map(dp => ({
+              <ChartSparklineExpand
+                title="Payments trend"
+                sparklineData={paymentsSparkline}
+                headline={
+                  <>
+                    {latestPayments !== null
+                      ? `${latestPayments.toLocaleString()} payments`
+                      : 'Payments trend'}
+                  </>
+                }
+              >
+                <div style={{ minHeight: '450px' }}>
+                  <MembershipPaymentsChart
+                    paymentsTrend={paymentsTrendData.currentYearTrend}
+                    multiYearData={
+                      // #243: Build multi-year payment data from time-series CDN
+                      // (analytics CDN only has current year payments)
+                      timeSeries
+                        ? ((): MultiYearPaymentData => {
+                            const currentPY = timeSeries.currentProgramYear
+                            const currentData =
+                              timeSeries.years[currentPY]?.dataPoints.map(
+                                dp => ({
                                   date: dp.date,
                                   payments: dp.payments,
                                   programYearDay: calculateProgramYearDay(
                                     dp.date
                                   ),
-                                })) ?? [],
-                            }))
-                            .filter(yt => yt.data.length > 0)
+                                })
+                              ) ?? []
+                            const previousYears = timeSeries.availableYears
+                              .filter(y => y !== currentPY)
+                              .map(y => ({
+                                label: y,
+                                data:
+                                  timeSeries.years[y]?.dataPoints.map(dp => ({
+                                    date: dp.date,
+                                    payments: dp.payments,
+                                    programYearDay: calculateProgramYearDay(
+                                      dp.date
+                                    ),
+                                  })) ?? [],
+                              }))
+                              .filter(yt => yt.data.length > 0)
+                            return {
+                              currentYear: {
+                                label: currentPY,
+                                data: currentData,
+                              },
+                              previousYears,
+                            }
+                          })()
+                        : paymentsTrendData.multiYearData
+                    }
+                    statistics={
+                      // #269: Override YoY when time-series data provides
+                      // multi-year payment history (analytics CDN is
+                      // current-year-only)
+                      (() => {
+                        const tsYoY = computePaymentYoYFromTimeSeries(
+                          timeSeries ?? null
+                        )
+                        if (tsYoY) {
+                          // Use time-series payments for consistency (#319)
+                          const tsPayments = getLatestPayments(
+                            timeSeries ?? null
+                          )
                           return {
-                            currentYear: {
-                              label: currentPY,
-                              data: currentData,
-                            },
-                            previousYears,
+                            ...paymentsTrendData.statistics,
+                            ...(tsPayments !== null && {
+                              currentPayments: tsPayments,
+                            }),
+                            yearOverYearChange: tsYoY.yearOverYearChange,
+                            trendDirection: tsYoY.trendDirection,
                           }
-                        })()
-                      : paymentsTrendData.multiYearData
-                  }
-                  statistics={
-                    // #269: Override YoY when time-series data provides
-                    // multi-year payment history (analytics CDN is
-                    // current-year-only)
-                    (() => {
-                      const tsYoY = computePaymentYoYFromTimeSeries(
-                        timeSeries ?? null
-                      )
-                      if (tsYoY) {
-                        // Use time-series payments for consistency (#319)
-                        const tsPayments = getLatestPayments(timeSeries ?? null)
-                        return {
-                          ...paymentsTrendData.statistics,
-                          ...(tsPayments !== null && {
-                            currentPayments: tsPayments,
-                          }),
-                          yearOverYearChange: tsYoY.yearOverYearChange,
-                          trendDirection: tsYoY.trendDirection,
                         }
-                      }
-                      return paymentsTrendData.statistics
-                    })()
-                  }
-                  isLoading={isLoadingPaymentsTrend}
-                />
-              </div>
+                        return paymentsTrendData.statistics
+                      })()
+                    }
+                    isLoading={isLoadingPaymentsTrend}
+                  />
+                </div>
+              </ChartSparklineExpand>
             ) : (
               isLoadingPaymentsTrend && (
                 <LoadingSkeleton variant="chart" height="450px" />

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -9,6 +9,7 @@ import {
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
 import { AwardsRaceSection } from '../components/AwardsRaceSection'
 import { LazyHistoricalRankChart as HistoricalRankChart } from '../components/LazyCharts'
+import { ChartSparklineExpand } from '../components/ChartSparklineExpand'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
 import { DataControlsBar } from '../components/DataControlsBar'
 import { useRankHistory } from '../hooks/useRankHistory'
@@ -250,6 +251,15 @@ const DistrictsPage: React.FC = () => {
     startDate: selectedProgramYear.startDate,
     endDate: selectedProgramYear.endDate,
   })
+
+  // #875 (epic #876, CC-3): collapsed-mobile sparkline for the multi-district
+  // Historical Rank Progression chart. A single line can only preview one
+  // series, so use the first selected district's aggregate-score history; the
+  // headline names how many districts the expanded chart compares.
+  const rankHistorySparkline = React.useMemo(
+    () => (rankHistoryData?.[0]?.history ?? []).map(p => p.aggregateScore),
+    [rankHistoryData]
+  )
 
   // Get unique regions for filter
   const regions = React.useMemo(() => {
@@ -1543,13 +1553,27 @@ const DistrictsPage: React.FC = () => {
             </div>
 
             {/* Historical Rank Chart */}
-            <HistoricalRankChart
-              data={rankHistoryData || []}
-              isLoading={isLoadingRankHistory}
-              isError={isErrorRankHistory}
-              error={rankHistoryError}
-              selectedProgramYear={selectedProgramYear}
-            />
+            <ChartSparklineExpand
+              title="Historical Rank Progression"
+              sparklineData={rankHistorySparkline}
+              headline={
+                <span className="chart-spark__headline-text">
+                  {(rankHistoryData?.length ?? 0) > 0
+                    ? `${rankHistoryData!.length} district${
+                        rankHistoryData!.length === 1 ? '' : 's'
+                      }`
+                    : 'Rank trend'}
+                </span>
+              }
+            >
+              <HistoricalRankChart
+                data={rankHistoryData || []}
+                isLoading={isLoadingRankHistory}
+                isError={isErrorRankHistory}
+                error={rankHistoryError}
+                selectedProgramYear={selectedProgramYear}
+              />
+            </ChartSparklineExpand>
           </div>
         </details>
 

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -1557,13 +1557,11 @@ const DistrictsPage: React.FC = () => {
               title="Historical Rank Progression"
               sparklineData={rankHistorySparkline}
               headline={
-                <span className="chart-spark__headline-text">
-                  {(rankHistoryData?.length ?? 0) > 0
-                    ? `${rankHistoryData!.length} district${
-                        rankHistoryData!.length === 1 ? '' : 's'
-                      }`
-                    : 'Rank trend'}
-                </span>
+                (rankHistoryData?.length ?? 0) > 0
+                  ? `${rankHistoryData!.length} district${
+                      rankHistoryData!.length === 1 ? '' : 's'
+                    }`
+                  : 'Rank trend'
               }
             >
               <HistoricalRankChart

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -168,12 +168,13 @@ describe('ClubDetailPage (#208)', () => {
 
     it('opens the mem-chart in a sheet when tapped', () => {
       setMobile(true)
-      const { container } = renderWithRoute()
+      renderWithRoute()
       fireEvent.click(
         screen.getByRole('button', { name: /expand membership trend chart/i })
       )
       expect(screen.getByRole('dialog')).toBeInTheDocument()
-      expect(container.querySelector('svg.mem-chart')).not.toBeNull()
+      // The sheet is portalled to document.body, not inside `container`.
+      expect(document.querySelector('svg.mem-chart')).not.toBeNull()
     })
 
     it('renders the mem-chart directly at desktop widths', () => {

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -2,7 +2,13 @@
  * Tests for ClubDetailPage (#208) — full subpage with routing.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import { screen, render, cleanup, within } from '@testing-library/react'
+import {
+  screen,
+  render,
+  cleanup,
+  within,
+  fireEvent,
+} from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
@@ -129,6 +135,55 @@ function renderWithRoute(
 describe('ClubDetailPage (#208)', () => {
   afterEach(() => {
     cleanup()
+  })
+
+  // #875 (epic #876 Sprint 2, CC-3): the membership trend collapses to a
+  // sparkline-then-expand wrapper below 768px. The page's matchMedia mock is
+  // writable, so flip the max-width query to mobile for this block only.
+  describe('mobile membership-trend collapse (#875)', () => {
+    const setMobile = (mobile: boolean) => {
+      ;(window.matchMedia as unknown as ReturnType<typeof vi.fn>) = vi
+        .fn()
+        .mockImplementation((query: string) => ({
+          matches: /max-width/.test(query) ? mobile : false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }))
+    }
+    afterEach(() => setMobile(false))
+
+    it('collapses the mem-chart behind an expand trigger', () => {
+      setMobile(true)
+      const { container } = renderWithRoute()
+      expect(container.querySelector('svg.mem-chart')).toBeNull()
+      expect(
+        screen.getByRole('button', { name: /expand membership trend chart/i })
+      ).toBeInTheDocument()
+    })
+
+    it('opens the mem-chart in a sheet when tapped', () => {
+      setMobile(true)
+      const { container } = renderWithRoute()
+      fireEvent.click(
+        screen.getByRole('button', { name: /expand membership trend chart/i })
+      )
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(container.querySelector('svg.mem-chart')).not.toBeNull()
+    })
+
+    it('renders the mem-chart directly at desktop widths', () => {
+      setMobile(false)
+      const { container } = renderWithRoute()
+      expect(container.querySelector('svg.mem-chart')).not.toBeNull()
+      expect(
+        screen.queryByRole('button', { name: /expand .* chart/i })
+      ).not.toBeInTheDocument()
+    })
   })
 
   it('renders club name and breadcrumbs', () => {

--- a/frontend/src/pages/__tests__/DistrictTrendsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictTrendsPage.test.tsx
@@ -9,7 +9,13 @@
 
 import React, { Suspense } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import {
   createMemoryRouter,
   RouterProvider,
@@ -249,6 +255,66 @@ describe('DistrictTrendsPage (#680 — ADR-005)', () => {
     const { router } = renderAt('/district/61?tab=trends')
     await waitFor(() => {
       expect(router.state.location.pathname).toBe('/district/61/trends')
+    })
+  })
+
+  // #875 (epic #876 Sprint 2): at <768px the multi-series charts collapse to a
+  // sparkline-then-expand wrapper (CC-3). Only the max-width media query is
+  // mobile so DarkModeProvider's prefers-color-scheme probe is unaffected.
+  describe('mobile chart collapse (#875)', () => {
+    const stubViewport = (mobile: boolean) =>
+      vi.stubGlobal(
+        'matchMedia',
+        vi.fn().mockImplementation((query: string) => ({
+          matches: /max-width/.test(query) ? mobile : false,
+          media: query,
+          onchange: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }))
+      )
+    afterEach(() => vi.unstubAllGlobals())
+
+    it('collapses membership + payments behind expand triggers', async () => {
+      stubViewport(true)
+      renderAt('/district/61/trends')
+      await screen.findByRole('navigation', { name: 'District sections' })
+      expect(
+        screen.queryByTestId('membership-trend-chart')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /expand membership trend chart/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /expand payments trend chart/i })
+      ).toBeInTheDocument()
+    })
+
+    it('opens the membership chart in a sheet when tapped, closes on Esc', async () => {
+      stubViewport(true)
+      renderAt('/district/61/trends')
+      const trigger = await screen.findByRole('button', {
+        name: /expand membership trend chart/i,
+      })
+      fireEvent.click(trigger)
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(screen.getByTestId('membership-trend-chart')).toBeInTheDocument()
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('renders charts directly at desktop widths (no trigger)', async () => {
+      stubViewport(false)
+      renderAt('/district/61/trends')
+      expect(
+        await screen.findByTestId('membership-trend-chart')
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /expand .* chart/i })
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/__tests__/DistrictsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.test.tsx
@@ -541,6 +541,46 @@ describe('DistrictsPage - Layout Order (#83)', () => {
     expect(summary!.textContent).toMatch(/Historical Rank Progression/i)
   })
 
+  // #875 (epic #876 Sprint 2, CC-3): below 768px the multi-series rank chart
+  // collapses to a sparkline-then-expand wrapper. setup.ts's matchMedia mock is
+  // writable; flip only the max-width query to mobile, restore in finally.
+  it('collapses Historical Rank Progression behind an expand trigger at <768px (#875)', async () => {
+    const original = window.matchMedia
+    ;(window.matchMedia as unknown as ReturnType<typeof vi.fn>) = vi
+      .fn()
+      .mockImplementation((query: string) => ({
+        matches: /max-width/.test(query),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+    try {
+      setupWithData()
+      const { container } = renderWithProviders(<DistrictsPage />)
+      await screen.findByText('District 1')
+      const historyDetails = Array.from(
+        container.querySelectorAll('details')
+      ).find(d =>
+        d
+          .querySelector('summary')
+          ?.textContent?.match(/Historical Rank Progression/i)
+      )
+      expect(historyDetails).toBeDefined()
+      // The collapsed view renders a tap target instead of the chart itself.
+      expect(
+        within(historyDetails!).getByRole('button', {
+          name: /expand historical rank progression chart/i,
+        })
+      ).toBeInTheDocument()
+    } finally {
+      window.matchMedia = original
+    }
+  })
+
   it('renders the redesign h1 "District Rankings" (#356)', async () => {
     setupWithData()
 


### PR DESCRIPTION
Closes nothing automatically — the sprint runner ticks the epic and closes #875 after live verification (avoids the close-before-tick race, R15/Lesson 106).

## What
Epic #876 Sprint 2 (mobile UX audit Epic D, CC-3). Applies the Sprint-1 `ChartSparklineExpand` wrapper to the multi-series chart surfaces so that at **<768px** they collapse to a headline + sparkline behind a tap target that opens the full desktop chart in a full-screen sheet. At **≥768px the wrapper returns its children verbatim — desktop is unchanged.**

### Surfaces wrapped (5 charts across the 4 audit surfaces)
- **District Trends** — `MembershipTrendChart` + `MembershipPaymentsChart` (`DistrictTrendsPage`)
- **Club detail** — hand-rolled `.mem-chart` membership trend (`ClubDetailPage`)
- **Rankings Progression** — `FullYearRankingChart` (`GlobalRankingsTab`) **and** `HistoricalRankChart` (`DistrictsPage`) — operator chose both rank charts

### Awards — de-scoped (operator decision)
The audit lists "Awards visualisations" as a 4th surface, but there is **no live multi-series Recharts awards chart** to wrap: `AwardsRaceSection` is a 3-card contender summary (and carries a CLS slot-reservation tripwire, Lesson 107), `AwardsPage` is leaderboard lists, and `EducationalAwardsChart` is unmounted. Operator confirmed: skip Awards this sprint.

## How
Each call site derives a `number[]` sparkline series from the **same data the chart plots** (no new data fetch, R3-clean — props from the parent) plus a compact headline, then wraps the chart. Sparkline derivations are memoized.
- Rank sparkline note: `HistoricalRankChart` is multi-district — only the first district's aggregate-score series is previewed (documented in-code); headline names the district count. `FullYearRankingChart` prefers `overallRank`, falling back to `aggregateScore` for older snapshots (scales not interleaved).

## Tests (TDD: red → green per surface)
- Mobile-collapse + sheet-open end-to-end tests added for **all four surfaces** (District Trends, Club detail, Ranking Progression, Historical Rank). Page mounts live in the integration project (`src/pages/__tests__/**`); `GlobalRankingsTab` is a component test — **no R22 unit-page-mount violation**.
- matchMedia stubs scope `mobile` to `max-width` only, leaving `prefers-color-scheme` untouched (DarkMode probe unaffected).
- Full suite: **3087 passed**. `/simplify` (dropped an undefined `chart-spark__headline-text` class, unified headline shape) + fresh-context `/review` (APPROVE-WITH-NITS, no High/Medium) both run.

## Verification
Dual-engine (Chromium + WebKit) 375px Playwright smoke against the PR preview channel — screenshots posted as the evidence comment after CI + preview deploy.