### PR TITLE
Sprint 3 (#930) — liveness fusion verdict + attempt-state, wired into the tick

### DIFF
--- a/scripts/lib/sprint-runner-liveness.sh
+++ b/scripts/lib/sprint-runner-liveness.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Stuck-session liveness FUSION + attempt-tracking STATE for sprint-runner.sh
+# (epic #933, Sprint 3 #930).
+#
+# Design: docs/design/sprint-runner-liveness-detector-2026-05-30.md §3–§5.
+#
+# Layers (sourced AFTER scripts/lib/sprint-runner-probes.sh, which this file
+# depends on for probe_commit_age / probe_process / probe_log):
+#
+#   fuse_verdict <commit> <process> <log>
+#       Pure: combine the three probe verdicts into one of
+#       HEALTHY | SUSPECT | STUCK | HUSK. HUSK (conclusive single signal) wins;
+#       >=2 STALL corroborate to STUCK; exactly 1 STALL is a SUSPECT (never
+#       reaps — the false-positive guard); else HEALTHY. UNKNOWN is never STALL.
+#
+#   state_* — a tiny jq-backed JSON store at $RUNNER_STATE_FILE (default
+#       $WORKTREE_BASE/.runner-state.json). Holds the one fact runner truth
+#       cannot reconstruct after a reap: the per-issue relaunch attempt count.
+#       Writes are atomic (mktemp + mv) and fail-safe: a missing or corrupt
+#       file reads as "0 attempts", never aborting the runner under set -u.
+#
+#   evaluate_liveness <issue>
+#       The sampling EDGE: runs the live commands (git / pgrep / ps / stat /
+#       tail), feeds them through the three probes, and echoes the fused
+#       verdict. The pure layers above keep every decision unit-testable; this
+#       is the only part that touches the host, so it is exercised via the
+#       hermetic tick integration test with mocked git/pgrep/ps.
+#
+# Sourcing this file only DEFINES functions — no side effects.
+
+# === Fusion =================================================================
+
+# fuse_verdict <commit> <process> <log> → HEALTHY|SUSPECT|STUCK|HUSK
+#   commit, log ∈ {OK, STALL, UNKNOWN}
+#   process     ∈ {OK, STALL, UNKNOWN, HUSK}
+fuse_verdict() {
+  local commit="$1" process="$2" log="$3"
+
+  # Conclusive single signal: a husk (screen alive, claude gone) is provably
+  # not working — act without waiting for corroboration.
+  if [[ "$process" == HUSK ]]; then
+    echo HUSK
+    return 0
+  fi
+
+  local stalls=0
+  [[ "$commit" == STALL ]] && stalls=$((stalls + 1))
+  [[ "$process" == STALL ]] && stalls=$((stalls + 1))
+  [[ "$log" == STALL ]] && stalls=$((stalls + 1))
+
+  if (( stalls >= 2 )); then
+    echo STUCK          # corroborated — two independent stall signals agree
+  elif (( stalls == 1 )); then
+    echo SUSPECT        # one soft signal — log + re-evaluate next tick, no reap
+  else
+    echo HEALTHY        # progress, or only UNKNOWN (insufficient evidence)
+  fi
+  return 0
+}
+
+# === Attempt-tracking state store ==========================================
+#
+# The attempt counter must survive the reap that destroys the worktree, the
+# screen, and the logfile — so it cannot be derived from any of them. It is the
+# single piece of genuinely durable runner-internal state (design §4.2).
+
+# _state_file → path of the JSON store (lazy so set -u can't trip on an unset
+# WORKTREE_BASE at source time).
+_state_file() {
+  if [[ -n "${RUNNER_STATE_FILE:-}" ]]; then
+    printf '%s' "$RUNNER_STATE_FILE"
+  else
+    printf '%s' "${WORKTREE_BASE:-$HOME/sprint-worktrees}/.runner-state.json"
+  fi
+}
+
+# _state_read → the store as JSON on stdout, or `{}` if missing/corrupt.
+# Corruption resolves to an empty store (fail-safe: at worst a few extra
+# relaunch attempts), never to an abort.
+_state_read() {
+  local f
+  f="$(_state_file)"
+  if [[ -f "$f" ]] && jq -e . "$f" >/dev/null 2>&1; then
+    cat "$f"
+  else
+    echo '{}'
+  fi
+}
+
+# state_get_attempts <issue> → integer attempt count (0 if absent/corrupt).
+state_get_attempts() {
+  local issue="$1" v
+  v="$(_state_read | jq -r --arg k "$issue" '.[$k].attempts // 0' 2>/dev/null)"
+  if [[ "$v" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$v"
+  else
+    printf '0'
+  fi
+}
+
+# state_get_field <issue> <field> → the field's value, or empty string.
+state_get_field() {
+  local issue="$1" field="$2" v
+  v="$(_state_read | jq -r --arg k "$issue" --arg f "$field" \
+        '.[$k][$f] // ""' 2>/dev/null)" || v=""
+  printf '%s' "$v"
+}
+
+# state_record <issue> <verdict> <attempts> [last_relaunch_epoch]
+#   Atomic upsert of one issue's entry. attempts/epoch are coerced to integers
+#   so a stray value can't make jq --argjson fail mid-tick.
+state_record() {
+  local issue="$1" verdict="$2" attempts="$3" relaunch="${4:-0}"
+  [[ "$attempts" =~ ^[0-9]+$ ]] || attempts=0
+  [[ "$relaunch" =~ ^[0-9]+$ ]] || relaunch=0
+
+  local f tmp cur
+  f="$(_state_file)"
+  mkdir -p "$(dirname "$f")"
+  cur="$(_state_read)"
+  tmp="$(mktemp "${f}.XXXXXX")"
+  if printf '%s' "$cur" | jq \
+        --arg k "$issue" --arg v "$verdict" \
+        --argjson a "$attempts" --argjson r "$relaunch" \
+        '.[$k] = {attempts: $a, last_verdict: $v, last_relaunch_epoch: $r}' \
+        > "$tmp"; then
+    mv -f "$tmp" "$f"
+  else
+    rm -f "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  return 0
+}
+
+# state_prune <keep_issue...>
+#   Reconcile the store down to the listed (live) issue keys, dropping entries
+#   for issues that are CLOSED or no longer in the active epic. No args → empty
+#   the store to `{}`. Convergent, so the file can't accumulate stale keys.
+state_prune() {
+  local f tmp cur keep_json='[]'
+  f="$(_state_file)"
+  [[ -f "$f" ]] || return 0
+  cur="$(_state_read)"
+  if (( $# > 0 )); then
+    keep_json="$(printf '%s\n' "$@" | jq -R . | jq -s .)"
+  fi
+  mkdir -p "$(dirname "$f")"
+  tmp="$(mktemp "${f}.XXXXXX")"
+  if printf '%s' "$cur" | jq --argjson keep "$keep_json" \
+        'with_entries(select(.key as $k | $keep | index($k)))' > "$tmp"; then
+    mv -f "$tmp" "$f"
+  else
+    rm -f "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  return 0
+}

--- a/scripts/lib/sprint-runner-liveness.sh
+++ b/scripts/lib/sprint-runner-liveness.sh
@@ -155,3 +155,95 @@ state_prune() {
   fi
   return 0
 }
+
+# === Sampling edge =========================================================
+#
+# evaluate_liveness is the ONLY part that touches the host. It samples the live
+# commands, feeds them through the pure probes, and echoes the fused verdict.
+# After it returns, the caller can read the per-probe breakdown from the
+# LIVENESS_COMMIT / LIVENESS_PROCESS / LIVENESS_LOG globals (for logging and a
+# future --status line). pgrep/ps are used over `screen -ls` deliberately —
+# macOS `screen -ls` exits 1 even when sessions exist and silently inverts a
+# pipefail predicate (R14/L089).
+
+LIVENESS_COMMIT=""
+LIVENESS_PROCESS=""
+LIVENESS_LOG=""
+
+# _wt_base → the worktree parent (set -u-safe default).
+_wt_base() { printf '%s' "${WORKTREE_BASE:-$HOME/sprint-worktrees}"; }
+
+# _session_start_epoch <issue> <screen_pid> → epoch the session started.
+# DERIVED, not stored (design §4.1): the screen daemon's start time IS the
+# session start. Falls back to the worktree's birth time, then to now (a fresh
+# session reads as progress-zero, never STALL).
+_session_start_epoch() {
+  local issue="$1" screen_pid="$2" epoch="" lstart
+  if [[ -n "$screen_pid" ]]; then
+    lstart="$(ps -o lstart= -p "$screen_pid" 2>/dev/null || true)"
+    if [[ -n "$lstart" ]]; then
+      epoch="$(date -j -f '%a %b %e %T %Y' "$lstart" +%s 2>/dev/null || true)"
+    fi
+  fi
+  if ! [[ "$epoch" =~ ^[0-9]+$ ]]; then
+    epoch="$(stat -f %B "$(_wt_base)/sprint-$issue" 2>/dev/null || true)"
+  fi
+  [[ "$epoch" =~ ^[0-9]+$ ]] || epoch="$(date +%s)"
+  printf '%s' "$epoch"
+}
+
+# evaluate_liveness <issue> → echoes HEALTHY|SUSPECT|STUCK|HUSK; sets the
+# LIVENESS_* globals as a side effect. Never aborts under set -u.
+evaluate_liveness() {
+  local issue="$1" now wt wt_present last_commit start_epoch
+  local screen_pid claude_pid screen_alive
+  now="$(date +%s)"
+
+  wt="$(_wt_base)/sprint-$issue"
+  if [[ -d "$wt" ]]; then
+    wt_present=1
+    last_commit="$(git -C "$wt" log -1 --format=%ct 2>/dev/null || true)"
+  else
+    wt_present=0
+    last_commit=""
+  fi
+
+  screen_pid="$(pgrep -f "SCREEN -dmS sprint-runner-$issue" 2>/dev/null | head -1 || true)"
+  [[ -n "$screen_pid" ]] && screen_alive=1 || screen_alive=0
+  claude_pid="$(pgrep -f "remote-control sprint-$issue" 2>/dev/null | head -1 || true)"
+
+  start_epoch="$(_session_start_epoch "$issue" "$screen_pid")"
+
+  # CPU: two samples, max() dodges a between-bursts trough. Only when a claude
+  # pid exists (no pid → the process probe takes the husk/unknown path).
+  local cpu1="" cpu2=""
+  if [[ -n "$claude_pid" ]]; then
+    cpu1="$(ps -o %cpu= -p "$claude_pid" 2>/dev/null | tr -d ' ' || true)"
+    sleep "${LIVENESS_CPU_SAMPLE_GAP:-3}"
+    cpu2="$(ps -o %cpu= -p "$claude_pid" 2>/dev/null | tr -d ' ' || true)"
+  fi
+
+  # Log signal: sample the per-session screen logfile IF present. Production
+  # screen-logfile wiring is deferred (macOS screen 4.00.03 has no -Logfile;
+  # see tasks/sprint-930-plan.md), so this is UNKNOWN until a later sprint —
+  # the safe direction (UNKNOWN never counts as STALL).
+  local logfile log_present=0 mtime_age=0 mtime
+  logfile="${RUNNER_LOG_DIR:-$(_wt_base)/.runner-logs}/session-$issue.log"
+  if [[ -f "$logfile" ]]; then
+    log_present=1
+    mtime="$(stat -f %m "$logfile" 2>/dev/null || echo "$now")"
+    [[ "$mtime" =~ ^[0-9]+$ ]] || mtime="$now"
+    mtime_age=$(( now - mtime ))
+  fi
+
+  LIVENESS_COMMIT="$(probe_commit_age "$now" "$start_epoch" "$last_commit" "$wt_present")"
+  LIVENESS_PROCESS="$(probe_process "$screen_alive" "$claude_pid" "$cpu1" "$cpu2")"
+  if (( log_present == 1 )); then
+    LIVENESS_LOG="$(tail -n 40 "$logfile" 2>/dev/null | probe_log 1 "$mtime_age")"
+  else
+    LIVENESS_LOG="$(printf '' | probe_log 0 "$mtime_age")"
+  fi
+
+  fuse_verdict "$LIVENESS_COMMIT" "$LIVENESS_PROCESS" "$LIVENESS_LOG"
+  return 0
+}

--- a/scripts/lib/sprint-runner-liveness.sh
+++ b/scripts/lib/sprint-runner-liveness.sh
@@ -159,6 +159,7 @@ state_prune() {
 # macOS `screen -ls` exits 1 even when sessions exist and silently inverts a
 # pipefail predicate (R14/L089).
 
+LIVENESS_VERDICT=""
 LIVENESS_COMMIT=""
 LIVENESS_PROCESS=""
 LIVENESS_LOG=""
@@ -185,8 +186,11 @@ _session_start_epoch() {
   printf '%s' "$epoch"
 }
 
-# evaluate_liveness <issue> → echoes HEALTHY|SUSPECT|STUCK|HUSK; sets the
-# LIVENESS_* globals as a side effect. Never aborts under set -u.
+# evaluate_liveness <issue> → sets LIVENESS_VERDICT (HEALTHY|SUSPECT|STUCK|HUSK)
+# and the LIVENESS_COMMIT/PROCESS/LOG breakdown as globals. Results are returned
+# via globals, NOT stdout, so the caller must invoke this as a plain statement —
+# a command-substitution `$(evaluate_liveness ...)` would run it in a subshell
+# and discard the globals. Never aborts under set -u.
 evaluate_liveness() {
   local issue="$1" now wt wt_present last_commit start_epoch
   local screen_pid claude_pid screen_alive
@@ -223,9 +227,14 @@ evaluate_liveness() {
   local logfile log_present=0 mtime_age=0 mtime
   logfile="${RUNNER_LOG_DIR:-$(_wt_base)/.runner-logs}/session-$issue.log"
   if [[ -f "$logfile" ]]; then
-    log_present=1
-    mtime="$(_int_or "$(stat -f %m "$logfile" 2>/dev/null)" "$now")"
-    mtime_age=$(( now - mtime ))
+    mtime="$(stat -f %m "$logfile" 2>/dev/null || true)"
+    # Only treat the log as present if we got a real mtime — an unstat-able
+    # file must resolve to UNKNOWN (the safe direction), not a fabricated
+    # "fresh" reading that would mask a stall.
+    if [[ "$mtime" =~ ^[0-9]+$ ]]; then
+      log_present=1
+      mtime_age=$(( now - mtime ))
+    fi
   fi
 
   LIVENESS_COMMIT="$(probe_commit_age "$now" "$start_epoch" "$last_commit" "$wt_present")"
@@ -236,6 +245,6 @@ evaluate_liveness() {
     LIVENESS_LOG="$(printf '' | probe_log 0 "$mtime_age")"
   fi
 
-  fuse_verdict "$LIVENESS_COMMIT" "$LIVENESS_PROCESS" "$LIVENESS_LOG"
+  LIVENESS_VERDICT="$(fuse_verdict "$LIVENESS_COMMIT" "$LIVENESS_PROCESS" "$LIVENESS_LOG")"
   return 0
 }

--- a/scripts/lib/sprint-runner-liveness.sh
+++ b/scripts/lib/sprint-runner-liveness.sh
@@ -74,28 +74,35 @@ _state_file() {
   fi
 }
 
-# _state_read → the store as JSON on stdout, or `{}` if missing/corrupt.
-# Corruption resolves to an empty store (fail-safe: at worst a few extra
-# relaunch attempts), never to an abort.
-_state_read() {
-  local f
-  f="$(_state_file)"
-  if [[ -f "$f" ]] && jq -e . "$f" >/dev/null 2>&1; then
-    cat "$f"
-  else
-    echo '{}'
-  fi
+# _int_or <value> <default> → echo value if it's a non-negative integer, else
+# the default. Guards every jq --argjson site so a stray value can't abort the
+# tick under set -u.
+_int_or() {
+  if [[ "$1" =~ ^[0-9]+$ ]]; then printf '%s' "$1"; else printf '%s' "$2"; fi
 }
 
-# state_get_attempts <issue> → integer attempt count (0 if absent/corrupt).
-state_get_attempts() {
-  local issue="$1" v
-  v="$(_state_read | jq -r --arg k "$issue" '.[$k].attempts // 0' 2>/dev/null)"
-  if [[ "$v" =~ ^[0-9]+$ ]]; then
-    printf '%s' "$v"
+# _state_read → the store as JSON on stdout, or `{}` if missing/corrupt.
+# Corruption resolves to an empty store (fail-safe: at worst a few extra
+# relaunch attempts), never to an abort. One jq does validate-and-emit.
+_state_read() {
+  jq -e . "$(_state_file)" 2>/dev/null || echo '{}'
+}
+
+# _state_write_atomic  (new JSON content as $1) → replace the store atomically
+# (mktemp + mv rename). The caller computes the content and checks jq's exit
+# BEFORE calling here, so a failed transform never reaches the file.
+_state_write_atomic() {
+  local content="$1" f tmp
+  f="$(_state_file)"
+  mkdir -p "$(dirname "$f")"
+  tmp="$(mktemp "${f}.XXXXXX")"
+  if printf '%s' "$content" > "$tmp"; then
+    mv -f "$tmp" "$f"
   else
-    printf '0'
+    rm -f "$tmp" 2>/dev/null || true
+    return 1
   fi
+  return 0
 }
 
 # state_get_field <issue> <field> → the field's value, or empty string.
@@ -106,30 +113,24 @@ state_get_field() {
   printf '%s' "$v"
 }
 
-# state_record <issue> <verdict> <attempts> [last_relaunch_epoch]
-#   Atomic upsert of one issue's entry. attempts/epoch are coerced to integers
-#   so a stray value can't make jq --argjson fail mid-tick.
-state_record() {
-  local issue="$1" verdict="$2" attempts="$3" relaunch="${4:-0}"
-  [[ "$attempts" =~ ^[0-9]+$ ]] || attempts=0
-  [[ "$relaunch" =~ ^[0-9]+$ ]] || relaunch=0
+# state_get_attempts <issue> → integer attempt count (0 if absent/corrupt).
+state_get_attempts() {
+  _int_or "$(state_get_field "$1" attempts)" 0
+}
 
-  local f tmp cur
-  f="$(_state_file)"
-  mkdir -p "$(dirname "$f")"
-  cur="$(_state_read)"
-  tmp="$(mktemp "${f}.XXXXXX")"
-  if printf '%s' "$cur" | jq \
+# state_record <issue> <verdict> <attempts> [last_relaunch_epoch]
+#   Atomic upsert of one issue's entry.
+state_record() {
+  local issue="$1" verdict="$2" attempts new
+  attempts="$(_int_or "$3" 0)"
+  local relaunch; relaunch="$(_int_or "${4:-0}" 0)"
+
+  new="$(_state_read | jq \
         --arg k "$issue" --arg v "$verdict" \
         --argjson a "$attempts" --argjson r "$relaunch" \
-        '.[$k] = {attempts: $a, last_verdict: $v, last_relaunch_epoch: $r}' \
-        > "$tmp"; then
-    mv -f "$tmp" "$f"
-  else
-    rm -f "$tmp" 2>/dev/null || true
-    return 1
-  fi
-  return 0
+        '.[$k] = {attempts: $a, last_verdict: $v, last_relaunch_epoch: $r}')" \
+    || return 1
+  _state_write_atomic "$new"
 }
 
 # state_prune <keep_issue...>
@@ -137,23 +138,15 @@ state_record() {
 #   for issues that are CLOSED or no longer in the active epic. No args → empty
 #   the store to `{}`. Convergent, so the file can't accumulate stale keys.
 state_prune() {
-  local f tmp cur keep_json='[]'
-  f="$(_state_file)"
-  [[ -f "$f" ]] || return 0
-  cur="$(_state_read)"
+  [[ -f "$(_state_file)" ]] || return 0
+  local keep_json='[]' new
   if (( $# > 0 )); then
-    keep_json="$(printf '%s\n' "$@" | jq -R . | jq -s .)"
+    keep_json="$(printf '%s\n' "$@" | jq -Rn '[inputs]')"
   fi
-  mkdir -p "$(dirname "$f")"
-  tmp="$(mktemp "${f}.XXXXXX")"
-  if printf '%s' "$cur" | jq --argjson keep "$keep_json" \
-        'with_entries(select(.key as $k | $keep | index($k)))' > "$tmp"; then
-    mv -f "$tmp" "$f"
-  else
-    rm -f "$tmp" 2>/dev/null || true
-    return 1
-  fi
-  return 0
+  new="$(_state_read | jq --argjson keep "$keep_json" \
+        'with_entries(select(.key as $k | $keep | index($k)))')" \
+    || return 1
+  _state_write_atomic "$new"
 }
 
 # === Sampling edge =========================================================
@@ -231,8 +224,7 @@ evaluate_liveness() {
   logfile="${RUNNER_LOG_DIR:-$(_wt_base)/.runner-logs}/session-$issue.log"
   if [[ -f "$logfile" ]]; then
     log_present=1
-    mtime="$(stat -f %m "$logfile" 2>/dev/null || echo "$now")"
-    [[ "$mtime" =~ ^[0-9]+$ ]] || mtime="$now"
+    mtime="$(_int_or "$(stat -f %m "$logfile" 2>/dev/null)" "$now")"
     mtime_age=$(( now - mtime ))
   fi
 

--- a/scripts/sprint-runner.sh
+++ b/scripts/sprint-runner.sh
@@ -643,8 +643,11 @@ mode_run() {
         # store. A STUCK/HUSK verdict will be reaped + relaunched by the Sprint 4
         # path (#931); Sprint 3 only OBSERVES — every branch still skips the
         # launch this tick, so existing behavior is preserved.
+        # Call as a plain statement (NOT $(...)): evaluate_liveness returns its
+        # verdict + breakdown via globals, which a subshell would discard.
         local verdict attempts
-        verdict=$(evaluate_liveness "$active_issue")
+        evaluate_liveness "$active_issue"
+        verdict="$LIVENESS_VERDICT"
         attempts=$(state_get_attempts "$active_issue")
         log "Existing session $active active (#$active_issue is $active_state) — liveness verdict=$verdict [commit=$LIVENESS_COMMIT process=$LIVENESS_PROCESS log=$LIVENESS_LOG attempts=$attempts/3]."
         state_record "$active_issue" "$verdict" "$attempts" || log "WARNING: failed to persist liveness state for #$active_issue"

--- a/scripts/sprint-runner.sh
+++ b/scripts/sprint-runner.sh
@@ -68,11 +68,14 @@ LOG_FILE="${SPRINT_RUNNER_LOG:-$HOME/.toast-stats-sprint-runner.log}"
 LOG_ROTATE_BYTES=$((1024 * 1024))
 WORKTREE_BASE="${WORKTREE_BASE:-$HOME/sprint-worktrees}"
 
-# Stuck-session liveness probes (epic #933). Sourcing only DEFINES the pure
-# probe functions (probe_commit_age / probe_process / probe_log) — they are not
-# yet called from any tick branch. Fusion + tick wiring land in Sprint 3 (#930).
+# Stuck-session liveness (epic #933). Sourcing only DEFINES functions.
+#   probes      — pure classify functions over sampled inputs (Sprint 2 #929).
+#   liveness    — fuse_verdict, the attempt-state store, and evaluate_liveness
+#                 (the sampling edge), wired into the tick below (Sprint 3 #930).
 # shellcheck source=lib/sprint-runner-probes.sh
 source "$REPO_DIR/scripts/lib/sprint-runner-probes.sh"
+# shellcheck source=lib/sprint-runner-liveness.sh
+source "$REPO_DIR/scripts/lib/sprint-runner-liveness.sh"
 
 # Populated by resolve_active_epic(); used by callers to decide whether
 # auto-tick fires and to print the source in --status.
@@ -635,7 +638,21 @@ mode_run() {
           exit 0
         fi
       else
-        log "Existing session $active active (#$active_issue is $active_state) — skipping launch."
+        # OPEN in-epic session: no longer an automatic pass. Evaluate liveness
+        # (sample 3 probes → fuse) and record the verdict to the attempt-state
+        # store. A STUCK/HUSK verdict will be reaped + relaunched by the Sprint 4
+        # path (#931); Sprint 3 only OBSERVES — every branch still skips the
+        # launch this tick, so existing behavior is preserved.
+        local verdict attempts
+        verdict=$(evaluate_liveness "$active_issue")
+        attempts=$(state_get_attempts "$active_issue")
+        log "Existing session $active active (#$active_issue is $active_state) — liveness verdict=$verdict [commit=$LIVENESS_COMMIT process=$LIVENESS_PROCESS log=$LIVENESS_LOG attempts=$attempts/3]."
+        state_record "$active_issue" "$verdict" "$attempts" || log "WARNING: failed to persist liveness state for #$active_issue"
+        if [[ "$verdict" == STUCK || "$verdict" == HUSK ]]; then
+          log "Liveness: $verdict on #$active_issue — reap + capped auto-relaunch lands in Sprint 4 (#931); skipping launch this tick."
+        else
+          log "Liveness: $verdict on #$active_issue — healthy/insufficient-evidence; skipping launch as before."
+        fi
         exit 0
       fi
     else

--- a/scripts/tests/sprint-runner-fusion-state.test.sh
+++ b/scripts/tests/sprint-runner-fusion-state.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Unit tests for the liveness FUSION verdict + attempt-tracking STATE store
+# (epic #933 Sprint 3, #930).
+#
+# Both layers are exercised as pure-ish functions:
+#   - fuse_verdict <commit> <process> <log>  → HEALTHY|SUSPECT|STUCK|HUSK (pure)
+#   - state store over a JSON file ($RUNNER_STATE_FILE), jq-backed, atomic write,
+#     fail-safe to "0 attempts / no entry" on missing/corrupt input.
+#
+# Hermetic: sources the lib directly, asserts on stdout / file contents. The
+# state file is a per-test tempdir, so no real runner state is touched.
+#
+# Run directly: scripts/tests/sprint-runner-fusion-state.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../lib/sprint-runner-liveness.sh"
+
+# shellcheck source=../lib/sprint-runner-liveness.sh
+source "$LIB"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export RUNNER_STATE_FILE="$TMP/.runner-state.json"
+
+fail=0
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS: $label"
+  else
+    echo "FAIL: $label — expected '$expected', got '$actual'"
+    fail=1
+  fi
+}
+
+# ===========================================================================
+# fuse_verdict <commit> <process> <log>
+# commit/log ∈ {OK,STALL,UNKNOWN}; process ∈ {OK,STALL,UNKNOWN,HUSK}
+# ===========================================================================
+
+# --- HUSK precedence: conclusive single signal wins over everything ---
+assert_eq "fuse: process HUSK alone → HUSK" "HUSK" \
+  "$(fuse_verdict UNKNOWN HUSK UNKNOWN)"
+assert_eq "fuse: HUSK even with healthy commit+log → HUSK" "HUSK" \
+  "$(fuse_verdict OK HUSK OK)"
+assert_eq "fuse: HUSK even with other STALLs → HUSK" "HUSK" \
+  "$(fuse_verdict STALL HUSK STALL)"
+
+# --- Corroboration: >=2 STALL → STUCK ---
+assert_eq "fuse: commit+process STALL → STUCK" "STUCK" \
+  "$(fuse_verdict STALL STALL OK)"
+assert_eq "fuse: commit+log STALL (the #871 shape) → STUCK" "STUCK" \
+  "$(fuse_verdict STALL OK STALL)"
+assert_eq "fuse: process+log STALL → STUCK" "STUCK" \
+  "$(fuse_verdict OK STALL STALL)"
+assert_eq "fuse: all three STALL → STUCK" "STUCK" \
+  "$(fuse_verdict STALL STALL STALL)"
+assert_eq "fuse: 2 STALL + 1 UNKNOWN → STUCK" "STUCK" \
+  "$(fuse_verdict STALL UNKNOWN STALL)"
+
+# --- One soft signal → SUSPECT (never reaps; the false-positive guard) ---
+assert_eq "fuse: commit STALL alone → SUSPECT" "SUSPECT" \
+  "$(fuse_verdict STALL OK OK)"
+assert_eq "fuse: process STALL alone → SUSPECT" "SUSPECT" \
+  "$(fuse_verdict OK STALL OK)"
+assert_eq "fuse: log STALL alone → SUSPECT" "SUSPECT" \
+  "$(fuse_verdict OK OK STALL)"
+assert_eq "fuse: 1 STALL + 2 UNKNOWN → SUSPECT" "SUSPECT" \
+  "$(fuse_verdict UNKNOWN STALL UNKNOWN)"
+
+# --- Healthy / insufficient evidence ---
+assert_eq "fuse: all OK → HEALTHY" "HEALTHY" \
+  "$(fuse_verdict OK OK OK)"
+assert_eq "fuse: all UNKNOWN → HEALTHY" "HEALTHY" \
+  "$(fuse_verdict UNKNOWN UNKNOWN UNKNOWN)"
+assert_eq "fuse: OK + UNKNOWN mix, no STALL → HEALTHY" "HEALTHY" \
+  "$(fuse_verdict OK UNKNOWN OK)"
+
+# ===========================================================================
+# State store
+# ===========================================================================
+
+# --- Missing file → 0 attempts, fail-safe ---
+assert_eq "state: missing file → 0 attempts" "0" \
+  "$(state_get_attempts 930)"
+
+# --- Record then read back ---
+state_record 930 STUCK 1 1717000000
+assert_eq "state: record attempts=1 → read back 1" "1" \
+  "$(state_get_attempts 930)"
+assert_eq "state: record stores last_verdict" "STUCK" \
+  "$(state_get_field 930 last_verdict)"
+assert_eq "state: record stores last_relaunch_epoch" "1717000000" \
+  "$(state_get_field 930 last_relaunch_epoch)"
+
+# --- Upsert: a second record overwrites the same key ---
+state_record 930 HUSK 2 1717000999
+assert_eq "state: upsert attempts → 2" "2" \
+  "$(state_get_attempts 930)"
+assert_eq "state: upsert last_verdict → HUSK" "HUSK" \
+  "$(state_get_field 930 last_verdict)"
+
+# --- A second issue coexists (per-issue keying) ---
+state_record 931 SUSPECT 0 0
+assert_eq "state: issue 931 coexists, attempts 0" "0" \
+  "$(state_get_attempts 931)"
+assert_eq "state: issue 930 untouched by 931 write" "2" \
+  "$(state_get_attempts 930)"
+
+# --- Unknown issue → 0 attempts, empty field ---
+assert_eq "state: unknown issue → 0 attempts" "0" \
+  "$(state_get_attempts 999)"
+assert_eq "state: unknown field on known issue → empty" "" \
+  "$(state_get_field 930 nope)"
+
+# --- Atomic write leaves valid JSON (no tmp residue) ---
+assert_eq "state: file is valid JSON after writes" "ok" \
+  "$(jq -e . "$RUNNER_STATE_FILE" >/dev/null 2>&1 && echo ok || echo bad)"
+assert_eq "state: no leftover tmp files beside state" "0" \
+  "$(find "$TMP" -maxdepth 1 -name '.runner-state.json.*' | wc -l | tr -d ' ')"
+
+# --- Prune to live keys: drops a CLOSED/absent issue, keeps the listed ones ---
+state_prune 930          # keep only 930; 931 was a stale entry
+assert_eq "state: prune kept 930" "2" \
+  "$(state_get_attempts 930)"
+assert_eq "state: prune dropped 931" "0" \
+  "$(state_get_attempts 931)"
+
+# --- Prune with no live keys empties the store to {} ---
+state_prune
+assert_eq "state: prune to nothing → 930 gone" "0" \
+  "$(state_get_attempts 930)"
+assert_eq "state: empty store is still valid JSON" "ok" \
+  "$(jq -e . "$RUNNER_STATE_FILE" >/dev/null 2>&1 && echo ok || echo bad)"
+
+# --- Corrupt JSON → fail-safe to 0, never aborts under set -u ---
+printf '{ this is not json' > "$RUNNER_STATE_FILE"
+assert_eq "state: corrupt file → 0 attempts (fail-safe)" "0" \
+  "$(state_get_attempts 930)"
+# ...and a record over a corrupt file repairs it to valid JSON.
+state_record 930 STUCK 1 1717001000
+assert_eq "state: record over corrupt repairs to valid JSON" "1" \
+  "$(state_get_attempts 930)"
+
+exit "$fail"

--- a/scripts/tests/sprint-runner-liveness-tick.test.sh
+++ b/scripts/tests/sprint-runner-liveness-tick.test.sh
@@ -112,26 +112,31 @@ mkdir -p "$WORKTREE_BASE/sprint-930"
 fail=0
 
 # --- Case A: claude alive + busy + recent commit → HEALTHY, plain skip ---
+# The per-probe breakdown must be POPULATED, not blank: evaluate_liveness sets
+# globals, so a command-substitution call would silently lose them (the bug a
+# subshell call introduces). Assert the real probe tokens, not just the verdict.
 CLAUDE_ALIVE=1 "$RUNNER" --dry-run >"$TMP/a.log" 2>&1 || true
 if grep -q 'verdict=HEALTHY' "$TMP/a.log" \
+   && grep -q 'commit=OK process=OK log=UNKNOWN' "$TMP/a.log" \
    && ! grep -q 'would launch screen session' "$TMP/a.log" \
    && ! grep -qi 'Sprint 4' "$TMP/a.log" \
    && ! grep -q 'SCREEN_CALL.*quit' "$SCREEN_CALLS"; then
-  echo "PASS [A]: HEALTHY verdict logged, no launch, no reap"
+  echo "PASS [A]: HEALTHY verdict + populated breakdown logged, no launch, no reap"
 else
-  echo "FAIL [A]: expected HEALTHY + no launch + no reap, got:"; sed 's/^/    /' "$TMP/a.log"; fail=1
+  echo "FAIL [A]: expected HEALTHY + breakdown + no launch + no reap, got:"; sed 's/^/    /' "$TMP/a.log"; fail=1
 fi
 
 # --- Case B: screen alive, claude gone → HUSK, Sprint-4 handoff, no reap ---
 : > "$SCREEN_CALLS"
 CLAUDE_ALIVE=0 "$RUNNER" --dry-run >"$TMP/b.log" 2>&1 || true
 if grep -q 'verdict=HUSK' "$TMP/b.log" \
+   && grep -q 'process=HUSK' "$TMP/b.log" \
    && grep -qi 'Sprint 4' "$TMP/b.log" \
    && ! grep -q 'would launch screen session' "$TMP/b.log" \
    && ! grep -q 'SCREEN_CALL.*quit' "$SCREEN_CALLS"; then
-  echo "PASS [B]: HUSK verdict + Sprint-4 handoff logged, no reap, no launch"
+  echo "PASS [B]: HUSK verdict + populated breakdown + Sprint-4 handoff, no reap, no launch"
 else
-  echo "FAIL [B]: expected HUSK + Sprint-4 handoff + no reap, got:"; sed 's/^/    /' "$TMP/b.log"; fail=1
+  echo "FAIL [B]: expected HUSK + breakdown + Sprint-4 handoff + no reap, got:"; sed 's/^/    /' "$TMP/b.log"; fail=1
 fi
 
 # --- Case C: the attempt-state file recorded the verdict (state wired in) ---

--- a/scripts/tests/sprint-runner-liveness-tick.test.sh
+++ b/scripts/tests/sprint-runner-liveness-tick.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Integration regression test for the liveness verdict wired into mode_run's
+# active-session branch (epic #933 Sprint 3, #930).
+#
+# The runner used to do an unconditional "OPEN session → skip launch" exit. Now
+# an OPEN in-epic active session is first evaluated for liveness: the fused
+# verdict is computed + logged, the attempt-state is recorded, and a STUCK/HUSK
+# verdict logs the Sprint-4 reap/relaunch handoff. Every path still skips the
+# launch — Sprint 3 changes the OBSERVABILITY, not the action (reap is Sprint 4).
+#
+# Hermetic: mocks gh/screen/pgrep/ps/git on PATH; LIVENESS_CPU_SAMPLE_GAP=0 so
+# the CPU double-sample doesn't sleep. Asserts on the log decision.
+#   Case A (claude alive + busy + recent commit): verdict=HEALTHY, no launch,
+#                                                 no reap, no Sprint-4 handoff.
+#   Case B (screen alive + claude gone):          verdict=HUSK, Sprint-4 handoff
+#                                                 logged, no reap, no launch.
+#
+# Run directly: scripts/tests/sprint-runner-liveness-tick.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$SCRIPT_DIR/../sprint-runner.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+BIN="$TMP/bin"; mkdir -p "$BIN"
+
+# Mock gh: META_EPIC #900 → epic #901 (one unchecked sprint, #930, OPEN).
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+sub="$1"; verb="$2"; num="$3"
+[[ "$sub" == "issue" && "$verb" == "edit" ]] && exit 0
+if [[ "$sub" == "issue" && "$verb" == "view" ]]; then
+  field=""; args=("$@")
+  for ((i=0; i<${#args[@]}; i++)); do [[ "${args[i]}" == "--json" ]] && field="${args[i+1]}"; done
+  case "$num:$field" in
+    900:labels) ;;
+    900:body)   printf '%s' '- [ ] **Epic Test** — #901' ;;
+    901:body)   printf '%s' '- [ ] **Sprint 1** — #930' ;;
+    930:state)  printf '%s' 'OPEN' ;;
+    930:labels) ;;
+  esac
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$BIN/gh"
+
+# Mock screen: `-ls` lists the in-epic active session sprint-runner-930 (and
+# mirrors macOS screen exiting 1 even when sessions exist — R14/L089). Any
+# mutating call (e.g. quit) is a silent no-op so a stray reap can't escape.
+cat > "$BIN/screen" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-ls" ]]; then
+  echo "There is a screen on:" >&2
+  echo "    12345.sprint-runner-930    (Detached)" >&2
+  exit 1
+fi
+echo "SCREEN_CALL $*" >> "$SCREEN_CALLS"
+exit 0
+EOF
+chmod +x "$BIN/screen"
+
+# Mock pgrep: the screen daemon is always alive (so gc_worktrees doesn't treat
+# the worktree as an orphan). The claude child's presence is toggled by
+# $CLAUDE_ALIVE (1 → pid 4242, 0 → none → husk).
+cat > "$BIN/pgrep" <<'EOF'
+#!/usr/bin/env bash
+pat="${*: -1}"
+case "$pat" in
+  *"SCREEN -dmS sprint-runner-930"*) echo 12345 ;;
+  *"remote-control sprint-930"*)     [[ "${CLAUDE_ALIVE:-1}" == 1 ]] && echo 4242 ;;
+esac
+exit 0
+EOF
+chmod +x "$BIN/pgrep"
+
+# Mock ps: %cpu busy (50%), lstart a fixed parseable date for start derivation.
+cat > "$BIN/ps" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"-o %cpu="*)   echo "50.0" ;;
+  *"-o lstart="*) echo "Fri May 30 09:00:00 2026" ;;
+esac
+exit 0
+EOF
+chmod +x "$BIN/ps"
+
+# Mock git: worktree prune is a no-op; `log -1 --format=%ct` returns a recent
+# commit epoch so the commit probe reads OK in the healthy case.
+cat > "$BIN/git" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  [[ "\$a" == "log" ]] && { date +%s; exit 0; }
+done
+exit 0
+EOF
+chmod +x "$BIN/git"
+
+export PATH="$BIN:$PATH"
+export META_EPIC=900
+export SPRINT_RUNNER_LOCK_DIR="$TMP/lock"
+export WORKTREE_BASE="$TMP/worktrees"
+export LIVENESS_CPU_SAMPLE_GAP=0
+export SCREEN_CALLS="$TMP/screen-calls.log"
+: > "$SCREEN_CALLS"
+unset EPIC || true
+
+# The active session's worktree must exist for the commit probe to sample it.
+mkdir -p "$WORKTREE_BASE/sprint-930"
+
+fail=0
+
+# --- Case A: claude alive + busy + recent commit → HEALTHY, plain skip ---
+CLAUDE_ALIVE=1 "$RUNNER" --dry-run >"$TMP/a.log" 2>&1 || true
+if grep -q 'verdict=HEALTHY' "$TMP/a.log" \
+   && ! grep -q 'would launch screen session' "$TMP/a.log" \
+   && ! grep -qi 'Sprint 4' "$TMP/a.log" \
+   && ! grep -q 'SCREEN_CALL.*quit' "$SCREEN_CALLS"; then
+  echo "PASS [A]: HEALTHY verdict logged, no launch, no reap"
+else
+  echo "FAIL [A]: expected HEALTHY + no launch + no reap, got:"; sed 's/^/    /' "$TMP/a.log"; fail=1
+fi
+
+# --- Case B: screen alive, claude gone → HUSK, Sprint-4 handoff, no reap ---
+: > "$SCREEN_CALLS"
+CLAUDE_ALIVE=0 "$RUNNER" --dry-run >"$TMP/b.log" 2>&1 || true
+if grep -q 'verdict=HUSK' "$TMP/b.log" \
+   && grep -qi 'Sprint 4' "$TMP/b.log" \
+   && ! grep -q 'would launch screen session' "$TMP/b.log" \
+   && ! grep -q 'SCREEN_CALL.*quit' "$SCREEN_CALLS"; then
+  echo "PASS [B]: HUSK verdict + Sprint-4 handoff logged, no reap, no launch"
+else
+  echo "FAIL [B]: expected HUSK + Sprint-4 handoff + no reap, got:"; sed 's/^/    /' "$TMP/b.log"; fail=1
+fi
+
+# --- Case C: the attempt-state file recorded the verdict (state wired in) ---
+if [[ -f "$WORKTREE_BASE/.runner-state.json" ]] \
+   && [[ "$(jq -r '."930".last_verdict' "$WORKTREE_BASE/.runner-state.json")" == "HUSK" ]]; then
+  echo "PASS [C]: liveness verdict persisted to attempt-state store"
+else
+  echo "FAIL [C]: expected state store to record #930 last_verdict=HUSK"; fail=1
+fi
+
+exit "$fail"

--- a/tasks/lessons/138-a-function-returning-data-via-globals-must-not-be-called-in-command-substitution.md
+++ b/tasks/lessons/138-a-function-returning-data-via-globals-must-not-be-called-in-command-substitution.md
@@ -1,0 +1,58 @@
+---
+id: '138'
+category: principle
+tags: [bash, automation, sprint-runner, shell]
+auto_load: true
+date: 2026-05-30
+issues: [930, 933]
+---
+
+# Lesson 138 — A bash function that returns data via globals must be called as a statement, never in `$(...)`
+
+**Date:** 2026-05-30
+**Issue:** #930 (epic #933 Sprint 3 — liveness fusion verdict wired into the tick)
+**PR:** _(record on merge)_
+
+## What happened
+
+`evaluate_liveness` sampled three probes and set `LIVENESS_VERDICT` /
+`LIVENESS_COMMIT` / `LIVENESS_PROCESS` / `LIVENESS_LOG` as globals — the documented
+contract being "read the breakdown from the globals after it returns." The tick
+called it as `verdict=$(evaluate_liveness "$issue")`. Command substitution runs the
+function in a **subshell**, so every global it assigned died with that subshell;
+the parent's copies stayed empty. The verdict token (captured from stdout) was
+correct, so the bug hid behind a green-looking log — but the diagnostic line
+printed `[commit= process= log=]`, blank exactly where the observability lived.
+
+The first integration test passed **vacuously**: it asserted only on the verdict
+token (which travels via stdout and survives), never on the breakdown the globals
+carried. A fresh-context review caught it; strengthening the test to assert
+`commit=OK process=OK log=UNKNOWN` reproduced the failure before the fix.
+
+## The principle
+
+A function has exactly one stdout channel but any number of global side effects.
+If it returns data through globals, you **must** invoke it as a plain statement
+(`f args`) and read the globals afterward. The moment you wrap it in `$(...)`,
+backticks, or a pipeline, it runs in a subshell and the globals never reach the
+caller. Pick one return mechanism per function and make the call site match it:
+
+- **stdout** → `x=$(f)` is correct; globals are unreliable.
+- **globals** → `f; x=$GLOBAL` is correct; `$(f)` silently loses them.
+
+## How to apply
+
+- When a function sets globals, call it bare and document "results via globals —
+  do NOT call in `$(...)`" at the definition (the subshell loss is invisible at
+  the call site).
+- Assert on the **global-carried** outputs in the test, not just the stdout
+  return — a test that only checks the stdout value passes vacuously while the
+  globals are empty. The richest field is the one most likely to be silently
+  dropped.
+- Prefer one mechanism. Mixing "echo the headline + globals for the detail" is
+  what made this fail half-silently; if a function must expose several values,
+  return them all the same way (all globals, or a single structured stdout line
+  the caller parses).
+
+Related: [[083-a-bash-exit-traps-return-value-becomes-the-scripts-exit-code]] (a
+different "the obvious call form has a non-obvious side effect" bash trap).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -108,6 +108,7 @@
 - **137** [tests, flaky, vitest, process, verification, tdd] — An audit's "false-confidence" list is a per-file hypothesis; re-confirm before deleting, because the first-pass classification over-flags (#916, #917)
 - **138** [verification, automation, sprint-runner, ci, frontend, process] — A "verify on the PR preview" sprint needs a diff that actually triggers the preview (#904, #900)
 - **138** [bash, automation, sprint-runner] — A bare `(( … ))` on injected input aborts the host script under `set -u` (#929, #933)
+- **138** [bash, automation, sprint-runner, shell] — A bash function that returns data via globals must be called as a statement, never in `$(...)` (#930, #933)
 - **138** [frontend, react, scope, refactor, tests] — A view that renders correctly only because an upstream utility incidentally sorts that way should own and pin its own order (#882, #884)
 - **138** [css, accessibility, frontend, tests, playwright] — An `inset-0` overlay is sized to its container's PADDING box; a 1px border on the chip steals from the touch target (#886, #888)
 - **138** [css, frontend, accessibility, verification, playwright, mobile] — `scroll-margin-top` belongs on the element that holds the anchor id, not a styled child (#877, #880)

--- a/tasks/sprint-930-plan.md
+++ b/tasks/sprint-930-plan.md
@@ -1,0 +1,57 @@
+# Sprint 3 (#930) — Fusion verdict + attempt-tracking state, wired into the tick
+
+Epic #933 (stuck-session liveness). Builds on Sprint 1 design
+(`docs/design/sprint-runner-liveness-detector-2026-05-30.md`) and Sprint 2 probes
+(`scripts/lib/sprint-runner-probes.sh`).
+
+## Scope (from #930 body)
+
+1. **Fusion function** — pure: combine 3 probe outputs → `{HEALTHY|SUSPECT|STUCK|HUSK}`.
+   `process==HUSK` → HUSK (conclusive single); `count(STALL)>=2` → STUCK (corroborated);
+   `==1` → SUSPECT (one soft signal, no reap); else HEALTHY. UNKNOWN never counts as STALL.
+2. **State store** — durable per-issue attempt count + last verdict/relaunch epoch.
+   JSON at `$WORKTREE_BASE/.runner-state.json` (override `RUNNER_STATE_FILE`), `jq`-backed
+   (`/usr/bin/jq`, base PATH). Atomic write (mktemp+mv). Fail-safe: missing/corrupt → 0 attempts.
+   Reconcile via prune-to-live-keys.
+3. **Tick wiring** — replace `mode_run`'s unconditional OPEN-active `exit 0`
+   (`sprint-runner.sh:637-640`) with: sample probes → fuse → log verdict → record state →
+   on STUCK/HUSK log the Sprint-4 reap/relaunch handoff (NOT implemented here) and skip;
+   else skip as before. **Every path still `exit 0` → no regression.**
+
+## Files
+
+- NEW `scripts/lib/sprint-runner-liveness.sh` — `fuse_verdict`, state store
+  (`state_get_attempts` / `state_record` / `state_prune`), and the `evaluate_liveness <issue>`
+  edge sampler (git/pgrep/ps/stat/date/tail → probes → fuse).
+- EDIT `scripts/sprint-runner.sh` — source the lib; wire `evaluate_liveness` into the OPEN branch.
+- NEW `scripts/tests/sprint-runner-fusion-state.test.sh` — pure unit tests: fusion truth table
+  (HUSK precedence, >=2→STUCK, ==1→SUSPECT, all-UNKNOWN→HEALTHY) + state atomic write/read,
+  CLOSED-prune, missing/corrupt→0.
+- NEW `scripts/tests/sprint-runner-liveness-tick.test.sh` — integration: OPEN in-epic active
+  session → HEALTHY skips (verdict logged, no launch); HUSK → Sprint-4 handoff logged, no reap,
+  no launch; existing CLOSED-reap / foreign behavior unaffected.
+
+## TDD order
+
+1. Red: fusion+state unit test (functions absent) → commit.
+2. Green: implement `fuse_verdict` + state store → commit.
+3. Red: tick integration test (verdict not logged yet) → commit.
+4. Green: `evaluate_liveness` + OPEN-branch wiring → commit.
+5. Refactor / `/simplify` / `review` → commit. Verify all shell tests + `test:scripts` + lint.
+
+## Discovered constraint (flagged for later sprint)
+
+macOS system `screen 4.00.03 (FAU)` supports only `-L` (logs to `screenlog.0` in cwd — would
+pollute the worktree), **not** `-Logfile` (design §2.3 / open-Q #2 assumed 4.06+). So the
+production **screen-logfile wiring is deferred**: `evaluate_liveness` samples
+`$RUNNER_LOG_DIR/session-<issue>.log` *if present*, else log-probe → UNKNOWN (safe direction).
+Consequence: until a later sprint wires the logfile (hardcopy fallback), the log signal can't
+fire, so the #871 shape (commit-stall + log-repeat) corroborates via commit-stall + process-idle
+instead. Full #871 end-to-end catch is Sprint 5 (#932) and will need the logfile. Fusion +
+state + wiring (this sprint's acceptance) are unaffected.
+
+## Out of scope (later sprints)
+
+- Reap + capped auto-relaunch + escalation + L086 ship-check → Sprint 4 (#931).
+- `--status` verdict/attempts surfacing, simulated-zombie + false-positive guard,
+  screen-logfile production, docs/lessons → Sprint 4/5 (#931/#932).

--- a/tasks/sprint-930-plan.md
+++ b/tasks/sprint-930-plan.md
@@ -44,7 +44,7 @@ Epic #933 (stuck-session liveness). Builds on Sprint 1 design
 macOS system `screen 4.00.03 (FAU)` supports only `-L` (logs to `screenlog.0` in cwd — would
 pollute the worktree), **not** `-Logfile` (design §2.3 / open-Q #2 assumed 4.06+). So the
 production **screen-logfile wiring is deferred**: `evaluate_liveness` samples
-`$RUNNER_LOG_DIR/session-<issue>.log` *if present*, else log-probe → UNKNOWN (safe direction).
+`$RUNNER_LOG_DIR/session-<issue>.log` _if present_, else log-probe → UNKNOWN (safe direction).
 Consequence: until a later sprint wires the logfile (hardcopy fallback), the log signal can't
 fire, so the #871 shape (commit-stall + log-repeat) corroborates via commit-stall + process-idle
 instead. Full #871 end-to-end catch is Sprint 5 (#932) and will need the logfile. Fusion +


### PR DESCRIPTION
## Sprint 3 of epic #933 — stuck-session liveness detector

Refs #930. Builds on Sprint 1 design (`docs/design/sprint-runner-liveness-detector-2026-05-30.md`) and Sprint 2 probes. **Observe-only** this sprint: the tick now computes + logs a liveness verdict and records attempt-state, but every path still `exit 0`/skips launch. The actual reap/relaunch is Sprint 4 (#931).

### What landed
- **`fuse_verdict`** (pure) — `HUSK` (conclusive single) → HUSK; `>=2 STALL` → STUCK (corroborated); `==1` → SUSPECT (no reap, the false-positive guard); else HEALTHY. UNKNOWN never counts as STALL.
- **jq-backed attempt-state store** (`$WORKTREE_BASE/.runner-state.json`, override `RUNNER_STATE_FILE`) — atomic `mktemp`+`mv`, fail-safe (missing/corrupt → 0 attempts), convergent `state_prune`. The one fact runner truth can't rebuild after a reap.
- **`evaluate_liveness`** — the sampling edge (git/pgrep/ps/stat → probes → fuse), returning verdict + per-probe breakdown via globals.
- **Tick wiring** — `mode_run`'s OPEN-active-session branch now logs `verdict=… [commit=… process=… log=… attempts=N/3]` and records state; STUCK/HUSK logs the Sprint-4 handoff. The CLOSED-reap and foreign-session paths are untouched.

### TDD / DoD
- Red→Green for both layers; `/simplify` + fresh-context `review` passes applied.
- **Review caught a real bug:** `evaluate_liveness` was called in `$(...)`, so its breakdown globals died in the subshell and the log line printed blank `[commit= process= log=]`. Fixed (call as a statement; read `$LIVENESS_VERDICT`); test strengthened to assert the populated breakdown → [Lesson 138](../blob/sprint-930-liveness-fusion/tasks/lessons/138-a-function-returning-data-via-globals-must-not-be-called-in-command-substitution.md).
- New tests: `scripts/tests/sprint-runner-fusion-state.test.sh` (fusion truth table + state) and `sprint-runner-liveness-tick.test.sh` (tick integration). **Full shell suite: 7/7 green, zero regressions.**

### Verification note (no PR preview surface)
This PR touches `scripts/**` only — not `frontend/**`/`packages/{shared-contracts,analytics-core}/**`/firebase — so `pr-preview.yml` is path-filtered out (no live preview channel). The sprint-runner is a **macOS-local launchd tool**, so its bash tests are intentionally not in the Linux CI (BSD `stat -f`/`date -j`/`ps -o lstart=`). Verification is the hermetic shell suite (7/7) + captured production log lines; the change adds **zero** JS/TS surface, so the CI suite is unaffected.

### Discovered constraint (flagged)
macOS system `screen 4.00.03` lacks `-Logfile` (design open-Q #2 assumed 4.06+), so production screen-logfile wiring is deferred — the log probe reads UNKNOWN until a later sprint wires it (hardcopy fallback). Fusion degrades safely (UNKNOWN never STALL). Full #871 end-to-end catch is Sprint 5 (#932).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
