### PR TITLE
feat(clubs): move "Close to Distinguished" preset into the toolbar, after Columns (#967)

### DIFF
--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -667,12 +667,12 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
             isGroupHidden={isGroupHidden}
             onToggle={toggleGroup}
           />
-        </div>
-
-        {/* Close-to-Distinguished preset (#903) — one action-oriented toggle in
-            place of the retired quick-filter row, sharing the canonical
-            predicate with the club-detail banner. */}
-        <div className="clubs-preset-bar">
+          {/* Close-to-Distinguished preset (#903) — moved into the toolbar
+              cluster, directly after Columns (#967). One action-oriented toggle
+              in place of the retired quick-filter row, sharing the canonical
+              predicate with the club-detail banner. It carries the shared
+              .clubs-filters-trigger treatment so it reads as one toolbar
+              language; .clubs-preset-chip adds only the pressed-state amber. */}
           <button
             type="button"
             className="clubs-filters-trigger clubs-preset-chip"
@@ -681,13 +681,17 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
           >
             🎯 Close to Distinguished
           </button>
-          {presetActive && (
-            <span className="clubs-preset-count" aria-live="polite">
-              {presetFilteredClubs.length} of {filteredClubs.length} clubs need
-              a nudge to Distinguished
-            </span>
-          )}
         </div>
+
+        {/* Preset feedback line — distinct from the table's "Showing N of M"
+            summary, and a polite live region for the toggle. Sits below the
+            single toolbar row rather than in its own control row (#967). */}
+        {presetActive && (
+          <p className="clubs-preset-count" aria-live="polite">
+            {presetFilteredClubs.length} of {filteredClubs.length} clubs need a
+            nudge to Distinguished
+          </p>
+        )}
 
         {/* Results Count and Quick Filters */}
         <div className="flex flex-wrap items-center gap-4 text-sm clubs-text-muted">

--- a/frontend/src/components/__tests__/ClubsTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.test.tsx
@@ -864,6 +864,33 @@ describe('ClubsTable', () => {
       expect(toggle).toHaveAttribute('aria-pressed', 'false')
     })
 
+    it('places the preset toggle inside the toolbar, directly after Columns (#967)', () => {
+      // #967: the preset moves out of its standalone row and into the single
+      // toolbar cluster — Search | Filters | Columns | Close to Distinguished.
+      const { container } = render(
+        <ClubsTable
+          clubs={presetClubs}
+          districtId="test-district"
+          isLoading={false}
+        />
+      )
+      const toolbar = container.querySelector('.clubs-filter-toolbar')
+      expect(toolbar).not.toBeNull()
+      const toggle = screen.getByRole('button', {
+        name: /close to distinguished/i,
+      })
+      // The preset lives in the toolbar row, not a separate presets row…
+      expect(toolbar).toContainElement(toggle)
+      // …and that standalone presets row is gone entirely.
+      expect(container.querySelector('.clubs-preset-bar')).toBeNull()
+      // Order within the toolbar: Columns, then the preset directly after it.
+      const columnsBtn = screen.getByRole('button', { name: /columns/i })
+      const buttons = Array.from(toolbar!.querySelectorAll('button'))
+      expect(buttons.indexOf(toggle)).toBeGreaterThan(
+        buttons.indexOf(columnsBtn)
+      )
+    })
+
     it('renders an unpressed toggle by default, with all clubs shown', () => {
       render(
         <ClubsTable

--- a/frontend/src/styles/clubs-table.css
+++ b/frontend/src/styles/clubs-table.css
@@ -6,15 +6,10 @@
    Columns buttons exactly — one visual language, no drift. The .clubs-preset-chip
    modifier below adds ONLY the pressed-state affordance (product accent amber),
    layered on top of the shared base. (Imported after app-shell.css in index.css,
-   so the equal-specificity pressed rules win source-order over the base hover.) */
-.clubs-preset-bar {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 0.25rem;
-}
-
+   so the equal-specificity pressed rules win source-order over the base hover.)
+   #967: the chip now lives inside .clubs-filter-toolbar (after Columns), so the
+   former standalone .clubs-preset-bar wrapper is gone; only the chip modifier
+   and the feedback-count line remain. */
 .clubs-preset-chip {
   white-space: nowrap;
 }
@@ -29,6 +24,8 @@
 }
 
 .clubs-preset-count {
+  margin-top: -0.5rem;
+  margin-bottom: 1rem;
   font-size: 0.8125rem;
   font-weight: 500;
   color: var(--color-tm-slate, #5b6470);


### PR DESCRIPTION
Closes nothing automatically — sprint-runner ticks/closes #967 after preview verification (tick-before-close, R15/L106).

## What
Moves the **Close to Distinguished** preset out of its standalone row and into the single toolbar cluster, immediately after the **Columns** button: `Search … | Filters | Columns | Close to Distinguished`. The separate `.clubs-preset-bar` row is removed; the preset-count feedback line now renders below the single toolbar row as a polite live region.

Epic #968 Sprint 2 (#967). Sprint 1 (#966) already restyled the chip to share the `.clubs-filters-trigger` treatment, so it joins the row already matching Filters/Columns.

## Acceptance criteria
- [x] CtD button sits in the toolbar, directly after Columns.
- [x] Filter + URL-sync behaviour unchanged (same `presetActive`/`presetFilteredClubs` pipeline step — R11).
- [x] Dark mode unchanged (shared `.clubs-filters-trigger` tokens + `.clubs-preset-chip` amber pressed state — R10).
- [x] Tests updated (`ClubsTable.test.tsx` — new placement test asserts toolbar membership + order, separate row gone).
- [ ] No layout overflow / CLS regression at 375/768/1280 px — verified on PR preview (dual-engine smoke, evidence to follow).

## Tests
- New: `places the preset toggle inside the toolbar, directly after Columns (#967)` (RED before, GREEN after).
- Full frontend suite: 3153 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)