### PR TITLE
feat(long-text): mobile-collapsed H2 sections + TOC anchor expand on /methodology (#877)

### DIFF
--- a/frontend/src/components/CollapsibleSection.tsx
+++ b/frontend/src/components/CollapsibleSection.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+
+/* CollapsibleSection — long-text page section (#877, epic #880 Sprint 1).
+
+   Long-text pages (Methodology) render as a tall wall of prose (CC-8 in the
+   mobile UX audit). On mobile each H2 section becomes a tap-to-expand
+   disclosure so readers can scan the TOC and open only what they want;
+   desktop earns the density and is left untouched.
+
+   `collapsible` is driven by useIsMobile() at the page level. When false
+   (desktop, and the jsdom default) this renders the exact static markup the
+   page shipped before — a plain <h2> with the body always visible, no button
+   — so there is provably no desktop effect. When true it renders the
+   WAI-ARIA disclosure pattern: a heading-wrapped toggle button with
+   aria-expanded + aria-controls (Lesson 128 — a show/hide control is a
+   disclosure button, never a tab; nothing here is a panel swap). */
+
+export interface CollapsibleSectionProps {
+  /** Anchor target id; the TOC links to `#${id}`. */
+  id: string
+  /** Two-digit section number badge (e.g. "01"). */
+  num: string
+  /** Section heading text. */
+  title: string
+  /** True on mobile — render the tap-to-expand disclosure. */
+  collapsible: boolean
+  /** Whether the section is expanded (only meaningful when collapsible). */
+  open: boolean
+  /** Tap handler; receives the section id. */
+  onToggle: (id: string) => void
+  children: React.ReactNode
+}
+
+const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
+  id,
+  num,
+  title,
+  collapsible,
+  open,
+  onToggle,
+  children,
+}) => {
+  if (!collapsible) {
+    // Desktop: unchanged static markup — no toggle, body always visible.
+    return (
+      <section id={id} className="methodology-section">
+        <h2 className="methodology-section__title">
+          <span className="methodology-section__num">{num}</span>
+          {title}
+        </h2>
+        {children}
+      </section>
+    )
+  }
+
+  const contentId = `${id}-content`
+  return (
+    <section
+      id={id}
+      className="methodology-section methodology-section--collapsible"
+    >
+      <h2 className="methodology-section__title">
+        <button
+          type="button"
+          className="methodology-section__toggle"
+          aria-expanded={open}
+          aria-controls={contentId}
+          onClick={() => onToggle(id)}
+        >
+          <span className="methodology-section__num">{num}</span>
+          <span className="methodology-section__toggle-text">{title}</span>
+          <span className="methodology-section__chevron" aria-hidden="true" />
+        </button>
+      </h2>
+      <div
+        id={contentId}
+        className="methodology-section__content"
+        hidden={!open}
+      >
+        {children}
+      </div>
+    </section>
+  )
+}
+
+export default CollapsibleSection

