### PR TITLE
refactor(clubs): remove the quick-filter chip row, keep the Filters drawer (#902)

### DIFF
--- a/frontend/src/__tests__/accessibility/ClubsControlsDarkModeContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/ClubsControlsDarkModeContrast.test.ts
@@ -144,30 +144,9 @@ interface Surface {
 }
 
 const SURFACES: Surface[] = [
-  {
-    // #815: the segmented status control merged into the single preset row;
-    // the active health-band chip is now `.clubs-quick-filter-chip--active`
-    // (covered below), and its count badge inverts to --link on --surface.
-    name: 'health preset active count badge',
-    fg: [
-      '.clubs-quick-filter-chip--active .clubs-quick-filter-chip__count',
-      'color',
-    ],
-    expectFgToken: 'var(--link)',
-    bgToken: 'var(--surface)',
-  },
-  {
-    name: 'quick-filter chip active label',
-    fg: ['.clubs-quick-filter-chip--active', 'color'],
-    expectFgToken: 'var(--link)',
-    bgToken: 'var(--loyal-50)',
-  },
-  {
-    name: 'quick-filter chip hover label',
-    fg: ['.clubs-quick-filter-chip:hover', 'color'],
-    expectFgToken: 'var(--link)',
-    bgToken: 'var(--surface-3)',
-  },
+  // #902: the quick-filter chip row (active/hover/count surfaces) was removed
+  // in Sprint 2 of epic #900, so its dark-mode contrast surfaces went with it.
+  // The filter-popover active state below is a separate control that survives.
   {
     name: 'filter popover operator/sort active',
     fg: ['.clubs-filter-btn--active', 'color'],
@@ -196,28 +175,30 @@ describe('Clubs controls dark-mode contrast (#670)', () => {
     }
   )
 
-  // The maroon "Clear" chip keeps `--maroon-500` in light (brand danger colour)
-  // but that token has no dark remap (#7b1828 → ~2:1 on the dark surface), so it
-  // needs a scoped `[data-theme='dark']` override (lesson 096, #e8879a). It sits
-  // on the chip's base `--surface` background.
-  it('quick-filter Clear chip clears AA in both themes (light token + dark override)', () => {
+  // The maroon "Clear all filters" pill (empty-state) keeps `--maroon-500` in
+  // light (brand danger colour) but that token has no dark remap (#7b1828 →
+  // ~2:1 on the dark surface), so it needs a scoped `[data-theme='dark']`
+  // override (lesson 096, #e8879a). It sits on its own `--surface` background.
+  // (#902: was `.clubs-quick-filter-chip__clear`; the chip row is gone, the
+  // pill survives as `.clubs-clear-filters-btn`.)
+  it('clear-filters pill clears AA in both themes (light token + dark override)', () => {
     const lightFg = resolveVar(
-      ruleProp(appShellCss, '.clubs-quick-filter-chip__clear', 'color'),
+      ruleProp(appShellCss, '.clubs-clear-filters-btn', 'color'),
       'light'
     )
     const lightBg = resolveVar(
-      ruleProp(appShellCss, '.clubs-quick-filter-chip', 'background-color'),
+      ruleProp(appShellCss, '.clubs-clear-filters-btn', 'background-color'),
       'light'
     )
     expect(
       calculateContrastRatio(lightFg, lightBg),
-      `clear chip light ${lightFg} on ${lightBg}`
+      `clear pill light ${lightFg} on ${lightBg}`
     ).toBeGreaterThanOrEqual(AA)
 
-    const darkFgRaw = darkOverride('.clubs-quick-filter-chip__clear', 'color')
+    const darkFgRaw = darkOverride('.clubs-clear-filters-btn', 'color')
     expect(
       darkFgRaw,
-      'clear chip needs a [data-theme="dark"] color override (maroon-500 has no remap)'
+      'clear pill needs a [data-theme="dark"] color override (maroon-500 has no remap)'
     ).not.toBeNull()
     const darkFg = resolveVar(darkFgRaw as string, 'dark')
     const darkBg = resolveVar('var(--surface)', 'dark')

--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -39,7 +39,6 @@ import {
   buildClubsDeltaColumns,
   CLUBS_DELTA_COLUMN_IDS,
 } from './clubsDeltaColumns'
-import { CLOSE_TO_DISTINGUISHED_MAX_MEMBERS } from '../utils/closeToDistinguished'
 import ClubCard from './ClubCard'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDebounce } from '../hooks/useDebounce'
@@ -317,62 +316,6 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
     },
     [setFilter]
   )
-
-  // Quick-filter chip active flags — derived once per render from filterState.
-  // The membersNeeded filter is shared by two chips that interpret different
-  // ranges (#433 close-to-distinguished = [1, 4]; needs-members = [2, ∞)).
-  //
-  // NOTE: this chip uses `membersNeeded` (computeMembersToDistinguished —
-  // qualification-aware, includes Goal 7/8 paths), while ClubDetailPage's
-  // banner uses `gap.members` (raw tier gap). They share the numeric ≤4
-  // bound but are not perfectly equivalent — a club can appear in this
-  // chip's filtered results without firing the banner on its detail page
-  // (e.g. goalsAchieved=4 with a Goal-7 path) and vice versa.
-  const membersNeededValue = (() => {
-    const f = getFilter('membersNeeded')
-    return Array.isArray(f?.value) ? f.value : null
-  })()
-  const isCloseToDistinguishedActive =
-    membersNeededValue?.[0] === 1 &&
-    membersNeededValue?.[1] === CLOSE_TO_DISTINGUISHED_MAX_MEMBERS
-  const isNeedsMembersActive =
-    membersNeededValue?.[0] === 2 && membersNeededValue?.[1] === null
-
-  // Health-band presets (#815 B2). Merged into the ONE preset row below: the
-  // old segmented `role="tablist"` status control and the quick-filter chips
-  // read as two unrelated systems (table-ux-review §1). These filter the same
-  // `status` field, single-select (choosing one replaces the prior; clicking
-  // the active one clears it). "All" is the absence of an active band — the
-  // "Total / Showing N" count line already carries the total. `aria-pressed`
-  // (not `role="tab"`): a filter toggles a set, it doesn't switch a panel — and
-  // it unifies the affordance with the intent chips in the same row.
-  const statusFilterValue = (() => {
-    const f = getFilter('status')
-    return Array.isArray(f?.value) ? (f.value as string[]) : []
-  })()
-  const isStatusActive = (status: string) =>
-    statusFilterValue.length === 1 && statusFilterValue[0] === status
-  const setStatusPreset = (status: string) => {
-    setFilter(
-      'status',
-      isStatusActive(status)
-        ? null
-        : { field: 'status', type: 'categorical', value: [status] }
-    )
-  }
-  // One pass, memoized on `clubs` (the sort below memoizes for the same
-  // reason) — the badges recompute only when the data changes, not on every
-  // filter/sort/scroll-cue re-render.
-  const statusCounts = useMemo(() => {
-    const counts = { thriving: 0, vulnerable: 0, intervention: 0 }
-    for (const c of clubs) {
-      if (c.currentStatus === 'thriving') counts.thriving++
-      else if (c.currentStatus === 'vulnerable') counts.vulnerable++
-      else if (c.currentStatus === 'intervention-required')
-        counts.intervention++
-    }
-    return counts
-  }, [clubs])
 
   // Get row background color based on status
   const getRowColor = (
@@ -721,193 +664,6 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
               </>
             )}
           </div>
-
-          {/* ONE preset row (#815 B2): health bands + intent presets, merged
-              from the former segmented control and the separate chip strip.
-              Health bands first (single-select, with counts) so a leader can
-              narrow by health, then layer an intent preset on top. */}
-          <div className="clubs-quick-filters">
-            <span className="clubs-quick-filters__label">Quick filters:</span>
-
-            {/* Health bands — Thriving / Vulnerable / Intervention, single-select
-                (#361 → #815). Each carries its count; "All" = none active. */}
-            {(
-              [
-                ['thriving', 'Thriving', statusCounts.thriving],
-                ['vulnerable', 'Vulnerable', statusCounts.vulnerable],
-                [
-                  'intervention-required',
-                  'Intervention',
-                  statusCounts.intervention,
-                ],
-              ] as const
-            ).map(([value, label, count]) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => setStatusPreset(value)}
-                className={
-                  'clubs-quick-filter-chip' +
-                  (isStatusActive(value)
-                    ? ' clubs-quick-filter-chip--active'
-                    : '')
-                }
-                aria-pressed={isStatusActive(value)}
-              >
-                {label}
-                <span className="clubs-quick-filter-chip__count">{count}</span>
-              </button>
-            ))}
-
-            {/* ⭐ Close to Distinguished — 1–4 more members (#433).
-                Threshold shared with ClubDetailPage banner. */}
-            <button
-              type="button"
-              onClick={() => {
-                if (isCloseToDistinguishedActive) {
-                  setFilter('membersNeeded', null)
-                } else {
-                  // Filter only — no hidden auto-sort (#815 B2). The chip used
-                  // to silently re-sort by membersNeeded, surprising the user
-                  // and overriding any column sort they'd chosen.
-                  setFilter('membersNeeded', {
-                    field: 'membersNeeded',
-                    type: 'numeric',
-                    value: [1, CLOSE_TO_DISTINGUISHED_MAX_MEMBERS],
-                  })
-                }
-              }}
-              className={
-                'clubs-quick-filter-chip' +
-                (isCloseToDistinguishedActive
-                  ? ' clubs-quick-filter-chip--active'
-                  : '')
-              }
-              aria-pressed={isCloseToDistinguishedActive}
-            >
-              <span
-                aria-hidden="true"
-                className="clubs-quick-filter-chip__star"
-              >
-                ★
-              </span>
-              Close to Distinguished
-            </button>
-
-            {/* Needs members — clubs short by 2+ to reach next tier */}
-            <button
-              type="button"
-              onClick={() => {
-                if (isNeedsMembersActive) {
-                  setFilter('membersNeeded', null)
-                } else {
-                  setFilter('membersNeeded', {
-                    field: 'membersNeeded',
-                    type: 'numeric',
-                    value: [2, null],
-                  })
-                }
-              }}
-              className={
-                'clubs-quick-filter-chip' +
-                (isNeedsMembersActive ? ' clubs-quick-filter-chip--active' : '')
-              }
-              aria-pressed={isNeedsMembersActive}
-            >
-              Needs members
-            </button>
-
-            {/* Missing renewals — clubs with 0 October renewals */}
-            <button
-              type="button"
-              onClick={() => {
-                const current = getFilter('octoberRenewals')
-                const isActive =
-                  Array.isArray(current?.value) &&
-                  current.value[0] === 0 &&
-                  current.value[1] === 0
-                if (isActive) {
-                  setFilter('octoberRenewals', null)
-                } else {
-                  setFilter('octoberRenewals', {
-                    field: 'octoberRenewals',
-                    type: 'numeric',
-                    value: [0, 0],
-                  })
-                }
-              }}
-              className={
-                'clubs-quick-filter-chip' +
-                (() => {
-                  const f = getFilter('octoberRenewals')
-                  return Array.isArray(f?.value) &&
-                    f.value[0] === 0 &&
-                    f.value[1] === 0
-                    ? ' clubs-quick-filter-chip--active'
-                    : ''
-                })()
-              }
-              aria-pressed={(() => {
-                const f = getFilter('octoberRenewals')
-                return (
-                  Array.isArray(f?.value) &&
-                  f.value[0] === 0 &&
-                  f.value[1] === 0
-                )
-              })()}
-            >
-              Missing renewals
-            </button>
-
-            {/* President's tier only */}
-            <button
-              type="button"
-              onClick={() => {
-                const current = getFilter('distinguished')
-                const isActive =
-                  Array.isArray(current?.value) &&
-                  (current.value as string[]).includes('President')
-                if (isActive) {
-                  setFilter('distinguished', null)
-                } else {
-                  setFilter('distinguished', {
-                    field: 'distinguished',
-                    type: 'categorical',
-                    value: ['President'],
-                  })
-                }
-              }}
-              className={
-                'clubs-quick-filter-chip' +
-                (() => {
-                  const f = getFilter('distinguished')
-                  return Array.isArray(f?.value) &&
-                    (f.value as string[]).includes('President')
-                    ? ' clubs-quick-filter-chip--active'
-                    : ''
-                })()
-              }
-              aria-pressed={(() => {
-                const f = getFilter('distinguished')
-                return (
-                  Array.isArray(f?.value) &&
-                  (f.value as string[]).includes('President')
-                )
-              })()}
-            >
-              President's tier only
-            </button>
-
-            {hasActiveFilters && (
-              <button
-                type="button"
-                onClick={clearAllFilters}
-                className="clubs-quick-filter-chip clubs-quick-filter-chip__clear"
-              >
-                Clear all ({activeFilterCount})
-              </button>
-            )}
-          </div>
         </div>
       </div>
 
@@ -986,7 +742,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
             <button
               type="button"
               onClick={clearAllFilters}
-              className="clubs-quick-filter-chip clubs-quick-filter-chip__clear mt-4 mx-auto"
+              className="clubs-clear-filters-btn mt-4 mx-auto"
             >
               Clear all filters
             </button>
@@ -1146,8 +902,9 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
       )}
 
       {/* Dedicated Filters drawer (#816). Instant-apply over the SAME filter
-          state the quick-filter chips and search box write to (R11) — one
-          mechanism, three entry points. */}
+          state the search box and ActiveFiltersBar write to (R11) — one
+          mechanism, multiple entry points. (The quick-filter chip row that
+          was a third entry point was removed in #902.) */}
       <FiltersPanel
         isOpen={isFiltersOpen}
         onClose={closeFilters}

--- a/frontend/src/components/__tests__/ClubsTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.test.tsx
@@ -699,8 +699,8 @@ describe('ClubsTable', () => {
         />
       )
 
-      // 'Thriving' appears in the status segmented filter button (#361)
-      // and as the status badge on the table row. Scope to the table body.
+      // 'Thriving' renders as the status badge on the table row. Scope to the
+      // table body (#902 removed the quick-filter chip that also showed it).
       const tbody = container.querySelector('tbody')
       expect(tbody).toBeTruthy()
       expect(tbody!.textContent).toMatch(/Thriving/)
@@ -749,63 +749,32 @@ describe('ClubsTable', () => {
     })
   })
 
