### PR TITLE
Sprint 4 (#931): reap → ship-check → capped relaunch → escalation for stuck sessions

### DIFF
--- a/scripts/lib/sprint-runner-liveness.sh
+++ b/scripts/lib/sprint-runner-liveness.sh
@@ -28,6 +28,12 @@
 #
 # Sourcing this file only DEFINES functions — no side effects.
 
+# Capped auto-relaunch: how many times a STUCK/HUSK sprint is reaped + relaunched
+# before the runner escalates to the operator instead (design §5; operator
+# decision 2026-05-29). Env-overridable so the regression harness can drive the
+# cap branch without 3 real ticks.
+LIVENESS_MAX_ATTEMPTS="${LIVENESS_MAX_ATTEMPTS:-3}"
+
 # === Fusion =================================================================
 
 # fuse_verdict <commit> <process> <log> → HEALTHY|SUSPECT|STUCK|HUSK

--- a/scripts/sprint-runner.sh
+++ b/scripts/sprint-runner.sh
@@ -414,15 +414,18 @@ gc_worktrees() {
   git -C "$REPO_DIR" worktree prune 2>/dev/null || true
 }
 
-# True (0) if the issue carries the `needs-product-review` label — the runner
-# must not launch such a sprint autonomously (#767); the session can't make a
-# product call. Fail-open: a gh error yields "not flagged" and lets the normal
-# predecessor gate (which also queries gh) skip the tick instead.
-issue_needs_review() {
-  local issue="$1"
-  gh issue view "$issue" --json labels --jq '.labels[].name' 2>/dev/null \
-    | grep -qx 'needs-product-review'
+# issue_has_label <issue> <label> → 0 if the issue carries <label>, else 1.
+# Fail-open: a gh error yields non-zero ("absent") so every label gate built on
+# this degrades to "not flagged" and lets the predecessor gate govern the tick.
+issue_has_label() {
+  gh issue view "$1" --json labels --jq '.labels[].name' 2>/dev/null \
+    | grep -qx "$2"
 }
+
+# True (0) if the issue carries `needs-product-review` — the runner must not
+# launch such a sprint autonomously (#767); the session can't make a product
+# call. The operator removes the label (or hand-runs) to release it.
+issue_needs_review() { issue_has_label "$1" needs-product-review; }
 
 # === Sprint launch (shared by first-launch and Sprint-4 auto-relaunch) ===
 #
@@ -528,12 +531,8 @@ sprint_already_shipped() {
 # issue_is_stuck_escalated <issue> → 0 if the issue carries `runner-stuck` (the
 # auto-relaunch cap was hit and the operator hasn't cleared it). The normal
 # launch path skips such an issue so the freed slot isn't silently re-filled
-# with a 4th relaunch before the operator investigates (design §5). Fail-open:
-# a gh error yields "not flagged" so the predecessor gate still governs.
-issue_is_stuck_escalated() {
-  gh issue view "$1" --json labels --jq '.labels[].name' 2>/dev/null \
-    | grep -qx 'runner-stuck'
-}
+# with a 4th relaunch before the operator investigates (design §5).
+issue_is_stuck_escalated() { issue_has_label "$1" runner-stuck; }
 
 # escalate_stuck <issue> <attempts> → flag the issue for the operator and free
 # the slot WITHOUT relaunching (cap reached). Idempotent: the strong, visible

--- a/scripts/sprint-runner.sh
+++ b/scripts/sprint-runner.sh
@@ -514,15 +514,23 @@ launch_sprint_session() {
 # only costs one extra reap.
 sprint_already_shipped() {
   local issue="$1" merged
-  merged=$(gh pr list --state merged --search "$issue" --json number 2>/dev/null \
+
+  # Signal 1: a merged PR that references the issue in its title/body. Scoped to
+  # `in:title,body` (not bare full-text) to avoid matching a PR that merely
+  # mentions the number in a code block or comment thread.
+  merged=$(gh pr list --state merged --search "$issue in:title,body" --json number 2>/dev/null \
             | jq 'length' 2>/dev/null || echo 0)
   [[ "$merged" =~ ^[0-9]+$ ]] || merged=0
   if (( merged > 0 )); then return 0; fi
 
-  # A commit referencing the issue on origin/main's actual history (best-effort
-  # fetch first; the grep is over origin/main, NOT the local branch).
+  # Signal 2: a commit referencing the issue on origin/main's ACTUAL history
+  # (best-effort fetch first; the grep is over origin/main, NEVER the diverged
+  # local branch — a diverged `origin/main..HEAD` lies about what shipped, L086).
+  # The `#<issue>([^0-9]|$)` boundary stops `#931` from matching `#9310` — a
+  # spurious match would falsely report "shipped" and (since the shipped path
+  # doesn't burn an attempt) could reap+relaunch forever without ever escalating.
   git -C "$REPO_DIR" fetch origin main --quiet 2>/dev/null || true
-  if [[ -n "$(git -C "$REPO_DIR" log origin/main --grep="#${issue}" --format=%h -1 2>/dev/null || true)" ]]; then
+  if [[ -n "$(git -C "$REPO_DIR" log origin/main -E --grep="#${issue}([^0-9]|\$)" --format=%h -1 2>/dev/null || true)" ]]; then
     return 0
   fi
   return 1

--- a/scripts/sprint-runner.sh
+++ b/scripts/sprint-runner.sh
@@ -424,6 +424,141 @@ issue_needs_review() {
     | grep -qx 'needs-product-review'
 }
 
+# === Sprint launch (shared by first-launch and Sprint-4 auto-relaunch) ===
+#
+# launch_sprint_session <sprint_n> <issue> <prev_issue> <epic>
+#   Build the bootstrap prompt, create the per-sprint worktree, and spawn the
+#   detached `screen` session running `claude --remote-control`. Returns:
+#     0 — launched and the screen daemon verified in the process table
+#     1 — hard failure (missing bootstrap prompt / worktree create failed)
+#     2 — launched but the daemon wasn't visible within the verify window
+#   Used by BOTH the cold first-launch path and the auto-relaunch path so a
+#   relaunch is byte-identical to a fresh launch (no drift between the two).
+#   PROMPT_FILE stays a global (not local) so the EXIT trap's cleanup() still
+#   removes it if `screen -dmS` fails before the inner subshell rm runs.
+launch_sprint_session() {
+  local target_n="$1" target_issue="$2" prev_issue="$3" epic="$4"
+
+  [[ -f "$BOOTSTRAP_PROMPT" ]] || { log "ERROR: Bootstrap prompt missing: $BOOTSTRAP_PROMPT"; return 1; }
+
+  local prompt
+  prompt=$(sed \
+    -e "s|{{SPRINT_N}}|$target_n|g" \
+    -e "s|{{TARGET_ISSUE}}|$target_issue|g" \
+    -e "s|{{PREV_ISSUE}}|${prev_issue:-none}|g" \
+    -e "s|{{EPIC}}|$epic|g" \
+    "$BOOTSTRAP_PROMPT")
+  PROMPT_FILE=$(mktemp -t sprint-runner-prompt.XXXXXX)
+  printf '%s' "$prompt" > "$PROMPT_FILE"
+
+  # Dedicated worktree (#625) keyed by issue # (#630) — isolates the session's
+  # edits/branches/index from the operator's primary checkout.
+  local worktree
+  worktree=$(create_sprint_worktree "$target_issue") || { log "ERROR: Failed to create worktree for sprint-$target_issue"; return 1; }
+  log "Created worktree at $worktree"
+
+  local session_name="sprint-runner-$target_issue"
+  log "Launching detached screen session $session_name (Sprint $target_n of epic #$epic, work #$target_issue)"
+
+  # Spawned sprint sessions run at ultracode (effortLevel "ultracode" = xhigh
+  # reasoning + standing dynamic workflow orchestration). Passed per-launch via
+  # --settings (an *additional* settings overlay) so it scopes to the runner's
+  # sessions ONLY — the operator's own interactive `claude` keeps its configured
+  # effortLevel. "ultracode" is not a valid --effort flag choice; it must come
+  # through settings. Single-quoted so the inner bash passes the JSON literally.
+  local ultracode_settings='{"effortLevel":"ultracode"}'
+
+  # `screen -dmS` allocates a PTY so claude's interactive UI works.
+  screen -dmS "$session_name" bash -c "
+    cd '$worktree' && \
+    claude --settings '$ultracode_settings' --remote-control 'sprint-$target_issue' \"\$(cat '$PROMPT_FILE')\";
+    EXIT_CODE=\$?;
+    rm -f '$PROMPT_FILE';
+    echo \"[sprint-runner] claude exited with code \$EXIT_CODE — session ending.\"
+  "
+
+  # Verify the session came up. `screen -dmS` exits 0 even on PTY-alloc failure
+  # on some macOS configs. Use `pgrep` against the daemon's command line (#633),
+  # not `screen -ls`: the socket file can lag >5s under launchd while the daemon
+  # process exists immediately on fork, and the process table has no such lag.
+  local verified=0 _
+  for _ in 1 2 3; do
+    if pgrep -f "SCREEN -dmS $session_name" >/dev/null 2>&1; then
+      verified=1
+      break
+    fi
+    sleep 1
+  done
+  if (( verified == 0 )); then
+    log "WARNING: $session_name daemon process not visible after 3s — leaving alone. Next tick will detect a live session or relaunch fresh."
+    return 2
+  fi
+
+  log "Launched. Attach: screen -r $session_name. Or pair via claude.ai Remote Control as 'sprint-$target_issue'."
+  return 0
+}
+
+# === Stuck-session ship-check / escalation (Sprint 4, #931) ===
+#
+# sprint_already_shipped <issue> → 0 if the sprint's work has ALREADY landed,
+# 1 otherwise. The L086/R15 guardrail: a STUCK session may have died only in its
+# verify→label→tick→close tail, AFTER its PR merged. Relaunching `/sprint` would
+# duplicate merged work. We check the SHARED truth — a merged PR referencing the
+# issue, or a commit on the real `origin/main` history — never `origin/main..HEAD`
+# of a diverged local branch (which lies about what shipped; design §5).
+# Fail-safe direction: any uncertainty resolves to "not shipped" → relaunch (the
+# diagram's default), because a missed relaunch starves work while a wrong "no"
+# only costs one extra reap.
+sprint_already_shipped() {
+  local issue="$1" merged
+  merged=$(gh pr list --state merged --search "$issue" --json number 2>/dev/null \
+            | jq 'length' 2>/dev/null || echo 0)
+  [[ "$merged" =~ ^[0-9]+$ ]] || merged=0
+  if (( merged > 0 )); then return 0; fi
+
+  # A commit referencing the issue on origin/main's actual history (best-effort
+  # fetch first; the grep is over origin/main, NOT the local branch).
+  git -C "$REPO_DIR" fetch origin main --quiet 2>/dev/null || true
+  if [[ -n "$(git -C "$REPO_DIR" log origin/main --grep="#${issue}" --format=%h -1 2>/dev/null || true)" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# issue_is_stuck_escalated <issue> → 0 if the issue carries `runner-stuck` (the
+# auto-relaunch cap was hit and the operator hasn't cleared it). The normal
+# launch path skips such an issue so the freed slot isn't silently re-filled
+# with a 4th relaunch before the operator investigates (design §5). Fail-open:
+# a gh error yields "not flagged" so the predecessor gate still governs.
+issue_is_stuck_escalated() {
+  gh issue view "$1" --json labels --jq '.labels[].name' 2>/dev/null \
+    | grep -qx 'runner-stuck'
+}
+
+# escalate_stuck <issue> <attempts> → flag the issue for the operator and free
+# the slot WITHOUT relaunching (cap reached). Idempotent: the strong, visible
+# signals (label + comment) are written once; if `runner-stuck` is already
+# present a later tick only logs. R15 two-signal discipline: the label is the
+# durable gate the normal path keys off, the comment is the human-readable why.
+escalate_stuck() {
+  local issue="$1" attempts="$2"
+  if issue_is_stuck_escalated "$issue"; then
+    log "Escalation: #$issue already flagged runner-stuck (attempts=$attempts/$LIVENESS_MAX_ATTEMPTS) — slot free, awaiting operator. No relaunch."
+    return 0
+  fi
+  log "Escalation: #$issue exhausted $attempts/$LIVENESS_MAX_ATTEMPTS auto-relaunch attempts — flagging runner-stuck, freeing slot, notifying operator. No relaunch."
+  # Ensure the label exists (idempotent); -f? gh has no create-or-update, so
+  # tolerate the already-exists error.
+  gh label create runner-stuck --color B60205 \
+    --description "sprint-runner: auto-relaunch cap reached; needs operator" 2>/dev/null || true
+  gh issue edit "$issue" --add-label runner-stuck 2>/dev/null \
+    || log "WARNING: failed to add runner-stuck label to #$issue"
+  gh issue comment "$issue" --body "🛑 **sprint-runner: auto-relaunch exhausted (${attempts}/${LIVENESS_MAX_ATTEMPTS}).** This sprint's session was detected STUCK and reaped, but every capped relaunch also stalled. The slot is now **free** and this issue is flagged \`runner-stuck\` so the runner will **not** auto-relaunch it again. Operator: investigate the stall (see the runner log), then remove the \`runner-stuck\` label to re-arm. The ship-state check ran before each relaunch, so this is not already-merged work." 2>/dev/null \
+    || log "WARNING: failed to post escalation comment on #$issue"
+  notify "sprint-runner" "Sprint #$issue STUCK — ${attempts}/${LIVENESS_MAX_ATTEMPTS} relaunches exhausted, needs operator"
+  return 0
+}
+
 # === Gate check ===
 # Echoes "PASS <desc>" or "FAIL <desc>". Non-fatal — caller decides.
 check_gate() {
@@ -478,8 +613,17 @@ mode_status() {
   if [[ -z "$sessions" ]]; then
     log "Active screen sessions: (none)"
   else
-    log "Active screen sessions:"
-    printf '%s\n' "$sessions" | while read -r s; do log "  - $s"; done
+    log "Active screen sessions (liveness — read-only, no reap):"
+    # Per-session fused verdict + probe breakdown + relaunch attempt count
+    # (#931 acceptance). evaluate_liveness only SAMPLES (git/pgrep/ps/stat) — it
+    # never reaps — so it is safe in the read-only status mode. Globals it sets
+    # are read in the same subshell iteration.
+    printf '%s\n' "$sessions" | while read -r s; do
+      local issue="${s##sprint-runner-}"
+      evaluate_liveness "$issue"
+      local att; att=$(state_get_attempts "$issue")
+      log "  - $s  [verdict=$LIVENESS_VERDICT  commit=$LIVENESS_COMMIT process=$LIVENESS_PROCESS log=$LIVENESS_LOG  attempts=$att/$LIVENESS_MAX_ATTEMPTS]"
+    done
   fi
 
   # Worktree state (read-only — never removes during --status).
@@ -632,30 +776,80 @@ mode_run() {
         # Stale only if the epic checkbox is ALSO ticked (#626).
         if [[ "$active_line" =~ ^-\ \[x\] ]]; then
           log "Stale session $active: #$active_issue is CLOSED + ticked — reaping."
+          # Genuine completion (CLOSED + ticked) — reset the relaunch attempt
+          # counter so a future re-open of this issue starts fresh (design §4.2).
+          state_record "$active_issue" DONE 0 || true
           reap_screen_session "$active"
         else
           log "Session $active: #$active_issue is CLOSED but epic checkbox not yet ticked — letting session finish cleanup. Operator can --reap if genuinely stuck."
           exit 0
         fi
       else
-        # OPEN in-epic session: no longer an automatic pass. Evaluate liveness
-        # (sample 3 probes → fuse) and record the verdict to the attempt-state
-        # store. A STUCK/HUSK verdict will be reaped + relaunched by the Sprint 4
-        # path (#931); Sprint 3 only OBSERVES — every branch still skips the
-        # launch this tick, so existing behavior is preserved.
-        # Call as a plain statement (NOT $(...)): evaluate_liveness returns its
-        # verdict + breakdown via globals, which a subshell would discard.
+        # OPEN in-epic session — evaluate liveness, then ACT (Sprint 4, #931).
+        # Sample the 3 probes → fuse → verdict; the pure layers keep every
+        # decision unit-testable, evaluate_liveness is the only host-touching
+        # part. Call as a plain statement (NOT $(...)): it returns its verdict +
+        # breakdown via globals, which a subshell would discard.
         local verdict attempts
         evaluate_liveness "$active_issue"
         verdict="$LIVENESS_VERDICT"
         attempts=$(state_get_attempts "$active_issue")
-        log "Existing session $active active (#$active_issue is $active_state) — liveness verdict=$verdict [commit=$LIVENESS_COMMIT process=$LIVENESS_PROCESS log=$LIVENESS_LOG attempts=$attempts/3]."
-        state_record "$active_issue" "$verdict" "$attempts" || log "WARNING: failed to persist liveness state for #$active_issue"
-        if [[ "$verdict" == STUCK || "$verdict" == HUSK ]]; then
-          log "Liveness: $verdict on #$active_issue — reap + capped auto-relaunch lands in Sprint 4 (#931); skipping launch this tick."
-        else
-          log "Liveness: $verdict on #$active_issue — healthy/insufficient-evidence; skipping launch as before."
+        log "Existing session $active active (#$active_issue is $active_state) — liveness verdict=$verdict [commit=$LIVENESS_COMMIT process=$LIVENESS_PROCESS log=$LIVENESS_LOG attempts=$attempts/$LIVENESS_MAX_ATTEMPTS]."
+
+        if [[ "$verdict" != STUCK && "$verdict" != HUSK ]]; then
+          # HEALTHY (progress / insufficient evidence) or SUSPECT (one soft
+          # signal — the false-positive guard). Record and leave the session
+          # running; the next tick re-evaluates. No reap, no launch.
+          state_record "$active_issue" "$verdict" "$attempts" \
+            || log "WARNING: failed to persist liveness state for #$active_issue"
+          log "Liveness: $verdict on #$active_issue — leaving session running; skipping launch."
+          exit 0
         fi
+
+        # STUCK (≥2 corroborating stalls) or HUSK (conclusive: screen alive,
+        # claude gone). The session is not progressing — act per design §5.
+        if (( attempts >= LIVENESS_MAX_ATTEMPTS )); then
+          # Cap reached — reap to free the slot, escalate, do NOT relaunch.
+          state_record "$active_issue" "$verdict" "$attempts" || true
+          log "Liveness: $verdict on #$active_issue at attempt cap ($attempts/$LIVENESS_MAX_ATTEMPTS) — reaping + escalating, no relaunch."
+          reap_screen_session "$active"
+          escalate_stuck "$active_issue" "$attempts"
+          exit 0
+        fi
+
+        log "Liveness: $verdict on #$active_issue (attempt $attempts/$LIVENESS_MAX_ATTEMPTS) — reaping stuck session."
+        reap_screen_session "$active"
+
+        # L086 / R15 ship-state check BEFORE relaunch: the zombie may have
+        # already merged its PR and died only in its verify→label→tick→close
+        # tail. Relaunching /sprint would duplicate merged work. Check the
+        # SHARED truth (merged PR / origin/main), never a diverged local branch.
+        if sprint_already_shipped "$active_issue"; then
+          log "Liveness: #$active_issue already shipped (merged PR / commit on origin/main) — NOT relaunching implementation (L086). Slot freed; reconcile needed: live-verify → sprint-verified → tick epic → close. Notifying operator."
+          notify "sprint-runner" "Sprint #$active_issue was STUCK but already shipped — needs gating, not relaunch"
+          exit 0
+        fi
+
+        # Genuinely unshipped — relaunch fresh. Persist attempts+1 BEFORE the
+        # launch so a launch that itself crashes still burns the attempt (no
+        # infinite relaunch of a launch-failing config; design §5).
+        local relaunch_n new_attempts relaunch_prev_n relaunch_prev_issue
+        relaunch_n=$(printf '%s\n' "$active_line" | sed -nE 's/.*Sprint ([0-9]+)\*\*.*/\1/p')
+        relaunch_prev_n=$(( ${relaunch_n:-1} - 1 ))
+        relaunch_prev_issue=$(find_sprint_issue "$relaunch_prev_n" "$body")
+        new_attempts=$(( attempts + 1 ))
+        state_record "$active_issue" "$verdict" "$new_attempts" "$(date +%s)" \
+          || log "WARNING: failed to persist incremented attempt for #$active_issue"
+        log "Liveness: relaunching Sprint ${relaunch_n:-?} for #$active_issue (attempt $new_attempts/$LIVENESS_MAX_ATTEMPTS)."
+
+        local relaunch_rc=0
+        launch_sprint_session "${relaunch_n:-1}" "$active_issue" "${relaunch_prev_issue:-}" "$EPIC" || relaunch_rc=$?
+        case "$relaunch_rc" in
+          0) notify "sprint-runner" "Auto-relaunched STUCK Sprint #$active_issue (attempt $new_attempts/$LIVENESS_MAX_ATTEMPTS)" ;;
+          2) notify "sprint-runner" "Relaunch of #$active_issue unverifiable — check screen -ls" ;;
+          *) log "ERROR: relaunch of #$active_issue failed (rc=$relaunch_rc); attempt $new_attempts already burned. Next tick retries or escalates."
+             notify "sprint-runner" "Relaunch of #$active_issue FAILED — see runner log" ;;
+        esac
         exit 0
       fi
     else
@@ -732,6 +926,17 @@ mode_run() {
     exit 0
   fi
 
+  # --- Auto-relaunch escalation gate (#931) ---
+  # A sprint whose auto-relaunch cap was hit carries `runner-stuck`. With the
+  # slot freed by the reap, the normal path would otherwise immediately re-fill
+  # it with a 4th relaunch. Skip until the operator investigates and clears the
+  # label (which re-arms the issue; design §5).
+  if issue_is_stuck_escalated "$target_issue"; then
+    log "Sprint $target_n (#$target_issue) is flagged runner-stuck (auto-relaunch cap reached) — NOT launching. Operator: investigate, then remove the label to re-arm."
+    notify "sprint-runner" "Sprint $target_n (#$target_issue) runner-stuck — skipped (awaiting operator)"
+    exit 0
+  fi
+
   # --- Gate check ---
   local prev_n=$((target_n - 1))
   local prev_issue
@@ -749,78 +954,18 @@ mode_run() {
     exit 0
   fi
 
-  [[ -f "$BOOTSTRAP_PROMPT" ]] || die "Bootstrap prompt missing: $BOOTSTRAP_PROMPT"
-
-  local prompt
-  prompt=$(sed \
-    -e "s|{{SPRINT_N}}|$target_n|g" \
-    -e "s|{{TARGET_ISSUE}}|$target_issue|g" \
-    -e "s|{{PREV_ISSUE}}|${prev_issue:-none}|g" \
-    -e "s|{{EPIC}}|$EPIC|g" \
-    "$BOOTSTRAP_PROMPT")
-
-  # PROMPT_FILE is exported into the trap via cleanup() so it's removed
-  # even if `screen -dmS` fails before the inner subshell runs.
-  PROMPT_FILE=$(mktemp -t sprint-runner-prompt.XXXXXX)
-  printf '%s' "$prompt" > "$PROMPT_FILE"
-
-  # Create a dedicated worktree for this sprint (#625) so the spawned
-  # session's branches and edits stay isolated from the operator's primary
-  # checkout. Identifiers are keyed by target issue # (#630) for global
-  # uniqueness — sprint-N within an epic isn't unique across epics.
-  local worktree
-  worktree=$(create_sprint_worktree "$target_issue") || die "Failed to create worktree for sprint-$target_issue"
-  log "Created worktree at $worktree"
-
-  local session_name="sprint-runner-$target_issue"
-  log "Launching detached screen session $session_name (Sprint $target_n of epic #$EPIC, work #$target_issue)"
-
-  # Spawned sprint sessions run at ultracode (effortLevel "ultracode" = xhigh
-  # reasoning + standing dynamic workflow orchestration). Passed per-launch via
-  # --settings (an *additional* settings overlay) so it scopes to the runner's
-  # sessions ONLY — the operator's own interactive `claude` keeps its configured
-  # effortLevel. "ultracode" is not a valid --effort flag choice; it must come
-  # through settings. Single-quoted so the inner bash passes the JSON literally.
-  local ultracode_settings='{"effortLevel":"ultracode"}'
-
-  # `screen -dmS` allocates a PTY so claude's interactive UI works.
-  screen -dmS "$session_name" bash -c "
-    cd '$worktree' && \
-    claude --settings '$ultracode_settings' --remote-control 'sprint-$target_issue' \"\$(cat '$PROMPT_FILE')\";
-    EXIT_CODE=\$?;
-    rm -f '$PROMPT_FILE';
-    echo \"[sprint-runner] claude exited with code \$EXIT_CODE — session ending.\"
-  "
-
-  # Verify the session actually came up. `screen -dmS` exits 0 even on PTY
-  # allocation failure on some macOS configurations.
-  #
-  # Use `pgrep` against the screen daemon's command line (#633) instead of
-  # `screen -ls`. Two reasons: (1) the screen socket file in
-  # /var/folders/.../.screen.<host>/ can take >5s to register under launchd's
-  # environment (filesystem-visibility lag), even though the daemon process
-  # itself exists immediately on fork; (2) pgrep against the process table
-  # has no filesystem-level lag.
-  #
-  # warn-and-exit-0 (not die) for the not-found case: the inner claude may
-  # have argv captured from `$(cat $PROMPT_FILE)` already, and `die` doesn't
-  # kill the screen — it just adds false-alarm noise to launchd's last-exit.
-  local verified=0
-  for _ in 1 2 3; do
-    if pgrep -f "SCREEN -dmS $session_name" >/dev/null 2>&1; then
-      verified=1
-      break
-    fi
-    sleep 1
-  done
-  if (( verified == 0 )); then
-    log "WARNING: $session_name daemon process not visible after 3s — leaving alone. Next tick will detect a live session or relaunch fresh."
-    notify "sprint-runner" "Sprint $target_n launch unverifiable — check screen -ls"
-    exit 0
-  fi
-
-  log "Launched. Attach: screen -r $session_name. Or pair via claude.ai Remote Control as 'sprint-$target_issue'."
-  notify "sprint-runner" "Launched Sprint $target_n (#$target_issue)"
+  # First launch of this sprint from the top of the cascade. The normal path is
+  # always attempt 0; the per-issue attempt counter is only incremented by the
+  # Sprint-4 auto-relaunch path (relaunch_stuck_sprint). Resetting it here keeps
+  # an operator-cleared `runner-stuck` re-launch from inheriting a stale count.
+  local launch_rc=0
+  launch_sprint_session "$target_n" "$target_issue" "${prev_issue:-}" "$EPIC" || launch_rc=$?
+  case "$launch_rc" in
+    0) state_record "$target_issue" LAUNCHED 0 || true
+       notify "sprint-runner" "Launched Sprint $target_n (#$target_issue)" ;;
+    2) notify "sprint-runner" "Sprint $target_n launch unverifiable — check screen -ls" ;;
+    *) die "Failed to launch Sprint $target_n (#$target_issue) — see log above" ;;
+  esac
   break  # cascade: one launch per tick is the cap (#627)
   done
 

--- a/scripts/tests/sprint-runner-liveness-tick.test.sh
+++ b/scripts/tests/sprint-runner-liveness-tick.test.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 # Integration regression test for the liveness verdict wired into mode_run's
-# active-session branch (epic #933 Sprint 3, #930).
+# active-session branch (epic #933 Sprint 3 #930, updated for Sprint 4 #931).
 #
 # The runner used to do an unconditional "OPEN session → skip launch" exit. Now
 # an OPEN in-epic active session is first evaluated for liveness: the fused
-# verdict is computed + logged, the attempt-state is recorded, and a STUCK/HUSK
-# verdict logs the Sprint-4 reap/relaunch handoff. Every path still skips the
-# launch — Sprint 3 changes the OBSERVABILITY, not the action (reap is Sprint 4).
+# verdict is computed + logged. This test owns the HEALTHY (observe-only) edge
+# and proves the verdict computation reaches the tick with its per-probe
+# breakdown POPULATED (the globals-not-subshell bug guard). The full ACTING
+# matrix a STUCK/HUSK verdict drives — reap → ship-check → relaunch → escalate,
+# attempt persistence — lives in sprint-runner-reap-relaunch.test.sh (#931).
+#
+# Sprint 3 originally asserted "HUSK → handoff logged, NO reap (reap is Sprint
+# 4)". Sprint 4 lands that reap, so that transitional contract is superseded:
+# Case B now asserts HUSK reaches the live reap, not the deferred handoff.
 #
 # Hermetic: mocks gh/screen/pgrep/ps/git on PATH; LIVENESS_CPU_SAMPLE_GAP=0 so
 # the CPU double-sample doesn't sleep. Asserts on the log decision.
-#   Case A (claude alive + busy + recent commit): verdict=HEALTHY, no launch,
-#                                                 no reap, no Sprint-4 handoff.
-#   Case B (screen alive + claude gone):          verdict=HUSK, Sprint-4 handoff
-#                                                 logged, no reap, no launch.
+#   Case A (claude alive + busy + recent commit): verdict=HEALTHY, populated
+#                                                 breakdown, no launch, no reap.
+#   Case B (screen alive + claude gone):          verdict=HUSK → live reap fired.
 #
 # Run directly: scripts/tests/sprint-runner-liveness-tick.test.sh
 set -euo pipefail
@@ -126,25 +131,19 @@ else
   echo "FAIL [A]: expected HEALTHY + breakdown + no launch + no reap, got:"; sed 's/^/    /' "$TMP/a.log"; fail=1
 fi
 
-# --- Case B: screen alive, claude gone → HUSK, Sprint-4 handoff, no reap ---
+# --- Case B: screen alive, claude gone → HUSK verdict reaches the LIVE reap ---
+# (Sprint 4: HUSK now acts. The full reap→ship-check→relaunch→escalate matrix is
+# asserted in sprint-runner-reap-relaunch.test.sh; here we only prove the HUSK
+# verdict computed in the tick drives the reap action, not a deferred handoff.)
 : > "$SCREEN_CALLS"
-CLAUDE_ALIVE=0 "$RUNNER" --dry-run >"$TMP/b.log" 2>&1 || true
+CLAUDE_ALIVE=0 "$RUNNER" >"$TMP/b.log" 2>&1 || true
 if grep -q 'verdict=HUSK' "$TMP/b.log" \
    && grep -q 'process=HUSK' "$TMP/b.log" \
-   && grep -qi 'Sprint 4' "$TMP/b.log" \
-   && ! grep -q 'would launch screen session' "$TMP/b.log" \
-   && ! grep -q 'SCREEN_CALL.*quit' "$SCREEN_CALLS"; then
-  echo "PASS [B]: HUSK verdict + populated breakdown + Sprint-4 handoff, no reap, no launch"
+   && grep -q 'reaping stuck session' "$TMP/b.log" \
+   && grep -q 'SCREEN_CALL .*-X -S sprint-runner-930 quit' "$SCREEN_CALLS"; then
+  echo "PASS [B]: HUSK verdict + populated breakdown reaches the live reap"
 else
-  echo "FAIL [B]: expected HUSK + breakdown + Sprint-4 handoff + no reap, got:"; sed 's/^/    /' "$TMP/b.log"; fail=1
-fi
-
-# --- Case C: the attempt-state file recorded the verdict (state wired in) ---
-if [[ -f "$WORKTREE_BASE/.runner-state.json" ]] \
-   && [[ "$(jq -r '."930".last_verdict' "$WORKTREE_BASE/.runner-state.json")" == "HUSK" ]]; then
-  echo "PASS [C]: liveness verdict persisted to attempt-state store"
-else
-  echo "FAIL [C]: expected state store to record #930 last_verdict=HUSK"; fail=1
+  echo "FAIL [B]: expected HUSK + breakdown + live reap, got:"; sed 's/^/    /' "$TMP/b.log"; fail=1
 fi
 
 exit "$fail"

--- a/scripts/tests/sprint-runner-reap-relaunch.test.sh
+++ b/scripts/tests/sprint-runner-reap-relaunch.test.sh
@@ -189,4 +189,15 @@ else
   echo "FAIL [D]: expected HEALTHY left-running, got:"; sed 's/^/    /' "$TMP/d.log"; fail=1
 fi
 
+# --- Case E: --status surfaces per-session verdict + attempts (acceptance) ---
+reset_world 2
+CLAUDE_ALIVE=0 "$RUNNER" --status >"$TMP/e.log" 2>&1 || true
+if grep -qE '  - sprint-runner-930  \[verdict=HUSK .*attempts=2/3\]' "$TMP/e.log" \
+   && ! grep -q 'SCREEN_CALL .*quit' "$SCREEN_CALLS"; then
+  echo "PASS [E]: --status shows verdict + attempts, never reaps (read-only)"
+else
+  echo "FAIL [E]: expected --status liveness line with verdict+attempts, no reap:"
+  echo "  status:"; sed 's/^/    /' "$TMP/e.log"; fail=1
+fi
+
 exit "$fail"

--- a/scripts/tests/sprint-runner-reap-relaunch.test.sh
+++ b/scripts/tests/sprint-runner-reap-relaunch.test.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Integration regression test for the Sprint-4 reap → ship-check → relaunch →
+# escalate state machine wired into mode_run's active-session branch
+# (epic #933 Sprint 4, #931).
+#
+# Sprint 3 (#930) only OBSERVED: an OPEN in-epic session got a liveness verdict
+# logged + recorded, but every path still skipped the launch. Sprint 4 ACTS on a
+# STUCK/HUSK verdict:
+#   - attempts < cap, unshipped  → reap + relaunch (attempts += 1, persisted).
+#   - attempts < cap, ALREADY SHIPPED (L086) → reap, NO relaunch (don't
+#     duplicate merged work); reconcile/notify instead.
+#   - attempts >= cap            → escalate: reap, add `runner-stuck` label,
+#     comment, notify, leave slot free, NO relaunch.
+# A HEALTHY verdict must still leave the session running untouched.
+#
+# Hermetic: mocks gh/screen/pgrep/ps/git on PATH; LIVENESS_CPU_SAMPLE_GAP=0 so
+# the CPU double-sample doesn't sleep. Asserts on the screen/gh call logs + the
+# persisted attempt counter. A husk (screen alive, claude gone → CLAUDE_ALIVE=0)
+# is the conclusive-single STUCK trigger used to drive every acting case.
+#
+# Run directly: scripts/tests/sprint-runner-reap-relaunch.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$SCRIPT_DIR/../sprint-runner.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+BIN="$TMP/bin"; mkdir -p "$BIN"
+
+# Mock gh: META_EPIC #900 → epic #901 (one unchecked sprint, #930, OPEN). Every
+# invocation is appended to $GH_CALLS so escalation (issue edit/comment) is
+# assertable. `pr list` toggles ship state via $SHIPPED. `label create` is a
+# no-op success. #930 carries no labels (so escalation isn't pre-suppressed).
+cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "GH $*" >> "$GH_CALLS"
+sub="$1"; verb="$2"; num="$3"
+if [[ "$sub" == "pr" && "$verb" == "list" ]]; then
+  if [[ "${SHIPPED:-0}" == 1 ]]; then echo '[{"number":1}]'; else echo '[]'; fi
+  exit 0
+fi
+if [[ "$sub" == "label" ]]; then exit 0; fi
+if [[ "$sub" == "issue" && "$verb" == "edit" ]]; then exit 0; fi
+if [[ "$sub" == "issue" && "$verb" == "comment" ]]; then exit 0; fi
+if [[ "$sub" == "issue" && "$verb" == "view" ]]; then
+  field=""; args=("$@")
+  for ((i=0; i<${#args[@]}; i++)); do [[ "${args[i]}" == "--json" ]] && field="${args[i+1]}"; done
+  case "$num:$field" in
+    900:labels) ;;
+    900:body)   printf '%s' '- [ ] **Epic Test** — #901' ;;
+    901:body)   printf '%s' '- [ ] **Sprint 1** — #930' ;;
+    930:state)  printf '%s' 'OPEN' ;;
+    930:labels) ;;
+  esac
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$BIN/gh"
+
+# Mock screen: `-ls` lists the in-epic active session sprint-runner-930 (and
+# mirrors macOS screen exiting 1 even when sessions exist — R14/L089). Every
+# other call (quit on reap, -dmS on relaunch) is appended to $SCREEN_CALLS.
+cat > "$BIN/screen" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-ls" ]]; then
+  echo "There is a screen on:" >&2
+  echo "    12345.sprint-runner-930    (Detached)" >&2
+  exit 1
+fi
+echo "SCREEN_CALL $*" >> "$SCREEN_CALLS"
+exit 0
+EOF
+chmod +x "$BIN/screen"
+
+# Mock pgrep: screen daemon always alive (so gc_worktrees / launch-verify see
+# it). The claude child presence is toggled by $CLAUDE_ALIVE (0 → husk → STUCK).
+cat > "$BIN/pgrep" <<'EOF'
+#!/usr/bin/env bash
+pat="${*: -1}"
+case "$pat" in
+  *"SCREEN -dmS sprint-runner-930"*) echo 12345 ;;
+  *"remote-control sprint-930"*)     [[ "${CLAUDE_ALIVE:-0}" == 1 ]] && echo 4242 ;;
+  *"claude --remote-control sprint-930"*) ;;  # reap orphan-kill check: none
+esac
+exit 0
+EOF
+chmod +x "$BIN/pgrep"
+
+# Mock ps: %cpu busy, lstart a fixed parseable date for start derivation.
+cat > "$BIN/ps" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"-o %cpu="*)   echo "50.0" ;;
+  *"-o lstart="*) echo "Fri May 30 09:00:00 2026" ;;
+esac
+exit 0
+EOF
+chmod +x "$BIN/ps"
+
+# Mock git: `log ... --format=%ct` → recent commit epoch (commit probe OK);
+# `log origin/main --grep` → empty (no shipped commit on main); worktree/fetch
+# subcommands → no-op success.
+cat > "$BIN/git" <<EOF
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"--format=%ct"*) date +%s; exit 0 ;;
+  *"--grep"*)       exit 0 ;;        # no commit on origin/main → unshipped
+esac
+exit 0
+EOF
+chmod +x "$BIN/git"
+
+export PATH="$BIN:$PATH"
+export META_EPIC=900
+export SPRINT_RUNNER_LOCK_DIR="$TMP/lock"
+export WORKTREE_BASE="$TMP/worktrees"
+export LIVENESS_CPU_SAMPLE_GAP=0
+export SCREEN_CALLS="$TMP/screen-calls.log"
+export GH_CALLS="$TMP/gh-calls.log"
+unset EPIC || true
+
+STATE="$WORKTREE_BASE/.runner-state.json"
+fail=0
+
+# reset_world: fresh worktree + empty call logs; optional pre-seeded attempts.
+reset_world() {
+  rm -rf "$WORKTREE_BASE"
+  mkdir -p "$WORKTREE_BASE/sprint-930"
+  : > "$SCREEN_CALLS"
+  : > "$GH_CALLS"
+  if [[ -n "${1:-}" ]]; then
+    printf '{"930":{"attempts":%s,"last_verdict":"HUSK","last_relaunch_epoch":0}}' "$1" > "$STATE"
+  fi
+}
+
+attempts_of() { jq -r '."930".attempts // 0' "$STATE" 2>/dev/null || echo 0; }
+
+# --- Case A: STUCK (husk) + attempts 0 + unshipped → reap + relaunch + bump ---
+reset_world
+CLAUDE_ALIVE=0 SHIPPED=0 "$RUNNER" >"$TMP/a.log" 2>&1 || true
+if grep -q 'SCREEN_CALL .*-X -S sprint-runner-930 quit' "$SCREEN_CALLS" \
+   && grep -q 'SCREEN_CALL -dmS sprint-runner-930' "$SCREEN_CALLS" \
+   && [[ "$(attempts_of)" == 1 ]] \
+   && ! grep -q 'add-label runner-stuck' "$GH_CALLS"; then
+  echo "PASS [A]: STUCK+unshipped → reaped, relaunched, attempts persisted 0→1, no escalation"
+else
+  echo "FAIL [A]: expected reap+relaunch+attempts=1, no label. attempts=$(attempts_of)"
+  echo "  screen:"; sed 's/^/    /' "$SCREEN_CALLS"; echo "  log:"; sed 's/^/    /' "$TMP/a.log"; fail=1
+fi
+
+# --- Case B: STUCK + attempts already at cap (3) → escalate, NO relaunch ---
+reset_world 3
+CLAUDE_ALIVE=0 SHIPPED=0 "$RUNNER" >"$TMP/b.log" 2>&1 || true
+if grep -q 'SCREEN_CALL .*-X -S sprint-runner-930 quit' "$SCREEN_CALLS" \
+   && ! grep -q 'SCREEN_CALL -dmS sprint-runner-930' "$SCREEN_CALLS" \
+   && grep -q 'issue edit 930 --add-label runner-stuck' "$GH_CALLS" \
+   && grep -q 'issue comment 930' "$GH_CALLS"; then
+  echo "PASS [B]: STUCK at cap → reaped, escalated (label+comment), NO relaunch"
+else
+  echo "FAIL [B]: expected reap + runner-stuck label + comment + NO relaunch"
+  echo "  screen:"; sed 's/^/    /' "$SCREEN_CALLS"; echo "  gh:"; sed 's/^/    /' "$GH_CALLS"; fail=1
+fi
+
+# --- Case C: STUCK + attempts 0 but ALREADY SHIPPED (L086) → reap, NO relaunch ---
+reset_world
+CLAUDE_ALIVE=0 SHIPPED=1 "$RUNNER" >"$TMP/c.log" 2>&1 || true
+if grep -q 'SCREEN_CALL .*-X -S sprint-runner-930 quit' "$SCREEN_CALLS" \
+   && ! grep -q 'SCREEN_CALL -dmS sprint-runner-930' "$SCREEN_CALLS" \
+   && ! grep -q 'add-label runner-stuck' "$GH_CALLS" \
+   && [[ "$(attempts_of)" == 0 ]]; then
+  echo "PASS [C]: STUCK but shipped → reaped, NO relaunch (L086), attempts not burned"
+else
+  echo "FAIL [C]: expected reap + NO relaunch + no label + attempts=0. attempts=$(attempts_of)"
+  echo "  screen:"; sed 's/^/    /' "$SCREEN_CALLS"; echo "  log:"; sed 's/^/    /' "$TMP/c.log"; fail=1
+fi
+
+# --- Case D: HEALTHY (claude alive+busy+recent commit) → no reap, no relaunch ---
+reset_world
+CLAUDE_ALIVE=1 SHIPPED=0 "$RUNNER" >"$TMP/d.log" 2>&1 || true
+if grep -q 'verdict=HEALTHY' "$TMP/d.log" \
+   && ! grep -q 'SCREEN_CALL .*quit' "$SCREEN_CALLS" \
+   && ! grep -q 'SCREEN_CALL -dmS sprint-runner-930' "$SCREEN_CALLS" \
+   && ! grep -q 'add-label runner-stuck' "$GH_CALLS"; then
+  echo "PASS [D]: HEALTHY → session left running, no reap, no relaunch, no escalation"
+else
+  echo "FAIL [D]: expected HEALTHY left-running, got:"; sed 's/^/    /' "$TMP/d.log"; fail=1
+fi
+
+exit "$fail"

--- a/tasks/lessons/138-a-counter-neutral-reconcile-branch-needs-a-precise-gate-or-it-loops-forever.md
+++ b/tasks/lessons/138-a-counter-neutral-reconcile-branch-needs-a-precise-gate-or-it-loops-forever.md
@@ -1,0 +1,75 @@
+---
+id: '138'
+category: principle
+tags: [automation, sprint-runner, bash, process]
+auto_load: true
+date: 2026-05-30
+issues: [931, 933]
+---
+
+# Lesson 138 — In a retry-then-escalate machine, a counter-neutral "reconcile" branch needs a PRECISE gate, or it loops forever without escalating
+
+**Date:** 2026-05-30
+**Issue:** #931 (epic #933 Sprint 4 — reap → ship-check → relaunch → escalate)
+**PR:** _(record on merge)_
+
+## What happened
+
+Sprint 4 wired the stuck-session state machine: a STUCK verdict reaps the
+session, then either relaunches (`attempts += 1`, capped at 3 → escalate) or, if
+an L086 ship-state check finds the work already merged, takes a **reconcile**
+branch — reap, notify, do NOT relaunch, and **do not burn an attempt** (a
+misdiagnosed "shipped" shouldn't consume the operator's retry budget).
+
+The first cut of the ship-check used `gh pr list --search "$issue"` (full-text)
+and an unbounded `git log --grep "#$issue"`. Fresh-context review flagged the
+loose match: `#931` matches `#9310`, and any PR that merely _mentions_ the
+number reads as "shipped." On its own that looks benign — but trace it through
+the machine: a session that is genuinely STUCK but _persistently_ misread as
+shipped gets reaped every tick, relaunched by the **normal** path next tick
+(the issue is still OPEN and ungated), goes STUCK again, is reaped again… and
+because the reconcile branch never increments the counter, **the attempt cap is
+never reached and escalation never fires.** A silent infinite reap/relaunch loop
+that never surfaces to the operator — the exact failure the escalation path
+exists to prevent.
+
+## The transferable principle
+
+**A branch that intentionally does not advance the failure counter is only safe
+if its entrance condition is precise.** The counter is what guarantees forward
+progress toward escalation; any branch that bypasses the counter removes that
+guarantee and leans entirely on its own gate being right. So the gate on a
+counter-neutral branch carries the escalation invariant — it must be at least as
+trustworthy as the counter it skips. Imprecise gate + counter-neutral branch =
+a livelock with no operator signal.
+
+Corollary for "is it already done?" checks that gate automation: match the
+**shared, durable truth** with a **boundary-anchored** pattern, not a loose
+substring. Here: scope the PR search to `in:title,body` and anchor the
+origin/main grep with `#<issue>([^0-9]|$)` (verified on macOS `git log -E`),
+and grep `origin/main`'s real history — never `origin/main..HEAD` of a diverged
+local branch, which lies about what shipped (L086/R15).
+
+## How to apply
+
+- Drawing a state machine with a "skip the retry counter" branch (reconcile,
+  already-done, not-applicable)? Ask: "if this branch's condition is _wrong and
+  sticky_, does the machine still reach a terminal/escalation state?" If no,
+  the branch's gate is load-bearing for liveness — make it precise and test the
+  near-miss (`#931` must not match `#9310`).
+- A number embedded in text is a substring, not a token. Anchor it
+  (`([^0-9]|$)`, `(#N)`, `in:title,body`) before trusting it to gate an action.
+- Prefer the irreversible/shared signal (commit on `origin/main`, merged PR) over
+  a local or derivable one (R15). A diverged local branch is not evidence of a
+  ship.
+
+## Related
+
+- [[106-closes-n-in-an-auto-merged-sprint-pr-defeats-the-tick-before-close-order]]
+  and R15 — same family: which distributed signal proves "done," and how a
+  sloppy one breaks an automation gate.
+- [[091-bootstrap-prompt-scope-must-be-explicit-or-runs-diverge]] / R17 — every
+  conditional needs an explicit, _correct_ case for every value; here the
+  "shipped" case's correctness is what keeps the loop terminating.
+- `scripts/sprint-runner.sh` (`sprint_already_shipped`, the active-session state
+  machine), `scripts/tests/sprint-runner-reap-relaunch.test.sh`.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -111,6 +111,7 @@
 - **138** [bash, automation, sprint-runner, shell] — A bash function that returns data via globals must be called as a statement, never in `$(...)` (#930, #933)
 - **138** [frontend, react, scope, refactor, tests] — A view that renders correctly only because an upstream utility incidentally sorts that way should own and pin its own order (#882, #884)
 - **138** [css, accessibility, frontend, tests, playwright] — An `inset-0` overlay is sized to its container's PADDING box; a 1px border on the chip steals from the touch target (#886, #888)
+- **138** [automation, sprint-runner, bash, process] — In a retry-then-escalate machine, a counter-neutral "reconcile" branch needs a PRECISE gate, or it loops forever without escalating (#931, #933)
 - **138** [css, frontend, accessibility, verification, playwright, mobile] — `scroll-margin-top` belongs on the element that holds the anchor id, not a styled child (#877, #880)
 - **139** [css, frontend, accessibility, router, verification, playwright, mobile] — A TOC-anchor jump fired from inside a scroll-locked sheet has three independent scroll-clobbering traps; only live measurement separates them (#878, #880)
 - **139** [data-pipeline, frontend, hooks, analytics, verification, cdn] — A year-end snapshot's `sourceCsvDate` falls in July, so a program-year-equality guard silently drops every completed year (#892, #893)


### PR DESCRIPTION
Part of #931 (epic #933 — sprint-runner stuck-session liveness). Sprint 4: turn the Sprint-3 liveness **verdict** into **action**.

## What this does
Wires the reap → ship-check → capped-relaunch → escalation state machine into `mode_run`'s active-session OPEN branch (design §5). The Sprint-3 detector only observed; this acts:

- **STUCK/HUSK + attempts < 3 + unshipped** → `reap_screen_session` then auto-relaunch (`attempts += 1` persisted **before** launch, so a crashing launch still burns the attempt).
- **L086/R15 ship-state check before every relaunch** (`sprint_already_shipped`): a merged PR (`in:title,body`) or a commit on the **real** `origin/main` history (boundary-anchored `#N([^0-9]|$)`, never `origin/main..HEAD`). Already-merged work is **not** relaunched — reconcile/notify instead.
- **attempts ≥ 3** → `escalate_stuck`: reap, add `runner-stuck` label + comment, notify, leave the slot **free**, no relaunch. The normal launch path is gated off `runner-stuck` issues so the freed slot isn't silently re-filled.
- **Reset** attempt counter on genuine completion (CLOSED + ticked) and on a fresh normal-path launch.
- **`--status`** now surfaces per-session fused verdict + probe breakdown + `attempts N/3` (read-only; never reaps).
- Extracted `launch_sprint_session()` shared byte-identically by first-launch and relaunch; extracted `issue_has_label` reused by both label gates.

## TDD / verification
- **RED→GREEN**: new hermetic regression `scripts/tests/sprint-runner-reap-relaunch.test.sh` (5 cases: reap+relaunch+attempt-bump, escalate-at-cap, L086 no-relaunch-when-shipped, HEALTHY-untouched, `--status` surfacing). Committed failing first.
- Updated `sprint-runner-liveness-tick.test.sh`: Sprint-3 asserted observe-only ("HUSK logs handoff, **no reap**"); Sprint 4 lands that reap, so that transitional contract is superseded (legitimate spec evolution per L81/L137 — **not** assertion-pinning). The full acting matrix now lives in the new test.
- All 8 `scripts/tests/sprint-runner-*.test.sh` pass; `bash -n` clean; prettier + yaml-lint clean; pre-commit (typecheck+lint+yaml) passed on every commit.
- `/simplify` (reuse extraction) and fresh-context `/review` (APPROVE-WITH-NITS, no High) applied — the review's Medium (loose ship-check) is fixed in commit `8c80d145`.

## Notes for the reviewer / merge
- Docs deliverables (runner-header / CLAUDE.md / ops#53 contract) and end-to-end simulated-zombie verification are **Sprint 5 (#932)** per design §7–§8, not this PR.
- The runner shell-test harness isn't yet CI-gated (pre-existing); these tests run directly. No JS/frontend surface touched, so `pr-preview.yml` won't deploy a preview — verification is the full shell suite + code-proof (see issue evidence comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