--- a/frontend/src/components/__tests__/CollapsibleSection.test.tsx
+++ b/frontend/src/components/__tests__/CollapsibleSection.test.tsx
@@ -1,0 +1,76 @@
+/* CollapsibleSection — long-text page disclosure (#877, epic #880 Sprint 1).
+
+   Desktop (collapsible=false) renders today's static markup unchanged: a
+   plain <h2> with the section visible, no toggle button. Mobile
+   (collapsible=true) renders the WAI-ARIA disclosure pattern (Lesson 128:
+   a disclosure button, NOT a tab) — collapsed by default, tap to expand. */
+
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import CollapsibleSection from '../CollapsibleSection'
+
+const renderSection = (
+  props: Partial<React.ComponentProps<typeof CollapsibleSection>> = {}
+) =>
+  render(
+    <CollapsibleSection
+      id="data-source"
+      num="01"
+      title="Data source & access"
+      collapsible={false}
+      open={false}
+      onToggle={() => {}}
+      {...props}
+    >
+      <p>Body paragraph content.</p>
+    </CollapsibleSection>
+  )
+
+describe('CollapsibleSection — desktop (collapsible=false)', () => {
+  it('renders a plain heading with no toggle button', () => {
+    renderSection({ collapsible: false })
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(
+      screen.getByRole('heading', { level: 2, name: /Data source & access/i })
+    ).toBeInTheDocument()
+  })
+
+  it('shows the section body unconditionally', () => {
+    renderSection({ collapsible: false, open: false })
+    expect(screen.getByText('Body paragraph content.')).toBeVisible()
+  })
+})
+
+describe('CollapsibleSection — mobile (collapsible=true)', () => {
+  it('renders the H2 as a disclosure button, not a tab', () => {
+    renderSection({ collapsible: true, open: false })
+    const btn = screen.getByRole('button', { name: /Data source & access/i })
+    expect(btn).toHaveAttribute('aria-expanded', 'false')
+    expect(btn).toHaveAttribute('aria-controls', 'data-source-content')
+    // Disclosure, never a tab (Lesson 128) — no tab/tablist semantics.
+    expect(screen.queryByRole('tab')).toBeNull()
+  })
+
+  it('collapses the body by default', () => {
+    renderSection({ collapsible: true, open: false })
+    expect(screen.getByText('Body paragraph content.')).not.toBeVisible()
+  })
+
+  it('reveals the body when open', () => {
+    renderSection({ collapsible: true, open: true })
+    const btn = screen.getByRole('button', { name: /Data source & access/i })
+    expect(btn).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Body paragraph content.')).toBeVisible()
+  })
+
+  it('calls onToggle with the section id when tapped', async () => {
+    const onToggle = vi.fn()
+    renderSection({ collapsible: true, open: false, onToggle })
+    await userEvent.click(
+      screen.getByRole('button', { name: /Data source & access/i })
+    )
+    expect(onToggle).toHaveBeenCalledWith('data-source')
+  })
+})

