### PR TITLE
feat(long-text): 'what does this page answer?' lede on /methodology + /history (#879)

### DIFF
--- a/frontend/src/__tests__/accessibility/LandingStaticDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/LandingStaticDarkModeContrast.test.ts
@@ -188,6 +188,7 @@ describe('Landing + static pages dark-mode contrast (#611)', () => {
     },
     { name: 'placeholder body', selector: '.placeholder-page__body' },
     { name: 'placeholder title', selector: '.placeholder-page__title' },
+    { name: 'long-text lede', selector: '.long-text-lede' },
   ]
 
   it.each(ALREADY_OK)('$name clears AA on the dark surface', ({ selector }) => {

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -28,10 +28,12 @@ const HistoryPage: React.FC = () => {
         Archive · {PROGRAM_YEARS_ON_FILE.length} program years on file
       </p>
       <h1 className="placeholder-page__title">Program Year History</h1>
-      <p className="placeholder-page__body">
-        Final standings and headline metrics for each completed Toastmasters
-        program year. Data is frozen at June 30; each year is preserved as it
-        stood when the year closed — no retroactive corrections.
+      {/* "What does this page answer?" lede (#879, epic #880 Sprint 3). The
+          other doc-style route; one scannable sentence above the year strip. */}
+      <p className="long-text-lede" data-testid="history-lede">
+        How each completed Toastmasters program year finished — final standings
+        frozen at June 30, no retroactive corrections — and which years are on
+        file here versus the TI archive.
       </p>
 
       <div className="history-page-year-strip" role="list">

--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -61,10 +61,14 @@ const MethodologyPage: React.FC = () => {
       <header className="methodology-page__header">
         <p className="placeholder-page__eyebrow">Reference · Updated 2026-05</p>
         <h1 className="placeholder-page__title">Methodology</h1>
-        <p className="placeholder-page__body">
-          How Toast Stats sources, processes, and ranks the worldwide
-          Toastmasters dashboard. Everything here is reproducible from public
-          data — no scraping, no inference.
+        {/* "What does this page answer?" lede (#879). One scannable sentence
+            above the section list so a (mobile) reader can decide whether to
+            dive into the ~16,000px of prose below. Replaces the older generic
+            intro — see docs/design/mobile-ux-audit-2026-05-28.md §14. */}
+        <p className="long-text-lede" data-testid="methodology-lede">
+          Where Toast Stats gets its numbers, how districts and regions are
+          ranked, and what every DCP tier and club-health label means — defined
+          once, from public data, here.
         </p>
       </header>
 

--- a/frontend/src/pages/__tests__/HistoryPage.lede.test.tsx
+++ b/frontend/src/pages/__tests__/HistoryPage.lede.test.tsx
@@ -1,0 +1,41 @@
+/* /history lede (#879, epic #880 Sprint 3 — Epic E).
+
+   The other doc-style long-text route. A one-sentence "what does this page
+   answer?" lede sits above the year strip so a reader knows what each
+   archived program year shows and which years are on file. */
+
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import HistoryPage from '../HistoryPage'
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <HistoryPage />
+    </MemoryRouter>
+  )
+
+describe('HistoryPage — "what does this page answer?" lede (#879)', () => {
+  it('renders a single lede element', () => {
+    renderPage()
+    expect(screen.getByTestId('history-lede')).toBeInTheDocument()
+  })
+
+  it('the lede summarises what the page answers (per-year standings / archive)', () => {
+    renderPage()
+    const lede = screen.getByTestId('history-lede').textContent || ''
+    expect(lede).toMatch(/year/i)
+    expect(lede).toMatch(/archive|on file|frozen|final|standing/i)
+  })
+
+  it('the lede appears above the year strip, so it reads first', () => {
+    renderPage()
+    const lede = screen.getByTestId('history-lede')
+    const strip = screen.getByRole('list')
+    expect(
+      lede.compareDocumentPosition(strip) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/__tests__/MethodologyPage.lede.test.tsx
+++ b/frontend/src/pages/__tests__/MethodologyPage.lede.test.tsx
@@ -1,0 +1,43 @@
+/* /methodology lede (#879, epic #880 Sprint 3 — Epic E).
+
+   A one-sentence "what does this page answer?" lede sits above the section
+   list so a (mobile) reader can decide whether to dive into the ~16,000px of
+   prose. See docs/design/mobile-ux-audit-2026-05-28.md §14 / Epic E. */
+
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import MethodologyPage from '../MethodologyPage'
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <MethodologyPage />
+    </MemoryRouter>
+  )
+
+describe('MethodologyPage — "what does this page answer?" lede (#879)', () => {
+  it('renders a single lede element', () => {
+    renderPage()
+    expect(screen.getByTestId('methodology-lede')).toBeInTheDocument()
+  })
+
+  it('the lede summarises what the page answers (data source, ranking, definitions)', () => {
+    renderPage()
+    const lede = screen.getByTestId('methodology-lede').textContent || ''
+    // It frames the questions the page resolves, not just "what this is".
+    expect(lede).toMatch(/rank/i)
+    expect(lede).toMatch(/tier|health|label|defin/i)
+  })
+
+  it('the lede appears above the section list (TOC), so it reads first', () => {
+    renderPage()
+    const lede = screen.getByTestId('methodology-lede')
+    const toc = screen.getByRole('navigation', { name: /on this page/i })
+    // DOM order: lede must precede the TOC nav.
+    expect(
+      lede.compareDocumentPosition(toc) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -374,6 +374,20 @@
     color: var(--ink-2);
   }
 
+  /* "What does this page answer?" lede for the long-text/doc-style routes
+     (/methodology, /history) — #879, epic #880 Sprint 3. Slightly larger and
+     more open than the generic body so it reads as a decision aid above the
+     section list. Colour is --ink-2 (AA-verified on the dark surface by
+     LandingStaticDarkModeContrast.test.ts), capped at a comfortable measure. */
+  .long-text-lede {
+    margin: 0;
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.5;
+    color: var(--ink-2);
+    max-width: 60ch;
+  }
+
   /* Districts page redesign chrome (#356). Lives inside DistrictsPage.tsx
      until #369 retires the file. The .districts-* namespace is intentional
      — Districts is its own surface, distinct from app-shell chrome and

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -378,7 +378,10 @@
      (/methodology, /history) — #879, epic #880 Sprint 3. Slightly larger and
      more open than the generic body so it reads as a decision aid above the
      section list. Colour is --ink-2 (AA-verified on the dark surface by
-     LandingStaticDarkModeContrast.test.ts), capped at a comfortable measure. */
+     LandingStaticDarkModeContrast.test.ts), capped at a comfortable measure.
+     Deliberately separate from .districts-page-header__lede (14px/1.45): that
+     class is in the isolated .districts-* surface namespace and must not leak
+     onto the doc-style routes — these pages want an airier prose measure. */
   .long-text-lede {
     margin: 0;
     font-family: var(--sans);

--- a/tasks/lessons/140-a-deliberate-surface-namespace-outranks-a-dry-reuse-flag.md
+++ b/tasks/lessons/140-a-deliberate-surface-namespace-outranks-a-dry-reuse-flag.md
@@ -1,0 +1,64 @@
+---
+id: '140'
+category: lesson
+tags: [css, frontend, refactoring, simplify, process]
+auto_load: true
+date: 2026-05-29
+issues: [879, 880]
+---
+
+# Lesson 140 — A deliberately-isolated surface namespace outranks a DRY "reuse" flag; a small typographic duplication is cheaper than cross-surface coupling
+
+**Date:** 2026-05-29
+**Issue:** #879 (epic #880 Sprint 3 — Epic E, "what does this page answer?" lede)
+**PR:** #936
+
+## What happened
+
+Sprint 3 added a `.long-text-lede` class for the two doc-style routes
+(`/methodology`, `/history`). The `/simplify` reuse agent correctly observed
+that it is near-identical to the existing `.districts-page-header__lede` —
+same `font-family`, `color: var(--ink-2)`, `max-width: 60ch`, differing only
+in `font-size` (15px vs 14px) and `line-height` (1.5 vs 1.45). On the DRY
+metric alone, that reads as duplication worth collapsing.
+
+I declined the merge. `.districts-*` is a **deliberately isolated surface
+namespace** (CLAUDE.md: "Districts is its own surface, distinct from app-shell
+chrome and from the legacy tm-\* brand classes"). Reusing
+`.districts-page-header__lede` on the methodology/history pages would couple
+two unrelated surfaces through a shared class: a future restyle of the
+Districts header lede would silently change the doc pages, and vice versa. The
+"cost" the reuse agent priced ($190 of maintenance for one extra rule) is far
+smaller than the cost of that coupling — an invisible cross-surface blast
+radius that no test would catch until a Districts change broke a doc page.
+
+## The transferable lesson
+
+**A reuse/DRY finding measures token duplication; it does not measure
+architectural boundaries. When collapsing the duplication would breach a
+namespace that was isolated on purpose, the boundary wins.** Two classes that
+_look_ alike are not duplication if they belong to surfaces that must be able
+to diverge independently. The right response to the flag is not to merge it and
+not to silently ignore it — it is to **document why the duplication is
+deliberate at the point of duplication**, so the next reader (and the next
+`/simplify` run) sees the boundary, not an oversight.
+
+## How to apply
+
+- Before collapsing two similar CSS classes, ask "do these belong to the same
+  surface?" If one is in an intentionally-namespaced surface (`.districts-*`,
+  legacy `tm-*`, brand `rt-*`), keep them separate.
+- Leave a one-line comment at the duplicated rule naming the sibling it
+  _looks_ like and why it stays distinct — converts "accidental duplication"
+  into "documented intent" and pre-empts the same flag next sprint.
+- A `/simplify` reuse finding is advice priced on one axis (duplication). You
+  own the merge decision; weigh it against coupling/blast-radius, which the
+  agent cannot see. Skipping a finding with a recorded reason is a valid,
+  expected outcome — same spirit as [[137-an-audits-false-confidence-list-is-a-per-file-hypothesis-reconfirm-before-deleting]].
+
+## Related
+
+- `tasks/rules.md` R10 (CSS-level overrides for cross-cutting concerns) and the
+  CLAUDE.md `.districts-*` namespace note — the boundary this lesson defends.
+- [[081-phase-gated-deferral-tests-move-with-the-spec]] — sibling "the
+  obvious-looking simplification is wrong once you know the intent" lesson.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -108,3 +108,4 @@
 - **137** [tests, flaky, vitest, process, verification, tdd] — An audit's "false-confidence" list is a per-file hypothesis; re-confirm before deleting, because the first-pass classification over-flags (#916, #917)
 - **138** [css, frontend, accessibility, verification, playwright, mobile] — `scroll-margin-top` belongs on the element that holds the anchor id, not a styled child (#877, #880)
 - **139** [css, frontend, accessibility, router, verification, playwright, mobile] — A TOC-anchor jump fired from inside a scroll-locked sheet has three independent scroll-clobbering traps; only live measurement separates them (#878, #880)
+- **140** [css, frontend, refactoring, simplify, process] — A deliberately-isolated surface namespace outranks a DRY "reuse" flag; a small typographic duplication is cheaper than cross-surface coupling (#879, #880)


### PR DESCRIPTION
## What & why

Epic #880 Sprint 3 (Epic E — kill CC-8). Adds a one-sentence **"what does this page answer?"** lede at the top of each long-text/doc-style route, above the section list, so a mobile reader can decide whether to dive into the prose (per `docs/design/mobile-ux-audit-2026-05-28.md` §14).

- **/methodology** (the CC-8 home, ~16,000px) — lede above the in-page TOC.
- **/history** (the other doc-style route) — lede above the year strip.

Replaces the older generic `.placeholder-page__body` intro on both pages with a sharper, question-framed lede (no double-intro / wall-of-prose).

## Changes

- New shared `.long-text-lede` CSS class (15px / 1.5 / `--ink-2` / 60ch) — kept deliberately distinct from the isolated `.districts-*` namespace.
- Dark-mode AA: `.long-text-lede` added to the `LandingStaticDarkModeContrast` no-regression list (clears 4.5:1 on the dark surface).
- TDD: RED tests assert the lede exists, frames the questions answered, and precedes the section list in DOM order.

## Verification

- Full frontend suite green (3117 tests). `/simplify` + fresh-context `/review` passed (APPROVE, no High/Medium).
- Live verification on the PR preview channel (Chromium + WebKit) to follow on this PR.

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)