### PR TITLE
feat(long-text): sticky 'Jump to ▾' chip under the page header (#878)

### DIFF
--- a/frontend/src/components/JumpToChip.tsx
+++ b/frontend/src/components/JumpToChip.tsx
@@ -82,7 +82,10 @@ const JumpToChip: React.FC<JumpToChipProps> = ({ sections, onJump }) => {
     sheet?.addEventListener('keydown', handleTab)
     return () => {
       sheet?.removeEventListener('keydown', handleTab)
-      chip?.focus()
+      // preventScroll: restoring focus to the chip must NOT scroll the page
+      // back to the chip's resting position — that would clobber a jump's
+      // scroll-into-view (the chip sits near the top of the document flow).
+      chip?.focus({ preventScroll: true })
     }
   }, [open])
 

--- a/frontend/src/components/JumpToChip.tsx
+++ b/frontend/src/components/JumpToChip.tsx
@@ -97,9 +97,26 @@ const JumpToChip: React.FC<JumpToChipProps> = ({ sections, onJump }) => {
   }, [open])
 
   const handleJump = useCallback(
-    (id: string) => {
+    (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+      // Drive the scroll ourselves rather than via the native hash anchor: at
+      // click time the sheet is still open and locks body scroll
+      // (overflow:hidden), so the browser's fragment scroll is computed against
+      // the locked state and ignores scroll-margin-top — landing the heading
+      // behind the chip bar (caught on the live preview). preventDefault, then
+      // after close() unlocks scroll and onJump() expands the target, scroll it
+      // into view on the next frame — scrollIntoView honours scroll-margin-top.
+      e.preventDefault()
       onJump(id)
       close()
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const target = document.getElementById(id)
+          target?.scrollIntoView?.({ behavior: 'auto', block: 'start' })
+          // Reflect the section in the URL (deep-link / refresh) without
+          // pushing a history entry or re-triggering a scroll.
+          window.history.replaceState(null, '', `#${id}`)
+        })
+      })
     },
     [onJump, close]
   )