--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -1,6 +1,8 @@
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useIsMobile } from '../hooks/useIsMobile'
+import CollapsibleSection from '../components/CollapsibleSection'
 
 /* Methodology page (#368). Authored fresh from analytics-core as the
    source of truth — Borda formula, DCP thresholds, club health
@@ -31,6 +33,28 @@ const SECTIONS: ReadonlyArray<{ id: string; num: string; title: string }> = [
 
 const MethodologyPage: React.FC = () => {
   useDocumentTitle('Methodology')
+
+  // On mobile each H2 section collapses by default; desktop is untouched
+  // (useIsMobile is false in jsdom too, so the static-content tests still
+  // see the full page). #877.
+  const isMobile = useIsMobile()
+  const [openIds, setOpenIds] = useState<ReadonlySet<string>>(() => new Set())
+
+  const toggle = useCallback((id: string) => {
+    setOpenIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  // A TOC anchor must reveal its target — otherwise the jump lands on a
+  // collapsed heading and the reader sees nothing below it.
+  const expand = useCallback((id: string) => {
+    setOpenIds(prev => (prev.has(id) ? prev : new Set(prev).add(id)))
+  }, [])
+
   return (
     <div className="methodology-page">
       <header className="methodology-page__header">
@@ -49,7 +73,11 @@ const MethodologyPage: React.FC = () => {
           {SECTIONS.map(s => (
             <li key={s.id} className="methodology-toc__item">
               <span className="methodology-toc__num">{s.num}</span>
-              <a href={`#${s.id}`} className="methodology-toc__link">
+              <a
+                href={`#${s.id}`}
+                className="methodology-toc__link"
+                onClick={() => expand(s.id)}
+              >
                 {s.title}
               </a>
             </li>
@@ -57,11 +85,14 @@ const MethodologyPage: React.FC = () => {
         </ol>
       </nav>
 
-      <section id="data-source" className="methodology-section">
-        <h2 className="methodology-section__title">
-          <span className="methodology-section__num">01</span>
-          Data source &amp; access
-        </h2>
+      <CollapsibleSection
+        id="data-source"
+        num="01"
+        title="Data source & access"
+        collapsible={isMobile}
+        open={openIds.has('data-source')}
+        onToggle={toggle}
+      >
         <p>
           All numbers come from the public{' '}
           <a
@@ -82,13 +113,16 @@ const MethodologyPage: React.FC = () => {
           stops publishing a file, the pipeline fails loudly rather than
           silently inferring values.
         </p>
-      </section>
+      </CollapsibleSection>
 
-      <section id="refresh-cadence" className="methodology-section">
-        <h2 className="methodology-section__title">
-          <span className="methodology-section__num">02</span>
-          Refresh cadence
-        </h2>
+      <CollapsibleSection
+        id="refresh-cadence"
+        num="02"
+        title="Refresh cadence"
+        collapsible={isMobile}
+        open={openIds.has('refresh-cadence')}
+        onToggle={toggle}
+      >
         <p>
           The data pipeline runs once daily at 09:15 UTC (≈04:15 ET / 02:15 PT)
           — the schedule lives in{' '}
@@ -101,13 +135,16 @@ const MethodologyPage: React.FC = () => {
           Stale-data indicator: every page surfaces a "Data fresh ·
           &lt;date&gt;" pill so you always know which snapshot you're seeing.
         </p>
-      </section>
+      </CollapsibleSection>
 
-      <section id="borda-count" className="methodology-section">
-        <h2 className="methodology-section__title">
-          <span className="methodology-section__num">03</span>
-          Borda count scoring
-        </h2>
+      <CollapsibleSection
+        id="borda-count"
+        num="03"
+        title="Borda count scoring"
+        collapsible={isMobile}
+        open={openIds.has('borda-count')}
+        onToggle={toggle}
+      >
         <p>
           Each district is ranked separately in three categories:
           <strong> Paid Clubs</strong>, <strong>Total Payments</strong>, and{' '}
@@ -131,13 +168,16 @@ const MethodologyPage: React.FC = () => {
           President's Extension, President's 20-Plus, and District Club
           Retention.
         </p>
-      </section>
+      </CollapsibleSection>
 
-      <section id="regions-borda" className="methodology-section">
-        <h2 className="methodology-section__title">
-          <span className="methodology-section__num">04</span>
-          Region-level scoring
-        </h2>
+      <CollapsibleSection
+        id="regions-borda"
+        num="04"
+        title="Region-level scoring"
+        collapsible={isMobile}
+        open={openIds.has('regions-borda')}
+        onToggle={toggle}
+      >
         <p>
           The{' '}
           <Link to="/regions" className="methodology-link">
@@ -182,13 +222,16 @@ const MethodologyPage: React.FC = () => {
           </Link>{' '}
           only when non-zero.
         </p>
-      </section>
+      </CollapsibleSection>
 
-      <section id="dcp-tiers" className="methodology-section">
-        <h2 className="methodology-section__title">
-          <span className="methodology-section__num">05</span>
-          DCP tier definitions
-        </h2>
+      <CollapsibleSection
+        id="dcp-tiers"
+        num="05"
+        title="DCP tier definitions"
+        collapsible={isMobile}
+        open={openIds.has('dcp-tiers')}
+        onToggle={toggle}
+      >
         <p>Distinguished Club Program tiers, in ascending order:</p>
         <ul>
           <li>
@@ -231,13 +274,16 @@ const MethodologyPage: React.FC = () => {
           — the same denominator that underpins the Distinguished tier
           definitions above.
         </p>
-      </section>
+      </CollapsibleSection>
 
-      <section id="club-health" className="methodology-section">
-        <h2 className="methodology-section__title">
-          <span className="methodology-section__num">06</span>
-          Club health classifications
-        </h2>
+      <CollapsibleSection
+        id="club-health"
+        num="06"
+        title="Club health classifications"
+        collapsible={isMobile}
+        open={openIds.has('club-health')}
+        onToggle={toggle}
+      >
         <p>
           Toast Stats classifies each club into one of three mutually exclusive
           health statuses, recomputed every snapshot from the current data
@@ -277,13 +323,16 @@ const MethodologyPage: React.FC = () => {
           analytics module. Toast Stats health is a project-specific overlay,
           not an official Toastmasters International metric.
         </p>
-      </section>
+      </CollapsibleSection>
 
-      <section id="district-membership-trend" className="methodology-section">
-        <h2 className="methodology-section__title">
-          <span className="methodology-section__num">07</span>
-          District Membership Trend
-        </h2>
+      <CollapsibleSection
+        id="district-membership-trend"
+        num="07"
+        title="District Membership Trend"
+        collapsible={isMobile}
+        open={openIds.has('district-membership-trend')}
+        onToggle={toggle}
+      >
         <p>
           The chart on the District Detail · Trends tab plots a single metric:
           the district&apos;s <strong>total paid members</strong> at each
@@ -322,13 +371,16 @@ const MethodologyPage: React.FC = () => {
           consecutive month-over-month deltas; the threshold and detection logic
           live in <code>frontend/src/components/MembershipTrendChart.tsx</code>.
         </p>
-      </section>
+      </CollapsibleSection>
 
-      <section id="glossary" className="methodology-section">
-        <h2 className="methodology-section__title">
-          <span className="methodology-section__num">08</span>
-          Glossary
-        </h2>
+      <CollapsibleSection
+        id="glossary"
+        num="08"
+        title="Glossary"
+        collapsible={isMobile}
+        open={openIds.has('glossary')}
+        onToggle={toggle}
+      >
         <dl className="methodology-glossary">
           <dt>Paid Club</dt>
           <dd>
@@ -360,13 +412,16 @@ const MethodologyPage: React.FC = () => {
             .
           </dd>
         </dl>
-      </section>
+      </CollapsibleSection>
 
-      <section id="caveats" className="methodology-section">
-        <h2 className="methodology-section__title">
-          <span className="methodology-section__num">09</span>
-          Caveats &amp; known issues
-        </h2>
+      <CollapsibleSection
+        id="caveats"
+        num="09"
+        title="Caveats & known issues"
+        collapsible={isMobile}
+        open={openIds.has('caveats')}
+        onToggle={toggle}
+      >
         <ul>
           <li>
             <strong>Pre-2019 data</strong> — Toast Stats only stores snapshots
@@ -394,13 +449,16 @@ const MethodologyPage: React.FC = () => {
             unrounded values.
           </li>
         </ul>
-      </section>
+      </CollapsibleSection>
 
-      <section id="changelog" className="methodology-section">
-        <h2 className="methodology-section__title">
-          <span className="methodology-section__num">10</span>
-          Changelog
-        </h2>
+      <CollapsibleSection
+        id="changelog"
+        num="10"
+        title="Changelog"
+        collapsible={isMobile}
+        open={openIds.has('changelog')}
+        onToggle={toggle}
+      >
         <p>
           Material methodology changes are recorded as ADRs in{' '}
           <code>docs/architecture-decisions/</code> and as releases on{' '}
@@ -430,7 +488,7 @@ const MethodologyPage: React.FC = () => {
             Epic #352.
           </li>
         </ul>
-      </section>
+      </CollapsibleSection>
     </div>
   )
 }

--- a/frontend/src/pages/__tests__/MethodologyPage.mobile.test.tsx
+++ b/frontend/src/pages/__tests__/MethodologyPage.mobile.test.tsx
@@ -1,0 +1,83 @@
+/* /methodology mobile disclosure (#877, epic #880 Sprint 1).
+
+   At <768px each H2 section collapses by default and expands on tap; the
+   in-page TOC anchor links expand their target section. Desktop is
+   unaffected (covered by MethodologyPage.test.tsx + the desktop case below,
+   where useIsMobile() is false). */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+const mockIsMobile = vi.fn()
+vi.mock('../../hooks/useIsMobile', () => ({
+  useIsMobile: () => mockIsMobile(),
+}))
+
+import MethodologyPage from '../MethodologyPage'
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <MethodologyPage />
+    </MemoryRouter>
+  )
+
+describe('MethodologyPage — mobile collapsed sections', () => {
+  beforeEach(() => mockIsMobile.mockReturnValue(true))
+
+  it('renders every H2 section as a disclosure button, collapsed by default', () => {
+    renderPage()
+    // 10 sections → 10 toggle buttons, all collapsed.
+    const toggles = screen
+      .getAllByRole('button')
+      .filter(b => b.getAttribute('aria-expanded') !== null)
+    expect(toggles).toHaveLength(10)
+    expect(
+      toggles.every(b => b.getAttribute('aria-expanded') === 'false')
+    ).toBe(true)
+    // A body-only string is present in the DOM but not visible while collapsed.
+    expect(
+      screen.getByText(/weights all three categories equally/i)
+    ).not.toBeVisible()
+  })
+
+  it('expands a section when its heading toggle is tapped', async () => {
+    renderPage()
+    const btn = screen.getByRole('button', { name: /Borda count scoring/i })
+    await userEvent.click(btn)
+    expect(btn).toHaveAttribute('aria-expanded', 'true')
+    expect(
+      screen.getByText(/weights all three categories equally/i)
+    ).toBeVisible()
+  })
+
+  it('expands the target section when a TOC anchor link is tapped', async () => {
+    renderPage()
+    // The TOC link (an <a>) is distinct from the section toggle (a <button>).
+    const tocLink = screen.getByRole('link', { name: /Borda count scoring/i })
+    await userEvent.click(tocLink)
+    const btn = screen.getByRole('button', { name: /Borda count scoring/i })
+    expect(btn).toHaveAttribute('aria-expanded', 'true')
+    expect(
+      screen.getByText(/weights all three categories equally/i)
+    ).toBeVisible()
+  })
+})
+
+describe('MethodologyPage — desktop unaffected', () => {
+  beforeEach(() => mockIsMobile.mockReturnValue(false))
+
+  it('renders no disclosure toggles and shows all bodies', () => {
+    renderPage()
+    const toggles = screen
+      .queryAllByRole('button')
+      .filter(b => b.getAttribute('aria-expanded') !== null)
+    expect(toggles).toHaveLength(0)
+    expect(
+      screen.getByText(/weights all three categories equally/i)
+    ).toBeVisible()
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -4185,6 +4185,64 @@
     color: var(--ink-3);
   }
 
+  /* Mobile disclosure (#877). These classes are only emitted by
+     CollapsibleSection when useIsMobile() is true, so they never apply at
+     desktop widths — desktop markup is the plain <h2>+body above. */
+  .methodology-section--collapsible {
+    margin-bottom: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .methodology-section--collapsible .methodology-section__title {
+    margin: 0;
+  }
+
+  .methodology-section__toggle {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    margin: 0;
+    /* 16px vertical padding + the 22px heading line lands the tap target
+       well above the 44px floor (Epic G / lesson 111 family). */
+    padding: 16px 0;
+    background: none;
+    border: none;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .methodology-section__toggle-text {
+    flex: 1;
+  }
+
+  .methodology-section__chevron {
+    flex-shrink: 0;
+    width: 9px;
+    height: 9px;
+    border-right: 2px solid var(--ink-3);
+    border-bottom: 2px solid var(--ink-3);
+    transform: rotate(45deg);
+    transition: transform 0.15s ease;
+  }
+
+  .methodology-section__toggle[aria-expanded='true']
+    .methodology-section__chevron {
+    transform: rotate(-135deg);
+  }
+
+  .methodology-section__content {
+    padding-bottom: 20px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .methodology-section__chevron {
+      transition: none;
+    }
+  }
+
   .methodology-link {
     color: var(--link);
     text-decoration: underline;

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -4138,6 +4138,10 @@
     line-height: 1.65;
     font-size: 14.5px;
     color: var(--ink);
+    /* The anchor id lives on this wrapper, so the TOC-jump offset must be
+       here — not on the child title (#877). Otherwise a #section jump lands
+       the heading under the fixed header. */
+    scroll-margin-top: 80px;
   }
 
   .methodology-section p,
@@ -4175,7 +4179,6 @@
     font-size: 22px;
     letter-spacing: -0.01em;
     color: var(--ink);
-    scroll-margin-top: 80px;
   }
 
   .methodology-section__num {
@@ -4186,8 +4189,9 @@
   }
 
   /* Mobile disclosure (#877). These classes are only emitted by
-     CollapsibleSection when useIsMobile() is true, so they never apply at
-     desktop widths — desktop markup is the plain <h2>+body above. */
+     CollapsibleSection when useIsMobile() is true, so they match nothing on
+     desktop (class-emission-gated, not media-gated) — desktop renders the
+     plain <h2>+body above. */
   .methodology-section--collapsible {
     margin-bottom: 0;
     border-bottom: 1px solid var(--line);

--- a/tasks/lessons/138-scroll-margin-top-belongs-on-the-element-that-holds-the-anchor-id.md
+++ b/tasks/lessons/138-scroll-margin-top-belongs-on-the-element-that-holds-the-anchor-id.md
@@ -1,0 +1,57 @@
+---
+id: '138'
+category: lesson
+tags: [css, frontend, accessibility, verification, playwright, mobile]
+auto_load: true
+date: 2026-05-29
+issues: [877, 880]
+---
+
+# Lesson 138 — `scroll-margin-top` belongs on the element that holds the anchor id, not a styled child
+
+**Date:** 2026-05-29
+**Issue:** #877 (epic #880 Sprint 1 — in-page TOC + mobile-collapsed H2s on /methodology)
+**PR:** [#934](https://github.com/taverns-red/toast-stats/pull/934)
+
+## What happened
+
+The Methodology page anchored each section as `<section id="borda-count">`
+with a child `<h2 class="methodology-section__title">`. The TOC-jump offset
+(`scroll-margin-top: 80px`, to clear the fixed top bar) had been placed on the
+**title**, not the section. The browser applies `scroll-margin` to the
+_fragment target_ — the element whose `id` matches the hash — which is the
+`<section>`. So the offset on the child was silently inert: every `#section`
+jump landed the heading **under** the fixed header. It went unnoticed because
+the desktop TOC was rarely used; Sprint 1 promoted the TOC to the primary
+mobile nav, which is what surfaced it. Fresh-context review caught it; the fix
+was one line — move `scroll-margin-top` to `.methodology-section`.
+
+## The principle
+
+**`scroll-margin-*` only does anything on the element the URL fragment
+actually targets.** When an `id` lives on a wrapper but the visible heading is
+a child, the offset must be on the wrapper. A "we already set scroll-margin"
+is not the same as "the jump lands right" — verify which element carries the
+`id`.
+
+## How to verify (don't trust `boundingBox().y`)
+
+Driving the anchor jump on the live preview at 375px caught a second trap:
+
+- **Playwright `locator.boundingBox().y` is document-relative**, not
+  viewport-relative. To assert "the heading landed inside the viewport, below
+  the header," read `getBoundingClientRect().top` via `page.evaluate` — that's
+  the viewport-relative number (here it settled at exactly `80`, the offset).
+- **The hash-scroll settles a tick after the click**, especially when the
+  click also fires a React state update (expanding the collapsed section). A
+  synchronous `scrollY` read returns `0` and flakes. Use
+  `await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)`
+  before measuring — never an arbitrary `waitForTimeout`.
+
+## Related
+
+- [[134-a-status-chip-in-an-overflowing-table-is-still-clipped-detable-the-row]]
+  — same "verify mobile geometry by bounding box, not `toBeVisible`" family;
+  this one adds _which_ box API is viewport-relative.
+- [[128-a-filter-control-is-aria-pressed-not-role-tab]] — the disclosure
+  pattern used for the collapsed sections (aria-expanded, not a tab).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -106,3 +106,4 @@
 - **135** [tests, flaky, vitest, ci, coverage, verification] — A global coverage threshold deterministically fails a filtered subset run; a flake harness must keep instrumentation but zero thresholds (#913, #917)
 - **136** [tests, flaky, vitest, ci, contention] — A flake detector must not inherit the stability cap it measures; cap the gate, pin the detector to max parallelism (#914, #917)
 - **137** [tests, flaky, vitest, process, verification, tdd] — An audit's "false-confidence" list is a per-file hypothesis; re-confirm before deleting, because the first-pass classification over-flags (#916, #917)
+- **138** [css, frontend, accessibility, verification, playwright, mobile] — `scroll-margin-top` belongs on the element that holds the anchor id, not a styled child (#877, #880)


### PR DESCRIPTION
Closes none. Implements **epic #880 Sprint 1** (#877) — kills CC-8 on the only long-text page (`/methodology`, ~16k px of prose).

> Per the tick-before-close ordering (Lesson 106 / R15), this PR intentionally does **not** auto-close #877 with `Closes #877` — the sprint runner ticks the epic checkbox before closing the sub-issue.

## What

- New `CollapsibleSection` component: desktop renders today's static `<h2>`+body markup **unchanged**; mobile (`useIsMobile()` < 768px) renders a WAI-ARIA **disclosure** (`<button aria-expanded aria-controls>`, Lesson 128 — a show/hide control is a disclosure, not a tab), collapsed by default.
- Wired `MethodologyPage`'s 10 sections through it. Page owns the open-state `Set`; TOC anchor clicks `expand()` their target so a jump never lands on a collapsed heading.
- Mobile toggle is a real `<button>` (keyboard Enter/Space for free), 16px padding + 22px heading → tap target clears the 44px floor.
- Fixed a latent anchor-scroll bug surfaced by review: `scroll-margin-top: 80px` was on `.methodology-section__title` but the anchor `id` is on the `.methodology-section` wrapper, so `#section` jumps landed under the fixed header. Moved the offset to the id-holding element.

## Acceptance criteria

- [x] TOC at top with anchor links jumping to sections (pre-existing TOC; jumps now land correctly).
- [x] Mobile: H2 sections collapsed by default; expand on tap.
- [x] No effect on desktop — `if (!collapsible)` returns byte-identical DOM; existing `MethodologyPage.test.tsx` passes 7/7.
- [ ] 375px Chromium + WebKit smoke — pending PR preview deploy (evidence to follow as a comment).

## Tests

- `CollapsibleSection.test.tsx` (unit): desktop = no button + body visible; mobile = aria-expanded disclosure, collapsed by default, toggles, no `tab` role.
- `MethodologyPage.mobile.test.tsx` (integration, page-mount → correctly in `pages/__tests__/`, R22): 10 collapsed disclosures by default, heading-tap expands, **TOC-link-tap expands target**, desktop renders no toggles.
- Full suite green (3099 tests); no-page-mounts / quarantine / project-partition guards all pass.

## Review

`/simplify` → clean (no fixes; YAGNI on generalizing the one-page component). Fresh-context `/review` → APPROVE-WITH-NITS; the medium finding (scroll offset) is fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)