### PR TITLE
feat(regions): sort region cards by a documented metric — region number asc (#882)

### DIFF
--- a/frontend/src/components/RegionGrid.tsx
+++ b/frontend/src/components/RegionGrid.tsx
@@ -28,9 +28,20 @@ const REQUIREMENT_LABELS: ReadonlyArray<{
 export const RegionGrid: React.FC<RegionGridProps> = ({ rollups }) => {
   if (rollups.length === 0) return null
 
+  // Default sort (#882): region number ascending. Chosen over a data-driven
+  // order (e.g. paid clubs descending) because a navigation grid of the 14
+  // fixed regions reads best in a stable, predictable sequence that matches
+  // the RegionFinder's numeric order — a metric-ranked order would reshuffle
+  // the cards as the season's data shifts. The grid owns this sort so it holds
+  // regardless of the order rollups arrive in (don't lean on aggregateRegions'
+  // incidental ordering — see RegionGrid.test.tsx #882).
+  const sorted = [...rollups].sort(
+    (a, b) => Number(a.region) - Number(b.region)
+  )
+
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-      {rollups.map(r => (
+      {sorted.map(r => (
         <Link
           key={r.region}
           to={`/region/${r.region}`}

--- a/frontend/src/components/__tests__/RegionGrid.test.tsx
+++ b/frontend/src/components/__tests__/RegionGrid.test.tsx
@@ -129,4 +129,21 @@ describe('RegionGrid (#495)', () => {
     const { container } = renderWithRouter(<RegionGrid rollups={[]} />)
     expect(container.firstChild).toBeNull()
   })
+
+  // #882 — the card grid owns its documented default sort (region number
+  // ascending), independent of the order its rollups arrive in. Pinned here
+  // so an upstream reorder (e.g. aggregateRegions switching to leaderboard
+  // order) can't silently re-sequence the cards.
+  it('sorts cards by region number ascending regardless of input order (#882)', () => {
+    const outOfOrder: RegionRollup[] = [
+      mkRollup({ region: '14', leadingDistrictName: 'District 14' }),
+      mkRollup({ region: '02', leadingDistrictName: 'District 02' }),
+      mkRollup({ region: '07', leadingDistrictName: 'District 57' }),
+    ]
+    renderWithRouter(<RegionGrid rollups={outOfOrder} />)
+    const hrefs = screen
+      .getAllByRole('link', { name: /region/i })
+      .map(a => a.getAttribute('href'))
+    expect(hrefs).toEqual(['/region/02', '/region/07', '/region/14'])
+  })
 })


### PR DESCRIPTION
Epic #884 (Mobile UX audit Epic F) Sprint 2. Closes-on-verify #882.

## What
Gives the `/regions` card grid an **explicit, documented default sort: region number ascending**, owned by `RegionGrid` itself.

## Why region number ascending (not "paid clubs descending")
The issue **title** proposed "paid clubs descending", but the issue **body** Goal + acceptance criteria set **region number ascending** as the default ("unless operator overrides during implementation"). The body carries the binding AC, so this PR implements region-number-asc. Rationale (named in the code comment): a navigation grid of the 14 fixed regions reads best in a stable, predictable sequence matching the RegionFinder's numeric order — a metric-ranked order would reshuffle cards as the season's data shifts.

> **Operator note:** the issue title still says "paid clubs descending" and contradicts the body. Flagging for the record; implemented per the body's AC.

## How
`aggregateRegions()` already emits region-asc order, so the cards rendered correctly *by coincidence* — the card surface didn't own or document that. This PR makes the sort explicit in `RegionGrid` with a comment naming the choice, so an upstream reorder (e.g. switching `aggregateRegions` to leaderboard order) can't silently re-sequence the cards. Pinned by a unit test feeding out-of-order input.

## Acceptance criteria
- [x] Cards sort by the documented metric (region number asc).
- [x] Choice named in a code comment (`RegionGrid.tsx`).
- [x] Tests added (red-first, no assertion pinning).
- [ ] 375px Chromium + WebKit smoke on preview (post-CI).
- [x] No regression at desktop widths (sort is width-independent; full suite green).

## Test plan
- `RegionGrid.test.tsx` — new test pins region-asc DOM order from `[14, 02, 07]` input (red before the feat commit).
- Full region suite (RegionGrid + aggregateRegions + RegionsPage) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)