@@ -171,7 +188,7 @@ const JumpToChip: React.FC<JumpToChipProps> = ({ sections, onJump }) => {
                       <a
                         href={`#${s.id}`}
                         className="jump-to-sheet__link"
-                        onClick={() => handleJump(s.id)}
+                        onClick={e => handleJump(e, s.id)}
                       >
                         <span className="jump-to-sheet__num">{s.num}</span>
                         <span className="jump-to-sheet__text">{s.title}</span>

--- a/frontend/src/components/JumpToChip.tsx
+++ b/frontend/src/components/JumpToChip.tsx
@@ -1,0 +1,190 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+/* JumpToChip — sticky "Jump to ▾" chip + TOC sheet (#878, epic #880 Sprint 2).
+
+   Long-text pages (Methodology, CC-8 in the mobile UX audit) are a ~20-viewport
+   scroll on a phone. Sprint 1 added an in-page TOC card at the top and collapsed
+   the H2 sections; this sprint pins a "Jump to ▾" chip under the page header so a
+   reader deep in the page can re-open that TOC and jump without scrolling back up.
+
+   Mobile-only: the page renders this component only when useIsMobile() is true,
+   so it adds no DOM on desktop (where the in-flow TOC card already serves) — the
+   same class-emission gating as CollapsibleSection (#877).
+
+   The sheet reuses the modal-dialog contract proven by ChartExpandSheet (#874):
+   portalled to <body> to escape clipped ancestors, dismissible three ways
+   (close button, Esc, backdrop), focus moved in on open and restored to the chip
+   on close, background scroll locked while open. Semantic tokens only, so dark
+   mode comes for free at the CSS layer (R10). The trigger uses
+   aria-haspopup="dialog" (WAI-ARIA modal-dialog pattern) rather than
+   aria-expanded — it opens a separate dialog, it is not an inline disclosure. */
+
+export interface JumpToSection {
+  /** Anchor target id; the sheet links to `#${id}`. */
+  id: string
+  /** Two-digit section number badge (e.g. "01"). */
+  num: string
+  /** Section heading text. */
+  title: string
+}
+
+export interface JumpToChipProps {
+  sections: ReadonlyArray<JumpToSection>
+  /** Called with the chosen section id before the hash jump — lets the page
+      reveal a collapsed target so the jump doesn't land on a hidden heading. */
+  onJump: (id: string) => void
+}
+
+const JumpToChip: React.FC<JumpToChipProps> = ({ sections, onJump }) => {
+  const [open, setOpen] = useState(false)
+  const chipRef = useRef<HTMLButtonElement>(null)
+  const sheetRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const titleId = useId()
+
+  const close = useCallback(() => setOpen(false), [])
+
+  // Esc-to-close (document-level, so it works before focus lands inside).
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open, close])
+
+  // Move focus into the sheet on open; restore it to the chip on close so
+  // keyboard/AT users return to the trigger, not the document top.
+  useEffect(() => {
+    if (!open) return
+    closeButtonRef.current?.focus()
+
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !sheetRef.current) return
+      const focusables = sheetRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      if (!first || !last) return
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    const sheet = sheetRef.current
+    sheet?.addEventListener('keydown', handleTab)
+    return () => {
+      sheet?.removeEventListener('keydown', handleTab)
+      chipRef.current?.focus()
+    }
+  }, [open])
+
+  // Lock background scroll while the sheet is open.
+  useEffect(() => {
+    if (!open) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [open])
+
+  const handleJump = useCallback(
+    (id: string) => {
+      onJump(id)
+      close()
+    },
+    [onJump, close]
+  )
+
+  return (
+    <div className="jump-to-bar">
+      <button
+        ref={chipRef}
+        type="button"
+        className="jump-to-chip"
+        aria-haspopup="dialog"
+        onClick={() => setOpen(true)}
+      >
+        Jump to
+        <span className="jump-to-chip__caret" aria-hidden="true">
+          ▾
+        </span>
+      </button>
+
+      {open &&
+        createPortal(
+          <div className="jump-to-sheet-overlay">
+            <div
+              className="jump-to-sheet-backdrop"
+              data-testid="jump-to-sheet-backdrop"
+              onClick={close}
+            />
+            <div
+              ref={sheetRef}
+              className="jump-to-sheet"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={titleId}
+            >
+              <div className="jump-to-sheet__header">
+                <h2 id={titleId} className="jump-to-sheet__title">
+                  Jump to a section
+                </h2>
+                <button
+                  ref={closeButtonRef}
+                  type="button"
+                  className="jump-to-sheet__close"
+                  aria-label="Close"
+                  onClick={close}
+                >
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M5 5l10 10M15 5L5 15"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <nav
+                aria-label="Jump to a section"
+                className="jump-to-sheet__nav"
+              >
+                <ol className="jump-to-sheet__list">
+                  {sections.map(s => (
+                    <li key={s.id} className="jump-to-sheet__item">
+                      <a
+                        href={`#${s.id}`}
+                        className="jump-to-sheet__link"
+                        onClick={() => handleJump(s.id)}
+                      >
+                        <span className="jump-to-sheet__num">{s.num}</span>
+                        <span className="jump-to-sheet__text">{s.title}</span>
+                      </a>
+                    </li>
+                  ))}
+                </ol>
+              </nav>
+            </div>
+          </div>,
+          document.body
+        )}
+    </div>
+  )
+}
+
+export default JumpToChip

