### PR TITLE
test(a11y): dual-engine 44px touch-target tripwire — Epic G Sprint 3 (#887)

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -169,3 +169,14 @@ jobs:
         # Safari-only rendering regression fails the webkit project while
         # Chromium stays green — exactly the #710 class.
         run: npx playwright test --config playwright.config.ts e2e/regions-legibility.smoke.ts
+
+      # Dual-engine 44px touch-target tripwire (#887, epic #888 Sprint 3). Locks
+      # in the #886 family-A/B/C fix: every interactive element on every routed
+      # page must keep the 44px floor in BOTH engines. WebKit ignores min-height
+      # on a native <select> without appearance:none (lesson 111), so a
+      # Chromium-only check is blind — runs both projects like the smoke above.
+      - name: Cross-engine 44px touch-target tripwire against preview
+        working-directory: frontend
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.url }}
+        run: npx playwright test --config playwright.config.ts e2e/touch-targets.smoke.ts

--- a/frontend/e2e/touch-targets.smoke.ts
+++ b/frontend/e2e/touch-targets.smoke.ts
@@ -1,0 +1,142 @@
+import { test, expect, type Page } from '@playwright/test'
+import { INTERACTIVE_SELECTORS } from '../src/utils/touchTargetUtils'
+
+/* Dual-engine 44×44px touch-target tripwire (#887, epic #888 "Epic G" Sprint 3).
+ *
+ * Locks in the Sprint-2 fix (#886): every interactive element on every routed
+ * page must keep the WCAG 2.5.5 / handoff 44px floor in BOTH Chromium and
+ * WebKit. The audit (#885) found 45 sub-44 instances in three component
+ * families — A (chip-select overlays, 30–34px tall), B (landing region chips,
+ * 36px wide), C (/regions finder chips, 40–41px wide). #886 lifted all three;
+ * this guard fails loudly if any regresses, or if a NEW sub-44 control ships.
+ *
+ * Why this shape (lessons 108 / 111 / 134 / 138):
+ *  - BOTH engines. A native <select> ignores `min-height` in WebKit unless it
+ *    opts out with `appearance:none` (L111); an `inset-0` overlay is 2px short
+ *    of a bordered label's box (L138). Chromium-only is blind to both. The two
+ *    playwright.config projects (`smoke`=Chromium, `webkit`=Safari) run this
+ *    file in each; a WebKit-only regression reds `webkit` while `smoke` stays
+ *    green — exactly the #710 class.
+ *  - Real geometry, not `toBeVisible` or a className (L108/134/138). A jsdom
+ *    class-contract test asserts `min-h-[44px]` is *present*; only a live
+ *    `boundingBox()` proves the rendered pixels. We measure the box.
+ *  - The selector set is imported from the PRODUCT's own `INTERACTIVE_SELECTORS`
+ *    (touchTargetUtils.ts) so the guard cannot drift from what the app, the
+ *    audit, and `useTouchTarget` consider interactive (R20 spirit).
+ *
+ * Exemptions (faithful to the #885 audit method):
+ *  - Inline prose links (`<a>` with computed `display:inline`, no `role=button`)
+ *    are WCAG 2.5.5-exempt — they live in flowing text, not as tap chrome.
+ *  - sr-only collapsed controls (≤1px box — e.g. `.tm-skip-link` is 1×1
+ *    off-screen at rest) are not real tap targets until focused; skipped. Real
+ *    defects are 30–42px (well above 1px), so this can't mask one.
+ */
+
+const FLOOR = 44 // px, WCAG 2.5.5 AAA / mobile handoff target
+const VIEWPORT = { width: 375, height: 812 } // iPhone-class portrait
+
+// One concrete instance of every route shape in App.tsx (the #885 audit set).
+// District 61 / club 01479548 / division A / region 1 are representative; the
+// three defect families are component-level, so params don't change them.
+const ROUTES = [
+  '/',
+  '/district/61',
+  '/district/61/clubs',
+  '/district/61/changes',
+  '/district/61/divisions',
+  '/district/61/rankings',
+  '/district/61/trends',
+  '/district/61/analytics',
+  '/district/61/division/A',
+  '/district/61/club/01479548',
+  '/club/01479548',
+  '/history',
+  '/methodology',
+  '/awards',
+  '/regions',
+  '/region/1',
+]
+
+interface Finding {
+  tag: string
+  testid: string | null
+  aria: string | null
+  cls: string
+  w: number
+  h: number
+}
+
+async function measureInteractiveTargets(
+  page: Page,
+  selectors: string[]
+): Promise<Finding[]> {
+  return page.evaluate(sels => {
+    const els = Array.from(document.querySelectorAll(sels.join(', ')))
+    const out: Finding[] = []
+    for (const el of els as HTMLElement[]) {
+      const cs = getComputedStyle(el)
+      // Mirror the product's own visibility filter (getAllInteractiveElements).
+      if (cs.display === 'none' || cs.visibility === 'hidden') continue
+      const rect = el.getBoundingClientRect()
+      // sr-only collapsed / zero-box: not a real tap target (see header).
+      if (rect.width <= 1 || rect.height <= 1) continue
+      const tag = el.tagName.toLowerCase()
+      // WCAG 2.5.5 inline-prose-link exemption.
+      const inlineProseLink =
+        tag === 'a' &&
+        cs.display === 'inline' &&
+        el.getAttribute('role') !== 'button'
+      if (inlineProseLink) continue
+      out.push({
+        tag,
+        testid: el.getAttribute('data-testid'),
+        aria: el.getAttribute('aria-label'),
+        cls: (el.getAttribute('class') || '').slice(0, 90),
+        w: Math.round(rect.width),
+        h: Math.round(rect.height),
+      })
+    }
+    return out
+  }, selectors)
+}
+
+function describe(f: Finding): string {
+  const id = f.testid
+    ? `[data-testid="${f.testid}"]`
+    : f.aria
+      ? `[aria-label="${f.aria}"]`
+      : f.cls
+        ? `.${f.cls.split(/\s+/).slice(0, 2).join('.')}`
+        : ''
+  return `${f.tag}${id} ${f.w}×${f.h}`
+}
+
+const selectors = [...INTERACTIVE_SELECTORS]
+
+for (const route of ROUTES) {
+  test(`every interactive element clears ${FLOOR}px at 375px — ${route}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(VIEWPORT)
+    await page.goto(route, { waitUntil: 'networkidle', timeout: 60_000 })
+    // Display-font reflow settles before we measure text-driven controls (L134).
+    await page.evaluate(() => document.fonts.ready)
+    await page.waitForTimeout(500)
+
+    const found = await measureInteractiveTargets(page, selectors)
+
+    // Non-vacuity: a blank/broken page (zero interactive elements) must not pass
+    // green. Every routed page has at least a nav/theme/menu control.
+    expect(
+      found.length,
+      `${route}: found 0 measurable interactive elements — page did not render`
+    ).toBeGreaterThan(0)
+
+    const failing = found.filter(f => f.w < FLOOR || f.h < FLOOR)
+    expect(
+      failing,
+      `${route}: ${failing.length} sub-${FLOOR}px target(s): ` +
+        failing.map(describe).join('; ')
+    ).toEqual([])
+  })
+}

--- a/frontend/e2e/touch-targets.smoke.ts
+++ b/frontend/e2e/touch-targets.smoke.ts
@@ -1,5 +1,8 @@
 import { test, expect, type Page } from '@playwright/test'
-import { INTERACTIVE_SELECTORS } from '../src/utils/touchTargetUtils'
+import {
+  INTERACTIVE_SELECTORS,
+  MIN_TOUCH_TARGET_PX,
+} from '../src/utils/touchTargetUtils'
 
 /* Dual-engine 44×44px touch-target tripwire (#887, epic #888 "Epic G" Sprint 3).
  *
@@ -32,7 +35,7 @@ import { INTERACTIVE_SELECTORS } from '../src/utils/touchTargetUtils'
  *    defects are 30–42px (well above 1px), so this can't mask one.
  */
 
-const FLOOR = 44 // px, WCAG 2.5.5 AAA / mobile handoff target
+const FLOOR = MIN_TOUCH_TARGET_PX // px, WCAG 2.5.5 / mobile handoff floor
 const VIEWPORT = { width: 375, height: 812 } // iPhone-class portrait
 
 // One concrete instance of every route shape in App.tsx (the #885 audit set).
@@ -68,7 +71,7 @@ interface Finding {
 
 async function measureInteractiveTargets(
   page: Page,
-  selectors: string[]
+  selectors: readonly string[]
 ): Promise<Finding[]> {
   return page.evaluate(sels => {
     const els = Array.from(document.querySelectorAll(sels.join(', ')))
@@ -111,8 +114,6 @@ function describe(f: Finding): string {
   return `${f.tag}${id} ${f.w}×${f.h}`
 }
 
-const selectors = [...INTERACTIVE_SELECTORS]
-
 for (const route of ROUTES) {
   test(`every interactive element clears ${FLOOR}px at 375px — ${route}`, async ({
     page,
@@ -123,7 +124,7 @@ for (const route of ROUTES) {
     await page.evaluate(() => document.fonts.ready)
     await page.waitForTimeout(500)
 
-    const found = await measureInteractiveTargets(page, selectors)
+    const found = await measureInteractiveTargets(page, INTERACTIVE_SELECTORS)
 
     // Non-vacuity: a blank/broken page (zero interactive elements) must not pass
     // green. Every routed page has at least a nav/theme/menu control.

--- a/frontend/e2e/touch-targets.smoke.ts
+++ b/frontend/e2e/touch-targets.smoke.ts
@@ -41,23 +41,34 @@ const VIEWPORT = { width: 375, height: 812 } // iPhone-class portrait
 // One concrete instance of every route shape in App.tsx (the #885 audit set).
 // District 61 / club 01479548 / division A / region 1 are representative; the
 // three defect families are component-level, so params don't change them.
-const ROUTES = [
-  '/',
-  '/district/61',
-  '/district/61/clubs',
-  '/district/61/changes',
-  '/district/61/divisions',
-  '/district/61/rankings',
-  '/district/61/trends',
-  '/district/61/analytics',
-  '/district/61/division/A',
-  '/district/61/club/01479548',
-  '/club/01479548',
-  '/history',
-  '/methodology',
-  '/awards',
-  '/regions',
-  '/region/1',
+//
+// `mustRender` is a CONTENT sentinel (not chrome): a selector for a control the
+// page is REQUIRED to mount before we measure. It does double duty — (1) it is
+// the content-ready wait (so we don't measure a half-rendered page, cf.
+// regions-legibility.smoke), and (2) it closes the vacuous-green hole: nav/theme
+// chrome renders even when a route's real content fails to load, so a bare
+// `found.length > 0` would pass having measured nothing relevant. Pinning the
+// family-bearing control means "the toolbar/finder #886 fixed didn't render" is
+// a loud red, not a silent pass. Routes the #885 audit found clean (no family
+// control) carry no sentinel — they still get the ≥1 non-vacuity floor.
+const CHIP_SELECT = '[data-testid$="-chip-select"]' // family A (shared toolbar)
+const ROUTES: { path: string; mustRender?: string }[] = [
+  { path: '/', mustRender: CHIP_SELECT }, // families A + B
+  { path: '/district/61', mustRender: CHIP_SELECT },
+  { path: '/district/61/clubs', mustRender: CHIP_SELECT },
+  { path: '/district/61/changes', mustRender: CHIP_SELECT },
+  { path: '/district/61/divisions', mustRender: CHIP_SELECT },
+  { path: '/district/61/rankings', mustRender: CHIP_SELECT },
+  { path: '/district/61/trends', mustRender: CHIP_SELECT },
+  { path: '/district/61/analytics', mustRender: CHIP_SELECT },
+  { path: '/district/61/division/A' },
+  { path: '/district/61/club/01479548' },
+  { path: '/club/01479548' },
+  { path: '/history' },
+  { path: '/methodology' },
+  { path: '/awards' },
+  { path: '/regions', mustRender: '.region-finder__chip' }, // family C
+  { path: '/region/1' },
 ]
 
 interface Finding {
@@ -114,12 +125,24 @@ function describe(f: Finding): string {
   return `${f.tag}${id} ${f.w}×${f.h}`
 }
 
-for (const route of ROUTES) {
-  test(`every interactive element clears ${FLOOR}px at 375px — ${route}`, async ({
+for (const { path, mustRender } of ROUTES) {
+  test(`every interactive element clears ${FLOOR}px at 375px — ${path}`, async ({
     page,
   }) => {
+    // The global config timeout (30s) governs the whole test; raise it so the
+    // 60s goto budget is actually reachable on a cold preview hitting the CDN.
+    test.setTimeout(90_000)
     await page.setViewportSize(VIEWPORT)
-    await page.goto(route, { waitUntil: 'networkidle', timeout: 60_000 })
+    await page.goto(path, { waitUntil: 'networkidle', timeout: 60_000 })
+
+    // Wait for the page's REQUIRED content control to mount before measuring —
+    // this is both the content-ready gate and the anti-vacuous-green guard.
+    if (mustRender) {
+      await page
+        .locator(mustRender)
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 })
+    }
     // Display-font reflow settles before we measure text-driven controls (L134).
     await page.evaluate(() => document.fonts.ready)
     await page.waitForTimeout(500)
@@ -130,13 +153,13 @@ for (const route of ROUTES) {
     // green. Every routed page has at least a nav/theme/menu control.
     expect(
       found.length,
-      `${route}: found 0 measurable interactive elements — page did not render`
+      `${path}: found 0 measurable interactive elements — page did not render`
     ).toBeGreaterThan(0)
 
     const failing = found.filter(f => f.w < FLOOR || f.h < FLOOR)
     expect(
       failing,
-      `${route}: ${failing.length} sub-${FLOOR}px target(s): ` +
+      `${path}: ${failing.length} sub-${FLOOR}px target(s): ` +
         failing.map(describe).join('; ')
     ).toEqual([])
   })

--- a/frontend/src/hooks/useTouchTarget.ts
+++ b/frontend/src/hooks/useTouchTarget.ts
@@ -8,7 +8,10 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { INTERACTIVE_SELECTORS } from '../utils/touchTargetUtils'
+import {
+  INTERACTIVE_SELECTORS,
+  MIN_TOUCH_TARGET_PX,
+} from '../utils/touchTargetUtils'
 
 export interface TouchTargetResult {
   width: number
@@ -30,7 +33,7 @@ export interface TouchTargetValidationOptions {
  */
 export function useTouchTarget(options: TouchTargetValidationOptions = {}) {
   const {
-    minSize = 44,
+    minSize = MIN_TOUCH_TARGET_PX,
     includeMargin = true,
     checkOnResize = true,
     onViolation,

--- a/frontend/src/hooks/useTouchTarget.ts
+++ b/frontend/src/hooks/useTouchTarget.ts
@@ -8,6 +8,7 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { INTERACTIVE_SELECTORS } from '../utils/touchTargetUtils'
 
 export interface TouchTargetResult {
   width: number
@@ -91,22 +92,8 @@ export function useTouchTarget(options: TouchTargetValidationOptions = {}) {
    */
   const validateAllTouchTargets = useCallback(
     (container: HTMLElement = document.body): TouchTargetResult[] => {
-      const interactiveSelectors = [
-        'button',
-        'a[href]',
-        'input:not([type="hidden"])',
-        'select',
-        'textarea',
-        '[tabindex]:not([tabindex="-1"])',
-        '[role="button"]',
-        '[role="link"]',
-        '[role="menuitem"]',
-        '[role="tab"]',
-        '[onclick]',
-      ]
-
       const elements = container.querySelectorAll(
-        interactiveSelectors.join(', ')
+        INTERACTIVE_SELECTORS.join(', ')
       )
       const results: TouchTargetResult[] = []
 

--- a/frontend/src/utils/touchTargetUtils.ts
+++ b/frontend/src/utils/touchTargetUtils.ts
@@ -6,6 +6,29 @@
  */
 
 /**
+ * The single selector set defining what counts as an interactive (tappable)
+ * element. Exported as the one source of truth so every consumer agrees:
+ * `getAllInteractiveElements` (runtime audit), `useTouchTarget`
+ * (`validateAllTouchTargets`), AND the dual-engine 44px touch-target tripwire
+ * smoke (`frontend/e2e/touch-targets.smoke.ts`, #887) all import this array.
+ * Drift between the product and its guard is the failure mode this prevents
+ * (R20 spirit — source the partition from the tool itself, not a re-typed glob).
+ */
+export const INTERACTIVE_SELECTORS = [
+  'button',
+  'a[href]',
+  'input:not([type="hidden"])',
+  'select',
+  'textarea',
+  '[tabindex]:not([tabindex="-1"])',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="menuitem"]',
+  '[role="tab"]',
+  '[onclick]',
+] as const
+
+/**
  * Utility function to check if an element is interactive
  */
 export function isInteractiveElement(element: HTMLElement): boolean {
@@ -32,21 +55,7 @@ export function isInteractiveElement(element: HTMLElement): boolean {
 export function getAllInteractiveElements(
   container: HTMLElement = document.body
 ): HTMLElement[] {
-  const interactiveSelectors = [
-    'button',
-    'a[href]',
-    'input:not([type="hidden"])',
-    'select',
-    'textarea',
-    '[tabindex]:not([tabindex="-1"])',
-    '[role="button"]',
-    '[role="link"]',
-    '[role="menuitem"]',
-    '[role="tab"]',
-    '[onclick]',
-  ]
-
-  const elements = container.querySelectorAll(interactiveSelectors.join(', '))
+  const elements = container.querySelectorAll(INTERACTIVE_SELECTORS.join(', '))
   return Array.from(elements).filter(element => {
     const htmlElement = element as HTMLElement
     const computedStyle = window.getComputedStyle(htmlElement)

--- a/frontend/src/utils/touchTargetUtils.ts
+++ b/frontend/src/utils/touchTargetUtils.ts
@@ -29,6 +29,14 @@ export const INTERACTIVE_SELECTORS = [
 ] as const
 
 /**
+ * The minimum tap-target dimension in px (WCAG 2.5.5 / mobile handoff floor).
+ * One source of truth for the policy: `useTouchTarget`'s default `minSize` and
+ * the dual-engine touch-target tripwire (`frontend/e2e/touch-targets.smoke.ts`,
+ * #887) both use it, so the guard and the runtime check the same number.
+ */
+export const MIN_TOUCH_TARGET_PX = 44
+
+/**
  * Utility function to check if an element is interactive
  */
 export function isInteractiveElement(element: HTMLElement): boolean {

--- a/tasks/lessons/141-a-page-sweep-tripwire-passes-vacuously-on-nav-chrome-gate-each-route-on-a-content-sentinel.md
+++ b/tasks/lessons/141-a-page-sweep-tripwire-passes-vacuously-on-nav-chrome-gate-each-route-on-a-content-sentinel.md
@@ -1,0 +1,73 @@
+---
+id: '141'
+category: lesson
+tags: [tests, playwright, e2e, verification, frontend, accessibility]
+auto_load: true
+date: 2026-05-29
+issues: [887, 888]
+---
+
+# Lesson 141 — A page-sweep tripwire passes vacuously on nav chrome; gate each route on a content sentinel, not a bare element count
+
+**Date:** 2026-05-29
+**Issue:** #887 (epic #888 Sprint 3 — touch-target tripwire)
+**PR:** [#944](https://github.com/taverns-red/toast-stats/pull/944)
+
+## What happened
+
+The Sprint-3 deliverable is a permanent dual-engine smoke that sweeps every
+routed page, queries every interactive element, and asserts each clears the
+44px touch-target floor (the #886 fix it locks in). My first cut guarded against
+a blank page with `expect(found.length).toBeGreaterThan(0)` — "if we measured at
+least one control, the page rendered."
+
+Fresh-context review caught the hole: the app shell (header, theme toggle,
+hamburger) renders on **every** route, _including_ when a route's real content
+fails to load. So a route whose family-A chip-select toolbar never mounted —
+the exact control the tripwire exists to guard — would still satisfy
+`found.length > 0` from nav chrome alone and pass **green having measured
+nothing relevant**. The sweep's breadth was an illusion: it counted chrome and
+called it coverage.
+
+## The transferable lesson
+
+**A page-sweep guard (touch-targets, a11y axe, contrast, coverage-by-route)
+that asserts "I found ≥1 thing" is vacuous, because shared chrome guarantees ≥1
+thing on a route that otherwise failed to render.** Breadth of the _selector_
+does not prove breadth of the _content_. Gate each route on a **content
+sentinel** — a locator for a control the page is _required_ to mount — and
+`waitFor` it before measuring. The sentinel does double duty: it's the
+content-ready wait (don't measure a half-painted page, cf.
+[[133-proxy-the-prod-cdn-and-give-each-git-state-its-own-served-dir]] /
+regions-legibility.smoke) **and** the anti-vacuous-green guard ("the toolbar
+didn't render" becomes a loud red instead of a silent pass).
+
+Here: the family-bearing routes pin `[data-testid$="-chip-select"]` (family A)
+or `.region-finder__chip` (family C); routes the #885 audit found clean keep
+only the ≥1 floor. The empirical proof the guard is non-vacuous is still the
+red run — a pre-#886 build must red the routes that carry the defect — but the
+sentinel is what stops a _future_ "controls stopped rendering" change from
+sailing through green.
+
+## How to apply
+
+- Writing a sweep that loops over pages/routes and asserts a property of "all
+  matched elements"? Ask: _what renders even when this page is broken?_ If the
+  answer is "nav/layout chrome," your non-vacuity floor must be a per-page
+  content sentinel, not a global count.
+- Make the sentinel the same selector family as the thing under test (the
+  control #886 fixed), so "didn't render" and "rendered wrong" both red.
+- This is the breadth-cousin of [[107-a-deferred-async-insert-cls-source-reactivates-the-moment-its-data-gets-populated]]:
+  a guard keyed off "data is usually present" silently expires the day it isn't.
+
+## Related
+
+- [[138-an-inset-0-overlay-is-sized-to-the-padding-box-a-border-steals-from-the-touch-target]]
+  and [[111-native-select-ignores-min-height-in-webkit-defeating-touch-targets]]
+  — the box-model / WebKit-native-control defects this tripwire guards; both are
+  caught only by a live `boundingBox()` in BOTH engines, never a className.
+- [[135-a-coverage-gate-fails-a-filtered-subset-run-zero-thresholds-in-a-flake-harness]],
+  [[136-a-flake-detector-must-not-inherit-the-stability-cap-it-measures]] — same
+  family: a detector that can't reproduce the failure reports a reassuring green.
+- `tasks/rules.md` R20 — the smoke imports `INTERACTIVE_SELECTORS` /
+  `MIN_TOUCH_TARGET_PX` from the product so the guard can't drift from the app.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -111,3 +111,4 @@
 - **138** [css, frontend, accessibility, verification, playwright, mobile] — `scroll-margin-top` belongs on the element that holds the anchor id, not a styled child (#877, #880)
 - **139** [css, frontend, accessibility, router, verification, playwright, mobile] — A TOC-anchor jump fired from inside a scroll-locked sheet has three independent scroll-clobbering traps; only live measurement separates them (#878, #880)
 - **140** [css, frontend, refactoring, simplify, process] — A deliberately-isolated surface namespace outranks a DRY "reuse" flag; a small typographic duplication is cheaper than cross-surface coupling (#879, #880)
+- **141** [tests, playwright, e2e, verification, frontend, accessibility] — A page-sweep tripwire passes vacuously on nav chrome; gate each route on a content sentinel, not a bare element count (#887, #888)

--- a/tasks/plan-887-touch-target-tripwire.md
+++ b/tasks/plan-887-touch-target-tripwire.md
@@ -1,0 +1,45 @@
+# Plan — #887 Epic G Sprint 3: dual-engine 44px touch-target tripwire
+
+**Epic:** #888. **Predecessor:** #886 (CLOSED — fixed families A/B/C). **Branch:** `sprint-887-touch-target-tripwire` (from `origin/main` @ e02bc698 — R19).
+
+## Goal
+
+A _permanent_ regression guard so every interactive element on every routed page
+keeps the 44×44px floor in **both** Chromium and WebKit. Locks in #886; catches a
+future regression of families A (chip-select overlays), B/C (region chips), or any
+new sub-44 control.
+
+## Design
+
+1. **Drift-proof selector source (R20 spirit).** Export `INTERACTIVE_SELECTORS`
+   from `frontend/src/utils/touchTargetUtils.ts`; have `getAllInteractiveElements`
+   and `useTouchTarget` both consume it (kills the existing duplicate). The e2e
+   smoke imports the same const → audit/product/test cannot drift.
+2. **`frontend/e2e/touch-targets.smoke.ts`** — drives the 15 route shapes from the
+   #885 audit at 375×812, in both engines (existing `smoke`=Chromium /
+   `webkit`=Safari projects). On each route:
+   - inject `INTERACTIVE_SELECTORS`, query visible (display≠none, visibility≠hidden)
+     interactive elements (mirrors product filter).
+   - measure `getBoundingClientRect()`; flag any < 44 in either dimension (L108/134:
+     real geometry, not `toBeVisible`/className).
+   - **Exempt** inline prose `<a>` (computed `display:inline`, not role=button) per
+     WCAG 2.5.5 / audit §method; **skip** sr-only collapsed elements (≤1px box —
+     `.tm-skip-link` is 1×1 off-screen at rest).
+   - **Non-vacuity floor:** assert ≥1 interactive element measured per route (a
+     blank/broken page must not pass green).
+   - settle on `document.fonts.ready` + rankings-table visible before measuring.
+3. **CI wiring** — add a step to `pr-preview.yml` running the smoke against the
+   deployed preview in both projects (mirrors the regions-legibility step, #713:
+   install chromium+webkit first).
+
+## Falsifiability (red proof)
+
+Tripwire is a guard on already-fixed code, so the "red" is demonstrated by running
+it against a **pre-#886 build** (lesson 133: serve each git state) → must flag
+families A/B/C (45 instances). Green = current build/preview, 0 failures, both
+engines. Both recorded in the evidence comment.
+
+## Out of scope
+
+No product UI change (the floor already ships via #886). No new route coverage
+beyond the audited 15 shapes (component-level families; params don't change them).


### PR DESCRIPTION
Epic **#888** (Mobile UX audit — Epic G) **Sprint 3**. Builds the *permanent* dual-engine regression guard that locks in Sprint 2's fix (#886). Refs #887 (closed by the sprint runner after verification — no auto-close keyword, per lesson 106).

## What
A Playwright smoke (`frontend/e2e/touch-targets.smoke.ts`) that drives the 15 routed page shapes from the #885 audit at **375×812** in **both** Chromium and WebKit, measures every interactive element's live `boundingBox()`, and fails if any clears **<44px** in either dimension — the WCAG 2.5.5 / mobile-handoff floor that #886 lifted families A/B/C to.

- **Both engines** (no `--project` flag → `smoke`=Chromium + `webkit`=Safari): WebKit ignores `min-height` on a native `<select>` without `appearance:none` (lesson 111) and an `inset-0` overlay is 2px short of a bordered label (lesson 138) — Chromium-only would be blind.
- **Real geometry, not className** (L108/134/138): a jsdom contract test asserts `min-h-[44px]` is *present*; only the live box proves the pixels.
- **Drift-proof:** the selector set + the 44px floor are imported from the product's own `INTERACTIVE_SELECTORS` / `MIN_TOUCH_TARGET_PX` (one source of truth — `useTouchTarget` and `getAllInteractiveElements` consume the same consts; R20 spirit).
- **Non-vacuous:** family-bearing routes pin a `mustRender` content sentinel (chip-select / region-finder) so "the control didn't mount" reds loudly instead of passing on bare nav chrome.
- **CI:** runs on every preview in both engines (`pr-preview.yml`), beside the existing legibility smoke.

## Falsifiability (red → green)
- **Red:** a local pre-#886 build reds `/` (A+B), `/changes` (A), `/regions` (C) in both engines (e.g. `button.region-finder__chip` 41×44, matching the audit).
- **Green:** current build passes **32/32** (16 routes × 2 engines) in both Chromium and WebKit.

## Scope
No product UI change — the floor already ships via #886. Test infra + a behavior-preserving selector/const refactor (`touchTargets` unit suite stays 12/12) + CI wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)