### PR TITLE
feat(chrome): collapse page header sub-line into title on mobile (#890)

### DIFF
--- a/frontend/src/components/DistrictDetailHeader.tsx
+++ b/frontend/src/components/DistrictDetailHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { DataControlsBar } from './DataControlsBar'
 import { HeaderActionsMenu } from './HeaderActionsMenu'
-import { formatProgramYearShort } from '../utils/programYear'
+import { ProgramYearTitleSuffix } from './ProgramYearTitleSuffix'
 import type { ProgramYear } from '../utils/programYear'
 
 /* District detail page header (#358). Extracted from DistrictDetailPage so
@@ -50,17 +50,7 @@ export const DistrictDetailHeader: React.FC<DistrictDetailHeaderProps> = ({
           </p>
           <h1 className="district-detail-page-header__title">
             {districtName}
-            {/* #890 — mobile collapses the Program Year eyebrow into this
-                title-line suffix to recover ~80px above the fold. Hidden on
-                desktop via CSS (the eyebrow shows there instead); the full
-                label stays in the program-year picker (py-chip). */}
-            <span
-              className="district-detail-page-header__title-py"
-              data-testid="district-detail-title-py"
-            >
-              {' · PY '}
-              {formatProgramYearShort(selectedProgramYear.year)}
-            </span>
+            <ProgramYearTitleSuffix programYear={selectedProgramYear} />
           </h1>
           <p
             className="district-detail-page-header__lede"

--- a/frontend/src/components/DistrictDetailHeader.tsx
+++ b/frontend/src/components/DistrictDetailHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { DataControlsBar } from './DataControlsBar'
 import { HeaderActionsMenu } from './HeaderActionsMenu'
+import { formatProgramYearShort } from '../utils/programYear'
 import type { ProgramYear } from '../utils/programYear'
 
 /* District detail page header (#358). Extracted from DistrictDetailPage so
@@ -47,7 +48,20 @@ export const DistrictDetailHeader: React.FC<DistrictDetailHeaderProps> = ({
           <p className="district-detail-page-header__eyebrow">
             Program Year {selectedProgramYear.label.replace(/-/g, '–')}
           </p>
-          <h1 className="district-detail-page-header__title">{districtName}</h1>
+          <h1 className="district-detail-page-header__title">
+            {districtName}
+            {/* #890 — mobile collapses the Program Year eyebrow into this
+                title-line suffix to recover ~80px above the fold. Hidden on
+                desktop via CSS (the eyebrow shows there instead); the full
+                label stays in the program-year picker (py-chip). */}
+            <span
+              className="district-detail-page-header__title-py"
+              data-testid="district-detail-title-py"
+            >
+              {' · PY '}
+              {formatProgramYearShort(selectedProgramYear.year)}
+            </span>
+          </h1>
           <p
             className="district-detail-page-header__lede"
             data-testid="district-detail-lede"

--- a/frontend/src/components/ProgramYearTitleSuffix.tsx
+++ b/frontend/src/components/ProgramYearTitleSuffix.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { formatProgramYearShort } from '../utils/programYear'
+import type { ProgramYear } from '../utils/programYear'
+
+/* #890 — mobile-only compact program-year suffix for page-header titles.
+   Rendered inside the <h1>; CSS hides it on desktop (where the full
+   "Program Year …" eyebrow shows above the title) and reveals it <768px, where
+   the eyebrow is hidden — so the title line carries the year and recovers ~80px
+   above the fold. Shared by the district-detail and landing headers via the
+   single `.page-header__title-py` rule.
+
+   aria-hidden: the heading's accessible name stays the plain title (e.g.
+   "District 61" / "District Rankings"); the program year stays available to
+   assistive tech via the program-year picker (py-chip) and, on desktop, the
+   eyebrow. */
+export const ProgramYearTitleSuffix: React.FC<{ programYear: ProgramYear }> = ({
+  programYear,
+}) => (
+  <span
+    className="page-header__title-py"
+    data-testid="page-header-title-py"
+    aria-hidden="true"
+  >
+    {' · PY '}
+    {formatProgramYearShort(programYear.year)}
+  </span>
+)

