### PR TITLE
feat(chrome): drop full footer on mobile; version+license behind 'About ▾' in hamburger (#889)

### DIFF
--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -1,17 +1,26 @@
 /* AppShell behavior contract — Epic #352 / Issue #354. */
 
 import React from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AppShell from '../../components/AppShell/AppShell'
 import { DarkModeProvider } from '../../contexts/DarkModeContext'
+import { useIsMobile } from '../../hooks/useIsMobile'
 
 // Mock the CDN service the CommandPalette (#422) lazy-fetches when the
 // shell mounts — keeps these tests isolated from the network layer.
 vi.mock('../../services/cdn', () => ({
   fetchCdnRankings: vi.fn().mockResolvedValue({ rankings: [], date: '' }),
+}))
+
+// #889: the footer is dropped at <768px (its meta moves to the nav "About"
+// disclosure). jsdom matchMedia would resolve useIsMobile to false anyway;
+// mocking it keeps the breakpoint explicit and lets the mobile case assert
+// the drop deterministically.
+vi.mock('../../hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(() => false),
 }))
 
 const renderShell = (initialPath = '/') => {
@@ -52,6 +61,8 @@ const renderShell = (initialPath = '/') => {
 }
 
 describe('AppShell (#354)', () => {
+  beforeEach(() => vi.mocked(useIsMobile).mockReturnValue(false))
+
   describe('top bar', () => {
     it('renders the brand mark with "TS" text', () => {
       renderShell()
@@ -215,6 +226,22 @@ describe('AppShell (#354)', () => {
       renderShell()
       const main = screen.getByRole('main')
       expect(main).toHaveAttribute('id', 'main-content')
+    })
+  })
+
+  describe('mobile footer chrome (#889)', () => {
+    it('drops the full footer at <768px', async () => {
+      const { useIsMobile } = await import('../../hooks/useIsMobile')
+      vi.mocked(useIsMobile).mockReturnValue(true)
+      renderShell()
+      expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument()
+    })
+
+    it('keeps the footer at desktop widths', async () => {
+      const { useIsMobile } = await import('../../hooks/useIsMobile')
+      vi.mocked(useIsMobile).mockReturnValue(false)
+      renderShell()
+      expect(screen.getByRole('contentinfo')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/AppShell/AppMeta.tsx
+++ b/frontend/src/components/AppShell/AppMeta.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+
+declare const __APP_VERSION__: string
+
+/* The site meta strip — attribution, data source, license, build version.
+   Rendered by the desktop footer (AppShellFooter) and, on mobile where the
+   footer is dropped, behind the "About ▾" nav disclosure (AppShellTopBar,
+   #889). Single source so the version logic and license URL never drift. */
+
+const AppMeta: React.FC = () => {
+  const version =
+    typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'
+
+  return (
+    <>
+      <div>
+        Toast Stats · ts.taverns.red · A{' '}
+        <a
+          href="https://taverns.red?utm_source=toast-stats&utm_medium=footer"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="app-shell-footer__link"
+        >
+          Red Taverns
+        </a>{' '}
+        production
+      </div>
+      <div className="app-shell-footer__meta">
+        <span data-testid="app-version">
+          Data:{' '}
+          <a
+            href="https://dashboards.toastmasters.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="app-shell-footer__link"
+          >
+            dashboards.toastmasters.org
+          </a>
+          {' · '}
+          <a
+            href="https://github.com/taverns-red/toast-stats/blob/main/LICENSE"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="app-shell-footer__link"
+          >
+            MIT License
+          </a>
+          {' · '}
+          {version}
+        </span>
+      </div>
+    </>
+  )
+}
+
+export default AppMeta

--- a/frontend/src/components/AppShell/AppShell.tsx
+++ b/frontend/src/components/AppShell/AppShell.tsx
@@ -4,6 +4,7 @@ import AppShellTopBar from './AppShellTopBar'
 import AppShellFooter from './AppShellFooter'
 import CommandPalette from './CommandPalette'
 import { useGoogleAnalytics } from '../../hooks/useGoogleAnalytics'
+import { useIsMobile } from '../../hooks/useIsMobile'
 
 /* Per Epic #352: no notifications/help/avatar (no auth today),
    no Regions/Awards "soon" stubs. ThemeToggle now lives in the top
@@ -15,6 +16,11 @@ import { useGoogleAnalytics } from '../../hooks/useGoogleAnalytics'
 
 const AppShell: React.FC = () => {
   useGoogleAnalytics()
+
+  // <768px: drop the full footer chrome to recover above-the-fold space on
+  // short pages (CC-11, Epic H #889). Its version/license meta moves to the
+  // nav "About ▾" disclosure. Desktop keeps the footer.
+  const isMobile = useIsMobile(768)
 
   const [paletteOpen, setPaletteOpen] = useState(false)
   const closePalette = useCallback(() => setPaletteOpen(false), [])
@@ -39,7 +45,7 @@ const AppShell: React.FC = () => {
       <main id="main-content" className="app-shell__main">
         <Outlet />
       </main>
-      <AppShellFooter />
+      {!isMobile && <AppShellFooter />}
       <CommandPalette isOpen={paletteOpen} onClose={closePalette} />
     </div>
   )

--- a/frontend/src/components/AppShell/AppShellFooter.tsx
+++ b/frontend/src/components/AppShell/AppShellFooter.tsx
@@ -1,57 +1,18 @@
 import React from 'react'
-
-declare const __APP_VERSION__: string
+import AppMeta from './AppMeta'
 
 /* Footer carries the meta strip (license, version, data source) only.
    The ThemeToggle moved to AppShellTopBar in #565 — chrome-level
-   controls all live in the header now. */
+   controls all live in the header now. On mobile (<768px) the footer is
+   dropped entirely and AppMeta surfaces behind the nav "About ▾"
+   disclosure instead (#889); AppShell gates the render. */
 
-const AppShellFooter: React.FC = () => {
-  const version =
-    typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'
-
-  return (
-    <footer role="contentinfo" className="app-shell-footer">
-      <div className="app-shell-footer__inner">
-        <div>
-          Toast Stats · ts.taverns.red · A{' '}
-          <a
-            href="https://taverns.red?utm_source=toast-stats&utm_medium=footer"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="app-shell-footer__link"
-          >
-            Red Taverns
-          </a>{' '}
-          production
-        </div>
-        <div className="app-shell-footer__meta">
-          <span data-testid="app-version">
-            Data:{' '}
-            <a
-              href="https://dashboards.toastmasters.org"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="app-shell-footer__link"
-            >
-              dashboards.toastmasters.org
-            </a>
-            {' · '}
-            <a
-              href="https://github.com/taverns-red/toast-stats/blob/main/LICENSE"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="app-shell-footer__link"
-            >
-              MIT License
-            </a>
-            {' · '}
-            {version}
-          </span>
-        </div>
-      </div>
-    </footer>
-  )
-}
+const AppShellFooter: React.FC = () => (
+  <footer role="contentinfo" className="app-shell-footer">
+    <div className="app-shell-footer__inner">
+      <AppMeta />
+    </div>
+  </footer>
+)
 
 export default AppShellFooter

--- a/frontend/src/components/AppShell/AppShellTopBar.tsx
+++ b/frontend/src/components/AppShell/AppShellTopBar.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { NavLink, Link, useLocation } from 'react-router-dom'
 import ThemeToggle from '../ThemeToggle'
+import AppMeta from './AppMeta'
+import { useIsMobile } from '../../hooks/useIsMobile'
 
 const NAV_ITEMS = [
   { to: '/', label: 'Districts', end: true },
@@ -20,6 +22,11 @@ const AppShellTopBar: React.FC = () => {
   const closeNav = useCallback(() => setNavOpen(false), [])
   const headerRef = useRef<HTMLElement>(null)
   const location = useLocation()
+
+  // <768px the footer chrome is dropped (#889); its version/license meta
+  // moves here behind a collapsed-by-default "About ▾" disclosure. Desktop
+  // keeps the footer, so this control is absent there entirely.
+  const isMobile = useIsMobile(768)
 
   // Close on route change — covers browser back/forward, not just link taps
   // (link taps also call closeNav). React's sanctioned "adjust state when a
@@ -118,6 +125,16 @@ const AppShellTopBar: React.FC = () => {
             {item.label}
           </NavLink>
         ))}
+        {isMobile && (
+          <details className="app-shell-nav-about">
+            <summary className="app-shell-nav__link app-shell-nav-about__summary">
+              About
+            </summary>
+            <div className="app-shell-nav-about__content">
+              <AppMeta />
+            </div>
+          </details>
+        )}
       </nav>
 
       <div className="app-shell-tools">

--- a/frontend/src/components/AppShell/__tests__/AppShellTopBar.about.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/AppShellTopBar.about.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * AppShellTopBar mobile "About ▾" disclosure (#889).
+ *
+ * Epic H Sprint 1: at <768px the full footer chrome is dropped and its
+ * version + license meta is surfaced behind a tappable "About ▾" inside
+ * the hamburger nav. Desktop keeps the footer and shows no About control.
+ *
+ * These tests cover the disclosure's *presence and contents* per
+ * breakpoint. The no-overflow / above-the-fold proof lives in the
+ * Playwright preview smoke (jsdom has no layout — lesson 066).
+ */
+
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { DarkModeProvider } from '../../../contexts/DarkModeContext'
+
+vi.mock('../../../hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(() => false),
+}))
+
+import { useIsMobile } from '../../../hooks/useIsMobile'
+import AppShellTopBar from '../AppShellTopBar'
+
+afterEach(() => cleanup())
+beforeEach(() => vi.mocked(useIsMobile).mockReturnValue(false))
+
+const renderBar = () =>
+  render(
+    <DarkModeProvider>
+      <MemoryRouter>
+        <AppShellTopBar />
+      </MemoryRouter>
+    </DarkModeProvider>
+  )
+
+describe('AppShellTopBar "About ▾" disclosure (#889)', () => {
+  describe('mobile (<768px)', () => {
+    beforeEach(() => vi.mocked(useIsMobile).mockReturnValue(true))
+
+    it('renders an "About" disclosure inside the primary nav', () => {
+      renderBar()
+      const nav = screen.getByRole('navigation', { name: /primary/i })
+      const details = within(nav).getByText('About').closest('details')
+      expect(details).not.toBeNull()
+    })
+
+    it('keeps the disclosure collapsed by default', () => {
+      renderBar()
+      const nav = screen.getByRole('navigation', { name: /primary/i })
+      const details = within(nav).getByText('About').closest('details')
+      expect(details).not.toHaveAttribute('open')
+    })
+
+    it('exposes the version + MIT License inside the disclosure', () => {
+      renderBar()
+      const nav = screen.getByRole('navigation', { name: /primary/i })
+      const details = within(nav).getByText('About').closest('details')!
+      expect(within(details).getByTestId('app-version')).toBeInTheDocument()
+      expect(
+        within(details).getByRole('link', { name: /mit license/i })
+      ).toBeInTheDocument()
+      // Version slot is non-empty and well-formed (no double-v / bare-v).
+      const text = details.textContent ?? ''
+      expect(text).toMatch(/MIT License\s*·\s*(?:v\d|dev)/i)
+      expect(text).not.toMatch(/v\s*v/i)
+      expect(text).not.toMatch(/vdev/i)
+    })
+  })
+
+  describe('desktop (≥768px)', () => {
+    it('renders no "About" control in the bar (footer carries the meta)', () => {
+      renderBar()
+      expect(screen.queryByText('About')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('app-version')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -188,6 +188,58 @@
     vertical-align: 1px;
   }
 
+  /* "About ▾" nav disclosure (#889) — mobile-only fold for the version +
+     license meta the dropped footer used to carry. The <summary> reuses
+     .app-shell-nav__link for the nav-item look + >=44px touch target; we
+     strip the native marker and supply our own rotating caret so it reads
+     "About ▾". Rendered only at <768px (JS-gated in AppShellTopBar), so the
+     desktop nav is untouched. */
+  .app-shell-nav-about {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .app-shell-nav-about__summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 44px;
+    list-style: none;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .app-shell-nav-about__summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .app-shell-nav-about__summary::after {
+    content: '▾';
+    font-size: 12px;
+    line-height: 1;
+    color: var(--ink-3);
+    transition: transform 150ms ease;
+  }
+
+  .app-shell-nav-about[open] .app-shell-nav-about__summary::after {
+    transform: rotate(180deg);
+  }
+
+  .app-shell-nav-about__summary:focus-visible {
+    outline: 2px solid var(--link);
+    outline-offset: 2px;
+  }
+
+  .app-shell-nav-about__content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 12px 12px;
+    font-family: var(--sans);
+    font-size: 12px;
+    color: var(--ink-3);
+  }
+
   .app-shell-tools {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Epic H Sprint 1 (CC-11) — recover above-the-fold space on mobile by dropping the always-on footer chrome, relocating its meta behind a tappable **About ▾** in the hamburger nav.

Closes-via-runner: #889 (issue closed by the sprint-runner after preview verification, not by this PR — preserves the tick-before-close ordering, L106/#626).

## What changed
- **`AppMeta`** (new) — single source for the footer meta strip (Red Taverns attribution, data source, MIT License, build version). Kills the version-logic / license-URL drift risk between the two render sites.
- **`AppShell`** — gates `<AppShellFooter/>` on `!useIsMobile(768)`: the footer is *removed from the DOM* on mobile (true space recovery, not a CSS visual hide).
- **`AppShellTopBar`** — mobile-only native `<details>` "About ▾" inside the primary nav, rendering `<AppMeta/>`. Collapsed by default; `<summary>` reuses `.app-shell-nav__link` for the nav-item look + ≥44px touch target; native marker stripped, CSS rotating caret supplies the ▾.
- **`app-shell.css`** — only *adds* new `.app-shell-nav-about*` rules; no shared rule edited (cardinality-safe, L120/L131). Tokens `--ink-2/-3`, `--link` are all dark-safe.

## Acceptance criteria
- [x] Mobile (<768px): footer chrome removed; About ▾ exposes version + license (+ data source + attribution — nothing lost).
- [x] Desktop footer unchanged; no About control in the bar.
- [x] Tests added (TDD Red→Green), no assertion pinning.
- [ ] 375px Chromium + WebKit smoke — run on preview channel (evidence to follow).

## Verification
- Full frontend suite green (3121 tests). TDD trail: Red `2447c30`, Green `174cfde`.
- Fresh-context review: APPROVE-WITH-NITS (no High/Medium). Nits cosmetic (BEM naming).
- Dual-engine 375px Playwright smoke on the PR preview pending (see evidence comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)