### PR TITLE
feat(history): per-year summary cards on /history (#892)

### DIFF
--- a/frontend/src/__tests__/integration/routing.test.tsx
+++ b/frontend/src/__tests__/integration/routing.test.tsx
@@ -13,11 +13,23 @@
    CSS-uppercased "live", so the assertion is real, not false-confidence. */
 
 import React from 'react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import HistoryPage from '../../pages/HistoryPage'
 import MethodologyPage from '../../pages/MethodologyPage'
+
+// HistoryPage now fetches per-year summary cards (#892). This routing test
+// only asserts the synchronous scaffold (heading, year strip, TI link), so
+// stub the data hook to keep it network-free and focused.
+vi.mock('../../hooks/useProgramYearSummaries', () => ({
+  useProgramYearSummaries: () => ({
+    summaries: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}))
 
 const renderRoute = (Page: React.ComponentType, path: string) => {
   const router = createMemoryRouter([{ path, element: <Page /> }], {

--- a/frontend/src/components/ProgramYearSummaryCards.tsx
+++ b/frontend/src/components/ProgramYearSummaryCards.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import type { ProgramYearSummary } from '../utils/programYearSummary'
+
+export interface ProgramYearSummaryCardsProps {
+  /** Completed program years, newest first. */
+  summaries: ProgramYearSummary[]
+  isLoading: boolean
+  isError: boolean
+}
+
+/** Number of skeleton cards rendered while loading — reserves height so the
+ *  real cards don't shift the page down on arrival (CLS — Lessons 79/125). */
+const SKELETON_COUNT = 3
+
+const formatNumber = (n: number): string => n.toLocaleString('en-US')
+
+const METRICS: Array<{
+  label: string
+  field: keyof Pick<
+    ProgramYearSummary,
+    | 'totalDistricts'
+    | 'totalPaidClubs'
+    | 'totalPayments'
+    | 'totalDistinguishedClubs'
+  >
+}> = [
+  { label: 'Districts', field: 'totalDistricts' },
+  { label: 'Paid clubs', field: 'totalPaidClubs' },
+  { label: 'Payments', field: 'totalPayments' },
+  { label: 'Distinguished', field: 'totalDistinguishedClubs' },
+]
+
+/**
+ * The /history per-year summary cards (#892). Presentational — the owning page
+ * fetches via `useProgramYearSummaries` and passes the result down. Renders a
+ * height-reserving skeleton while loading, an inline notice on error/empty, and
+ * one card per completed program year (newest first) otherwise. Each card links
+ * into the landing page filtered to that program year (`/?py=<startYear>`).
+ */
+export const ProgramYearSummaryCards: React.FC<
+  ProgramYearSummaryCardsProps
+> = ({ summaries, isLoading, isError }) => {
+  if (isLoading) {
+    return (
+      <div className="history-year-cards" data-testid="history-year-cards">
+        {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+          <div
+            key={i}
+            className="history-year-card history-year-card--skeleton"
+            data-testid="history-year-card-skeleton"
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="history-year-cards__notice" role="status">
+        Couldn’t load year-end standings right now. Please try again shortly.
+      </div>
+    )
+  }
+
+  if (summaries.length === 0) {
+    return (
+      <div className="history-year-cards__notice" role="status">
+        No completed program years on file yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="history-year-cards" data-testid="history-year-cards">
+      {summaries.map(s => (
+        <Link
+          key={s.startYear}
+          to={`/?py=${s.startYear}`}
+          className="history-year-card"
+          data-testid="history-year-card"
+          aria-label={`View ${s.label} final standings`}
+        >
+          <div className="history-year-card__head">
+            <span className="history-year-card__year">{s.label}</span>
+            <span className="history-year-card__frozen">
+              Final · frozen Jun 30
+            </span>
+          </div>
+
+          <dl className="history-year-card__metrics">
+            {METRICS.map(({ label, field }) => (
+              <div key={field} className="history-year-card__metric">
+                <dt className="history-year-card__metric-label">{label}</dt>
+                <dd className="history-year-card__metric-value">
+                  {formatNumber(s[field])}
+                </dd>
+              </div>
+            ))}
+          </dl>
+
+          <div className="history-year-card__top">
+            <span className="history-year-card__top-label">Top districts</span>
+            <ol className="history-year-card__top-list">
+              {s.topDistricts.map(d => (
+                <li key={d.districtId} className="history-year-card__top-item">
+                  <span className="history-year-card__top-rank">
+                    {d.overallRank}
+                  </span>
+                  <span className="history-year-card__top-name">
+                    {d.districtName}
+                  </span>
+                  <span className="history-year-card__top-region">
+                    Region {d.region}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/__tests__/ProgramYearSummaryCards.test.tsx
+++ b/frontend/src/components/__tests__/ProgramYearSummaryCards.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for ProgramYearSummaryCards (#892).
+ *
+ * Presentational: takes the summaries + query state as props and renders the
+ * /history per-year cards. No data fetching here (that's the hook's job).
+ */
+
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ProgramYearSummaryCards } from '../ProgramYearSummaryCards'
+import type { ProgramYearSummary } from '../../utils/programYearSummary'
+
+const summary = (over: Partial<ProgramYearSummary>): ProgramYearSummary => ({
+  startYear: 2024,
+  label: '2024-25',
+  yearEndDate: '2025-06-30',
+  totalDistricts: 126,
+  totalPaidClubs: 14266,
+  totalPayments: 549577,
+  totalDistinguishedClubs: 6460,
+  topDistricts: [
+    {
+      districtId: '94',
+      districtName: 'District 94',
+      region: '11',
+      overallRank: 1,
+    },
+    {
+      districtId: '42',
+      districtName: 'District 42',
+      region: '7',
+      overallRank: 2,
+    },
+  ],
+  ...over,
+})
+
+const renderCards = (
+  props: Partial<React.ComponentProps<typeof ProgramYearSummaryCards>>
+) =>
+  render(
+    <MemoryRouter>
+      <ProgramYearSummaryCards
+        summaries={[]}
+        isLoading={false}
+        isError={false}
+        {...props}
+      />
+    </MemoryRouter>
+  )
+
+describe('ProgramYearSummaryCards (#892)', () => {
+  it('reserves space with skeleton cards while loading (CLS — Lesson 79/125)', () => {
+    renderCards({ isLoading: true })
+    expect(
+      screen.getAllByTestId('history-year-card-skeleton').length
+    ).toBeGreaterThan(0)
+  })
+
+  it('shows an error notice when the fetch failed', () => {
+    renderCards({ isError: true })
+    expect(screen.getByRole('status')).toHaveTextContent(/load|try again/i)
+  })
+
+  it('shows an empty notice when no completed years are on file', () => {
+    renderCards({ summaries: [] })
+    expect(screen.getByRole('status')).toHaveTextContent(
+      /no completed program years/i
+    )
+  })
+
+  it('renders one card per summary, in the order given (newest first)', () => {
+    renderCards({
+      summaries: [
+        summary({ startYear: 2024, label: '2024-25' }),
+        summary({ startYear: 2023, label: '2023-24' }),
+      ],
+    })
+    const cards = screen.getAllByTestId('history-year-card')
+    expect(cards).toHaveLength(2)
+    expect(cards[0]).toHaveTextContent('2024-25')
+    expect(cards[1]).toHaveTextContent('2023-24')
+  })
+
+  it('shows headline aggregate metrics, thousands-separated', () => {
+    renderCards({ summaries: [summary({})] })
+    const card = screen.getByTestId('history-year-card')
+    expect(within(card).getByText('14,266')).toBeInTheDocument()
+    expect(within(card).getByText('549,577')).toBeInTheDocument()
+    expect(within(card).getByText('6,460')).toBeInTheDocument()
+  })
+
+  it('lists the top districts with their final rank', () => {
+    renderCards({ summaries: [summary({})] })
+    const card = screen.getByTestId('history-year-card')
+    expect(within(card).getByText(/District 94/)).toBeInTheDocument()
+    expect(within(card).getByText(/District 42/)).toBeInTheDocument()
+  })
+
+  it('links each card into the landing page filtered to that program year', () => {
+    renderCards({ summaries: [summary({ startYear: 2023, label: '2023-24' })] })
+    const link = screen.getByRole('link', { name: /2023-24/i })
+    expect(link).toHaveAttribute('href', '/?py=2023')
+  })
+})

--- a/frontend/src/hooks/__tests__/useProgramYearSummaries.test.tsx
+++ b/frontend/src/hooks/__tests__/useProgramYearSummaries.test.tsx
@@ -125,6 +125,26 @@ describe('useProgramYearSummaries (#892)', () => {
     )
   })
 
+  it('drops a year whose year-end file fell back to current rankings', async () => {
+    // cdn.ts silently returns CURRENT v1/rankings.json when a per-date file
+    // 404s — that must never render current standings on a past "final" card.
+    mockedDates.mockResolvedValue({
+      dates: ['2022-09-30', '2023-06-30', '2023-09-30', '2024-06-30'],
+      count: 4,
+      generatedAt: '2024-07-01T00:00:00Z',
+    })
+    mockedRankings.mockImplementation(d =>
+      // Simulate the fallback for 2022-23: returns data dated in 2025-26.
+      Promise.resolve(rankingsData(d === '2023-06-30' ? '2026-05-28' : d))
+    )
+
+    const { result } = renderHook(() => useProgramYearSummaries(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // 2022-23 dropped (stale current data); 2023-24 kept.
+    expect(result.current.summaries.map(s => s.label)).toEqual(['2023-24'])
+  })
+
   it('surfaces an error when the dates index fetch fails', async () => {
     mockedDates.mockRejectedValue(new Error('CDN down'))
 

--- a/frontend/src/hooks/__tests__/useProgramYearSummaries.test.tsx
+++ b/frontend/src/hooks/__tests__/useProgramYearSummaries.test.tsx
@@ -125,6 +125,25 @@ describe('useProgramYearSummaries (#892)', () => {
     )
   })
 
+  it('keeps a completed year whose freeze CSV is dated in July (real data shape)', async () => {
+    // The year-end snapshot stored under snapshots/2024-06-30/ carries
+    // sourceCsvDate 2024-07-19 — the June-30 freeze is published ~3 weeks later.
+    // The guard must not mistake that lag for the current-data fallback.
+    mockedDates.mockResolvedValue({
+      dates: ['2023-09-30', '2024-06-30'],
+      count: 2,
+      generatedAt: '2024-07-20T00:00:00Z',
+    })
+    mockedRankings.mockImplementation(d =>
+      Promise.resolve(rankingsData(d === '2024-06-30' ? '2024-07-19' : d))
+    )
+
+    const { result } = renderHook(() => useProgramYearSummaries(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.summaries.map(s => s.label)).toEqual(['2023-24'])
+  })
+
   it('drops a year whose year-end file fell back to current rankings', async () => {
     // cdn.ts silently returns CURRENT v1/rankings.json when a per-date file
     // 404s — that must never render current standings on a past "final" card.

--- a/frontend/src/hooks/__tests__/useProgramYearSummaries.test.tsx
+++ b/frontend/src/hooks/__tests__/useProgramYearSummaries.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for useProgramYearSummaries (#892).
+ *
+ * The hook assembles the /history per-year cards from two EXISTING CDN
+ * endpoints — the dates index (year-end date per completed program year) and
+ * that date's all-districts rankings — with no new pipeline step.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactNode } from 'react'
+import { useProgramYearSummaries } from '../useProgramYearSummaries'
+import { fetchCdnDates, fetchCdnRankingsForDate } from '../../services/cdn'
+import { getCurrentProgramYear } from '../../utils/programYear'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn(),
+  fetchCdnRankingsForDate: vi.fn(),
+}))
+
+const mockedDates = vi.mocked(fetchCdnDates)
+const mockedRankings = vi.mocked(fetchCdnRankingsForDate)
+
+const wrapper = ({ children }: { children: ReactNode }) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+const rankingEntry = (id: string, rank: number) => ({
+  districtId: id,
+  districtName: `District ${id}`,
+  region: '1',
+  paidClubs: 50,
+  paidClubBase: 50,
+  clubGrowthPercent: 0,
+  totalPayments: 2000,
+  paymentBase: 2000,
+  paymentGrowthPercent: 0,
+  activeClubs: 50,
+  distinguishedClubs: 10,
+  selectDistinguished: 2,
+  presidentsDistinguished: 1,
+  distinguishedPercent: 20,
+  clubsRank: rank,
+  paymentsRank: rank,
+  distinguishedRank: rank,
+  aggregateScore: 1000 - rank,
+  overallRank: rank,
+})
+
+const rankingsData = (date: string) => ({
+  rankings: [rankingEntry('1', 1), rankingEntry('2', 2), rankingEntry('3', 3)],
+  date,
+  generatedAt: `${date}T00:00:00Z`,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useProgramYearSummaries (#892)', () => {
+  it('returns one summary per completed program year, newest first', async () => {
+    // Two clearly-past, completed program years (2022-23 and 2023-24).
+    mockedDates.mockResolvedValue({
+      dates: [
+        '2022-09-30',
+        '2023-06-30', // year-end 2022-23
+        '2023-09-30',
+        '2024-06-30', // year-end 2023-24
+      ],
+      count: 4,
+      generatedAt: '2024-07-01T00:00:00Z',
+    })
+    mockedRankings.mockImplementation(d => Promise.resolve(rankingsData(d)))
+
+    const { result } = renderHook(() => useProgramYearSummaries(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.summaries.map(s => s.label)).toEqual([
+      '2023-24',
+      '2022-23',
+    ])
+    // Year-end snapshot date drives the rankings fetch for each year.
+    expect(mockedRankings).toHaveBeenCalledWith('2024-06-30')
+    expect(mockedRankings).toHaveBeenCalledWith('2023-06-30')
+  })
+
+  it('aggregates each year from its year-end rankings', async () => {
+    mockedDates.mockResolvedValue({
+      dates: ['2022-09-30', '2023-06-30'],
+      count: 2,
+      generatedAt: '2024-07-01T00:00:00Z',
+    })
+    mockedRankings.mockImplementation(d => Promise.resolve(rankingsData(d)))
+
+    const { result } = renderHook(() => useProgramYearSummaries(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const s = result.current.summaries[0]!
+    expect(s.totalDistricts).toBe(3)
+    expect(s.totalPaidClubs).toBe(150)
+    expect(s.topDistricts.map(d => d.overallRank)).toEqual([1, 2, 3])
+  })
+
+  it('excludes the current, incomplete program year', async () => {
+    const current = getCurrentProgramYear()
+    // A snapshot inside the current PY (Sept of its start year) — not yet frozen.
+    mockedDates.mockResolvedValue({
+      dates: [`${current.year}-09-30`, '2023-06-30'],
+      count: 2,
+      generatedAt: `${current.year}-09-30T00:00:00Z`,
+    })
+    mockedRankings.mockImplementation(d => Promise.resolve(rankingsData(d)))
+
+    const { result } = renderHook(() => useProgramYearSummaries(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const labels = result.current.summaries.map(s => s.label)
+    expect(labels).toContain('2022-23')
+    expect(labels).not.toContain(
+      `${current.year}-${String((current.year + 1) % 100).padStart(2, '0')}`
+    )
+  })
+
+  it('surfaces an error when the dates index fetch fails', async () => {
+    mockedDates.mockRejectedValue(new Error('CDN down'))
+
+    const { result } = renderHook(() => useProgramYearSummaries(), { wrapper })
+    // Query-level retry (×2 with backoff) delays the error by ~3s.
+    await waitFor(() => expect(result.current.isError).toBe(true), {
+      timeout: 5000,
+    })
+    expect(result.current.summaries).toEqual([])
+  })
+})

--- a/frontend/src/hooks/useProgramYearSummaries.ts
+++ b/frontend/src/hooks/useProgramYearSummaries.ts
@@ -29,7 +29,14 @@ export interface UseProgramYearSummariesResult {
   error: Error | null
 }
 
-/** Program year (Jul 1 – Jun 30) a snapshot date belongs to, as a start year. */
+/**
+ * Program year (Jul 1 – Jun 30) a snapshot date belongs to, as a start year.
+ *
+ * Parses the ISO string by hand on purpose — do NOT swap this for the
+ * `new Date()`-based `getProgramYearForDate`: that reads the month in LOCAL
+ * time, so a `YYYY-07-01` boundary date parses to June 30 in any negative-UTC
+ * zone and lands in the wrong program year. String parsing is timezone-safe.
+ */
 function startYearOf(dateStr: string): number {
   const [y, m] = dateStr.split('-')
   const year = parseInt(y!, 10)

--- a/frontend/src/hooks/useProgramYearSummaries.ts
+++ b/frontend/src/hooks/useProgramYearSummaries.ts
@@ -21,6 +21,14 @@ import {
 
 export const programYearSummariesQueryKey = ['program-year-summaries'] as const
 
+/**
+ * How many days after June 30 a legitimate year-end freeze may be dated. The
+ * year-end CSV is published ~mid-July (sourceCsvDate ~Jul 18-19), so a few
+ * weeks of lag is normal; the cdn.ts current-data fallback is months-to-years
+ * newer and falls well outside this window.
+ */
+const MAX_YEAR_END_LAG_DAYS = 120
+
 export interface UseProgramYearSummariesResult {
   /** Completed program years, newest first. */
   summaries: ProgramYearSummary[]
@@ -70,9 +78,16 @@ export function useProgramYearSummaries(): UseProgramYearSummariesResult {
           // `fetchCdnRankingsForDate` silently falls back to the CURRENT
           // v1/rankings.json when a year-end file 404s. Building a past-year
           // "final standings" card from current data would be actively
-          // misleading, so drop any year whose returned data isn't from that
-          // program year rather than render it.
-          if (startYearOf(date) !== startYear) return null
+          // misleading, so drop any year whose returned data is far newer than
+          // its year-end. NOTE: a real year-end freeze is published a few weeks
+          // AFTER June 30 (sourceCsvDate ~mid-July), so this is a date-window
+          // check, not a same-program-year check — July data is legitimate; the
+          // fallback's current data is months-to-years newer.
+          const lagDays =
+            (Date.parse(date) - Date.parse(yearEndDate)) / 86_400_000
+          if (!Number.isFinite(lagDays) || lagDays > MAX_YEAR_END_LAG_DAYS) {
+            return null
+          }
           return buildProgramYearSummary(startYear, yearEndDate, rankings)
         })
       )

--- a/frontend/src/hooks/useProgramYearSummaries.ts
+++ b/frontend/src/hooks/useProgramYearSummaries.ts
@@ -64,12 +64,20 @@ export function useProgramYearSummaries(): UseProgramYearSummariesResult {
         .filter(([sy]) => new Date(`${sy + 1}-06-30T23:59:59`) < now)
         .sort(([a], [b]) => b - a)
 
-      return Promise.all(
+      const built = await Promise.all(
         completed.map(async ([startYear, yearEndDate]) => {
-          const { rankings } = await fetchCdnRankingsForDate(yearEndDate)
+          const { rankings, date } = await fetchCdnRankingsForDate(yearEndDate)
+          // `fetchCdnRankingsForDate` silently falls back to the CURRENT
+          // v1/rankings.json when a year-end file 404s. Building a past-year
+          // "final standings" card from current data would be actively
+          // misleading, so drop any year whose returned data isn't from that
+          // program year rather than render it.
+          if (startYearOf(date) !== startYear) return null
           return buildProgramYearSummary(startYear, yearEndDate, rankings)
         })
       )
+
+      return built.filter((s): s is ProgramYearSummary => s !== null)
     },
     staleTime: 15 * 60 * 1000, // 15 min — archived years are immutable
     gcTime: 30 * 60 * 1000,

--- a/frontend/src/hooks/useProgramYearSummaries.ts
+++ b/frontend/src/hooks/useProgramYearSummaries.ts
@@ -1,0 +1,79 @@
+/**
+ * useProgramYearSummaries (#892) — data for the /history per-year summary cards.
+ *
+ * Assembled entirely from EXISTING CDN endpoints, no new pipeline step:
+ *   1. `fetchCdnDates()` — all snapshot dates. Grouped by program year
+ *      (Jul 1 – Jun 30), the latest date in each COMPLETED year is its
+ *      year-end snapshot.
+ *   2. `fetchCdnRankingsForDate(yearEndDate)` — that date's all-districts
+ *      standings, reduced to the card view-model by `buildProgramYearSummary`.
+ *
+ * The current (incomplete) program year is excluded — a card only exists once
+ * the year is frozen at June 30.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { fetchCdnDates, fetchCdnRankingsForDate } from '../services/cdn'
+import {
+  buildProgramYearSummary,
+  type ProgramYearSummary,
+} from '../utils/programYearSummary'
+
+export const programYearSummariesQueryKey = ['program-year-summaries'] as const
+
+export interface UseProgramYearSummariesResult {
+  /** Completed program years, newest first. */
+  summaries: ProgramYearSummary[]
+  isLoading: boolean
+  isError: boolean
+  error: Error | null
+}
+
+/** Program year (Jul 1 – Jun 30) a snapshot date belongs to, as a start year. */
+function startYearOf(dateStr: string): number {
+  const [y, m] = dateStr.split('-')
+  const year = parseInt(y!, 10)
+  const month = parseInt(m!, 10)
+  return month >= 7 ? year : year - 1
+}
+
+export function useProgramYearSummaries(): UseProgramYearSummariesResult {
+  const query = useQuery({
+    queryKey: programYearSummariesQueryKey,
+    queryFn: async (): Promise<ProgramYearSummary[]> => {
+      const { dates } = await fetchCdnDates()
+
+      // Group snapshot dates by program year, tracking each year's latest date.
+      const latestByYear = new Map<number, string>()
+      for (const d of dates) {
+        const sy = startYearOf(d)
+        const cur = latestByYear.get(sy)
+        if (!cur || d > cur) latestByYear.set(sy, d)
+      }
+
+      // Keep only COMPLETED years (frozen at June 30), newest first.
+      const now = new Date()
+      const completed = [...latestByYear.entries()]
+        .filter(([sy]) => new Date(`${sy + 1}-06-30T23:59:59`) < now)
+        .sort(([a], [b]) => b - a)
+
+      return Promise.all(
+        completed.map(async ([startYear, yearEndDate]) => {
+          const { rankings } = await fetchCdnRankingsForDate(yearEndDate)
+          return buildProgramYearSummary(startYear, yearEndDate, rankings)
+        })
+      )
+    },
+    staleTime: 15 * 60 * 1000, // 15 min — archived years are immutable
+    gcTime: 30 * 60 * 1000,
+    retry: failureCount => failureCount < 2,
+    retryDelay: attemptIndex => Math.min(1000 * 2 ** attemptIndex, 30000),
+  })
+
+  return {
+    summaries: query.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+  }
+}

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,32 +1,28 @@
 import React from 'react'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useProgramYearSummaries } from '../hooks/useProgramYearSummaries'
+import { ProgramYearSummaryCards } from '../components/ProgramYearSummaryCards'
+import {
+  getCurrentProgramYear,
+  formatProgramYearShort,
+} from '../utils/programYear'
 
-/* History page (#367). The 2026 design specifies year-end snapshot
-   cards (top 5 districts + headline metrics + notable note) for each
-   archived program year. That data is NOT currently fetched on the
-   client — it lives in archived snapshots that would need a new GCS
-   index endpoint to surface. Filing as a follow-up.
+/* History page (#367, #892). Per-year summary cards — top-5 districts +
+   headline metrics for each COMPLETED program year — assembled from existing
+   CDN endpoints (dates index → year-end all-districts rankings), newest first.
+   Each card links into the landing page filtered to that program year.
 
-   This v1 ships the page header + year-strip chip row pointing to the
-   archive years on file, plus the TI archive callout for pre-2019. */
-
-const PROGRAM_YEARS_ON_FILE = [
-  { label: '2025–26', current: true },
-  { label: '2024–25' },
-  { label: '2023–24' },
-  { label: '2022–23' },
-  { label: '2021–22' },
-  { label: '2020–21' },
-  { label: '2019–20' },
-]
+   The year strip and card list are data-driven, so years with no snapshot data
+   (e.g. the 2021-22 COVID gap) are correctly absent rather than hardcoded. */
 
 const HistoryPage: React.FC = () => {
   useDocumentTitle('Program Year History')
+  const { summaries, isLoading, isError } = useProgramYearSummaries()
+  const currentPY = getCurrentProgramYear()
+
   return (
     <div className="placeholder-page">
-      <p className="placeholder-page__eyebrow">
-        Archive · {PROGRAM_YEARS_ON_FILE.length} program years on file
-      </p>
+      <p className="placeholder-page__eyebrow">Program year archive</p>
       <h1 className="placeholder-page__title">Program Year History</h1>
       {/* "What does this page answer?" lede (#879, epic #880 Sprint 3). The
           other doc-style route; one scannable sentence above the year strip. */}
@@ -36,21 +32,26 @@ const HistoryPage: React.FC = () => {
         file here versus the TI archive.
       </p>
 
-      <div className="history-page-year-strip" role="list">
-        {PROGRAM_YEARS_ON_FILE.map(year => (
+      <div
+        className="history-page-year-strip"
+        role="list"
+        data-testid="history-year-strip"
+      >
+        <span
+          role="listitem"
+          className="history-page-year-chip history-page-year-chip--current"
+          aria-current="page"
+        >
+          {formatProgramYearShort(currentPY.year)}
+          <span className="history-page-year-chip__live">· LIVE</span>
+        </span>
+        {summaries.map(s => (
           <span
-            key={year.label}
+            key={s.startYear}
             role="listitem"
-            className={
-              'history-page-year-chip' +
-              (year.current ? ' history-page-year-chip--current' : '')
-            }
-            aria-current={year.current ? 'page' : undefined}
+            className="history-page-year-chip"
           >
-            {year.label}
-            {year.current && (
-              <span className="history-page-year-chip__live">· LIVE</span>
-            )}
+            {s.label}
           </span>
         ))}
         <span
@@ -61,11 +62,15 @@ const HistoryPage: React.FC = () => {
         </span>
       </div>
 
+      <ProgramYearSummaryCards
+        summaries={summaries}
+        isLoading={isLoading}
+        isError={isError}
+      />
+
       <div className="districts-methodology-callout" style={{ marginTop: 32 }}>
-        <strong>Per-year summary cards coming soon.</strong> The full archive UI
-        (top 5 districts + headline metrics per year) needs a new year-end
-        snapshot endpoint — tracked as a follow-up. For pre-2019 data, see the
-        official{' '}
+        <strong>Pre-2019 data.</strong> Years before 2019 aren’t on file here.
+        For those, see the official{' '}
         <a
           href="https://dashboards.toastmasters.org"
           target="_blank"

--- a/frontend/src/pages/__tests__/HistoryPage.lede.test.tsx
+++ b/frontend/src/pages/__tests__/HistoryPage.lede.test.tsx
@@ -5,10 +5,22 @@
    archived program year shows and which years are on file. */
 
 import React from 'react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import HistoryPage from '../HistoryPage'
+
+// HistoryPage fetches per-year summary cards (#892); this lede test asserts the
+// synchronous header/strip only, so stub the data hook (empty = no cards, the
+// year strip stays the sole role="list").
+vi.mock('../../hooks/useProgramYearSummaries', () => ({
+  useProgramYearSummaries: () => ({
+    summaries: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}))
 
 const renderPage = () =>
   render(

--- a/frontend/src/pages/__tests__/staticPageTitles.test.tsx
+++ b/frontend/src/pages/__tests__/staticPageTitles.test.tsx
@@ -2,11 +2,22 @@
    Methodology and History have no async data, so their title is deterministic
    on mount — the simplest end of the per-route title contract (F-SA3). */
 
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, cleanup, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import MethodologyPage from '../MethodologyPage'
 import HistoryPage from '../HistoryPage'
+
+// HistoryPage fetches per-year cards (#892); the title is still synchronous on
+// mount, so stub the data hook to keep this title test network-free.
+vi.mock('../../hooks/useProgramYearSummaries', () => ({
+  useProgramYearSummaries: () => ({
+    summaries: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}))
 
 afterEach(() => cleanup())
 

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -4193,6 +4193,180 @@
     border: 1px dashed var(--line);
   }
 
+  /* Per-year summary cards (#892). Responsive grid; each card links into the
+     landing page for that program year. */
+  .history-year-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+  }
+
+  .history-year-cards__notice {
+    margin-top: 24px;
+    padding: 16px 18px;
+    border-radius: 10px;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    color: var(--ink-2);
+    font-family: var(--sans);
+    font-size: 14px;
+  }
+
+  .history-year-card {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    /* Reserve enough height that the loaded card matches the skeleton, so the
+       async arrival doesn't shift the page (CLS — Lessons 79/125). */
+    min-height: 220px;
+    padding: 18px;
+    border-radius: 12px;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    color: var(--ink);
+    font-family: var(--sans);
+    text-decoration: none;
+    transition:
+      border-color 0.15s ease,
+      box-shadow 0.15s ease,
+      transform 0.15s ease;
+  }
+
+  a.history-year-card:hover {
+    border-color: var(--loyal-200);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+    transform: translateY(-2px);
+  }
+
+  a.history-year-card:focus-visible {
+    outline: 2px solid var(--link);
+    outline-offset: 2px;
+  }
+
+  .history-year-card--skeleton {
+    background-image: linear-gradient(
+      100deg,
+      var(--surface) 30%,
+      var(--line) 50%,
+      var(--surface) 70%
+    );
+    background-size: 200% 100%;
+    animation: history-year-card-shimmer 1.4s ease-in-out infinite;
+  }
+
+  @keyframes history-year-card-shimmer {
+    from {
+      background-position: 200% 0;
+    }
+    to {
+      background-position: -200% 0;
+    }
+  }
+
+  .history-year-card__head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .history-year-card__year {
+    font-family: var(--display, var(--sans));
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--ink);
+  }
+
+  .history-year-card__frozen {
+    font-size: 11px;
+    color: var(--ink-3);
+    white-space: nowrap;
+  }
+
+  .history-year-card__metrics {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px 16px;
+    margin: 0;
+  }
+
+  .history-year-card__metric {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .history-year-card__metric-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--ink-3);
+  }
+
+  .history-year-card__metric-value {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink);
+  }
+
+  .history-year-card__top {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: auto;
+  }
+
+  .history-year-card__top-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--ink-3);
+  }
+
+  .history-year-card__top-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .history-year-card__top-item {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--ink-2);
+  }
+
+  .history-year-card__top-rank {
+    flex: none;
+    min-width: 18px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--loyal-500);
+  }
+
+  [data-theme='dark'] .history-year-card__top-rank {
+    color: var(--link);
+  }
+
+  .history-year-card__top-name {
+    font-weight: 500;
+    color: var(--ink);
+  }
+
+  .history-year-card__top-region {
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--ink-3);
+    white-space: nowrap;
+  }
+
   /* Methodology page (#368) — TOC + numbered sections. */
   .methodology-page {
     max-width: 1280px;

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -4203,6 +4203,13 @@
   }
 
   .history-year-cards__notice {
+    /* Reserve height comparable to a loaded/loading card so the
+       loading→error and loading→empty transitions don't collapse the section
+       and shift the page (CLS — Lesson 125 covers error/empty, not just
+       loading). */
+    display: flex;
+    align-items: center;
+    min-height: 220px;
     margin-top: 24px;
     padding: 16px 18px;
     border-radius: 10px;

--- a/frontend/src/utils/__tests__/programYearSummary.test.ts
+++ b/frontend/src/utils/__tests__/programYearSummary.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for programYearSummary (#892).
+ *
+ * Pure aggregation: one program year's all-districts rankings → the
+ * per-year card view-model (headline totals + top-N districts).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildProgramYearSummary,
+  type DistrictRankingLite,
+} from '../programYearSummary'
+
+const r = (over: Partial<DistrictRankingLite>): DistrictRankingLite => ({
+  districtId: '1',
+  districtName: 'District 1',
+  region: '1',
+  overallRank: 1,
+  aggregateScore: 100,
+  paidClubs: 50,
+  totalPayments: 2000,
+  distinguishedClubs: 10,
+  ...over,
+})
+
+describe('buildProgramYearSummary (#892)', () => {
+  it('formats the compact label and start year from the start year', () => {
+    const s = buildProgramYearSummary(2024, '2025-06-30', [r({})])
+    expect(s.startYear).toBe(2024)
+    expect(s.label).toBe('2024-25')
+    expect(s.yearEndDate).toBe('2025-06-30')
+  })
+
+  it('sums headline metrics across every district', () => {
+    const s = buildProgramYearSummary(2024, '2025-06-30', [
+      r({
+        districtId: '1',
+        paidClubs: 50,
+        totalPayments: 2000,
+        distinguishedClubs: 10,
+      }),
+      r({
+        districtId: '2',
+        paidClubs: 30,
+        totalPayments: 1500,
+        distinguishedClubs: 5,
+      }),
+      r({
+        districtId: '3',
+        paidClubs: 20,
+        totalPayments: 500,
+        distinguishedClubs: 0,
+      }),
+    ])
+    expect(s.totalDistricts).toBe(3)
+    expect(s.totalPaidClubs).toBe(100)
+    expect(s.totalPayments).toBe(4000)
+    expect(s.totalDistinguishedClubs).toBe(15)
+  })
+
+  it('returns the top 5 districts ordered by overallRank ascending', () => {
+    const rankings = [7, 3, 1, 9, 2, 5, 4].map((rank, i) =>
+      r({ districtId: `d${i}`, overallRank: rank, aggregateScore: 1000 - rank })
+    )
+    const s = buildProgramYearSummary(2024, '2025-06-30', rankings)
+    expect(s.topDistricts.map(d => d.overallRank)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('breaks overallRank ties deterministically by aggregateScore desc (Lesson 120)', () => {
+    // Two districts tie at rank 1 (a real shape seen on 2023-06-30 CDN data).
+    const rankings = [
+      r({ districtId: 'A', overallRank: 1, aggregateScore: 80 }),
+      r({ districtId: 'B', overallRank: 1, aggregateScore: 95 }),
+      r({ districtId: 'C', overallRank: 3, aggregateScore: 70 }),
+    ]
+    const s = buildProgramYearSummary(2024, '2025-06-30', rankings)
+    // Higher aggregateScore wins the tie → B before A.
+    expect(s.topDistricts.map(d => d.districtId)).toEqual(['B', 'A', 'C'])
+  })
+
+  it('returns all districts when fewer than the top-N exist', () => {
+    const s = buildProgramYearSummary(2024, '2025-06-30', [
+      r({ districtId: '1', overallRank: 1 }),
+      r({ districtId: '2', overallRank: 2 }),
+    ])
+    expect(s.topDistricts).toHaveLength(2)
+  })
+
+  it('carries only the presentational district fields into topDistricts', () => {
+    const s = buildProgramYearSummary(2024, '2025-06-30', [
+      r({
+        districtId: '42',
+        districtName: 'District 42',
+        region: '7',
+        overallRank: 1,
+      }),
+    ])
+    expect(s.topDistricts[0]).toEqual({
+      districtId: '42',
+      districtName: 'District 42',
+      region: '7',
+      overallRank: 1,
+    })
+  })
+
+  it('handles an empty rankings array with zeroed totals and no top districts', () => {
+    const s = buildProgramYearSummary(2024, '2025-06-30', [])
+    expect(s.totalDistricts).toBe(0)
+    expect(s.totalPaidClubs).toBe(0)
+    expect(s.totalPayments).toBe(0)
+    expect(s.totalDistinguishedClubs).toBe(0)
+    expect(s.topDistricts).toEqual([])
+  })
+})

--- a/frontend/src/utils/programYearSummary.ts
+++ b/frontend/src/utils/programYearSummary.ts
@@ -9,6 +9,8 @@
  * the card's view-model: headline aggregate metrics + the top-5 districts.
  */
 
+import { formatProgramYearShort } from './programYear'
+
 /** The subset of a CDN ranking entry the summary needs. */
 export interface DistrictRankingLite {
   districtId: string
@@ -96,7 +98,7 @@ export function buildProgramYearSummary(
 
   return {
     startYear,
-    label: `${startYear}-${String((startYear + 1) % 100).padStart(2, '0')}`,
+    label: formatProgramYearShort(startYear),
     yearEndDate,
     totalDistricts: rankings.length,
     ...totals,

--- a/frontend/src/utils/programYearSummary.ts
+++ b/frontend/src/utils/programYearSummary.ts
@@ -1,0 +1,105 @@
+/**
+ * programYearSummary (#892, epic #893) — pure aggregation for the /history
+ * per-year summary cards.
+ *
+ * The cards are assembled entirely from EXISTING CDN endpoints (no new
+ * pipeline step): the dates index gives each completed program year's
+ * year-end snapshot date, and that date's all-districts rankings give every
+ * district's final standing. This module turns one year's rankings array into
+ * the card's view-model: headline aggregate metrics + the top-5 districts.
+ */
+
+/** The subset of a CDN ranking entry the summary needs. */
+export interface DistrictRankingLite {
+  districtId: string
+  districtName: string
+  region: string
+  overallRank: number
+  aggregateScore: number
+  paidClubs: number
+  totalPayments: number
+  distinguishedClubs: number
+}
+
+/** One of the top-N districts shown on a card. */
+export interface TopDistrict {
+  districtId: string
+  districtName: string
+  region: string
+  overallRank: number
+}
+
+/** View-model for a single program-year summary card. */
+export interface ProgramYearSummary {
+  /** Calendar year the program year started (e.g. 2024 for 2024-25). */
+  startYear: number
+  /** Compact display label, e.g. "2024-25". */
+  label: string
+  /** The year-end snapshot date the standings are frozen at, e.g. "2025-06-30". */
+  yearEndDate: string
+  /** Number of districts ranked that year. */
+  totalDistricts: number
+  /** Sum of paid clubs across all districts. */
+  totalPaidClubs: number
+  /** Sum of total payments across all districts. */
+  totalPayments: number
+  /** Sum of distinguished clubs across all districts. */
+  totalDistinguishedClubs: number
+  /** Up to `topN` districts, best overall rank first. */
+  topDistricts: TopDistrict[]
+}
+
+export const DEFAULT_TOP_N = 5
+
+/**
+ * Build the view-model for one program year's summary card from that year's
+ * year-end all-districts rankings.
+ *
+ * @param startYear   Calendar year the program year started (2024 → "2024-25").
+ * @param yearEndDate The snapshot date the standings are frozen at.
+ * @param rankings    Every district's final standing for the year.
+ * @param topN        How many top districts to surface (default 5).
+ */
+export function buildProgramYearSummary(
+  startYear: number,
+  yearEndDate: string,
+  rankings: DistrictRankingLite[],
+  topN: number = DEFAULT_TOP_N
+): ProgramYearSummary {
+  const totals = rankings.reduce(
+    (acc, d) => {
+      acc.totalPaidClubs += d.paidClubs
+      acc.totalPayments += d.totalPayments
+      acc.totalDistinguishedClubs += d.distinguishedClubs
+      return acc
+    },
+    { totalPaidClubs: 0, totalPayments: 0, totalDistinguishedClubs: 0 }
+  )
+
+  // overallRank can tie (a real shape in the CDN data); break ties
+  // deterministically so the card order is stable across renders (Lesson 120):
+  // higher aggregateScore first, then districtId as a final tiebreak.
+  const topDistricts: TopDistrict[] = [...rankings]
+    .sort(
+      (a, b) =>
+        a.overallRank - b.overallRank ||
+        b.aggregateScore - a.aggregateScore ||
+        a.districtId.localeCompare(b.districtId)
+    )
+    .slice(0, topN)
+    .map(({ districtId, districtName, region, overallRank }) => ({
+      districtId,
+      districtName,
+      region,
+      overallRank,
+    }))
+
+  return {
+    startYear,
+    label: `${startYear}-${String((startYear + 1) % 100).padStart(2, '0')}`,
+    yearEndDate,
+    totalDistricts: rankings.length,
+    ...totals,
+    topDistricts,
+  }
+}


### PR DESCRIPTION
## Sprint 1 of epic #893 — build per-year summary cards on `/history`

Replaces the `/history` "coming soon" stub with **per-year summary cards** — top-5 districts + headline metrics for each completed program year, newest first, each linking into the landing page filtered to that year (`/?py=<startYear>`).

### Feasibility (the epic's gate)
Assembled entirely from **existing CDN endpoints — no new pipeline step**:
- `fetchCdnDates()` → group snapshot dates by program year → year-end date per *completed* year.
- `fetchCdnRankingsForDate(yearEndDate)` → all-districts standings → summed headline metrics + top-5 (deterministic tiebreak on `aggregateScore`, since `overallRank` ties in the real data — Lesson 120).

The old hardcoded year list was also **wrong** (it listed 2021-22, which has zero snapshots — the COVID data gap). The new cards + year strip are data-driven, so absent years correctly disappear.

### What's here
- `utils/programYearSummary.ts` — pure aggregation (7 tests).
- `hooks/useProgramYearSummaries.ts` — query over the two CDN endpoints (5 tests).
- `components/ProgramYearSummaryCards.tsx` — presentational cards w/ loading skeleton (7 tests).
- `HistoryPage.tsx` — data-driven rewrite; current-year LIVE chip stays synchronous.
- Card styles in `app-shell.css`; dark-mode parity verified.

### Quality gates
- TDD throughout (Red→Green per unit). 19 new tests; **full suite 3146 pass, 0 fail**.
- `/simplify` pass: reuse `formatProgramYearShort`; documented the timezone-safe year parse.
- Fresh-context review fixes folded in:
  - **Guard against `fetchCdnRankingsForDate`'s silent fallback** to current `rankings.json` on a 404 — a past-year card never renders current standings.
  - **CLS**: error/empty notices reserve the skeleton's height (Lesson 125 covers error/empty, not just loading).
- R22/partition guards green (page mounts in integration project); typecheck clean; prettier clean.

### Verification
Live verification on the PR preview channel (Chromium + WebKit) to follow once the preview deploys.

Refs #892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)