### PR TITLE
feat(region): card-based sparse-region empty state for /region/:n (#883)

### DIFF
--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -4,7 +4,7 @@
    React-Query cache). */
 
 import React from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { fetchCdnRankings } from '../services/cdn'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
@@ -331,22 +331,32 @@ const RegionPage: React.FC = () => {
     return (
       <EmptyState
         title="Could not load region"
-        message="The rankings file is unavailable. Try again in a moment."
+        message="The rankings file is unavailable. Try again in a moment, or browse all regions."
         icon="data"
+        action={{
+          label: 'View all regions',
+          onClick: () => navigate('/regions'),
+        }}
       />
     )
   }
 
+  // Sparse region: no districts map to this region number. Use the shared
+  // card-based EmptyState with a real recovery CTA instead of a bare-prose
+  // paragraph (#883, Epic F — kill CC-10 prose empty state). EmptyState
+  // shares the loaded-state card geometry, so the empty/error/loaded
+  // terminal states stay layout-consistent (lesson 125).
   if (regionDistricts.length === 0) {
     return (
-      <div className="app-shell__page">
-        <p className="placeholder-page__eyebrow">Region</p>
-        <h1 className="placeholder-page__title">Region {region}</h1>
-        <p className="placeholder-page__body">
-          No districts found for region {region}.{' '}
-          <Link to="/">Back to all districts</Link>.
-        </p>
-      </div>
+      <EmptyState
+        title={`No districts in Region ${region}`}
+        message={`We don't have any districts on record for Region ${region}. Browse all regions to find the one you're looking for.`}
+        icon="data"
+        action={{
+          label: 'View all regions',
+          onClick: () => navigate('/regions'),
+        }}
+      />
     )
   }
 

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { cleanup, render, screen, within } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import RegionPage from '../RegionPage'
@@ -61,6 +67,80 @@ const renderRegion = (region: string) => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+})
+
+// Render with a sibling /regions route so a CTA navigation can be asserted
+// by the destination it lands on (the regions overview card grid).
+const renderRegionWithRegionsRoute = (region: string) => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/region/${region}`]}>
+        <Routes>
+          <Route path="/region/:n" element={<RegionPage />} />
+          <Route
+            path="/regions"
+            element={<div data-testid="regions-overview">All regions</div>}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('RegionPage empty & error recovery affordances (#883)', () => {
+  // Sprint 3 (epic #884, Epic F): kill the bare-prose empty state on
+  // /region/:n. A sparse region (no matching districts) must render the
+  // shared card-based EmptyState with a real CTA button, not a prose
+  // paragraph + inline <Link>.
+  it('renders a card EmptyState (not prose) for a region with no districts', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      // Only region "1" exists; region "99" is empty.
+      rankings: [mkRanking({ districtId: '1', region: '1' })],
+      date: '2026-05-12',
+    })
+    renderRegionWithRegionsRoute('99')
+
+    // The shared EmptyState renders a tm-card. The old prose block used
+    // .placeholder-page__body with an inline <Link>. Wait on the
+    // distinguishing copy first — the loading skeleton also uses
+    // role="status", so we can't key off the role alone.
+    const heading = await screen.findByText(/no districts in region 99/i)
+    expect(heading.closest('.tm-card')).not.toBeNull()
+    expect(
+      document.querySelector('.placeholder-page__body')
+    ).not.toBeInTheDocument()
+  })
+
+  it('offers a "View all regions" CTA that navigates to /regions', async () => {
+    mockedFetchCdnRankings.mockResolvedValueOnce({
+      rankings: [mkRanking({ districtId: '1', region: '1' })],
+      date: '2026-05-12',
+    })
+    renderRegionWithRegionsRoute('99')
+
+    const cta = await screen.findByRole('button', {
+      name: /view all regions/i,
+    })
+    fireEvent.click(cta)
+    expect(await screen.findByTestId('regions-overview')).toBeInTheDocument()
+  })
+
+  it('renders a card EmptyState with a recovery CTA when the rankings fetch fails', async () => {
+    mockedFetchCdnRankings.mockRejectedValueOnce(new Error('boom'))
+    renderRegionWithRegionsRoute('2')
+
+    const heading = await screen.findByText(/could not load region/i)
+    const card = heading.closest('.tm-card')!
+    expect(card).not.toBeNull()
+    const cta = within(card as HTMLElement).getByRole('button', {
+      name: /view all regions/i,
+    })
+    fireEvent.click(cta)
+    expect(await screen.findByTestId('regions-overview')).toBeInTheDocument()
+  })
 })
 
 describe('RegionPage tier column (#517 #513)', () => {


### PR DESCRIPTION
## Summary

Sprint 3 of epic #884 (Mobile UX audit Epic F). Kills the bare-prose empty state (CC-10) on \`/region/:n\` for a region with no districts, replacing it with the shared card-based \`EmptyState\` + a "View all regions" CTA. The error branch gets the same recovery CTA so the empty / error / loaded terminal states stay card-consistent (lesson 125).

Reuses the **existing** \`EmptyState\` from \`components/ErrorDisplay.tsx\` (R7 — don't bolt on a second component). Drops the now-unused \`Link\` import.

## Acceptance criteria (Epic F §3)

- [x] Sparse region (`/region/:n`, no matching districts) renders a card + button, not prose
- [x] Error branch offers a recovery affordance (consistent with empty)

## Tests (TDD)

New `describe('RegionPage empty & error recovery affordances (#883)')` in `RegionPage.test.tsx`:
- empty branch renders a `tm-card` EmptyState (no `.placeholder-page__body`)
- "View all regions" CTA navigates to `/regions`
- error branch renders a card EmptyState with the same recovery CTA

All 3110 frontend tests pass.

## Notes

Supersedes closed PR #940 (prior session's discarded approach). Branched fresh from `origin/main`.

Refs #883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)