--- a/frontend/src/components/JumpToChip.tsx
+++ b/frontend/src/components/JumpToChip.tsx
@@ -59,6 +59,7 @@ const JumpToChip: React.FC<JumpToChipProps> = ({ sections, onJump }) => {
   // keyboard/AT users return to the trigger, not the document top.
   useEffect(() => {
     if (!open) return
+    const chip = chipRef.current
     closeButtonRef.current?.focus()
 
     const handleTab = (e: KeyboardEvent) => {
@@ -81,7 +82,7 @@ const JumpToChip: React.FC<JumpToChipProps> = ({ sections, onJump }) => {
     sheet?.addEventListener('keydown', handleTab)
     return () => {
       sheet?.removeEventListener('keydown', handleTab)
-      chipRef.current?.focus()
+      chip?.focus()
     }
   }, [open])
 

--- a/frontend/src/components/__tests__/JumpToChip.test.tsx
+++ b/frontend/src/components/__tests__/JumpToChip.test.tsx
@@ -1,0 +1,107 @@
+/* JumpToChip — sticky "Jump to ▾" chip + TOC sheet (#878, epic #880 Sprint 2).
+
+   A mobile-only sticky chip pinned under the page header that opens the
+   long-text TOC as a modal sheet, so a reader deep in the page can jump to a
+   section without scrolling back to the top. This unit suite renders the
+   component in isolation (no page mount — R22) and drives the dialog contract:
+   open on tap, list every section, jump + close on selection, dismiss via Esc /
+   backdrop / close button. */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import JumpToChip from '../JumpToChip'
+
+const SECTIONS = [
+  { id: 'data-source', num: '01', title: 'Data source & access' },
+  { id: 'borda-count', num: '03', title: 'Borda count scoring' },
+  { id: 'glossary', num: '08', title: 'Glossary' },
+] as const
+
+const renderChip = (onJump = vi.fn()) => {
+  render(
+    <MemoryRouter>
+      <JumpToChip sections={SECTIONS} onJump={onJump} />
+    </MemoryRouter>
+  )
+  return onJump
+}
+
+describe('JumpToChip', () => {
+  beforeEach(() => {
+    document.body.style.overflow = ''
+  })
+
+  it('renders a "Jump to" chip that signals it opens a dialog', () => {
+    renderChip()
+    const chip = screen.getByRole('button', { name: /jump to/i })
+    expect(chip).toHaveAttribute('aria-haspopup', 'dialog')
+  })
+
+  it('keeps the sheet closed until the chip is tapped', () => {
+    renderChip()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens a labelled modal dialog listing every section on tap', async () => {
+    renderChip()
+    await userEvent.click(screen.getByRole('button', { name: /jump to/i }))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    // Every section is a jump link inside the sheet.
+    for (const s of SECTIONS) {
+      const link = within(dialog).getByRole('link', {
+        name: new RegExp(s.title, 'i'),
+      })
+      expect(link).toHaveAttribute('href', `#${s.id}`)
+    }
+  })
+
+  it('calls onJump with the section id and closes the sheet when a link is tapped', async () => {
+    const onJump = renderChip()
+    await userEvent.click(screen.getByRole('button', { name: /jump to/i }))
+    const dialog = screen.getByRole('dialog')
+    await userEvent.click(
+      within(dialog).getByRole('link', { name: /Borda count scoring/i })
+    )
+    expect(onJump).toHaveBeenCalledWith('borda-count')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('closes on Escape', async () => {
+    renderChip()
+    await userEvent.click(screen.getByRole('button', { name: /jump to/i }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    await userEvent.keyboard('{Escape}')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('closes on backdrop click', async () => {
+    renderChip()
+    await userEvent.click(screen.getByRole('button', { name: /jump to/i }))
+    await userEvent.click(screen.getByTestId('jump-to-sheet-backdrop'))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('closes via the explicit close button', async () => {
+    renderChip()
+    await userEvent.click(screen.getByRole('button', { name: /jump to/i }))
+    const dialog = screen.getByRole('dialog')
+    await userEvent.click(
+      within(dialog).getByRole('button', { name: /close/i })
+    )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('moves focus into the sheet on open and restores it to the chip on close', async () => {
+    renderChip()
+    const chip = screen.getByRole('button', { name: /jump to/i })
+    await userEvent.click(chip)
+    const closeBtn = screen.getByRole('button', { name: /close/i })
+    expect(closeBtn).toHaveFocus()
+    await userEvent.keyboard('{Escape}')
+    expect(chip).toHaveFocus()
+  })
+})

--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useIsMobile } from '../hooks/useIsMobile'
 import CollapsibleSection from '../components/CollapsibleSection'
+import JumpToChip from '../components/JumpToChip'
 
 /* Methodology page (#368). Authored fresh from analytics-core as the
    source of truth — Borda formula, DCP thresholds, club health
@@ -66,6 +67,11 @@ const MethodologyPage: React.FC = () => {
           data — no scraping, no inference.
         </p>
       </header>
+
+      {/* Mobile-only sticky chip: re-open the TOC as a sheet without scrolling
+          back to the top (#878). Reuses `expand` so a jump reveals the
+          collapsed target section. Desktop keeps the in-flow TOC card below. */}
+      {isMobile && <JumpToChip sections={SECTIONS} onJump={expand} />}
 
       <nav aria-label="On this page" className="methodology-toc">
         <p className="methodology-toc__title">On this page</p>

--- a/frontend/src/pages/__tests__/MethodologyPage.mobile.test.tsx
+++ b/frontend/src/pages/__tests__/MethodologyPage.mobile.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 
@@ -64,6 +64,32 @@ describe('MethodologyPage — mobile collapsed sections', () => {
     expect(
       screen.getByText(/weights all three categories equally/i)
     ).toBeVisible()
+  })
+})
+
+describe('MethodologyPage — sticky Jump-to chip (#878)', () => {
+  beforeEach(() => mockIsMobile.mockReturnValue(true))
+
+  it('renders the sticky "Jump to" chip on mobile', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: /jump to/i })).toHaveAttribute(
+      'aria-haspopup',
+      'dialog'
+    )
+  })
+
+  it('opens a sheet and expands the chosen section when its sheet link is tapped', async () => {
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /jump to/i }))
+    const dialog = screen.getByRole('dialog')
+    // Jump to a section that is collapsed by default.
+    await userEvent.click(
+      within(dialog).getByRole('link', { name: /Borda count scoring/i })
+    )
+    // Sheet closed and the target section is now expanded.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    const toggle = screen.getByRole('button', { name: /Borda count scoring/i })
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
   })
 })
 

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -4247,6 +4247,180 @@
     }
   }
 
