### PR TITLE
feat: shared Close-to-Distinguished predicate + clubs-table preset (#903)

### DIFF
--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -10,6 +10,8 @@ import {
 } from '@tanstack/react-table'
 import type { SnapshotDiff } from '@toastmasters/shared-contracts'
 import { ClubTrend } from '../hooks/useDistrictAnalytics'
+import { calculateClubProjection } from '../utils/dcpProjections'
+import { isCloseToDistinguished } from '../utils/closeToDistinguished'
 import { ExportButton } from './ExportButton'
 import { exportClubPerformance, exportSnapshotDiff } from '../utils/csvExport'
 import { LoadingSkeleton } from './LoadingSkeleton'
@@ -340,12 +342,26 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   // Feed the table a name-ascending base order so its STABLE sort reproduces the
   // pre-migration "secondary sort by club name (always ascending)" tiebreak in
   // both directions (see clubsColumns.tsx). Memoized on filteredClubs.
+  // "Close to Distinguished" preset (#903) — a new pipeline step (R11) layered
+  // on the column filters, powered by the ONE shared canonical predicate so it
+  // can never diverge from the club-detail-card banner.
+  const [presetActive, setPresetActive] = useState(false)
+  const presetFilteredClubs = useMemo(() => {
+    if (!presetActive) return filteredClubs
+    return filteredClubs.filter(club =>
+      isCloseToDistinguished({
+        projection: calculateClubProjection(club),
+        cspSubmitted: club.cspSubmitted,
+      })
+    )
+  }, [filteredClubs, presetActive])
+
   const nameSortedClubs = useMemo(
     () =>
-      [...filteredClubs].sort((a, b) =>
+      [...presetFilteredClubs].sort((a, b) =>
         a.clubName.toLowerCase().localeCompare(b.clubName.toLowerCase())
       ),
-    [filteredClubs]
+    [presetFilteredClubs]
   )
 
   // Sort state is CONTROLLED by sortField/sortDirection — the URL-synced source
@@ -651,6 +667,26 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
             isGroupHidden={isGroupHidden}
             onToggle={toggleGroup}
           />
+        </div>
+
+        {/* Close-to-Distinguished preset (#903) — one action-oriented toggle in
+            place of the retired quick-filter row, sharing the canonical
+            predicate with the club-detail banner. */}
+        <div className="clubs-preset-bar">
+          <button
+            type="button"
+            className="clubs-preset-chip"
+            aria-pressed={presetActive}
+            onClick={() => setPresetActive(p => !p)}
+          >
+            🎯 Close to Distinguished
+          </button>
+          {presetActive && (
+            <span className="clubs-preset-count" aria-live="polite">
+              {presetFilteredClubs.length} of {filteredClubs.length} clubs need
+              a nudge to Distinguished
+            </span>
+          )}
         </div>
 
         {/* Results Count and Quick Filters */}

--- a/frontend/src/components/__tests__/ClubsTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.test.tsx
@@ -774,7 +774,7 @@ describe('ClubsTable', () => {
       expect(screen.queryByText(/quick filters:/i)).not.toBeInTheDocument()
     })
 
-    it('no longer exposes any of the four removed quick-filter chips', () => {
+    it('no longer exposes the removed quick-filter chips', () => {
       render(
         <ClubsTable
           clubs={clubs}
@@ -783,9 +783,10 @@ describe('ClubsTable', () => {
         />
       )
 
-      expect(
-        screen.queryByRole('button', { name: /close to distinguished/i })
-      ).not.toBeInTheDocument()
+      // The legacy "Needs members" / "Missing renewals" / "President's tier" /
+      // health-band chips are gone. (The single shared "Close to Distinguished"
+      // preset added in Sprint 3 #903 is a deliberate, separate control — see
+      // the "Close to Distinguished preset (#903)" describe below.)
       expect(
         screen.queryByRole('button', { name: /needs members/i })
       ).not.toBeInTheDocument()
@@ -813,6 +814,90 @@ describe('ClubsTable', () => {
       expect(
         screen.getByRole('button', { name: /^filters/i })
       ).toBeInTheDocument()
+    })
+  })
+
+  describe('Close to Distinguished preset (#903)', () => {
+    // The single shared preset that replaced the legacy quick-filter row. It is
+    // powered by the SAME canonical isCloseToDistinguished predicate as the
+    // club-detail-card banner, computed from each club's projection.
+    //
+    // Default createMockClub: members 20 / goals 5 / base 20 → projection is
+    // Distinguished, so it is NOT close (a useful OUT baseline).
+    const presetClubs = [
+      // IN: members 18 (base 18, gap 2), goals 4 → NotDistinguished, close.
+      createMockClub({
+        clubId: 'c-near',
+        clubName: 'NearClub',
+        membershipTrend: [{ date: '2025-09-01', count: 18 }],
+        dcpGoalsTrend: [{ date: '2025-09-01', goalsAchieved: 4 }],
+      }),
+      // OUT: only 1 DCP goal (< 3).
+      createMockClub({
+        clubId: 'c-far',
+        clubName: 'FarClub',
+        membershipTrend: [{ date: '2025-09-01', count: 18 }],
+        dcpGoalsTrend: [{ date: '2025-09-01', goalsAchieved: 1 }],
+      }),
+      // OUT: already Distinguished (default members 20 / goals 5).
+      createMockClub({ clubId: 'c-done', clubName: 'DoneClub' }),
+    ]
+
+    it('renders an unpressed toggle by default, with all clubs shown', () => {
+      render(
+        <ClubsTable
+          clubs={presetClubs}
+          districtId="test-district"
+          isLoading={false}
+        />
+      )
+      const toggle = screen.getByRole('button', {
+        name: /close to distinguished/i,
+      })
+      expect(toggle).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByText('NearClub')).toBeInTheDocument()
+      expect(screen.getByText('FarClub')).toBeInTheDocument()
+      expect(screen.getByText('DoneClub')).toBeInTheDocument()
+    })
+
+    it('narrows to only matching clubs when toggled on, and shows a count', () => {
+      render(
+        <ClubsTable
+          clubs={presetClubs}
+          districtId="test-district"
+          isLoading={false}
+        />
+      )
+      const toggle = screen.getByRole('button', {
+        name: /close to distinguished/i,
+      })
+      fireEvent.click(toggle)
+      expect(toggle).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByText('NearClub')).toBeInTheDocument()
+      expect(screen.queryByText('FarClub')).not.toBeInTheDocument()
+      expect(screen.queryByText('DoneClub')).not.toBeInTheDocument()
+      // Preset count line (distinct from the table's "Showing N of M" summary).
+      expect(
+        screen.getByText(/1 of 3 clubs need a nudge to distinguished/i)
+      ).toBeInTheDocument()
+    })
+
+    it('restores the full list when toggled back off', () => {
+      render(
+        <ClubsTable
+          clubs={presetClubs}
+          districtId="test-district"
+          isLoading={false}
+        />
+      )
+      const toggle = screen.getByRole('button', {
+        name: /close to distinguished/i,
+      })
+      fireEvent.click(toggle)
+      fireEvent.click(toggle)
+      expect(toggle).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByText('FarClub')).toBeInTheDocument()
+      expect(screen.getByText('DoneClub')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,6 +41,7 @@
 @import './styles/components/status-indicators.css';
 @import './styles/components/alerts.css';
 @import './styles/components/app-shell.css';
+@import './styles/clubs-table.css';
 @import './styles/components/chart-sparkline-expand.css';
 @import './styles/components/district-narrative.css';
 @import './styles/components/district-subnav.css';

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -26,11 +26,7 @@ import {
   type ClubDCPProjection,
   type DistinguishedLevel,
 } from '../utils/dcpProjections'
-import { CLOSE_TO_DISTINGUISHED_MAX_MEMBERS } from '../utils/closeToDistinguished'
-import {
-  computeMembersToDistinguished,
-  deriveGoalContext,
-} from '../utils/membersToDistinguished'
+import { isCloseToDistinguished } from '../utils/closeToDistinguished'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 import ErrorBoundary from '../components/ErrorBoundary'
@@ -281,24 +277,32 @@ const ClubDetailPage: React.FC = () => {
     return calculateClubProjection(club)
   }, [club])
 
-  // Close-to-Distinguished result (#620). The issue asks us to reuse the
-  // `membersToDistinguished` engine: it returns non-null only when adding
-  // members is the *only* remaining barrier (closing the membership
-  // qualification gap and/or earning the member-based DCP goals 7 & 8). We then
-  // bound it by the calibrated CLOSE_TO_DISTINGUISHED_MAX_MEMBERS threshold so
-  // the banner is encouragement, not noise (preserves the #433 fix that
-  // suppressed far-off clubs). Already-Distinguished clubs return null upstream.
-  const closeToDistinguished = useMemo(() => {
-    if (!club || !projection) return null
-    const result = computeMembersToDistinguished(
-      projection,
-      deriveGoalContext(club)
-    )
-    if (!result) return null
-    return result.membersNeeded <= CLOSE_TO_DISTINGUISHED_MAX_MEMBERS
-      ? result
-      : null
-  }, [club, projection])
+  // Close-to-Distinguished banner gate (#620, #903). Uses the ONE shared
+  // canonical predicate (closeToDistinguished.ts) — NotDistinguished, members
+  // gap <= 3, goals >= 3, CSP submitted-or-unknown — so this banner and the
+  // clubs-table preset can never diverge. The encouragement copy below is
+  // derived locally from the projection's already-floored gap.
+  const isCloseBanner = useMemo(
+    () =>
+      !!club &&
+      !!projection &&
+      isCloseToDistinguished({
+        projection,
+        cspSubmitted: club.cspSubmitted,
+      }),
+    [club, projection]
+  )
+  const closeBannerCopy = useMemo(() => {
+    if (!projection) return ''
+    const { members, goals } = projection.gapToDistinguished
+    const parts: string[] = []
+    if (members > 0)
+      parts.push(`${members} more member${members > 1 ? 's' : ''}`)
+    if (goals > 0) parts.push(`${goals} more DCP goal${goals > 1 ? 's' : ''}`)
+    return parts.length > 0
+      ? `Just ${parts.join(' and ')} to reach Distinguished.`
+      : 'On track for Distinguished — finish strong!'
+  }, [projection])
 
   // Filter trends by program year
   const programYear = effectiveProgramYear ?? selectedProgramYear
@@ -857,9 +861,11 @@ const ClubDetailPage: React.FC = () => {
           {/* Close-to-Distinguished call-out (#366, #433; repositioned #620).
               club-reference.html places it directly below the 2/3 + 1/3 trend
               row and above the DCP Goals panel — moved here from above the
-              stats grid. Trigger + copy now come from the membersToDistinguished
-              engine (see the `closeToDistinguished` memo). */}
-          {closeToDistinguished && (
+              stats grid. Show/hide is now gated by the shared canonical
+              isCloseToDistinguished predicate (#903) so this banner and the
+              clubs-table preset agree by construction; the copy is derived
+              locally from the projection's gap. */}
+          {isCloseBanner && (
             <section
               role="region"
               aria-labelledby="close-to-distinguished-heading"
@@ -879,29 +885,7 @@ const ClubDetailPage: React.FC = () => {
                   Close to Distinguished
                 </h2>
                 <p className="club-close-to-distinguished__copy">
-                  {closeToDistinguished.goalsEarned.length === 0 ? (
-                    <>
-                      This club has already met the required goals. They only
-                      need{' '}
-                      <strong>
-                        {closeToDistinguished.membersNeeded} more member
-                        {closeToDistinguished.membersNeeded > 1 ? 's' : ''}
-                      </strong>{' '}
-                      to achieve Distinguished status.
-                    </>
-                  ) : (
-                    <>
-                      <strong>
-                        {closeToDistinguished.membersNeeded} more member
-                        {closeToDistinguished.membersNeeded > 1 ? 's' : ''}
-                      </strong>{' '}
-                      will earn the remaining DCP goal
-                      {closeToDistinguished.goalsEarned.length > 1
-                        ? 's'
-                        : ''}{' '}
-                      and lock in Distinguished status.
-                    </>
-                  )}
+                  {closeBannerCopy}
                 </p>
               </div>
             </section>

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -502,13 +502,14 @@ describe('Close-to-Distinguished call-out — ClubDetailPage', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('renders the call-out at the upper boundary — exactly 4 members short (#433)', () => {
-    // 5 goals (gap=0). To get memberGap=4 we need both
-    //   absoluteGap = 20 - currentMembers = 4 → currentMembers = 16
-    //   growthGap   = 3  - netGrowth      ≥ 4 → netGrowth ≤ -1 → base ≥ 17
+  it('renders the call-out at the upper boundary — exactly 3 members short (#903)', () => {
+    // #903 tightened the members gap from <=4 (old #433) to <=3 (the canonical
+    // gapToDistinguished.members rule). 5 goals (gap=0). For memberGap=3:
+    //   absoluteGap = 20 - currentMembers = 3 → currentMembers = 17
+    //   growthGap   = 3  - netGrowth      ≥ 3 → netGrowth ≤ 0 → base ≥ 17
     setClubOverrides({
       membershipBase: 17,
-      membershipTrend: [{ date: '2026-03-15', count: 16 }],
+      membershipTrend: [{ date: '2026-03-15', count: 17 }],
       dcpGoalsTrend: [{ date: '2026-03-15', goalsAchieved: 5 }],
       distinguishedLevel: 'NotDistinguished',
       aprilRenewals: 0,
@@ -520,12 +521,13 @@ describe('Close-to-Distinguished call-out — ClubDetailPage', () => {
     ).toBeInTheDocument()
   })
 
-  it('does NOT render the call-out when 5 members short — just past the threshold (#433)', () => {
-    // 5 goals (gap=0). currentMembers=15, base=17 → netGrowth=-2,
-    // absoluteGap=5, growthGap=5, memberGap=5.
+  it('does NOT render the call-out when 4 members short — just past the #903 threshold', () => {
+    // #903: memberGap=4 no longer qualifies (was the old #433 boundary).
+    // 5 goals (gap=0). currentMembers=16, base=17 → netGrowth=-1,
+    // absoluteGap=4, growthGap=4, memberGap=4.
     setClubOverrides({
       membershipBase: 17,
-      membershipTrend: [{ date: '2026-03-15', count: 15 }],
+      membershipTrend: [{ date: '2026-03-15', count: 16 }],
       dcpGoalsTrend: [{ date: '2026-03-15', goalsAchieved: 5 }],
       distinguishedLevel: 'NotDistinguished',
       aprilRenewals: 0,

--- a/frontend/src/styles/clubs-table.css
+++ b/frontend/src/styles/clubs-table.css
@@ -1,0 +1,47 @@
+
+/* Close-to-Distinguished preset (#903) — one action-oriented chip that replaced
+   the retired quick-filter row. Reuses toolbar tokens so dark mode inherits;
+   the pressed state uses the product accent (--rt-stats amber). */
+.clubs-preset-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.clubs-preset-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-tm-loyal, #004165);
+  background: var(--color-tm-fog, #f3f5f7);
+  border: 1px solid var(--color-tm-mist, #d6dde3);
+  border-radius: 999px;
+  cursor: pointer;
+  min-height: 44px;
+  white-space: nowrap;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.clubs-preset-chip:hover {
+  background: var(--color-tm-mist, #d6dde3);
+}
+
+.clubs-preset-chip[aria-pressed='true'] {
+  color: #fff;
+  background: var(--rt-stats, #d4873f);
+  border-color: var(--rt-stats, #d4873f);
+}
+
+.clubs-preset-count {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-tm-slate, #5b6470);
+}

--- a/frontend/src/utils/__tests__/closeToDistinguished.test.ts
+++ b/frontend/src/utils/__tests__/closeToDistinguished.test.ts
@@ -1,39 +1,109 @@
 import { describe, expect, it } from 'vitest'
 import {
-  CLOSE_TO_DISTINGUISHED_MAX_MEMBERS,
   isCloseToDistinguished,
+  type CloseToDistinguishedInput,
 } from '../closeToDistinguished'
 
-describe('closeToDistinguished — shared threshold for "close to Distinguished"', () => {
-  describe('CLOSE_TO_DISTINGUISHED_MAX_MEMBERS', () => {
-    it('is 4 — within reach in a single membership drive', () => {
-      expect(CLOSE_TO_DISTINGUISHED_MAX_MEMBERS).toBe(4)
+/**
+ * Canonical "Close to Distinguished" predicate — the ONE definition both the
+ * clubs-table preset and the club-detail banner consume (epic #900, Sprint 1
+ * spec in docs/design/close-to-distinguished-predicate.md). All four AND:
+ *   1. currentLevel === 'NotDistinguished'
+ *   2. gapToDistinguished.members <= 3   (already floored min by the projection)
+ *   3. currentGoals >= 3
+ *   4. cspSubmitted === true || === undefined
+ */
+function makeInput(
+  overrides: Partial<{
+    currentLevel: CloseToDistinguishedInput['projection']['currentLevel']
+    currentGoals: number
+    members: number
+    goals: number
+    cspSubmitted: boolean | undefined
+  }> = {}
+): CloseToDistinguishedInput {
+  const {
+    currentLevel = 'NotDistinguished',
+    currentGoals = 4,
+    members = 2,
+    goals = 1,
+    cspSubmitted = true,
+  } = overrides
+  return {
+    projection: {
+      currentLevel,
+      currentGoals,
+      gapToDistinguished: { goals, members },
+    },
+    cspSubmitted,
+  }
+}
+
+describe('isCloseToDistinguished — canonical shared predicate', () => {
+  it('IN for a club that satisfies all four conditions', () => {
+    expect(isCloseToDistinguished(makeInput())).toBe(true)
+  })
+
+  describe('condition 1 — not already Distinguished+', () => {
+    it.each(['Distinguished', 'Select', 'President', 'Smedley'] as const)(
+      'OUT when currentLevel is %s',
+      level => {
+        expect(isCloseToDistinguished(makeInput({ currentLevel: level }))).toBe(
+          false
+        )
+      }
+    )
+    it('IN when currentLevel is NotDistinguished', () => {
+      expect(
+        isCloseToDistinguished(makeInput({ currentLevel: 'NotDistinguished' }))
+      ).toBe(true)
     })
   })
 
-  describe('isCloseToDistinguished', () => {
-    it('returns false when goal gap is non-zero (not yet at 5 DCP goals)', () => {
-      expect(isCloseToDistinguished({ goals: 1, members: 2 })).toBe(false)
+  describe('condition 2 — members gap <= 3', () => {
+    it('IN at the boundary (gap exactly 3)', () => {
+      expect(isCloseToDistinguished(makeInput({ members: 3 }))).toBe(true)
     })
+    it('OUT just past the boundary (gap 4)', () => {
+      expect(isCloseToDistinguished(makeInput({ members: 4 }))).toBe(false)
+    })
+    it('IN when membership already met (gap 0)', () => {
+      expect(isCloseToDistinguished(makeInput({ members: 0 }))).toBe(true)
+    })
+  })
 
-    it('returns false when no members are needed (already qualifies)', () => {
-      expect(isCloseToDistinguished({ goals: 0, members: 0 })).toBe(false)
+  describe('condition 3 — DCP goals >= 3', () => {
+    it('IN at the boundary (goals exactly 3)', () => {
+      expect(isCloseToDistinguished(makeInput({ currentGoals: 3 }))).toBe(true)
     })
+    it('OUT just below the boundary (goals 2)', () => {
+      expect(isCloseToDistinguished(makeInput({ currentGoals: 2 }))).toBe(false)
+    })
+  })
 
-    it('returns true at the lower boundary — 1 member needed', () => {
-      expect(isCloseToDistinguished({ goals: 0, members: 1 })).toBe(true)
+  describe('condition 4 — CSP submitted or unknown', () => {
+    it('IN when cspSubmitted true', () => {
+      expect(isCloseToDistinguished(makeInput({ cspSubmitted: true }))).toBe(
+        true
+      )
     })
+    it('OUT when cspSubmitted false', () => {
+      expect(isCloseToDistinguished(makeInput({ cspSubmitted: false }))).toBe(
+        false
+      )
+    })
+    it('IN when cspSubmitted undefined (pre-2025 data)', () => {
+      expect(
+        isCloseToDistinguished(makeInput({ cspSubmitted: undefined }))
+      ).toBe(true)
+    })
+  })
 
-    it('returns true at the upper boundary — 4 members needed', () => {
-      expect(isCloseToDistinguished({ goals: 0, members: 4 })).toBe(true)
-    })
-
-    it('returns false when 5 members are needed (just past the boundary)', () => {
-      expect(isCloseToDistinguished({ goals: 0, members: 5 })).toBe(false)
-    })
-
-    it('returns false when 12 members are needed (the original bug report)', () => {
-      expect(isCloseToDistinguished({ goals: 0, members: 12 })).toBe(false)
-    })
+  it('OUT when multiple conditions fail at once', () => {
+    expect(
+      isCloseToDistinguished(
+        makeInput({ members: 5, currentGoals: 1, cspSubmitted: false })
+      )
+    ).toBe(false)
   })
 })

--- a/frontend/src/utils/closeToDistinguished.ts
+++ b/frontend/src/utils/closeToDistinguished.ts
@@ -1,11 +1,37 @@
-import type { TierGap } from './dcpProjections'
+import type { ClubDCPProjection } from './dcpProjections'
 
-export const CLOSE_TO_DISTINGUISHED_MAX_MEMBERS = 4
+/**
+ * Canonical "Close to Distinguished" predicate (epic #900, Sprint 1 spec in
+ * docs/design/close-to-distinguished-predicate.md).
+ *
+ * Single source of truth consumed by BOTH the clubs-table preset chip and the
+ * club-detail-card banner — neither surface re-derives the rule (Lesson 052).
+ *
+ * A club is "close" when ALL four hold:
+ *   1. Not already Distinguished+ — `currentLevel === 'NotDistinguished'`.
+ *   2. Members gap <= 3 — `gapToDistinguished.members`, which
+ *      `calculateClubProjection` already computes as the floored
+ *      min(20 - members, 3 - netGrowth). We reuse it, never re-derive it.
+ *   3. DCP goals >= 3 — 2 or fewer points from the 5 needed.
+ *   4. CSP submitted OR unknown — `true` and `undefined` both eligible
+ *      (pre-2025 data has no CSP field; treat absent as eligible).
+ */
+export interface CloseToDistinguishedInput {
+  projection: Pick<
+    ClubDCPProjection,
+    'currentLevel' | 'currentGoals' | 'gapToDistinguished'
+  >
+  cspSubmitted: boolean | undefined
+}
 
-export function isCloseToDistinguished(gap: TierGap): boolean {
+export function isCloseToDistinguished(
+  input: CloseToDistinguishedInput
+): boolean {
+  const { projection, cspSubmitted } = input
   return (
-    gap.goals === 0 &&
-    gap.members > 0 &&
-    gap.members <= CLOSE_TO_DISTINGUISHED_MAX_MEMBERS
+    projection.currentLevel === 'NotDistinguished' &&
+    projection.gapToDistinguished.members <= 3 &&
+    projection.currentGoals >= 3 &&
+    (cspSubmitted === true || cspSubmitted === undefined)
   )
 }


### PR DESCRIPTION
Part of epic #900, **Sprint 3 (#903)**.

## What
- **New canonical predicate** `isCloseToDistinguished({projection, cspSubmitted})` (`frontend/src/utils/closeToDistinguished.ts`) — the single source of truth, reusing `projection.gapToDistinguished.members` (the already-floored `min(20-members, 3-netGrowth)`) so the gap formula is never re-derived. Replaces the legacy gap-only predicate + `CLOSE_TO_DISTINGUISHED_MAX_MEMBERS` constant. 15 boundary unit tests.
- **Clubs table** gains one action-oriented **"Close to Distinguished" preset** toggle (`aria-pressed`, 44px tap target, Lesson 128) where the legacy quick-filter row was, with a live result count. New pipeline step (R11) feeding the sort; amber product-accent (`--rt-stats`) pressed state, dark-safe via toolbar tokens.
- **Club-detail banner** now delegates its show/hide to the same shared predicate (was an inline `computeMembersToDistinguished` + `CLOSE_TO_DISTINGUISHED_MAX_MEMBERS` gate). Encouragement copy derived locally from `projection.gapToDistinguished`. Added CSP-false / CSP-undefined / goals-floor condition tests the old engine couldn't express.

## Predicate (all AND, per epic #900 + Sprint 1 spec)
1. `currentLevel === 'NotDistinguished'` (not already Distinguished+)
2. `gapToDistinguished.members <= 3`
3. `currentGoals >= 3`
4. `cspSubmitted === true || cspSubmitted === undefined`

## Scope of "no divergence"
The **preset chip and the detail-card banner** now consume one helper, so they agree by construction. **Caveat:** the Filters-drawer "Members Needed" column still uses the older `computeMembersToDistinguished` engine (epic spec §5 deliberately keeps the drawer plumbing this sprint). So a user filtering the drawer to `membersNeeded ≤ N` can still get a different set than the preset — that convergence is out of scope for #903.

## Verification (actually run)
- `npm run quality:check` — **green**: typecheck + lint + yaml + format + tests. Test totals: frontend 3151, collector-cli 737, analytics-core 791, shared-contracts 134 — all passing, zero regressions.
- `/simplify` (4 agents) + `/review` (fresh-context) run. Fixes applied from their findings: the preset stylesheet was an orphaned, never-imported file (chip would have shipped unstyled / sub-44px) — now imported from `index.css`; the `#433` banner boundary tests were re-expressed to the new `<=3` spec (members 17/base 17 = gap 3 → IN; 16/17 = gap 4 → OUT). Spec change, not assertion pinning.
- Dual-engine (Chromium + WebKit) Playwright smoke on the PR preview channel: to be run on this PR once the preview deploys; screenshots will be attached.

Sub-issue close + label handled after preview verification (tick-before-close ordering, #626).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