-  describe('Close-to-Distinguished quick-filter chip (#433)', () => {
-    it('clicking the chip filters to clubs needing 1–4 members (not exactly 1)', () => {
-      const onFilterChange = vi.fn()
-      const clubs = [createMockClub({ clubId: 'club-1' })]
+  describe('Quick-filter chip row removed (#902)', () => {
+    // Sprint 2 of epic #900 deletes the entire `.clubs-quick-filters` row
+    // (health bands + Close-to-Distinguished + Needs members + Missing
+    // renewals + President's tier + Clear-all). Precise drawer column-filters
+    // (FiltersPanel / ActiveFiltersBar) are intentionally untouched — a single
+    // shared "Close to Distinguished" preset lands in Sprint 3 (#903).
+    const clubs = [
+      createMockClub({ clubId: 'club-1', currentStatus: 'vulnerable' }),
+      createMockClub({ clubId: 'club-2', currentStatus: 'thriving' }),
+    ]
 
-      render(
+    it('renders no quick-filter chip row and no "Quick filters:" label', () => {
+      const { container } = render(
         <ClubsTable
           clubs={clubs}
           districtId="test-district"
           isLoading={false}
-          onFilterChange={onFilterChange}
         />
       )
 
-      const chip = screen.getByRole('button', {
-        name: /close to distinguished/i,
-      })
-      fireEvent.click(chip)
-
-      expect(onFilterChange).toHaveBeenCalled()
-      const lastCall =
-        onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1]
-      const filterState = lastCall![0] as Record<
-        string,
-        { value: [number | null, number | null] }
-      >
-      expect(filterState.membersNeeded).toBeDefined()
-      expect(filterState.membersNeeded!.value).toEqual([1, 4])
-    })
-  })
-
-  describe('Consolidated preset filter row (#815)', () => {
-    it('clicking "Close to Distinguished" does NOT trigger a hidden sort change', () => {
-      const onSortChange = vi.fn()
-      const clubs = [createMockClub({ clubId: 'club-1' })]
-
-      render(
-        <ClubsTable
-          clubs={clubs}
-          districtId="test-district"
-          isLoading={false}
-          onSortChange={onSortChange}
-        />
-      )
-
-      fireEvent.click(
-        screen.getByRole('button', { name: /close to distinguished/i })
-      )
-
-      // The chip filters; it must not silently re-sort the table (#815 B2 —
-      // the hidden auto-sort surprise removed).
-      expect(onSortChange).not.toHaveBeenCalled()
+      expect(container.querySelector('.clubs-quick-filters')).toBeNull()
+      expect(container.querySelector('.clubs-quick-filter-chip')).toBeNull()
+      expect(screen.queryByText(/quick filters:/i)).not.toBeInTheDocument()
     })
 
-    it('renders a single preset row — no separate status tablist', () => {
-      const clubs = [createMockClub({ clubId: 'club-1' })]
-
+    it('no longer exposes any of the four removed quick-filter chips', () => {
       render(
         <ClubsTable
           clubs={clubs}
@@ -814,96 +783,36 @@ describe('ClubsTable', () => {
         />
       )
 
-      expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
-      expect(screen.queryByRole('tab')).not.toBeInTheDocument()
-    })
-
-    it('exposes health presets as toggle buttons (aria-pressed)', () => {
-      const clubs = [
-        createMockClub({ clubId: 'club-1', currentStatus: 'vulnerable' }),
-      ]
-
-      render(
-        <ClubsTable
-          clubs={clubs}
-          districtId="test-district"
-          isLoading={false}
-        />
-      )
-
-      const vulnerable = screen.getByRole('button', { name: /^vulnerable/i })
-      expect(vulnerable).toHaveAttribute('aria-pressed', 'false')
-    })
-
-    it('clicking a health preset writes the status filter', () => {
-      const onFilterChange = vi.fn()
-      const clubs = [
-        createMockClub({ clubId: 'club-1', currentStatus: 'vulnerable' }),
-      ]
-
-      render(
-        <ClubsTable
-          clubs={clubs}
-          districtId="test-district"
-          isLoading={false}
-          onFilterChange={onFilterChange}
-        />
-      )
-
-      fireEvent.click(screen.getByRole('button', { name: /^vulnerable/i }))
-
-      const lastCall =
-        onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1]
-      const filterState = lastCall![0] as Record<string, { value: string[] }>
-      expect(filterState.status!.value).toEqual(['vulnerable'])
-    })
-
-    it('health presets are single-select: a second choice replaces the first', () => {
-      const onFilterChange = vi.fn()
-      const clubs = [
-        createMockClub({ clubId: 'club-1', currentStatus: 'vulnerable' }),
-        createMockClub({ clubId: 'club-2', currentStatus: 'thriving' }),
-      ]
-
-      render(
-        <ClubsTable
-          clubs={clubs}
-          districtId="test-district"
-          isLoading={false}
-          onFilterChange={onFilterChange}
-        />
-      )
-
-      fireEvent.click(screen.getByRole('button', { name: /^thriving/i }))
-      fireEvent.click(screen.getByRole('button', { name: /^vulnerable/i }))
-
-      const lastCall =
-        onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1]
-      const filterState = lastCall![0] as Record<string, { value: string[] }>
-      expect(filterState.status!.value).toEqual(['vulnerable'])
-    })
-
-    it('shows a count badge on each health preset', () => {
-      const clubs = [
-        createMockClub({ clubId: 'club-1', currentStatus: 'vulnerable' }),
-        createMockClub({ clubId: 'club-2', currentStatus: 'vulnerable' }),
-        createMockClub({ clubId: 'club-3', currentStatus: 'thriving' }),
-      ]
-
-      render(
-        <ClubsTable
-          clubs={clubs}
-          districtId="test-district"
-          isLoading={false}
-        />
-      )
-
-      // Scope to the count badge so the assertion can't pass on an incidental
-      // "2" elsewhere in the label.
-      const vulnerable = screen.getByRole('button', { name: /^vulnerable/i })
       expect(
-        vulnerable.querySelector('.clubs-quick-filter-chip__count')?.textContent
-      ).toBe('2')
+        screen.queryByRole('button', { name: /close to distinguished/i })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /needs members/i })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /missing renewals/i })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /president's tier only/i })
+      ).not.toBeInTheDocument()
+      // The health-band chips (aria-pressed toggles) are gone too.
+      expect(
+        screen.queryByRole('button', { name: /^vulnerable/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('keeps the drawer Filters trigger (precise column-filters survive)', () => {
+      render(
+        <ClubsTable
+          clubs={clubs}
+          districtId="test-district"
+          isLoading={false}
+        />
+      )
+
+      expect(
+        screen.getByRole('button', { name: /^filters/i })
+      ).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
@@ -283,13 +283,19 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
     expect(screen.queryByText(/beta speakers/i)).not.toBeInTheDocument()
   })
 
-  it("writes ?distinguished= when the President's-tier preset is activated (#817)", async () => {
+  it('writes ?distinguished= when a Tier column-filter is applied via the drawer (#817, #902)', async () => {
+    // #902 removed the quick-filter chip row; the drawer is now the single UI
+    // entry point for column filters. The page-level filter→URL write glue is
+    // field-agnostic — exercising it through the surviving drawer keeps the
+    // contract covered (the President's-tier preset chip is gone).
     const user = userEvent.setup()
     const { router } = renderAt('/district/61/clubs')
     await screen.findByText(/alpha toastmasters/i)
 
+    await user.click(screen.getByRole('button', { name: /^filters/i }))
+    const dialog = screen.getByRole('dialog')
     await user.click(
-      screen.getByRole('button', { name: /President's tier only/i })
+      within(dialog).getByRole('checkbox', { name: 'President' })
     )
 
     await waitFor(() => {
@@ -313,18 +319,19 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
     expect(screen.queryByText(/alpha toastmasters/i)).not.toBeInTheDocument()
   })
 
-  it('writes ?status= to the URL when a health preset is activated', async () => {
+  it('writes ?status= to the URL when the Status filter is applied via the drawer (#902)', async () => {
     const user = userEvent.setup()
     const { router } = renderAt('/district/61/clubs')
 
     await screen.findByText(/alpha toastmasters/i)
 
-    // #815: health bands are now toggle buttons in the single preset row, not
-    // tabs in a segmented control.
-    const vulnerableChip = screen.getByRole('button', {
-      name: /^vulnerable/i,
-    })
-    await user.click(vulnerableChip)
+    // #902: health-band selection now lives in the Filters drawer (the chip
+    // row was removed). Same `status` field, same filter→URL write path.
+    await user.click(screen.getByRole('button', { name: /^filters/i }))
+    const dialog = screen.getByRole('dialog')
+    await user.click(
+      within(dialog).getByRole('checkbox', { name: 'vulnerable' })
+    )
 
     await waitFor(() => {
       const params = new URLSearchParams(router.state.location.search)
@@ -332,18 +339,21 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
     })
   })
 
-  it('clears ?status= from the URL when the active health preset is toggled off', async () => {
+  it('clears ?status= from the URL when the Status filter is unchecked in the drawer (#902)', async () => {
     const user = userEvent.setup()
     const { router } = renderAt('/district/61/clubs?status=vulnerable')
 
     await screen.findByText(/beta speakers/i)
 
-    // No more "All" button (#815) — clicking the active band toggles it off.
-    const vulnerableChip = screen.getByRole('button', {
-      name: /^vulnerable/i,
+    await user.click(screen.getByRole('button', { name: /^filters/i }))
+    const dialog = screen.getByRole('dialog')
+    const vulnerable = within(dialog).getByRole('checkbox', {
+      name: 'vulnerable',
     })
-    expect(vulnerableChip).toHaveAttribute('aria-pressed', 'true')
-    await user.click(vulnerableChip)
+    // Loaded from the URL, so it starts checked; unchecking the only selected
+    // value clears the filter and the param.
+    expect(vulnerable).toBeChecked()
+    await user.click(vulnerable)
 
     await waitFor(() => {
       const params = new URLSearchParams(router.state.location.search)

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -35,8 +35,7 @@
     backdrop-filter: saturate(140%) blur(8px);
   }
 
-  @supports (backdrop-filter: blur(1px)) or
-    (-webkit-backdrop-filter: blur(1px)) {
+  @supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
     .app-shell-top-bar {
       background-color: rgba(var(--rds-surface-rgb), 0.85);
     }
@@ -143,7 +142,9 @@
     font-family: var(--sans);
     font-weight: 500;
     font-size: 15px;
-    transition: background-color 150ms ease, color 150ms ease;
+    transition:
+      background-color 150ms ease,
+      color 150ms ease;
   }
 
   .app-shell-nav__link:hover {
@@ -849,7 +850,10 @@
     padding: 6px 12px;
     border-radius: var(--rds-radius-sm);
     cursor: pointer;
-    transition: background-color 150ms, border-color 150ms, color 150ms;
+    transition:
+      background-color 150ms,
+      border-color 150ms,
+      color 150ms;
   }
 
   .districts-toolbar__sort-btn:hover {
@@ -877,7 +881,10 @@
     padding: 4px 10px;
     border-radius: 999px;
     cursor: pointer;
-    transition: background-color 150ms, border-color 150ms, color 150ms;
+    transition:
+      background-color 150ms,
+      border-color 150ms,
+      color 150ms;
     /* 44px: WCAG 2.5.5 / handoff touch-target floor (#886, epic #888 Sprint 2).
        Audit #885 measured these chips 36px wide (width was the short side;
        height already cleared 44). text-align:center keeps the single-digit
@@ -934,7 +941,10 @@
     padding: 6px 12px;
     border-radius: 999px;
     cursor: pointer;
-    transition: background-color 150ms, border-color 150ms, color 150ms;
+    transition:
+      background-color 150ms,
+      border-color 150ms,
+      color 150ms;
     /* 44px: WCAG 2.5.5 / handoff touch-target floor (#886, epic #888 Sprint 2).
        Audit #885 measured these chips 40–41px wide — same width-short shape as
        .districts-toolbar__region-chip. */
@@ -981,7 +991,9 @@
     font-family: var(--sans);
     font-size: 13px;
     color: var(--ink);
-    transition: border-color 150ms, background-color 150ms;
+    transition:
+      border-color 150ms,
+      background-color 150ms;
   }
 
   .districts-toolbar__search-input::placeholder {
@@ -2355,99 +2367,32 @@
     margin-top: 12px;
   }
 
-  /* Clubs tab quick-filter chip strip (#24 follow-up). Sits above the
-     ClubsTable toolbar on the District detail Clubs tab. Since #815 this is
-     the SINGLE preset row: health bands (with count badges) + intent presets. */
-  .clubs-quick-filters {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .clubs-quick-filters__label {
-    font-family: var(--sans);
-    font-size: 12px;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--ink-3);
-    margin-right: 4px;
-  }
-
-  .clubs-quick-filter-chip {
+  /* "Clear all filters" pill in the clubs-table empty (no-results) state.
+     The quick-filter chip row was removed in Sprint 2 of epic #900 (#902);
+     this is the last surviving pill, restyled into a dedicated self-contained
+     class (was .clubs-quick-filter-chip.clubs-quick-filter-chip__clear). The
+     maroon text/border has no dark remap — see the [data-theme='dark']
+     override in dark-mode.css (lesson 096). */
+  .clubs-clear-filters-btn {
     display: inline-flex;
     align-items: center;
     gap: 6px;
     padding: 4px 12px;
     border-radius: 999px;
-    border: 1px solid var(--line);
+    border: 1px solid rgba(123, 24, 40, 0.25);
     background-color: var(--surface);
-    color: var(--ink-2);
+    color: var(--maroon-500);
     font-family: var(--sans);
     font-size: 12px;
     font-weight: 500;
     cursor: pointer;
-    transition: background-color 150ms, border-color 150ms, color 150ms;
+    transition:
+      background-color 150ms,
+      border-color 150ms,
+      color 150ms;
   }
 
-  .clubs-quick-filter-chip:hover {
-    background-color: var(--surface-3);
-    border-color: var(--loyal-200);
-    color: var(--link);
-  }
-
-  /* Active chip matches the segmented control: --link text on --loyal-50,
-     not a solid --loyal-500 fill — keeps the accent dark-safe (#670). */
-  .clubs-quick-filter-chip--active {
-    background-color: var(--loyal-50);
-    border-color: var(--loyal-200);
-    color: var(--link);
-  }
-
-  .clubs-quick-filter-chip--active:hover {
-    background-color: var(--loyal-100);
-    border-color: var(--loyal-200);
-    color: var(--link);
-  }
-
-  /* Star stays gold in both rest and active states (the active fill is now
-     a light tint, so a white star would vanish). */
-  .clubs-quick-filter-chip__star {
-    color: var(--yellow-600);
-  }
-
-  /* Count badge on the health-band presets (#815). Pill of --surface-3 / --ink-3
-     at rest; on the active chip it inverts to --link on --surface to match the
-     active label (dark-safe via --link, lessons 093/096). */
-  .clubs-quick-filter-chip__count {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 20px;
-    padding: 0 6px;
-    height: 16px;
-    margin-left: 2px;
-    border-radius: 999px;
-    background-color: var(--surface-3);
-    color: var(--ink-3);
-    font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
-    font-weight: 500;
-    font-size: 11px;
-    line-height: 1;
-  }
-
-  .clubs-quick-filter-chip--active .clubs-quick-filter-chip__count {
-    background-color: var(--surface);
-    color: var(--link);
-  }
-
-  .clubs-quick-filter-chip__clear {
-    color: var(--maroon-500);
-    border-color: rgba(123, 24, 40, 0.25);
-  }
-
-  .clubs-quick-filter-chip__clear:hover {
+  .clubs-clear-filters-btn:hover {
     background-color: rgba(123, 24, 40, 0.06);
     border-color: var(--maroon-500);
     color: var(--maroon-500);
@@ -2515,7 +2460,9 @@
     background-color: transparent;
     color: var(--link);
     cursor: pointer;
-    transition: background-color 150ms, color 150ms;
+    transition:
+      background-color 150ms,
+      color 150ms;
   }
 
   .clubs-active-filters__remove:hover {
@@ -3234,7 +3181,9 @@
     white-space: nowrap;
     cursor: pointer;
     border-bottom: 3px solid transparent;
-    transition: color 150ms ease, background-color 150ms ease,
+    transition:
+      color 150ms ease,
+      background-color 150ms ease,
       border-color 150ms ease;
   }
 

--- a/frontend/src/styles/dark-mode.css
+++ b/frontend/src/styles/dark-mode.css
@@ -11,136 +11,136 @@
 /* ─── Semantic Design Tokens ─── */
 
 :root {
-    /* Light mode defaults (matching existing Tailwind values) */
-    --surface-primary: #FFFFFF;
-    --surface-secondary: #F9FAFB;
-    --surface-card: #FFFFFF;
-    --surface-card-hover: #F3F4F6;
-    --text-heading: #111827;
-    --text-body: #374151;
-    --text-muted: #6B7280;
-    --border-default: #E5E7EB;
-    --border-subtle: #D1D5DB;
-    --shadow-color: rgba(0, 0, 0, 0.1);
+  /* Light mode defaults (matching existing Tailwind values) */
+  --surface-primary: #ffffff;
+  --surface-secondary: #f9fafb;
+  --surface-card: #ffffff;
+  --surface-card-hover: #f3f4f6;
+  --text-heading: #111827;
+  --text-body: #374151;
+  --text-muted: #6b7280;
+  --border-default: #e5e7eb;
+  --border-subtle: #d1d5db;
+  --shadow-color: rgba(0, 0, 0, 0.1);
 }
 
 /* ─── Taverns-Red Dark Palette ─── */
 
 [data-theme='dark'] {
-    /* Backgrounds */
-    --surface-primary: #0C0A0F;
-    --surface-secondary: #14111A;
-    --surface-card: #1A1722;
-    --surface-card-hover: #221E2D;
+  /* Backgrounds */
+  --surface-primary: #0c0a0f;
+  --surface-secondary: #14111a;
+  --surface-card: #1a1722;
+  --surface-card-hover: #221e2d;
 
-    /* Text */
-    --text-heading: #F0ECF5;
-    --text-body: rgba(240, 236, 245, 0.87);
-    --text-muted: #9B95A5;
+  /* Text */
+  --text-heading: #f0ecf5;
+  --text-body: rgba(240, 236, 245, 0.87);
+  --text-muted: #9b95a5;
 
-    /* Borders */
-    --border-default: rgba(255, 255, 255, 0.06);
-    --border-subtle: rgba(255, 255, 255, 0.10);
+  /* Borders */
+  --border-default: rgba(255, 255, 255, 0.06);
+  --border-subtle: rgba(255, 255, 255, 0.1);
 
-    /* Shadows */
-    --shadow-color: rgba(0, 0, 0, 0.4);
+  /* Shadows */
+  --shadow-color: rgba(0, 0, 0, 0.4);
 
-    /* Taverns-red accents */
-    --accent-red: #C13B3B;
-    --accent-red-dark: #8B1A1A;
-    --accent-maple: #D4873F;
-    --accent-maple-light: #E8A55C;
-    --accent-amber: #F5C36A;
-    --accent-cream: #FFF8ED;
+  /* Taverns-red accents */
+  --accent-red: #c13b3b;
+  --accent-red-dark: #8b1a1a;
+  --accent-maple: #d4873f;
+  --accent-maple-light: #e8a55c;
+  --accent-amber: #f5c36a;
+  --accent-cream: #fff8ed;
 
-    /* ─── Toastmasters Brand Token Overrides ─── */
-    --tm-black: #F0ECF5;
-    --tm-loyal-blue: #5DADE2;
-    --tm-loyal-blue-100: rgba(93, 173, 226, 1.0);
-    --tm-loyal-blue-90: rgba(93, 173, 226, 0.9);
-    --tm-loyal-blue-80: rgba(93, 173, 226, 0.8);
-    --tm-loyal-blue-70: rgba(93, 173, 226, 0.7);
-    --tm-loyal-blue-60: rgba(93, 173, 226, 0.6);
-    --tm-loyal-blue-50: rgba(93, 173, 226, 0.5);
-    --tm-loyal-blue-40: rgba(93, 173, 226, 0.4);
-    --tm-loyal-blue-30: rgba(93, 173, 226, 0.3);
-    --tm-loyal-blue-20: rgba(93, 173, 226, 0.2);
-    --tm-loyal-blue-10: rgba(93, 173, 226, 0.1);
-    --tm-true-maroon: #E8879A;
-    --tm-true-maroon-100: rgba(232, 135, 154, 1.0);
-    --tm-true-maroon-90: rgba(232, 135, 154, 0.9);
-    --tm-true-maroon-80: rgba(232, 135, 154, 0.8);
-    --tm-true-maroon-70: rgba(232, 135, 154, 0.7);
-    --tm-true-maroon-60: rgba(232, 135, 154, 0.6);
-    --tm-true-maroon-50: rgba(232, 135, 154, 0.5);
-    --tm-cool-gray: #C0C8C7;
-    --tm-cool-gray-80: rgba(192, 200, 199, 0.8);
-    --tm-cool-gray-60: rgba(192, 200, 199, 0.6);
-    --tm-cool-gray-40: rgba(192, 200, 199, 0.4);
-    --tm-cool-gray-20: rgba(192, 200, 199, 0.2);
-    --tm-cool-gray-10: rgba(192, 200, 199, 0.1);
+  /* ─── Toastmasters Brand Token Overrides ─── */
+  --tm-black: #f0ecf5;
+  --tm-loyal-blue: #5dade2;
+  --tm-loyal-blue-100: rgba(93, 173, 226, 1);
+  --tm-loyal-blue-90: rgba(93, 173, 226, 0.9);
+  --tm-loyal-blue-80: rgba(93, 173, 226, 0.8);
+  --tm-loyal-blue-70: rgba(93, 173, 226, 0.7);
+  --tm-loyal-blue-60: rgba(93, 173, 226, 0.6);
+  --tm-loyal-blue-50: rgba(93, 173, 226, 0.5);
+  --tm-loyal-blue-40: rgba(93, 173, 226, 0.4);
+  --tm-loyal-blue-30: rgba(93, 173, 226, 0.3);
+  --tm-loyal-blue-20: rgba(93, 173, 226, 0.2);
+  --tm-loyal-blue-10: rgba(93, 173, 226, 0.1);
+  --tm-true-maroon: #e8879a;
+  --tm-true-maroon-100: rgba(232, 135, 154, 1);
+  --tm-true-maroon-90: rgba(232, 135, 154, 0.9);
+  --tm-true-maroon-80: rgba(232, 135, 154, 0.8);
+  --tm-true-maroon-70: rgba(232, 135, 154, 0.7);
+  --tm-true-maroon-60: rgba(232, 135, 154, 0.6);
+  --tm-true-maroon-50: rgba(232, 135, 154, 0.5);
+  --tm-cool-gray: #c0c8c7;
+  --tm-cool-gray-80: rgba(192, 200, 199, 0.8);
+  --tm-cool-gray-60: rgba(192, 200, 199, 0.6);
+  --tm-cool-gray-40: rgba(192, 200, 199, 0.4);
+  --tm-cool-gray-20: rgba(192, 200, 199, 0.2);
+  --tm-cool-gray-10: rgba(192, 200, 199, 0.1);
 
-    /* Override the body base styles */
-    color-scheme: dark;
+  /* Override the body base styles */
+  color-scheme: dark;
 }
 
 /* ─── Root & Body Overrides ─── */
 
 [data-theme='dark'] body {
-    background-color: var(--surface-primary);
-    color: var(--text-body);
+  background-color: var(--surface-primary);
+  color: var(--text-body);
 }
 
 /* ─── Background Overrides ─── */
 
 [data-theme='dark'] .bg-white {
-    background-color: var(--surface-card) !important;
+  background-color: var(--surface-card) !important;
 }
 
 [data-theme='dark'] .bg-gray-50 {
-    background-color: var(--surface-secondary) !important;
+  background-color: var(--surface-secondary) !important;
 }
 
 [data-theme='dark'] .bg-gray-100 {
-    background-color: #1E1B27 !important;
+  background-color: #1e1b27 !important;
 }
 
 [data-theme='dark'] .bg-gray-200 {
-    background-color: #252230 !important;
+  background-color: #252230 !important;
 }
 
 [data-theme='dark'] .bg-gray-300 {
-    background-color: #2D2A38 !important;
+  background-color: #2d2a38 !important;
 }
 
 [data-theme='dark'] .bg-gray-400 {
-    background-color: #3A3648 !important;
+  background-color: #3a3648 !important;
 }
 
 [data-theme='dark'] .bg-gray-500 {
-    background-color: #4A4658 !important;
+  background-color: #4a4658 !important;
 }
 
 [data-theme='dark'] .bg-gray-900 {
-    background-color: #0C0A0F !important;
+  background-color: #0c0a0f !important;
 }
 
 /* ─── Text Overrides ─── */
 
 [data-theme='dark'] .text-gray-900 {
-    color: var(--text-heading) !important;
+  color: var(--text-heading) !important;
 }
 
 [data-theme='dark'] .text-gray-800 {
-    color: var(--text-heading) !important;
+  color: var(--text-heading) !important;
 }
 
 [data-theme='dark'] .text-gray-700 {
-    color: var(--text-body) !important;
+  color: var(--text-body) !important;
 }
 
 [data-theme='dark'] .text-gray-600 {
-    color: var(--text-muted) !important;
+  color: var(--text-muted) !important;
 }
 
 /* #609: gray-500/400 were hardcoded #6B6575 — 3.16:1 on the page surface and
@@ -148,151 +148,155 @@
    body text the Region pages use (table headers, KPI bases, card sublabels).
    Map them to --text-muted like gray-600 already does (5.06–6.10:1). */
 [data-theme='dark'] .text-gray-500 {
-    color: var(--text-muted) !important;
+  color: var(--text-muted) !important;
 }
 
 [data-theme='dark'] .text-gray-400 {
-    color: var(--text-muted) !important;
+  color: var(--text-muted) !important;
 }
 
 [data-theme='dark'] .text-gray-300 {
-    color: #9B95A5 !important;
+  color: #9b95a5 !important;
 }
 
 /* ─── Border Overrides ─── */
 
 [data-theme='dark'] .border-gray-100 {
-    border-color: var(--border-default) !important;
+  border-color: var(--border-default) !important;
 }
 
 [data-theme='dark'] .border-gray-200 {
-    border-color: var(--border-default) !important;
+  border-color: var(--border-default) !important;
 }
 
 [data-theme='dark'] .border-gray-300 {
-    border-color: var(--border-subtle) !important;
+  border-color: var(--border-subtle) !important;
 }
 
 [data-theme='dark'] .border-gray-400 {
-    border-color: var(--border-subtle) !important;
+  border-color: var(--border-subtle) !important;
 }
 
 [data-theme='dark'] .border-tm-cool-gray-20 {
-    border-color: var(--border-default) !important;
+  border-color: var(--border-default) !important;
 }
 
 [data-theme='dark'] .border-tm-cool-gray-30 {
-    border-color: var(--border-subtle) !important;
+  border-color: var(--border-subtle) !important;
 }
 
 [data-theme='dark'] .border-tm-cool-gray {
-    border-color: rgba(255, 255, 255, 0.12) !important;
+  border-color: rgba(255, 255, 255, 0.12) !important;
 }
 
 /* ─── Shadow Overrides ─── */
 
 [data-theme='dark'] .shadow-sm {
-    box-shadow: 0 1px 2px var(--shadow-color) !important;
+  box-shadow: 0 1px 2px var(--shadow-color) !important;
 }
 
 [data-theme='dark'] .shadow-md {
-    box-shadow: 0 4px 6px var(--shadow-color), 0 2px 4px rgba(0, 0, 0, 0.2) !important;
+  box-shadow:
+    0 4px 6px var(--shadow-color),
+    0 2px 4px rgba(0, 0, 0, 0.2) !important;
 }
 
 [data-theme='dark'] .shadow-lg {
-    box-shadow: 0 10px 15px var(--shadow-color), 0 4px 6px rgba(0, 0, 0, 0.2) !important;
+  box-shadow:
+    0 10px 15px var(--shadow-color),
+    0 4px 6px rgba(0, 0, 0, 0.2) !important;
 }
 
 /* ─── Brand Component Overrides ─── */
 
 [data-theme='dark'] .tm-card {
-    background-color: var(--surface-card);
-    color: var(--text-body);
-    border-color: var(--border-default);
+  background-color: var(--surface-card);
+  color: var(--text-body);
+  border-color: var(--border-default);
 }
 
 [data-theme='dark'] .tm-card:hover {
-    background-color: var(--surface-card-hover);
+  background-color: var(--surface-card-hover);
 }
 
 [data-theme='dark'] .tm-card-header h1,
 [data-theme='dark'] .tm-card-header h2,
 [data-theme='dark'] .tm-card-header h3 {
-    color: var(--text-heading);
+  color: var(--text-heading);
 }
 
 [data-theme='dark'] .tm-card-header {
-    border-bottom-color: var(--border-default);
+  border-bottom-color: var(--border-default);
 }
 
 [data-theme='dark'] .tm-card-footer {
-    border-top-color: var(--border-default);
+  border-top-color: var(--border-default);
 }
 
 [data-theme='dark'] .tm-panel {
-    color: var(--text-body);
+  color: var(--text-body);
 }
 
 [data-theme='dark'] .tm-panel-default {
-    background-color: var(--surface-secondary);
-    border-color: var(--border-default);
+  background-color: var(--surface-secondary);
+  border-color: var(--border-default);
 }
 
 [data-theme='dark'] .tm-panel-subtle {
-    background-color: rgba(26, 23, 34, 0.5);
-    border-color: var(--border-default);
+  background-color: rgba(26, 23, 34, 0.5);
+  border-color: var(--border-default);
 }
 
 /* ─── Scroll Fade ─── */
 
-[data-theme='dark'] .tab-scroll-fade[data-scrollable-right="true"]::after {
-    background: linear-gradient(to right, transparent, var(--surface-primary));
+[data-theme='dark'] .tab-scroll-fade[data-scrollable-right='true']::after {
+  background: linear-gradient(to right, transparent, var(--surface-primary));
 }
 
 /* ─── Sticky Column Shadow ─── */
 
 [data-theme='dark'] .sticky-column-shadow {
-    box-shadow: 4px 0 6px -2px rgba(0, 0, 0, 0.4);
+  box-shadow: 4px 0 6px -2px rgba(0, 0, 0, 0.4);
 }
 
 /* ─── Hover State Overrides ─── */
 
 [data-theme='dark'] .hover\:bg-gray-50:hover {
-    background-color: var(--surface-card-hover) !important;
+  background-color: var(--surface-card-hover) !important;
 }
 
 [data-theme='dark'] .hover\:bg-gray-100:hover {
-    background-color: #252230 !important;
+  background-color: #252230 !important;
 }
 
 [data-theme='dark'] .hover\:bg-gray-200:hover {
-    background-color: #2D2A38 !important;
+  background-color: #2d2a38 !important;
 }
 
 [data-theme='dark'] .hover\:bg-tm-loyal-blue-10:hover {
-    background-color: rgba(0, 60, 113, 0.15) !important;
+  background-color: rgba(0, 60, 113, 0.15) !important;
 }
 
 /* ─── Colored Row Hover Overrides ─── */
 
 [data-theme='dark'] .hover\:bg-red-100:hover {
-    background-color: rgba(185, 28, 28, 0.20) !important;
+  background-color: rgba(185, 28, 28, 0.2) !important;
 }
 
 [data-theme='dark'] .hover\:bg-yellow-100:hover {
-    background-color: rgba(161, 98, 7, 0.20) !important;
+  background-color: rgba(161, 98, 7, 0.2) !important;
 }
 
 [data-theme='dark'] .hover\:bg-green-200:hover {
-    background-color: rgba(22, 163, 74, 0.20) !important;
+  background-color: rgba(22, 163, 74, 0.2) !important;
 }
 
 [data-theme='dark'] .hover\:bg-blue-200:hover {
-    background-color: rgba(37, 99, 235, 0.20) !important;
+  background-color: rgba(37, 99, 235, 0.2) !important;
 }
 
 [data-theme='dark'] .hover\:bg-blue-50:hover {
-    background-color: rgba(37, 99, 235, 0.10) !important;
+  background-color: rgba(37, 99, 235, 0.1) !important;
 }
 
 /* ═══════════════════════════════════════════
@@ -303,57 +307,57 @@
 /* ─── Red Backgrounds ─── */
 
 [data-theme='dark'] .bg-red-50 {
-    background-color: rgba(185, 28, 28, 0.10) !important;
+  background-color: rgba(185, 28, 28, 0.1) !important;
 }
 
 [data-theme='dark'] .bg-red-100 {
-    background-color: rgba(185, 28, 28, 0.18) !important;
+  background-color: rgba(185, 28, 28, 0.18) !important;
 }
 
 [data-theme='dark'] .bg-red-200 {
-    background-color: rgba(185, 28, 28, 0.25) !important;
+  background-color: rgba(185, 28, 28, 0.25) !important;
 }
 
 /* ─── Yellow/Amber Backgrounds ─── */
 
 [data-theme='dark'] .bg-yellow-50 {
-    background-color: rgba(161, 98, 7, 0.10) !important;
+  background-color: rgba(161, 98, 7, 0.1) !important;
 }
 
 [data-theme='dark'] .bg-yellow-100 {
-    background-color: rgba(161, 98, 7, 0.18) !important;
+  background-color: rgba(161, 98, 7, 0.18) !important;
 }
 
 [data-theme='dark'] .bg-yellow-200 {
-    background-color: rgba(161, 98, 7, 0.25) !important;
+  background-color: rgba(161, 98, 7, 0.25) !important;
 }
 
 /* ─── Green Backgrounds ─── */
 
 [data-theme='dark'] .bg-green-50 {
-    background-color: rgba(22, 163, 74, 0.10) !important;
+  background-color: rgba(22, 163, 74, 0.1) !important;
 }
 
 [data-theme='dark'] .bg-green-100 {
-    background-color: rgba(22, 163, 74, 0.18) !important;
+  background-color: rgba(22, 163, 74, 0.18) !important;
 }
 
 [data-theme='dark'] .bg-green-200 {
-    background-color: rgba(22, 163, 74, 0.25) !important;
+  background-color: rgba(22, 163, 74, 0.25) !important;
 }
 
 /* ─── Blue Backgrounds ─── */
 
 [data-theme='dark'] .bg-blue-50 {
-    background-color: rgba(37, 99, 235, 0.10) !important;
+  background-color: rgba(37, 99, 235, 0.1) !important;
 }
 
 [data-theme='dark'] .bg-blue-100 {
-    background-color: rgba(37, 99, 235, 0.18) !important;
+  background-color: rgba(37, 99, 235, 0.18) !important;
 }
 
 [data-theme='dark'] .bg-blue-200 {
-    background-color: rgba(37, 99, 235, 0.25) !important;
+  background-color: rgba(37, 99, 235, 0.25) !important;
 }
 
 /* ═══════════════════════════════════════════
@@ -363,11 +367,11 @@
 
 [data-theme='dark'] .text-red-700,
 [data-theme='dark'] .text-red-800 {
-    color: #FCA5A5 !important;
+  color: #fca5a5 !important;
 }
 
 [data-theme='dark'] .text-red-600 {
-    color: #F87171 !important;
+  color: #f87171 !important;
 }
 
 /* #610: -900 joins the group. The club anniversary badge (the only consumer)
@@ -377,20 +381,20 @@
 [data-theme='dark'] .text-yellow-700,
 [data-theme='dark'] .text-yellow-800,
 [data-theme='dark'] .text-yellow-900 {
-    color: #FDE68A !important;
+  color: #fde68a !important;
 }
 
 [data-theme='dark'] .text-yellow-600 {
-    color: #FBBF24 !important;
+  color: #fbbf24 !important;
 }
 
 [data-theme='dark'] .text-green-700,
 [data-theme='dark'] .text-green-800 {
-    color: #86EFAC !important;
+  color: #86efac !important;
 }
 
 [data-theme='dark'] .text-green-600 {
-    color: #4ADE80 !important;
+  color: #4ade80 !important;
 }
 
 /* #610: -900 joins the group — see the yellow note above. The upcoming-
@@ -398,11 +402,11 @@
 [data-theme='dark'] .text-blue-700,
 [data-theme='dark'] .text-blue-800,
 [data-theme='dark'] .text-blue-900 {
-    color: #93C5FD !important;
+  color: #93c5fd !important;
 }
 
 [data-theme='dark'] .text-blue-600 {
-    color: #60A5FA !important;
+  color: #60a5fa !important;
 }
 
 /* ═══════════════════════════════════════════
@@ -412,22 +416,22 @@
 [data-theme='dark'] .border-red-200,
 [data-theme='dark'] .border-red-300,
 [data-theme='dark'] .border-red-400 {
-    border-color: rgba(248, 113, 113, 0.30) !important;
+  border-color: rgba(248, 113, 113, 0.3) !important;
 }
 
 [data-theme='dark'] .border-yellow-200,
 [data-theme='dark'] .border-yellow-300 {
-    border-color: rgba(251, 191, 36, 0.30) !important;
+  border-color: rgba(251, 191, 36, 0.3) !important;
 }
 
 [data-theme='dark'] .border-green-200,
 [data-theme='dark'] .border-green-300 {
-    border-color: rgba(74, 222, 128, 0.30) !important;
+  border-color: rgba(74, 222, 128, 0.3) !important;
 }
 
 [data-theme='dark'] .border-blue-200,
 [data-theme='dark'] .border-blue-300 {
-    border-color: rgba(96, 165, 250, 0.30) !important;
+  border-color: rgba(96, 165, 250, 0.3) !important;
 }
 
 /* ═══════════════════════════════════════════
@@ -436,23 +440,23 @@
    ═══════════════════════════════════════════ */
 
 [data-theme='dark'] select,
-[data-theme='dark'] input[type="text"],
-[data-theme='dark'] input[type="search"],
-[data-theme='dark'] input[type="date"],
-[data-theme='dark'] input[type="number"] {
-    background-color: var(--surface-card) !important;
-    color: var(--text-body) !important;
-    border-color: var(--border-subtle) !important;
+[data-theme='dark'] input[type='text'],
+[data-theme='dark'] input[type='search'],
+[data-theme='dark'] input[type='date'],
+[data-theme='dark'] input[type='number'] {
+  background-color: var(--surface-card) !important;
+  color: var(--text-body) !important;
+  border-color: var(--border-subtle) !important;
 }
 
 [data-theme='dark'] select option {
-    background-color: var(--surface-card);
-    color: var(--text-body);
+  background-color: var(--surface-card);
+  color: var(--text-body);
 }
 
 /* Search bar placeholder */
 [data-theme='dark'] input::placeholder {
-    color: var(--text-muted) !important;
+  color: var(--text-muted) !important;
 }
 
 /* ═══════════════════════════════════════════
@@ -460,21 +464,21 @@
    ═══════════════════════════════════════════ */
 
 [data-theme='dark'] blockquote {
-    background-color: var(--surface-secondary) !important;
-    border-color: var(--border-subtle) !important;
-    color: var(--text-body) !important;
+  background-color: var(--surface-secondary) !important;
+  border-color: var(--border-subtle) !important;
+  color: var(--text-body) !important;
 }
 
 /* ═══════════════════════════════════════════
    Divider Overrides
    ═══════════════════════════════════════════ */
 
-[data-theme='dark'] .divide-gray-200>*+* {
-    border-color: var(--border-default) !important;
+[data-theme='dark'] .divide-gray-200 > * + * {
+  border-color: var(--border-default) !important;
 }
 
-[data-theme='dark'] .divide-gray-100>*+* {
-    border-color: var(--border-default) !important;
+[data-theme='dark'] .divide-gray-100 > * + * {
+  border-color: var(--border-default) !important;
 }
 
 /* ═══════════════════════════════════════════
@@ -483,16 +487,16 @@
    ═══════════════════════════════════════════ */
 
 [data-theme='dark'] td.sticky {
-    background-color: var(--surface-card) !important;
+  background-color: var(--surface-card) !important;
 }
 
 [data-theme='dark'] th.sticky {
-    background-color: var(--surface-secondary) !important;
+  background-color: var(--surface-secondary) !important;
 }
 
 /* Pinned row sticky columns */
 [data-theme='dark'] tr.bg-blue-50 td.sticky {
-    background-color: rgba(37, 99, 235, 0.10) !important;
+  background-color: rgba(37, 99, 235, 0.1) !important;
 }
 
 /* Landing rankings table sticky key column (#811). Its default bg is the
@@ -502,13 +506,14 @@
    No !important: the cell carries no Tailwind bg utility to override, and
    !important here would beat the row-hover rule and desync the pinned cell's
    highlight from its row in dark mode. */
-[data-theme='dark'] .districts-rankings-table__sticky-col[data-row-tint='mine'] {
-    background-color: rgba(161, 98, 7, 0.1);
+[data-theme='dark']
+  .districts-rankings-table__sticky-col[data-row-tint='mine'] {
+  background-color: rgba(161, 98, 7, 0.1);
 }
 
 [data-theme='dark']
-    .districts-rankings-table__sticky-col[data-row-tint='pinned'] {
-    background-color: rgba(37, 99, 235, 0.1);
+  .districts-rankings-table__sticky-col[data-row-tint='pinned'] {
+  background-color: rgba(37, 99, 235, 0.1);
 }
 
 /* Club table sticky key column (#812). Default bg is themed var(--surface)
@@ -520,24 +525,24 @@
    the hovered tinted row. No !important (the cell carries no Tailwind bg utility
    to override, and it would desync the row-hover highlight — Lesson 107). */
 [data-theme='dark'] .clubs-table__sticky-col[data-row-tint='vulnerable'] {
-    background-color: rgba(161, 98, 7, 0.1);
+  background-color: rgba(161, 98, 7, 0.1);
 }
 [data-theme='dark'] .clubs-table__sticky-col[data-row-tint='intervention'] {
-    background-color: rgba(185, 28, 28, 0.1);
+  background-color: rgba(185, 28, 28, 0.1);
 }
 [data-theme='dark']
-    #clubs-table
-    tbody
-    tr:hover
-    .clubs-table__sticky-col[data-row-tint='vulnerable'] {
-    background-color: rgba(161, 98, 7, 0.2);
+  #clubs-table
+  tbody
+  tr:hover
+  .clubs-table__sticky-col[data-row-tint='vulnerable'] {
+  background-color: rgba(161, 98, 7, 0.2);
 }
 [data-theme='dark']
-    #clubs-table
-    tbody
-    tr:hover
-    .clubs-table__sticky-col[data-row-tint='intervention'] {
-    background-color: rgba(185, 28, 28, 0.2);
+  #clubs-table
+  tbody
+  tr:hover
+  .clubs-table__sticky-col[data-row-tint='intervention'] {
+  background-color: rgba(185, 28, 28, 0.2);
 }
 
 /* ═══════════════════════════════════════════
@@ -546,35 +551,35 @@
    ═══════════════════════════════════════════ */
 
 [data-theme='dark'] .from-blue-50 {
-    --tw-gradient-from: rgba(37, 99, 235, 0.10) !important;
+  --tw-gradient-from: rgba(37, 99, 235, 0.1) !important;
 }
 
 [data-theme='dark'] .to-blue-100 {
-    --tw-gradient-to: rgba(37, 99, 235, 0.18) !important;
+  --tw-gradient-to: rgba(37, 99, 235, 0.18) !important;
 }
 
 [data-theme='dark'] .from-green-50 {
-    --tw-gradient-from: rgba(22, 163, 74, 0.10) !important;
+  --tw-gradient-from: rgba(22, 163, 74, 0.1) !important;
 }
 
 [data-theme='dark'] .to-green-100 {
-    --tw-gradient-to: rgba(22, 163, 74, 0.18) !important;
+  --tw-gradient-to: rgba(22, 163, 74, 0.18) !important;
 }
 
 [data-theme='dark'] .from-red-50 {
-    --tw-gradient-from: rgba(185, 28, 28, 0.10) !important;
+  --tw-gradient-from: rgba(185, 28, 28, 0.1) !important;
 }
 
 [data-theme='dark'] .to-red-100 {
-    --tw-gradient-to: rgba(185, 28, 28, 0.18) !important;
+  --tw-gradient-to: rgba(185, 28, 28, 0.18) !important;
 }
 
 [data-theme='dark'] .from-yellow-50 {
-    --tw-gradient-from: rgba(161, 98, 7, 0.10) !important;
+  --tw-gradient-from: rgba(161, 98, 7, 0.1) !important;
 }
 
 [data-theme='dark'] .to-yellow-100 {
-    --tw-gradient-to: rgba(161, 98, 7, 0.18) !important;
+  --tw-gradient-to: rgba(161, 98, 7, 0.18) !important;
 }
 
 /* ═══════════════════════════════════════════
@@ -586,51 +591,51 @@
    ═══════════════════════════════════════════ */
 
 [data-theme='dark'] .text-tm-black {
-    color: var(--text-heading) !important;
+  color: var(--text-heading) !important;
 }
 
 [data-theme='dark'] .text-tm-loyal-blue {
-    color: #5DADE2 !important;
+  color: #5dade2 !important;
 }
 
 [data-theme='dark'] .text-tm-loyal-blue-80 {
-    color: rgba(93, 173, 226, 0.85) !important;
+  color: rgba(93, 173, 226, 0.85) !important;
 }
 
 [data-theme='dark'] .text-tm-loyal-blue-70 {
-    color: rgba(93, 173, 226, 0.75) !important;
+  color: rgba(93, 173, 226, 0.75) !important;
 }
 
 [data-theme='dark'] .text-tm-true-maroon {
-    color: #E8879A !important;
+  color: #e8879a !important;
 }
 
 [data-theme='dark'] .text-tm-cool-gray {
-    color: #C0C8C7 !important;
+  color: #c0c8c7 !important;
 }
 
 [data-theme='dark'] .bg-tm-loyal-blue {
-    background-color: #1A6B8A !important;
+  background-color: #1a6b8a !important;
 }
 
 [data-theme='dark'] .bg-tm-loyal-blue-10 {
-    background-color: rgba(93, 173, 226, 0.10) !important;
+  background-color: rgba(93, 173, 226, 0.1) !important;
 }
 
 [data-theme='dark'] .bg-tm-loyal-blue-20 {
-    background-color: rgba(93, 173, 226, 0.15) !important;
+  background-color: rgba(93, 173, 226, 0.15) !important;
 }
 
 [data-theme='dark'] .bg-tm-loyal-blue-30 {
-    background-color: rgba(93, 173, 226, 0.22) !important;
+  background-color: rgba(93, 173, 226, 0.22) !important;
 }
 
 [data-theme='dark'] .border-tm-loyal-blue {
-    border-color: #5DADE2 !important;
+  border-color: #5dade2 !important;
 }
 
 [data-theme='dark'] .border-tm-loyal-blue-20 {
-    border-color: rgba(93, 173, 226, 0.25) !important;
+  border-color: rgba(93, 173, 226, 0.25) !important;
 }
 
 /* ═══════════════════════════════════════════
@@ -638,19 +643,19 @@
    ═══════════════════════════════════════════ */
 
 [data-theme='dark'] .bg-amber-50 {
-    background-color: rgba(161, 98, 7, 0.10) !important;
+  background-color: rgba(161, 98, 7, 0.1) !important;
 }
 
 [data-theme='dark'] .bg-amber-100 {
-    background-color: rgba(161, 98, 7, 0.18) !important;
+  background-color: rgba(161, 98, 7, 0.18) !important;
 }
 
 [data-theme='dark'] .text-amber-800 {
-    color: #FCD34D !important;
+  color: #fcd34d !important;
 }
 
 [data-theme='dark'] .text-amber-900 {
-    color: #FDE68A !important;
+  color: #fde68a !important;
 }
 
 /* bg-amber-50/N is Tailwind's opacity-modifier syntax. The compiled
@@ -661,16 +666,16 @@
    below targets the exact compiled form Tailwind emits and so reaches
    any element actually wearing the class. */
 [data-theme='dark'] .bg-amber-50\/50 {
-    background-color: rgba(161, 98, 7, 0.12) !important;
+  background-color: rgba(161, 98, 7, 0.12) !important;
 }
 
 /* Orange text used in DCP projections status */
 [data-theme='dark'] .text-orange-600 {
-    color: #FB923C !important;
+  color: #fb923c !important;
 }
 
 [data-theme='dark'] .text-orange-700 {
-    color: #FDBA74 !important;
+  color: #fdba74 !important;
 }
 
 /* ═══════════════════════════════════════════
@@ -689,23 +694,23 @@
    In dark mode the white text stays; tone the maroon down slightly so
    the pill doesn't burn against the dark surface. */
 [data-theme='dark'] .bg-tm-true-maroon {
-    background-color: #8B2D3C !important;
+  background-color: #8b2d3c !important;
 }
 
 [data-theme='dark'] .border-tm-true-maroon {
-    border-color: #8B2D3C !important;
+  border-color: #8b2d3c !important;
 }
 
 /* Select tier — base uses `bg-tm-cool-gray text-gray-900`. In dark
    mode swap to a translucent gray with light text. */
 [data-theme='dark'] .bg-tm-cool-gray {
-    background-color: rgba(192, 200, 199, 0.18) !important;
+  background-color: rgba(192, 200, 199, 0.18) !important;
 }
 
 /* Presidents tier — base uses `bg-tm-happy-yellow text-gray-900`.
    Dark-mode: muted golden bg + dark text stays readable. */
 [data-theme='dark'] .bg-tm-happy-yellow {
-    background-color: rgba(247, 209, 100, 0.85) !important;
+  background-color: rgba(247, 209, 100, 0.85) !important;
 }
 
 /* #609: the golden chip keeps a light bg, so its text must stay DARK. The
@@ -713,21 +718,21 @@
    is 1.70:1. This compound selector (more specific) restores dark text on the
    chip, the readable pairing the comment above always intended (8.94:1). */
 [data-theme='dark'] .bg-tm-happy-yellow.text-gray-900 {
-    color: #111827 !important;
+  color: #111827 !important;
 }
 
 [data-theme='dark'] .border-tm-happy-yellow {
-    border-color: rgba(247, 209, 100, 0.85) !important;
+  border-color: rgba(247, 209, 100, 0.85) !important;
 }
 
 [data-theme='dark'] .border-yellow-500 {
-    border-color: rgba(247, 209, 100, 0.65) !important;
+  border-color: rgba(247, 209, 100, 0.65) !important;
 }
 
 /* Smedley tier — base uses `bg-purple-100 text-purple-900
    border-purple-400`. Dark-mode: translucent purple + light text. */
 [data-theme='dark'] .bg-purple-100 {
-    background-color: rgba(168, 85, 247, 0.20) !important;
+  background-color: rgba(168, 85, 247, 0.2) !important;
 }
 
 /* #609: the Region page (and DistrictTierChip) Smedley chips use bg-purple-200,
@@ -735,69 +740,69 @@
    stayed light purple (#e9d5ff), 1.00:1. Mirror the bg-purple-100 treatment so
    the lightened text reads (10.33:1). */
 [data-theme='dark'] .bg-purple-200 {
-    background-color: rgba(168, 85, 247, 0.20) !important;
+  background-color: rgba(168, 85, 247, 0.2) !important;
 }
 
 [data-theme='dark'] .text-purple-900 {
-    color: #E9D5FF !important;
+  color: #e9d5ff !important;
 }
 
 [data-theme='dark'] .border-purple-400 {
-    border-color: rgba(168, 85, 247, 0.55) !important;
+  border-color: rgba(168, 85, 247, 0.55) !important;
 }
 
 /* ─── Additional Awards chips ─── */
 
 /* Club Strength Award — `bg-green-50 text-green-800 border-green-200` */
 [data-theme='dark'] .bg-green-50 {
-    background-color: rgba(34, 197, 94, 0.10) !important;
+  background-color: rgba(34, 197, 94, 0.1) !important;
 }
 
 [data-theme='dark'] .text-green-800 {
-    color: #86EFAC !important;
+  color: #86efac !important;
 }
 
 [data-theme='dark'] .border-green-200 {
-    border-color: rgba(34, 197, 94, 0.30) !important;
+  border-color: rgba(34, 197, 94, 0.3) !important;
 }
 
 /* Leadership Excellence — `bg-purple-50 text-purple-800 border-purple-200` */
 [data-theme='dark'] .bg-purple-50 {
-    background-color: rgba(168, 85, 247, 0.10) !important;
+  background-color: rgba(168, 85, 247, 0.1) !important;
 }
 
 [data-theme='dark'] .text-purple-800 {
-    color: #DDD6FE !important;
+  color: #ddd6fe !important;
 }
 
 [data-theme='dark'] .border-purple-200 {
-    border-color: rgba(168, 85, 247, 0.30) !important;
+  border-color: rgba(168, 85, 247, 0.3) !important;
 }
 
 /* Education & Training — `bg-blue-50 text-blue-800 border-blue-200` */
 [data-theme='dark'] .bg-blue-50 {
-    background-color: rgba(59, 130, 246, 0.10) !important;
+  background-color: rgba(59, 130, 246, 0.1) !important;
 }
 
 [data-theme='dark'] .text-blue-800 {
-    color: #BFDBFE !important;
+  color: #bfdbfe !important;
 }
 
 [data-theme='dark'] .border-blue-200 {
-    border-color: rgba(59, 130, 246, 0.30) !important;
+  border-color: rgba(59, 130, 246, 0.3) !important;
 }
 
 /* Club Growth (CGD) — `bg-teal-50 text-teal-800 border-teal-200` */
 [data-theme='dark'] .bg-teal-50 {
-    background-color: rgba(20, 184, 166, 0.10) !important;
+  background-color: rgba(20, 184, 166, 0.1) !important;
 }
 
 [data-theme='dark'] .text-teal-800 {
-    color: #99F6E4 !important;
+  color: #99f6e4 !important;
 }
 
 [data-theme='dark'] .border-teal-200 {
-    border-color: rgba(20, 184, 166, 0.30) !important;
+  border-color: rgba(20, 184, 166, 0.3) !important;
 }
 
 /* ═══════════════════════════════════════════
@@ -829,91 +834,93 @@
 /* ─── loyal-blue (high opacity — emphasis fills) ─── */
 
 [data-theme='dark'] .bg-tm-loyal-blue-80 {
-    background-color: rgba(93, 173, 226, 0.55) !important;
+  background-color: rgba(93, 173, 226, 0.55) !important;
 }
 
 [data-theme='dark'] .bg-tm-loyal-blue-90 {
-    background-color: rgba(93, 173, 226, 0.7) !important;
+  background-color: rgba(93, 173, 226, 0.7) !important;
 }
 
 [data-theme='dark'] .border-tm-loyal-blue-30 {
-    border-color: rgba(93, 173, 226, 0.35) !important;
+  border-color: rgba(93, 173, 226, 0.35) !important;
 }
 
 /* ─── cool-gray (subtle surface tints + dividers) ─── */
 
 [data-theme='dark'] .bg-tm-cool-gray-10 {
-    background-color: rgba(192, 200, 199, 0.06) !important;
+  background-color: rgba(192, 200, 199, 0.06) !important;
 }
 
 [data-theme='dark'] .bg-tm-cool-gray-20 {
-    background-color: rgba(192, 200, 199, 0.12) !important;
+  background-color: rgba(192, 200, 199, 0.12) !important;
 }
 
 [data-theme='dark'] .bg-tm-cool-gray-30 {
-    background-color: rgba(192, 200, 199, 0.2) !important;
+  background-color: rgba(192, 200, 199, 0.2) !important;
 }
 
 [data-theme='dark'] .bg-tm-cool-gray-80 {
-    background-color: rgba(192, 200, 199, 0.4) !important;
+  background-color: rgba(192, 200, 199, 0.4) !important;
 }
 
 /* ─── happy-yellow (callouts, accents) ─── */
 
 [data-theme='dark'] .bg-tm-happy-yellow-20 {
-    background-color: rgba(247, 209, 100, 0.15) !important;
+  background-color: rgba(247, 209, 100, 0.15) !important;
 }
 
 [data-theme='dark'] .bg-tm-happy-yellow-30 {
-    background-color: rgba(247, 209, 100, 0.22) !important;
+  background-color: rgba(247, 209, 100, 0.22) !important;
 }
 
 [data-theme='dark'] .bg-tm-happy-yellow-80 {
-    background-color: rgba(247, 209, 100, 0.55) !important;
+  background-color: rgba(247, 209, 100, 0.55) !important;
 }
 
 [data-theme='dark'] .text-tm-happy-yellow-80 {
-    color: rgba(247, 209, 100, 0.9) !important;
+  color: rgba(247, 209, 100, 0.9) !important;
 }
 
 /* ─── true-maroon (status pills, emphasis chips) ─── */
 
 [data-theme='dark'] .bg-tm-true-maroon-10 {
-    background-color: rgba(232, 135, 154, 0.1) !important;
+  background-color: rgba(232, 135, 154, 0.1) !important;
 }
 
 [data-theme='dark'] .bg-tm-true-maroon-20 {
-    background-color: rgba(232, 135, 154, 0.16) !important;
+  background-color: rgba(232, 135, 154, 0.16) !important;
 }
 
 [data-theme='dark'] .bg-tm-true-maroon-80 {
-    background-color: rgba(232, 135, 154, 0.55) !important;
+  background-color: rgba(232, 135, 154, 0.55) !important;
 }
 
 [data-theme='dark'] .border-tm-true-maroon-30 {
-    border-color: rgba(232, 135, 154, 0.35) !important;
+  border-color: rgba(232, 135, 154, 0.35) !important;
 }
 
 /* ─── Clubs quick-filter "Clear all" chip (#670, epic #665 Sprint 4) ───
    The chip text/border uses the brand --maroon-500 (#7b1828), which has NO
    dark remap — on the dark --surface it lands at ~2:1. Scoped override to the
    dark maroon #e8879a the theme already uses for --tm-true-maroon (lesson 096):
-   light mode is byte-identical, dark passes AA. The segmented / quick-chip /
-   filter-popover active states need no override here — they were re-skinned to
-   the --link token, which remaps itself (R10, lesson 093). */
-[data-theme='dark'] .clubs-quick-filter-chip__clear {
-    color: #e8879a;
-    border-color: rgba(232, 135, 154, 0.3);
+   light mode is byte-identical, dark passes AA. The filter-popover active
+   states need no override here — they were re-skinned to the --link token,
+   which remaps itself (R10, lesson 093). */
+[data-theme='dark'] .clubs-clear-filters-btn {
+  color: #e8879a;
+  border-color: rgba(232, 135, 154, 0.3);
 }
 
-[data-theme='dark'] .clubs-quick-filter-chip__clear:hover {
-    background-color: rgba(232, 135, 154, 0.1);
-    border-color: #e8879a;
-    color: #e8879a;
+[data-theme='dark'] .clubs-clear-filters-btn:hover {
+  background-color: rgba(232, 135, 154, 0.1);
+  border-color: #e8879a;
+  color: #e8879a;
 }
 
 /* ─── Transition for Theme Switch ─── */
 
 html[data-theme] body {
-    transition: background-color 0.3s ease, color 0.3s ease;
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       }
     },
     "frontend": {
-      "version": "3.5.1",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.0",


### PR DESCRIPTION
## Sprint 2 of epic #900 — remove all existing clubs quick-filter chips

Deletes the entire `.clubs-quick-filters` row from `ClubsTable` and its now-dead wiring. The precise drawer column-filters stay untouched; the single shared **"Close to Distinguished"** preset lands in Sprint 3 (#903).

### Removed
- The `.clubs-quick-filters` row: Thriving / Vulnerable / Intervention health bands, Close-to-Distinguished, Needs members, Missing renewals, President's tier, the "Quick filters:" label, and the chip Clear-all.
- Dead derived state: `statusCounts`, `isStatusActive`/`setStatusPreset`/`statusFilterValue`, `isCloseToDistinguishedActive`/`isNeedsMembersActive`/`membersNeededValue`, and the `CLOSE_TO_DISTINGUISHED_MAX_MEMBERS` import.
- All `.clubs-quick-filter*` CSS (Lesson 119 shape-grep). The surviving empty-state pill is restyled into a self-contained `.clubs-clear-filters-btn` (+ dark-mode override).

### Intentionally kept
- `FiltersPanel`, `ActiveFiltersBar`, `useColumnFilters`, and every drawer column-filter (status/health, membersNeeded, octoberRenewals, distinguished).
- `closeToDistinguished.ts` — still consumed by the `ClubDetailPage` banner; Sprint 3 owns the consolidation.

### Tests (TDD)
- **Red→Green:** replaced the chip describes in `ClubsTable.test.tsx` with a removal guard (no chip row, no chip buttons, drawer trigger survives) — failed against chip-present code, passes after removal.
- Converted the three `DistrictClubsPage` chip-write tests to drive the **surviving drawer**, preserving the page's filter→URL write/clear contract (Lesson 071).
- Retargeted the a11y dark-mode contrast suite to `.clubs-clear-filters-btn`; dropped the dead chip-surface assertions (re-confirmed per Lesson 137).

### Verification
- `npx tsc --noEmit` clean (after `build:shared-contracts` + `build:analytics-core`, R16).
- Full frontend suite: **3140 passed / 251 files**, zero regressions.
- `test:no-page-mounts:check` OK (R22). Lint: 0 errors (1 pre-existing TanStack warning).
- Live preview verification to follow on the PR preview channel.

Part of #902.
🤖 Generated with [Claude Code](https://claude.com/claude-code)