+  /* Sticky "Jump to ▾" chip + TOC sheet (#878, epic #880 Sprint 2).
+     Emitted only on mobile (the page renders <JumpToChip> when useIsMobile()),
+     so these classes match nothing on desktop — class-emission-gated, like the
+     CollapsibleSection mobile classes above. */
+
+  /* The bar is sticky (not fixed) so it reserves its own space in normal flow
+     and never overlaps the content it sits above — it pins just under the
+     56px-tall sticky top bar as the reader scrolls. The blurred surface masks
+     prose scrolling beneath it. Horizontal safe-area padding keeps the chip
+     clear of a landscape notch. */
+  .jump-to-bar {
+    position: sticky;
+    top: 56px;
+    z-index: 30;
+    margin: -8px -24px 24px;
+    padding: 8px max(24px, env(safe-area-inset-left)) 8px
+      max(24px, env(safe-area-inset-right));
+    background-color: rgba(var(--rds-surface-rgb), 0.85);
+    -webkit-backdrop-filter: saturate(140%) blur(8px);
+    backdrop-filter: saturate(140%) blur(8px);
+    border-bottom: 1px solid var(--line);
+  }
+
+  .jump-to-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    /* >=44px touch target (WCAG 2.5.5). */
+    min-height: 44px;
+    padding: 0 16px;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    box-shadow: var(--rds-shadow-sm);
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--ink);
+    cursor: pointer;
+  }
+
+  .jump-to-chip:hover {
+    background-color: var(--surface-2);
+  }
+
+  .jump-to-chip:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+  }
+
+  .jump-to-chip__caret {
+    font-size: 11px;
+    color: var(--ink-3);
+    line-height: 1;
+  }
+
+  /* Bottom sheet, portalled to <body> (escapes the page's overflow context). */
+  .jump-to-sheet-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 80;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+
+  .jump-to-sheet-backdrop {
+    position: absolute;
+    inset: 0;
+    background-color: rgba(15, 23, 42, 0.55);
+  }
+
+  .jump-to-sheet {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    max-height: 80vh;
+    background-color: var(--surface);
+    border-top-left-radius: var(--rds-radius-lg);
+    border-top-right-radius: var(--rds-radius-lg);
+    /* Clear the home indicator on notched phones. */
+    padding-bottom: env(safe-area-inset-bottom);
+    animation: jump-to-sheet-in 180ms ease-out;
+  }
+
+  @keyframes jump-to-sheet-in {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .jump-to-sheet {
+      animation: none;
+    }
+  }
+
+  .jump-to-sheet__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .jump-to-sheet__title {
+    margin: 0;
+    font-family: var(--serif);
+    font-size: 17px;
+    font-weight: 700;
+    color: var(--ink);
+  }
+
+  .jump-to-sheet__close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border: none;
+    background: none;
+    border-radius: 0.5rem;
+    color: var(--ink-2);
+    cursor: pointer;
+  }
+
+  .jump-to-sheet__close:hover {
+    background-color: var(--surface-2);
+    color: var(--ink);
+  }
+
+  .jump-to-sheet__close:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+  }
+
+  .jump-to-sheet__nav {
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .jump-to-sheet__list {
+    list-style: none;
+    margin: 0;
+    padding: 8px 0;
+  }
+
+  .jump-to-sheet__link {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    /* >=44px touch target per row (WCAG 2.5.5). */
+    min-height: 44px;
+    padding: 0 16px;
+    color: var(--ink);
+    text-decoration: none;
+    font-size: 15px;
+  }
+
+  .jump-to-sheet__link:hover {
+    background-color: var(--surface-2);
+  }
+
+  .jump-to-sheet__num {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--ink-3);
+    min-width: 22px;
+  }
+
   .methodology-link {
     color: var(--link);
     text-decoration: underline;

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -4140,8 +4140,20 @@
     color: var(--ink);
     /* The anchor id lives on this wrapper, so the TOC-jump offset must be
        here — not on the child title (#877). Otherwise a #section jump lands
-       the heading under the fixed header. */
+       the heading under the fixed header. 80px clears the 56px sticky top bar
+       with breathing room. */
     scroll-margin-top: 80px;
+  }
+
+  /* On mobile the sticky "Jump to ▾" chip bar (#878) stacks below the 56px
+     top bar (~61px tall), so a #section jump offset of only 80px would land
+     the heading behind the chip. Clear both here so the jumped-to heading is
+     fully visible — the chip is rendered only at <768px (useIsMobile), the
+     same breakpoint this query matches. */
+  @media (max-width: 767px) {
+    .methodology-section {
+      scroll-margin-top: 124px;
+    }
   }
 
   .methodology-section p,

