### PR TITLE
fix(clubs): restyle "Close to Distinguished" preset to match toolbar buttons (#966)

### DIFF
--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -675,7 +675,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
         <div className="clubs-preset-bar">
           <button
             type="button"
-            className="clubs-preset-chip"
+            className="clubs-filters-trigger clubs-preset-chip"
             aria-pressed={presetActive}
             onClick={() => setPresetActive(p => !p)}
           >

--- a/frontend/src/components/__tests__/ClubsTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.test.tsx
@@ -843,6 +843,27 @@ describe('ClubsTable', () => {
       createMockClub({ clubId: 'c-done', clubName: 'DoneClub' }),
     ]
 
+    it('shares the toolbar-button treatment with Filters/Columns (#966)', () => {
+      // The preset must match the Filters/Columns look-and-feel: it carries the
+      // canonical .clubs-filters-trigger class (same border/radius/padding/
+      // height/hover/focus/dark-mode tokens) instead of a bespoke pill. The
+      // .clubs-preset-chip modifier stays only for the aria-pressed amber fill.
+      render(
+        <ClubsTable
+          clubs={presetClubs}
+          districtId="test-district"
+          isLoading={false}
+        />
+      )
+      const toggle = screen.getByRole('button', {
+        name: /close to distinguished/i,
+      })
+      expect(toggle).toHaveClass('clubs-filters-trigger')
+      expect(toggle).toHaveClass('clubs-preset-chip')
+      // Toggle semantics preserved — aria-pressed, NOT role=tab (Lesson 128).
+      expect(toggle).toHaveAttribute('aria-pressed', 'false')
+    })
+
     it('renders an unpressed toggle by default, with all clubs shown', () => {
       render(
         <ClubsTable

--- a/frontend/src/styles/clubs-table.css
+++ b/frontend/src/styles/clubs-table.css
@@ -1,7 +1,12 @@
 
-/* Close-to-Distinguished preset (#903) — one action-oriented chip that replaced
-   the retired quick-filter row. Reuses toolbar tokens so dark mode inherits;
-   the pressed state uses the product accent (--rt-stats amber). */
+/* Close-to-Distinguished preset (#903, restyled #966) — one action-oriented
+   toggle that replaced the retired quick-filter row. It now carries the shared
+   .clubs-filters-trigger class (app-shell.css) so its border / radius / padding
+   / 44px height / hover / focus-ring / dark-mode tokens match the Filters and
+   Columns buttons exactly — one visual language, no drift. The .clubs-preset-chip
+   modifier below adds ONLY the pressed-state affordance (product accent amber),
+   layered on top of the shared base. (Imported after app-shell.css in index.css,
+   so the equal-specificity pressed rules win source-order over the base hover.) */
 .clubs-preset-bar {
   display: flex;
   align-items: center;
@@ -11,32 +16,15 @@
 }
 
 .clubs-preset-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.5rem 0.9rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--color-tm-loyal, #004165);
-  background: var(--color-tm-fog, #f3f5f7);
-  border: 1px solid var(--color-tm-mist, #d6dde3);
-  border-radius: 999px;
-  cursor: pointer;
-  min-height: 44px;
   white-space: nowrap;
-  transition:
-    background 0.15s ease,
-    color 0.15s ease,
-    border-color 0.15s ease;
 }
 
-.clubs-preset-chip:hover {
-  background: var(--color-tm-mist, #d6dde3);
-}
-
-.clubs-preset-chip[aria-pressed='true'] {
+/* Active toggle — amber fill so the pressed state reads as an active filter,
+   not just another idle toolbar button. Overrides the shared base + its hover. */
+.clubs-preset-chip[aria-pressed='true'],
+.clubs-preset-chip[aria-pressed='true']:hover {
   color: #fff;
-  background: var(--rt-stats, #d4873f);
+  background-color: var(--rt-stats, #d4873f);
   border-color: var(--rt-stats, #d4873f);
 }
 


### PR DESCRIPTION
## Summary

Sprint 1 of epic #968. The **"Close to Distinguished"** filter preset rendered as a bespoke rounded pill (`border-radius: 999px`, `--color-tm-*` tokens) that didn't match the **Filters** and **Columns** buttons in the clubs toolbar. This restyles it to the shared treatment.

**Note on file paths:** the issue/epic reference `ClubFilterPresets.tsx` and `clubs/ClubTableToolbar.tsx`, which don't exist in the codebase. The actual preset button lives in `frontend/src/components/ClubsTable.tsx` and its styles in `frontend/src/styles/clubs-table.css`. The canonical toolbar-button treatment (`.clubs-filters-trigger`) lives in `app-shell.css` and is already shared by the Columns button — so this change makes the preset reuse that same class.

## What changed

- **`ClubsTable.tsx`** — the preset button now carries `className="clubs-filters-trigger clubs-preset-chip"`, inheriting the exact border / `0.5rem` radius / padding / 44px height / hover / focus-ring / dark-mode tokens used by Filters and Columns. `.clubs-preset-chip` is now just a modifier.
- **`clubs-table.css`** — stripped the duplicated pill base; `.clubs-preset-chip` keeps only the `aria-pressed` amber pressed-state (`--rt-stats`), layered on the shared base. Imported after `app-shell.css`, so the equal-specificity pressed rule wins source-order over the base hover.

## Acceptance criteria

- [x] CtD button visually matches Filters/Columns (same variant/tokens) — shares `.clubs-filters-trigger`.
- [x] Active state via `aria-pressed` (NOT `role=tab`) with a clear pressed style (Lesson 128).
- [x] Filter behaviour unchanged — same `isCloseToDistinguished` predicate, same pipeline step.
- [ ] Verified at 375 / 768 / 1280 px + dark mode on the PR preview (dual-engine Playwright, pending preview deploy).
- [x] Tests updated (`ClubsTable.test.tsx` — new assertion that the button shares the toolbar treatment).

Scope: **restyle only**. Repositioning the preset into the toolbar row is Sprint 2 (#967).

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)