### PR TITLE
feat(region): card-based empty/error states for /region/:n (#883)

### DIFF
--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,14 +1,62 @@
-// RED stub — replaced by the GREEN implementation in the next commit (#883).
 import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 
 export interface EmptyStateProps {
+  /** Short headline, e.g. "No districts here yet". */
   title: string
+  /** One-line explanation of why the surface is empty. */
   message: string
+  /** Label for the primary recovery action. */
   actionLabel: string
+  /** Router destination for the recovery action. */
   actionHref: string
+  /** Optional decorative icon; a default compass glyph is used otherwise. */
   icon?: ReactNode
 }
 
-export function EmptyState(_props: EmptyStateProps) {
-  return null
+/**
+ * EmptyState — a shared recovery affordance for empty / error surfaces (CC-10).
+ *
+ * Replaces bare-prose dead-ends with a card: a decorative icon, a one-line
+ * explanation, and a primary action rendered as a real, 44px-tall button
+ * (`<Link>` styled as a button) so the user always has a tappable way out.
+ * See docs/design/mobile-ux-audit-2026-05-28.md §CC-10.
+ */
+export function EmptyState({
+  title,
+  message,
+  actionLabel,
+  actionHref,
+  icon,
+}: EmptyStateProps) {
+  return (
+    <div className="empty-state" role="status">
+      <span className="empty-state__icon">{icon ?? <DefaultIcon />}</span>
+      <h2 className="empty-state__title">{title}</h2>
+      <p className="empty-state__message">{message}</p>
+      <Link to={actionHref} className="empty-state__action">
+        {actionLabel}
+      </Link>
+    </div>
+  )
+}
+
+function DefaultIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      width="40"
+      height="40"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M14.5 9.5 11 11l-1.5 3.5L13 13l1.5-3.5z" />
+    </svg>
+  )
 }

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,14 @@
+// RED stub — replaced by the GREEN implementation in the next commit (#883).
+import type { ReactNode } from 'react'
+
+export interface EmptyStateProps {
+  title: string
+  message: string
+  actionLabel: string
+  actionHref: string
+  icon?: ReactNode
+}
+
+export function EmptyState(_props: EmptyStateProps) {
+  return null
+}

--- a/frontend/src/components/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/__tests__/EmptyState.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { EmptyState } from '../EmptyState'
+
+function renderEmptyState(props: Parameters<typeof EmptyState>[0]) {
+  return render(
+    <MemoryRouter>
+      <EmptyState {...props} />
+    </MemoryRouter>,
+  )
+}
+
+describe('EmptyState', () => {
+  it('renders the title and message', () => {
+    renderEmptyState({
+      title: 'Nothing here yet',
+      message: 'There is no data to show.',
+      actionLabel: 'Go home',
+      actionHref: '/',
+    })
+    expect(screen.getByText('Nothing here yet')).toBeInTheDocument()
+    expect(screen.getByText('There is no data to show.')).toBeInTheDocument()
+  })
+
+  it('renders the action as a router link to the given href', () => {
+    renderEmptyState({
+      title: 'Nothing here yet',
+      message: 'There is no data to show.',
+      actionLabel: 'View all regions',
+      actionHref: '/regions',
+    })
+    const action = screen.getByRole('link', { name: 'View all regions' })
+    expect(action).toHaveAttribute('href', '/regions')
+  })
+
+  it('styles the action as a button affordance (not a bare text link)', () => {
+    renderEmptyState({
+      title: 'Nothing here yet',
+      message: 'There is no data to show.',
+      actionLabel: 'View all regions',
+      actionHref: '/regions',
+    })
+    const action = screen.getByRole('link', { name: 'View all regions' })
+    expect(action).toHaveClass('empty-state__action')
+  })
+
+  it('renders a decorative icon hidden from assistive tech', () => {
+    const { container } = renderEmptyState({
+      title: 'Nothing here yet',
+      message: 'There is no data to show.',
+      actionLabel: 'Go home',
+      actionHref: '/',
+    })
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('wraps content in a card container', () => {
+    const { container } = renderEmptyState({
+      title: 'Nothing here yet',
+      message: 'There is no data to show.',
+      actionLabel: 'Go home',
+      actionHref: '/',
+    })
+    expect(container.querySelector('.empty-state')).not.toBeNull()
+  })
+})

--- a/frontend/src/styles/components/empty-state.css
+++ b/frontend/src/styles/components/empty-state.css
@@ -1,0 +1,60 @@
+/* EmptyState — shared recovery-affordance card for empty/error surfaces (CC-10). */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.75rem;
+  max-width: 28rem;
+  margin: 2rem auto;
+  padding: 2rem 1.5rem;
+  border: 1px solid var(--color-border, #e2e8f0);
+  border-radius: 0.75rem;
+  background: var(--color-surface, #fff);
+}
+
+.empty-state__icon {
+  color: var(--color-text-muted, #64748b);
+  line-height: 0;
+}
+
+.empty-state__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text, #0f172a);
+}
+
+.empty-state__message {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--color-text-muted, #64748b);
+}
+
+/* Primary action — real button affordance, 44px minimum touch target. */
+.empty-state__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  margin-top: 0.5rem;
+  padding: 0 1.25rem;
+  border-radius: 0.5rem;
+  background: var(--rt-stats, #d4873f);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9375rem;
+  text-decoration: none;
+  transition:
+    filter 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.empty-state__action:hover {
+  filter: brightness(0.95);
+}
+
+.empty-state__action:focus-visible {
+  outline: 2px solid var(--rt-stats, #d4873f);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## What & why

Epic #884 Sprint 3 — kills the bare-prose dead-end on `/region/:n` (CC-10 from the mobile UX audit, `docs/design/mobile-ux-audit-2026-05-28.md`).

Introduces a small, reusable `<EmptyState>` (the audit's prescribed shared affordance: decorative icon + one-line message + a real **44px** button-styled `<Link>`) and adopts it on `RegionPage` for **both** the empty and error states. Scope stays on this one page; broader adoption (per-club stub, 404) is left for later per the audit.

## Acceptance criteria
- [x] Sparse `/region/:n` shows a card-based empty state with an action button (`View all regions` → `/regions`).
- [x] No bare-prose error/empty state remains on this page (both `.region-page__empty` and `.region-page__error` removed; dead CSS deleted).
- [x] Tests added/updated, no assertion pinning. RED→GREEN commits separate.

## TDD
- RED: `test(region): failing specs for card-based empty/error states (#883)`
- GREEN: `feat(region): card-based empty/error states via shared EmptyState (#883)`

## Verification
- Full frontend suite green; R22 no-page-mounts guard green; typecheck/lint/format/build green.
- Live preview smoke (375px Chromium + WebKit) to follow on the PR preview channel.

## Review notes (Low, for triage)
- `EmptyState` uses `role="status"` (polite live region) rather than `role="alert"` for the error case — acceptable for a single shared component, and it is announced on the async loading→error transition. Reuses the same `--color-*` / `--rt-stats` tokens as neighboring region cards, so dark-mode and the 44px touch target are covered without a bespoke override.

Closes #883 via the sprint-runner flow (label + epic tick + close handled post-merge, not via `Closes` keyword — Lesson 106).