--- a/tasks/lessons/139-an-anchor-jump-from-a-scroll-locked-sheet-has-three-scroll-clobbering-traps.md
+++ b/tasks/lessons/139-an-anchor-jump-from-a-scroll-locked-sheet-has-three-scroll-clobbering-traps.md
@@ -1,0 +1,85 @@
+---
+id: '139'
+category: lesson
+tags: [css, frontend, accessibility, router, verification, playwright, mobile]
+auto_load: true
+date: 2026-05-29
+issues: [878, 880]
+---
+
+# Lesson 139 — A TOC-anchor jump fired from inside a scroll-locked sheet has three independent scroll-clobbering traps; only live measurement separates them
+
+**Date:** 2026-05-29
+**Issue:** #878 (epic #880 Sprint 2 — sticky "Jump to ▾" chip + TOC sheet on /methodology)
+**PR:** [#935](https://github.com/taverns-red/toast-stats/pull/935)
+
+## What happened
+
+The chip opens the TOC as a modal **sheet** (`role="dialog"`, body
+`overflow:hidden` while open), and tapping a section link should close the
+sheet and jump to that `#section`. The unit/integration tests were green (they
+assert `aria-expanded` flips, not geometry — jsdom can't see layout, L66). On
+the live 375px preview the jump kept landing the heading at the very top of the
+viewport, **behind the new sticky chip bar** — i.e. the exact "obscures
+content" failure the acceptance criterion forbids. It took three separate fixes,
+each isolated by _measuring on the preview_, not by reasoning:
+
+1. **Stale offset.** `scroll-margin-top: 80px` (Sprint 1, sized for the 56px top
+   bar alone) no longer clears the ~61px chip bar stacked under it. Bump to
+   124px **only at `<768px`** (the chip is mobile-only). A sticky element added
+   _above_ anchored content silently invalidates every downstream
+   `scroll-margin-top` — same family as L138.
+2. **Native hash scroll fires while scroll is locked.** Clicking `<a href="#id">`
+   while the sheet still has `body{overflow:hidden}` computes the fragment
+   scroll against the locked state and ignores `scroll-margin-top`.
+   `preventDefault()` and drive `el.scrollIntoView({block:'start'})` yourself
+   **after** `close()` unlocks scroll + `onJump()` expands the target (double
+   `requestAnimationFrame`). `scrollIntoView` honours `scroll-margin-top`;
+   the native locked scroll did not.
+3. **Focus-restore scrolls back to the trigger.** The dialog's focus-trap
+   restores focus to the opener on close; the opener (the chip) sits near the
+   **top** of document flow, so `chip.focus()` scrolled the page back up and
+   clobbered the jump. Restore with `focus({ preventScroll: true })`.
+
+## The verification trap on top of all that (the part that cost the most)
+
+Even with the product correct, the Playwright smoke still read `headingTop ≈ 9`.
+`scroll-behavior: smooth` is set globally, so the jump **animates ~900ms and
+overshoots the target, pausing ~90ms at the overshoot before correcting back**.
+L138's `expect.poll(scrollY > 0)` returns mid-flight; a naive "two equal frames"
+settle check **false-positively settles on the overshoot plateau**. A live diag
+(`setInterval` sampling `scrollY`) showed the truth: `[…1107,1109,1109,1090,
+1050,…,994,994,994]` → final `getBoundingClientRect().top === 124`, exactly the
+offset. The product was right the whole time. Fix the _measurement_: require
+`scrollY` unchanged for ≥8 consecutive 30ms polls (~240ms, longer than the
+overshoot plateau) before asserting geometry.
+
+## How to apply
+
+- Adding a sticky/fixed bar above anchored content? Re-derive `scroll-margin-top`
+  for **every** anchor target to clear the new chrome's full stacked height,
+  scoped to the breakpoint where the chrome exists.
+- A hash/anchor jump triggered from inside a scroll-locked modal must
+  `preventDefault` and scroll **programmatically after unlock** — the native
+  scroll is computed against `overflow:hidden`.
+- Restoring focus to a near-top trigger on dialog close needs
+  `focus({ preventScroll: true })`, or it scrolls the page to the trigger.
+- Verifying a _smooth_-scroll landing: poll until `scrollY` is **stable across a
+  window longer than the overshoot plateau**, not until it is merely `> 0` or
+  "two equal frames." Confirm with a `scrollY` time-series diag before blaming
+  the product — here all three product fixes were real, but the final red was
+  the test measuring the overshoot.
+
+## Related
+
+- [[138-scroll-margin-top-belongs-on-the-element-that-holds-the-anchor-id]]
+  — the Sprint 1 predecessor: which element carries the offset, and `scrollY`
+  settles a tick after the click. This sprint extends it: a sticky bar
+  invalidates the offset value, and smooth scroll overshoots the settle.
+- [[134-a-status-chip-in-an-overflowing-table-is-still-clipped-detable-the-row]]
+  — verify mobile geometry by bounding box, and measure after `fonts.ready`.
+- [[130-a-debounced-outward-push-must-gate-on-the-debounce-having-settled]]
+  — same shape one layer over: assert on the _settled_ value, not a transient.
+- `frontend/src/components/JumpToChip.tsx`,
+  `frontend/src/styles/components/app-shell.css` (`.methodology-section`
+  `@media (max-width: 767px)`).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -107,3 +107,4 @@
 - **136** [tests, flaky, vitest, ci, contention] — A flake detector must not inherit the stability cap it measures; cap the gate, pin the detector to max parallelism (#914, #917)
 - **137** [tests, flaky, vitest, process, verification, tdd] — An audit's "false-confidence" list is a per-file hypothesis; re-confirm before deleting, because the first-pass classification over-flags (#916, #917)
 - **138** [css, frontend, accessibility, verification, playwright, mobile] — `scroll-margin-top` belongs on the element that holds the anchor id, not a styled child (#877, #880)
+- **139** [css, frontend, accessibility, router, verification, playwright, mobile] — A TOC-anchor jump fired from inside a scroll-locked sheet has three independent scroll-clobbering traps; only live measurement separates them (#878, #880)


### PR DESCRIPTION
## Summary
Epic #880 Sprint 2 (mobile UX audit Epic E — CC-8). Adds a **mobile-only sticky "Jump to ▾" chip** pinned under the page header on the Methodology long-text page. Tapping it opens the Sprint-1 TOC as a bottom **sheet**, so a reader deep in the page can jump to any section without scrolling back to the top. Selecting a section reuses the Sprint-1 `expand` logic to reveal the collapsed target, then jumps via the native hash anchor.

Closes-after-verify: #878 (label + epic tick + close handled by the sprint runner per the ordering in #626).

## Acceptance criteria
- [x] Sticky chip below the page header; tap opens TOC sheet.
- [x] Chip respects safe-area insets; doesn't obscure content.

## Design / implementation notes
- **New `JumpToChip` component** — reuses the proven modal-dialog contract from `ChartExpandSheet` (#874): portalled to `<body>`, dismissible via close button / Esc / backdrop, focus moved in on open and restored to the chip on close, background scroll locked. Trigger uses `aria-haspopup="dialog"` (WAI-ARIA modal pattern), not `aria-expanded`.
- **`position: sticky` (not `fixed`)** so the bar reserves its own flow space and never overlaps the content above it — directly satisfies "doesn't obscure content". Pins at `top: 56px`, just under the 56px sticky top bar.
- **Safe-area insets**: horizontal `env(safe-area-inset-left/right)` on the chip bar (landscape notch) and `env(safe-area-inset-bottom)` on the sheet (home indicator).
- **Mobile-only / zero desktop effect**: the page renders `<JumpToChip>` only when `useIsMobile()` is true — class-emission-gated like Sprint 1's `CollapsibleSection`. Desktop keeps the in-flow TOC card. All `.jump-to-*` classes are new (cardinality-checked, R131).
- 44px touch targets on the chip, sheet rows, and close button (WCAG 2.5.5).

## Tests
- `JumpToChip.test.tsx` — component unit (no page mount, R22): chip opens labelled modal dialog listing every section; link calls `onJump` + closes; Esc / backdrop / close-button dismiss; focus moves in on open and restores to chip on close.
- `MethodologyPage.mobile.test.tsx` — page integration: chip renders on mobile (not desktop); tapping a sheet link expands the target collapsed section.
- Full frontend suite: **3110 passed**. R22 no-page-mount guard passes.

## Verification
Pending: dual-engine (Chromium + WebKit) Playwright smoke at 375px on the PR preview channel — measure the chip sticks under the header, opens the sheet, jump lands the heading in-viewport, and the chip is within the viewport bounds (bounding box, per Lessons 134/138). Screenshots to follow on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)