--- a/frontend/src/components/__tests__/DistrictDetailHeader.test.tsx
+++ b/frontend/src/components/__tests__/DistrictDetailHeader.test.tsx
@@ -46,7 +46,7 @@ describe('DistrictDetailHeader DataControlsBar adoption (#531 #528)', () => {
 describe('DistrictDetailHeader mobile sub-line collapse (#890)', () => {
   it('renders a compact PY suffix inside the title (shown on mobile via CSS)', () => {
     renderHeader()
-    const suffix = screen.getByTestId('district-detail-title-py')
+    const suffix = screen.getByTestId('page-header-title-py')
     // Lives inside the H1 title so it collapses onto the title line on mobile.
     const title = screen.getByRole('heading', { level: 1 })
     expect(title).toContainElement(suffix)

--- a/frontend/src/components/__tests__/DistrictDetailHeader.test.tsx
+++ b/frontend/src/components/__tests__/DistrictDetailHeader.test.tsx
@@ -43,6 +43,25 @@ describe('DistrictDetailHeader DataControlsBar adoption (#531 #528)', () => {
   })
 })
 
+describe('DistrictDetailHeader mobile sub-line collapse (#890)', () => {
+  it('renders a compact PY suffix inside the title (shown on mobile via CSS)', () => {
+    renderHeader()
+    const suffix = screen.getByTestId('district-detail-title-py')
+    // Lives inside the H1 title so it collapses onto the title line on mobile.
+    const title = screen.getByRole('heading', { level: 1 })
+    expect(title).toContainElement(suffix)
+    expect(title).toHaveTextContent('District 61')
+    expect(suffix).toHaveTextContent(/·\s*PY\s*2025-26/)
+  })
+
+  it('keeps the full Program Year eyebrow in the DOM (shown on desktop)', () => {
+    renderHeader()
+    // Desktop sub-line unchanged — the eyebrow still carries the full label;
+    // CSS hides it <768px. Both surfaces render so neither width loses the PY.
+    expect(screen.getByText(/Program Year 2025–2026/)).toBeInTheDocument()
+  })
+})
+
 describe('DistrictDetailHeader action cluster consolidation (#676)', () => {
   it('moves Export + Share behind a single overflow menu, not inline buttons', () => {
     renderHeader()

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -26,6 +26,7 @@ import {
   getAvailableProgramYears,
   filterDatesByProgramYear,
   getMostRecentDateInProgramYear,
+  formatProgramYearShort,
 } from '../utils/programYear'
 import { DistrictRanking } from '../types/districts'
 import { arrayToCSV, downloadCSV } from '../utils/csvExport'
@@ -492,10 +493,19 @@ const DistrictsPage: React.FC = () => {
       <div className="districts-page">
         <div className="districts-page-header">
           <div className="districts-page-header__intro">
-            <p className="districts-page-header__eyebrow">
+            {/* #890 — `--py` scopes the mobile hide to the landing only; the
+                shared .districts-page-header__eyebrow rule is left untouched so
+                Region/Division/Area eyebrows (non-PY text) keep showing. */}
+            <p className="districts-page-header__eyebrow districts-page-header__eyebrow--py">
               Program Year {selectedProgramYear.label.replace(/-/g, '–')}
             </p>
-            <h1 className="districts-page-header__title">District Rankings</h1>
+            <h1 className="districts-page-header__title">
+              District Rankings
+              <span className="districts-page-header__title-py">
+                {' · PY '}
+                {formatProgramYearShort(selectedProgramYear.year)}
+              </span>
+            </h1>
             <p className="districts-page-header__lede">
               Compare district performance across paid clubs, payments, and
               distinguished clubs.
@@ -675,10 +685,19 @@ const DistrictsPage: React.FC = () => {
         {/* Redesigned page header (#356) */}
         <div className="districts-page-header">
           <div className="districts-page-header__intro">
-            <p className="districts-page-header__eyebrow">
+            {/* #890 — `--py` scopes the mobile hide to the landing only; the
+                shared .districts-page-header__eyebrow rule is left untouched so
+                Region/Division/Area eyebrows (non-PY text) keep showing. */}
+            <p className="districts-page-header__eyebrow districts-page-header__eyebrow--py">
               Program Year {selectedProgramYear.label.replace(/-/g, '–')}
             </p>
-            <h1 className="districts-page-header__title">District Rankings</h1>
+            <h1 className="districts-page-header__title">
+              District Rankings
+              <span className="districts-page-header__title-py">
+                {' · PY '}
+                {formatProgramYearShort(selectedProgramYear.year)}
+              </span>
+            </h1>
             <p className="districts-page-header__lede">
               Compare district performance across paid clubs, payments, and
               distinguished clubs.

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -26,8 +26,8 @@ import {
   getAvailableProgramYears,
   filterDatesByProgramYear,
   getMostRecentDateInProgramYear,
-  formatProgramYearShort,
 } from '../utils/programYear'
+import { ProgramYearTitleSuffix } from '../components/ProgramYearTitleSuffix'
 import { DistrictRanking } from '../types/districts'
 import { arrayToCSV, downloadCSV } from '../utils/csvExport'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -501,10 +501,7 @@ const DistrictsPage: React.FC = () => {
             </p>
             <h1 className="districts-page-header__title">
               District Rankings
-              <span className="districts-page-header__title-py">
-                {' · PY '}
-                {formatProgramYearShort(selectedProgramYear.year)}
-              </span>
+              <ProgramYearTitleSuffix programYear={selectedProgramYear} />
             </h1>
             <p className="districts-page-header__lede">
               Compare district performance across paid clubs, payments, and
@@ -693,10 +690,7 @@ const DistrictsPage: React.FC = () => {
             </p>
             <h1 className="districts-page-header__title">
               District Rankings
-              <span className="districts-page-header__title-py">
-                {' · PY '}
-                {formatProgramYearShort(selectedProgramYear.year)}
-              </span>
+              <ProgramYearTitleSuffix programYear={selectedProgramYear} />
             </h1>
             <p className="districts-page-header__lede">
               Compare district performance across paid clubs, payments, and

--- a/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
@@ -329,7 +329,7 @@ describe('DistrictsPage mobile sub-line collapse (#890)', () => {
     const { container } = renderWithProviders(<DistrictsPage />)
     await screen.findByText('District 7')
 
-    const suffix = container.querySelector('.districts-page-header__title-py')
+    const suffix = container.querySelector('.page-header__title-py')
     expect(suffix).not.toBeNull()
     expect(suffix!.textContent).toMatch(/·\s*PY\s*\d{4}-\d{2}/)
 

--- a/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
@@ -303,3 +303,53 @@ describe('DistrictsPage terminal-state CLS slot (#915 V9, Lesson 125)', () => {
     expectReservedShell(container)
   })
 })
+
+/**
+ * Mobile sub-line collapse (#890, epic #891 Sprint 2 — Epic H / CC-11).
+ *
+ * The landing header carries the same redundant "Program Year 2025–2026"
+ * eyebrow as the district-detail header. At <768px it collapses into a compact
+ * "· PY 2025-26" suffix on the title line to recover ~80px above the fold;
+ * desktop keeps the eyebrow above the title. jsdom has no media queries
+ * (Lesson 66), so these assert the structural hooks the CSS keys off — the
+ * per-breakpoint visibility is proven on the PR preview channel.
+ *
+ * Scope guard (Lesson 120/131): `.districts-page-header__eyebrow` is SHARED
+ * chrome (RegionPage / RegionsPage / DivisionPage / AreaPage reuse it with
+ * non-PY text). The mobile hide is keyed off a landing-only `--py` modifier so
+ * those siblings' eyebrows are untouched.
+ */
+describe('DistrictsPage mobile sub-line collapse (#890)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a compact PY suffix inside the landing title (shown on mobile via CSS)', async () => {
+    setupSingleRow()
+    const { container } = renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    const suffix = container.querySelector('.districts-page-header__title-py')
+    expect(suffix).not.toBeNull()
+    expect(suffix!.textContent).toMatch(/·\s*PY\s*\d{4}-\d{2}/)
+
+    const title = screen.getByRole('heading', {
+      level: 1,
+      name: /District Rankings/i,
+    })
+    expect(title).toContainElement(suffix as HTMLElement)
+  })
+
+  it('marks the landing eyebrow with the --py modifier so only the landing hides it on mobile', async () => {
+    setupSingleRow()
+    const { container } = renderWithProviders(<DistrictsPage />)
+    await screen.findByText('District 7')
+
+    const eyebrow = container.querySelector('.districts-page-header__eyebrow')
+    expect(eyebrow).not.toBeNull()
+    // Scope marker — the shared eyebrow rule is NOT touched; only --py hides.
+    expect(eyebrow!.className).toMatch(/districts-page-header__eyebrow--py/)
+    // Full label preserved for desktop (CSS hides it <768px).
+    expect(eyebrow!.textContent).toMatch(/Program Year \d{4}–\d{4}/)
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -550,6 +550,14 @@
     .page-header__title-py {
       display: inline;
     }
+
+    /* #890 — 28px is oversized at 375px; the longer landing title ("District
+       Rankings") + PY suffix overflows to a 2nd line. Drop to 22px on mobile so
+       the title stays single-line (recovering more above-the-fold height — the
+       epic's goal). Desktop keeps 28px. */
+    .districts-page-header__title {
+      font-size: 22px;
+    }
   }
 
   .districts-page-header__lede {
@@ -3060,6 +3068,12 @@
   @media (max-width: 767px) {
     .district-detail-page-header__eyebrow {
       display: none;
+    }
+
+    /* Match the landing header's mobile title size (#890) for a consistent
+       single-line title-with-PY-suffix across page headers. */
+    .district-detail-page-header__title {
+      font-size: 22px;
     }
   }
 

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -521,11 +521,12 @@
   }
 
   /* #890 — mobile collapse of the Program Year eyebrow onto the title line.
-     Hidden by default (desktop shows the eyebrow); revealed <768px where the
-     `--py` eyebrow is hidden. Subordinate size/weight so the title never wraps
-     to a 2nd line. The dark remap mirrors the eyebrow's #609 fix — --maroon-500
-     is 1.69:1 on the dark surface, so the suffix borrows the same #e8879a. */
-  .districts-page-header__title-py {
+     Shared by the landing and district-detail headers (see ProgramYearTitleSuffix).
+     Hidden by default (desktop shows the eyebrow); revealed <768px. Subordinate
+     size/weight so the title never wraps to a 2nd line. The dark remap mirrors
+     the eyebrow's #609 fix — --maroon-500 is 1.69:1 on the dark surface, so the
+     suffix borrows the same #e8879a. */
+  .page-header__title-py {
     display: none;
     font-size: 0.6em;
     font-weight: 700;
@@ -534,16 +535,19 @@
     white-space: nowrap;
   }
 
-  [data-theme='dark'] .districts-page-header__title-py {
+  [data-theme='dark'] .page-header__title-py {
     color: #e8879a;
   }
 
   @media (max-width: 767px) {
+    /* `--py` scopes the hide to the landing eyebrow only — the shared
+       .districts-page-header__eyebrow rule (Region/Division/Area pages) is
+       left untouched (Lesson 120/131). */
     .districts-page-header__eyebrow--py {
       display: none;
     }
 
-    .districts-page-header__title-py {
+    .page-header__title-py {
       display: inline;
     }
   }
@@ -3049,32 +3053,13 @@
     color: var(--ink);
   }
 
-  /* #890 — the title-line PY suffix is the mobile collapse of the eyebrow.
-     Hidden by default (desktop shows the full eyebrow above the title);
-     revealed <768px where the eyebrow is hidden. Sized down and muted so it
-     reads as a subordinate suffix and never pushes the title to a 2nd line. */
-  .district-detail-page-header__title-py {
-    display: none;
-    font-size: 0.6em;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    color: var(--maroon-500);
-    white-space: nowrap;
-  }
-
-  /* --maroon-500 is 1.69:1 on the dark surface (#609); lift to the same
-     #e8879a the dark eyebrow uses so the mobile suffix clears AA. */
-  [data-theme='dark'] .district-detail-page-header__title-py {
-    color: #e8879a;
-  }
-
+  /* #890 — mobile collapse of the eyebrow onto the title line. The shared
+     `.page-header__title-py` rule (defined with the landing header) styles and
+     reveals the suffix; here we only hide this header's (unshared) eyebrow
+     <768px. */
   @media (max-width: 767px) {
     .district-detail-page-header__eyebrow {
       display: none;
-    }
-
-    .district-detail-page-header__title-py {
-      display: inline;
     }
   }
 

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -3021,6 +3021,29 @@
     color: var(--ink);
   }
 
+  /* #890 — the title-line PY suffix is the mobile collapse of the eyebrow.
+     Hidden by default (desktop shows the full eyebrow above the title);
+     revealed <768px where the eyebrow is hidden. Sized down and muted so it
+     reads as a subordinate suffix and never pushes the title to a 2nd line. */
+  .district-detail-page-header__title-py {
+    display: none;
+    font-size: 0.6em;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--maroon-500);
+    white-space: nowrap;
+  }
+
+  @media (max-width: 767px) {
+    .district-detail-page-header__eyebrow {
+      display: none;
+    }
+
+    .district-detail-page-header__title-py {
+      display: inline;
+    }
+  }
+
   .district-detail-page-header__lede {
     margin: 0;
     font-family: var(--sans);

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -520,6 +520,34 @@
     color: var(--ink);
   }
 
+  /* #890 — mobile collapse of the Program Year eyebrow onto the title line.
+     Hidden by default (desktop shows the eyebrow); revealed <768px where the
+     `--py` eyebrow is hidden. Subordinate size/weight so the title never wraps
+     to a 2nd line. The dark remap mirrors the eyebrow's #609 fix — --maroon-500
+     is 1.69:1 on the dark surface, so the suffix borrows the same #e8879a. */
+  .districts-page-header__title-py {
+    display: none;
+    font-size: 0.6em;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--maroon-500);
+    white-space: nowrap;
+  }
+
+  [data-theme='dark'] .districts-page-header__title-py {
+    color: #e8879a;
+  }
+
+  @media (max-width: 767px) {
+    .districts-page-header__eyebrow--py {
+      display: none;
+    }
+
+    .districts-page-header__title-py {
+      display: inline;
+    }
+  }
+
   .districts-page-header__lede {
     margin: 0;
     font-family: var(--sans);
@@ -3032,6 +3060,12 @@
     letter-spacing: 0.04em;
     color: var(--maroon-500);
     white-space: nowrap;
+  }
+
+  /* --maroon-500 is 1.69:1 on the dark surface (#609); lift to the same
+     #e8879a the dark eyebrow uses so the mobile suffix clears AA. */
+  [data-theme='dark'] .district-detail-page-header__title-py {
+    color: #e8879a;
   }
 
   @media (max-width: 767px) {


### PR DESCRIPTION
Closes none (sprint-runner ticks the epic + closes #890 post-verification — avoids the Closes-auto-close ordering trap, Lesson 106). Tracks **#890** (epic #891 Sprint 2 — Mobile UX audit Epic H / CC-11).

## What
At <768px, the redundant "Program Year 2025–2026" eyebrow above the page title is hidden and a compact `· PY 2025-26` suffix is rendered on the title line instead — recovering ~80px above the fold. Desktop is unchanged (eyebrow above title). Applied to both header surfaces that carry the PY eyebrow:
- `DistrictDetailHeader` (district detail route)
- `DistrictsPage` landing rankings header (both the loaded and CLS-stable shell blocks)

## How / key decisions
- New shared `ProgramYearTitleSuffix` component + single `.page-header__title-py` CSS rule (dedupes the suffix across 3 call sites; /simplify pass).
- Reuses the **existing** `formatProgramYearShort` util (R6/R7) rather than adding a near-duplicate.
- **Scope guard (Lesson 120/131):** `.districts-page-header__eyebrow` is *shared* chrome (Region/Division/Area pages reuse it with non-PY text). The mobile hide is keyed off a landing-only `--py` modifier, so the shared rule is untouched. `.district-detail-page-header__eyebrow` is *not* shared → hidden directly.
- **A11y:** the suffix is `aria-hidden` so the `<h1>` accessible name stays the plain title ("District 61"/"District Rankings"). The program year stays available to AT via the program-year picker (py-chip) and the desktop eyebrow. (An `aria-label` on an in-heading span would have polluted the heading's accessible name.)

## Tests
- Unit/integration assert the structural hooks (jsdom can't see media queries — Lesson 66): suffix present inside the `<h1>`, eyebrow retains full label, landing `--py` modifier present.
- Full frontend suite green (3126 tests).
- **Live per-breakpoint verification (375px Chromium + WebKit) pending on the PR preview channel** per the AC.

## Reviewer nit (operator triage)
Suffix renders **"PY 2025-26"** (hyphen, 4-digit start) — the AC's *e.g.* was "PY 25–26" (en-dash, 2-digit). Kept the existing helper's format for reuse; the eyebrow (en-dash) and suffix (hyphen) never render simultaneously. Easy to switch to "25–26"/en-dash if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)