### PR TITLE
feat(ux): deep-link Clubs 'Close to Distinguished' preset + RegionsPage region finder (#979)

### DIFF
--- a/frontend/src/components/ClubsTable.tsx
+++ b/frontend/src/components/ClubsTable.tsx
@@ -187,6 +187,10 @@ interface ClubsTableProps {
   onFilterChange?:
     | ((state: import('./filters/types').FilterState) => void)
     | undefined
+  /** Initial "Close to Distinguished" preset state from URL params (#979) */
+  initialPresetActive?: boolean | undefined
+  /** Callback when the preset toggles — for URL param sync (#979). */
+  onPresetChange?: ((active: boolean) => void) | undefined
   /** Reference date for anniversary computation. Defaults to `new Date()`.
    *  Tests inject a fixed date to keep year counts deterministic (#448). */
   referenceDate?: Date
@@ -244,6 +248,8 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   onSortChange,
   initialFilterState,
   onFilterChange,
+  initialPresetActive,
+  onPresetChange,
   referenceDate,
   snapshotDiff,
 }) => {
@@ -345,7 +351,18 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
   // "Close to Distinguished" preset (#903) — a new pipeline step (R11) layered
   // on the column filters, powered by the ONE shared canonical predicate so it
   // can never diverge from the club-detail-card banner.
-  const [presetActive, setPresetActive] = useState(false)
+  // Seeded from the URL (#979) via initialPresetActive; toggling notifies the
+  // owning page through onPresetChange, which writes `?preset=`. Local state is
+  // the live source of truth for the render (mirrors the sort/dir seam) — the
+  // page never pushes the value back in, so there is no inward-sync race.
+  const [presetActive, setPresetActive] = useState(initialPresetActive ?? false)
+  const handlePresetToggle = useCallback(() => {
+    setPresetActive(prev => {
+      const next = !prev
+      onPresetChange?.(next)
+      return next
+    })
+  }, [onPresetChange])
   const presetFilteredClubs = useMemo(() => {
     if (!presetActive) return filteredClubs
     return filteredClubs.filter(club =>
@@ -677,7 +694,7 @@ export const ClubsTable: React.FC<ClubsTableProps> = ({
             type="button"
             className="clubs-filters-trigger clubs-preset-chip"
             aria-pressed={presetActive}
-            onClick={() => setPresetActive(p => !p)}
+            onClick={handlePresetToggle}
           >
             🎯 Close to Distinguished
           </button>

--- a/frontend/src/components/__tests__/ClubsTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubsTable.test.tsx
@@ -947,6 +947,44 @@ describe('ClubsTable', () => {
       expect(screen.getByText('FarClub')).toBeInTheDocument()
       expect(screen.getByText('DoneClub')).toBeInTheDocument()
     })
+
+    // URL-sync seam (#979): the page owns the `?preset=` param and seeds the
+    // toggle via initialPresetActive; the toggle notifies via onPresetChange.
+    it('starts pressed and pre-filtered when initialPresetActive is true', () => {
+      render(
+        <ClubsTable
+          clubs={presetClubs}
+          districtId="test-district"
+          isLoading={false}
+          initialPresetActive
+        />
+      )
+      const toggle = screen.getByRole('button', {
+        name: /close to distinguished/i,
+      })
+      expect(toggle).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByText('NearClub')).toBeInTheDocument()
+      expect(screen.queryByText('FarClub')).not.toBeInTheDocument()
+    })
+
+    it('calls onPresetChange with the new pressed state on toggle', () => {
+      const onPresetChange = vi.fn()
+      render(
+        <ClubsTable
+          clubs={presetClubs}
+          districtId="test-district"
+          isLoading={false}
+          onPresetChange={onPresetChange}
+        />
+      )
+      const toggle = screen.getByRole('button', {
+        name: /close to distinguished/i,
+      })
+      fireEvent.click(toggle)
+      expect(onPresetChange).toHaveBeenCalledWith(true)
+      fireEvent.click(toggle)
+      expect(onPresetChange).toHaveBeenCalledWith(false)
+    })
   })
 
   describe('Row Click Handler', () => {

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -30,6 +30,9 @@ import {
   paramsToFilterState,
   filterStateToParams,
   FILTER_PARAM_KEYS,
+  PRESET_PARAM,
+  PRESET_CLOSE_TO_DISTINGUISHED,
+  paramsToPresetActive,
 } from '../utils/clubFilterUrl'
 
 /* District Clubs Page (#570, epic #568 Phase 2; URL-sync generalised #817).
@@ -83,6 +86,33 @@ const DistrictClubsPage: React.FC = () => {
             next.set('sort', field)
             next.set('dir', direction)
           }
+          return next
+        },
+        { replace: true }
+      )
+    },
+    [setSearchParams]
+  )
+
+  // "Close to Distinguished" preset URL state (#979). Like sort/dir, the preset
+  // is a single-writer param with its own handler — disjoint from the filter
+  // reconcile's FILTER_PARAM_KEYS, so a filter change never wipes it and the two
+  // never collide in one batch (no lesson-070 race). Initial value read once on
+  // mount; later updates flow through onPresetChange. The page owns the param;
+  // ClubsTable seeds its local toggle from it (R3).
+  const initialPresetActive = useMemo(
+    () => paramsToPresetActive(searchParams),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  const handlePresetChange = useCallback(
+    (active: boolean) => {
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          if (active) next.set(PRESET_PARAM, PRESET_CLOSE_TO_DISTINGUISHED)
+          else next.delete(PRESET_PARAM)
           return next
         },
         { replace: true }
@@ -274,6 +304,8 @@ const DistrictClubsPage: React.FC = () => {
                   onSortChange={handleSortChange}
                   initialFilterState={initialFilterState}
                   onFilterChange={handleFilterChange}
+                  initialPresetActive={initialPresetActive}
+                  onPresetChange={handlePresetChange}
                   snapshotDiff={snapshotDiff}
                 />
                 <ProspectiveClubsPanel clubs={analytics?.prospectiveClubs} />

--- a/frontend/src/pages/RegionsPage.tsx
+++ b/frontend/src/pages/RegionsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { fetchCdnRankings } from '../services/cdn'
 import { aggregateRegions } from '../utils/aggregateRegions'
@@ -6,6 +6,16 @@ import { RegionGrid } from '../components/RegionGrid'
 import { RegionFinder } from '../components/RegionFinder'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
+import { useUrlState } from '../hooks/useUrlState'
+
+/* Region selection is URL state (#979) so it survives reload, back, and shared
+   links — `?region=07`. Module-level options keep a stable reference so
+   useUrlState's value memo isn't busted each render. `null` ("All regions")
+   serialises to '' and is dropped from the URL, keeping the default clean. */
+const REGION_URL_OPTIONS = {
+  parse: (raw: string): string | null => raw || null,
+  serialize: (value: string | null): string => value ?? '',
+}
 
 /* RegionsPage (#496) — overview of all 14 numbered regions.
 
@@ -28,7 +38,11 @@ const RegionsPage: React.FC = () => {
     staleTime: 15 * 60 * 1000,
   })
 
-  const [selectedRegion, setSelectedRegion] = useState<string | null>(null)
+  const [selectedRegion, setSelectedRegion] = useUrlState<string | null>(
+    'region',
+    null,
+    REGION_URL_OPTIONS
+  )
 
   const rollups = useMemo(
     () => (data?.rankings ? aggregateRegions(data.rankings) : []),

--- a/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
@@ -319,6 +319,52 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
     expect(screen.queryByText(/alpha toastmasters/i)).not.toBeInTheDocument()
   })
 
+  it('honors ?preset=close-to-distinguished on load — the toggle is pressed (#979)', async () => {
+    renderAt('/district/61/clubs?preset=close-to-distinguished')
+
+    const toggle = await screen.findByRole('button', {
+      name: /close to distinguished/i,
+    })
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('writes ?preset=close-to-distinguished when the preset is toggled on (#979)', async () => {
+    const user = userEvent.setup()
+    const { router } = renderAt('/district/61/clubs')
+
+    await screen.findByText(/alpha toastmasters/i)
+    const toggle = screen.getByRole('button', {
+      name: /close to distinguished/i,
+    })
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(toggle)
+
+    await waitFor(() => {
+      const params = new URLSearchParams(router.state.location.search)
+      expect(params.get('preset')).toBe('close-to-distinguished')
+    })
+  })
+
+  it('clears ?preset= from the URL when the preset is toggled back off (#979)', async () => {
+    const user = userEvent.setup()
+    const { router } = renderAt(
+      '/district/61/clubs?preset=close-to-distinguished'
+    )
+
+    const toggle = await screen.findByRole('button', {
+      name: /close to distinguished/i,
+    })
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+
+    await user.click(toggle)
+
+    await waitFor(() => {
+      const params = new URLSearchParams(router.state.location.search)
+      expect(params.has('preset')).toBe(false)
+    })
+  })
+
   it('writes ?status= to the URL when the Status filter is applied via the drawer (#902)', async () => {
     const user = userEvent.setup()
     const { router } = renderAt('/district/61/clubs')

--- a/frontend/src/pages/__tests__/RegionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionsPage.test.tsx
@@ -1,10 +1,17 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import RegionsPage from '../RegionsPage'
+
+/* Reads the live URL search string so URL-sync round-trips are assertable
+   (#979 — region deep link). */
+const LocationProbe = () => {
+  const { search } = useLocation()
+  return <div data-testid="loc-search">{search}</div>
+}
 
 /* Sprint C test suite (#496, #492). Red-first per Lesson 54. */
 
@@ -72,6 +79,22 @@ const renderPage = () => {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={['/regions']}>
+        <Routes>
+          <Route path="/regions" element={<RegionsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const renderPageAt = (url: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[url]}>
+        <LocationProbe />
         <Routes>
           <Route path="/regions" element={<RegionsPage />} />
         </Routes>
@@ -154,5 +177,57 @@ describe('RegionsPage (#496)', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /all regions/i }))
     expect(screen.getAllByText(/Region 01/).length).toBeGreaterThan(0)
+  })
+
+  describe('deep-link region selection (#979)', () => {
+    it('isolates the region named in ?region= on load', async () => {
+      renderPageAt('/regions?region=07')
+      await screen.findByRole('link', { name: /^region 07/i })
+      // Region 07 is pre-selected from the URL; Region 01 is filtered out.
+      expect(
+        screen.getByRole('button', { name: /^region 07$/i })
+      ).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.queryByText(/Region 01/)).not.toBeInTheDocument()
+    })
+
+    it('writes ?region= to the URL when a region is selected', async () => {
+      renderPageAt('/regions')
+      await screen.findByRole('link', { name: /^region 01/i })
+
+      await userEvent.click(
+        screen.getByRole('button', { name: /^region 07$/i })
+      )
+      await waitFor(() =>
+        expect(screen.getByTestId('loc-search').textContent).toContain(
+          'region=07'
+        )
+      )
+    })
+
+    it('clears ?region= when "All regions" is reselected', async () => {
+      renderPageAt('/regions?region=07')
+      await screen.findByRole('link', { name: /^region 07/i })
+
+      await userEvent.click(
+        screen.getByRole('button', { name: /all regions/i })
+      )
+      await waitFor(() =>
+        expect(screen.getByTestId('loc-search').textContent).not.toContain(
+          'region='
+        )
+      )
+    })
+
+    it('self-heals an unknown ?region= to All (page-level validation, Lesson 124)', async () => {
+      renderPageAt('/regions?region=99')
+      await screen.findByRole('link', { name: /^region 01/i })
+      // 99 is not a real region id, so the grid shows everything and "All
+      // regions" is the effective selection — never a stranded empty grid.
+      expect(
+        screen.getByRole('button', { name: /all regions/i })
+      ).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getAllByText(/Region 01/).length).toBeGreaterThan(0)
+      expect(screen.getAllByText(/Region 07/).length).toBeGreaterThan(0)
+    })
   })
 })

--- a/frontend/src/utils/__tests__/clubFilterUrl.test.ts
+++ b/frontend/src/utils/__tests__/clubFilterUrl.test.ts
@@ -8,6 +8,9 @@ import {
   paramsToFilterState,
   filterStateToParams,
   FILTER_PARAM_KEYS,
+  PRESET_PARAM,
+  PRESET_CLOSE_TO_DISTINGUISHED,
+  paramsToPresetActive,
 } from '../clubFilterUrl'
 import type { FilterState } from '../../components/filters/types'
 
@@ -217,5 +220,34 @@ describe('clubFilterUrl — round-trip', () => {
     }
     const sp = new URLSearchParams(filterStateToParams(original))
     expect(paramsToFilterState(sp)).toEqual(original)
+  })
+})
+
+describe('clubFilterUrl — "Close to Distinguished" preset (#979)', () => {
+  it('reads ?preset=close-to-distinguished as active', () => {
+    expect(
+      paramsToPresetActive(
+        params(`${PRESET_PARAM}=${PRESET_CLOSE_TO_DISTINGUISHED}`)
+      )
+    ).toBe(true)
+  })
+
+  it('treats an absent preset param as inactive', () => {
+    expect(paramsToPresetActive(params(''))).toBe(false)
+    expect(paramsToPresetActive(params('status=vulnerable'))).toBe(false)
+  })
+
+  it('ignores an unknown preset value (only the canonical token activates)', () => {
+    expect(paramsToPresetActive(params(`${PRESET_PARAM}=something-else`))).toBe(
+      false
+    )
+  })
+
+  it('keeps `preset` OUT of FILTER_PARAM_KEYS so a filter reconcile never wipes it', () => {
+    // The filter reconcile in DistrictClubsPage deletes every FILTER_PARAM_KEYS
+    // entry then re-emits present filters. The preset is a separate pipeline
+    // step (not a column filter), written by its own handler — including it here
+    // would silently clear the preset on any filter change.
+    expect(FILTER_PARAM_KEYS).not.toContain(PRESET_PARAM)
   })
 })

--- a/frontend/src/utils/clubFilterUrl.ts
+++ b/frontend/src/utils/clubFilterUrl.ts
@@ -27,6 +27,25 @@ import {
 const SEARCH_PARAM = 'search'
 const STATUS_PARAM = 'status'
 
+/**
+ * "Close to Distinguished" preset (#979). The preset is a separate pipeline
+ * step layered on the column filters (R11), NOT a column filter — so it lives
+ * here (the single club-URL contract module, no parallel param scheme) but is
+ * deliberately kept OUT of FILTER_PARAM_KEYS: the page's wholesale filter
+ * reconcile deletes every FILTER_PARAM_KEYS entry then re-emits present filters,
+ * and `filterStateToParams` never emits `preset`, so including it would clear
+ * the preset on any filter change. The preset gets its own single writer on the
+ * page (the proven sort/dir pattern — disjoint key, no shared-batch trigger, so
+ * no lesson-070 same-batch race). Only the canonical token activates it.
+ */
+export const PRESET_PARAM = 'preset'
+export const PRESET_CLOSE_TO_DISTINGUISHED = 'close-to-distinguished'
+
+/** Read whether the "Close to Distinguished" preset is active from the URL. */
+export function paramsToPresetActive(params: URLSearchParams): boolean {
+  return params.get(PRESET_PARAM) === PRESET_CLOSE_TO_DISTINGUISHED
+}
+
 /** Status internal ⇄ URL alias (kept stable for shared links / legacy redirect). */
 const statusUrlToInternal = (raw: string | null): string | null => {
   switch (raw) {

--- a/tasks/lessons/145-a-non-filter-param-layered-on-the-filtered-set-must-stay-out-of-the-reconcile-key-set.md
+++ b/tasks/lessons/145-a-non-filter-param-layered-on-the-filtered-set-must-stay-out-of-the-reconcile-key-set.md
@@ -1,0 +1,70 @@
+---
+id: '145'
+category: lesson
+tags: [router, react, hooks, frontend, scope]
+auto_load: true
+date: 2026-05-30
+issues: [979, 969]
+---
+
+# Lesson 145 — A URL param that's a pipeline step layered on the filtered set must NOT join the wholesale filter-reconcile key set
+
+**Date:** 2026-05-30
+**Issue:** #979 (epic #969 Sprint 3 — deep-link the Clubs "Close to Distinguished" preset + RegionsPage region finder)
+**PR:** [#988](https://github.com/taverns-red/toast-stats/pull/988)
+
+## What happened
+
+The clubs page round-trips its column filters through the URL via one
+**wholesale reconcile** (`clubFilterUrl` + `FILTER_PARAM_KEYS`): on any filter
+change it deletes _every_ key the codec owns, then re-emits only what
+`filterStateToParams(state)` produces. This is the lesson-070 fix — reconciling
+the full set sidesteps the same-batch `prev`-snapshot clobber.
+
+Deep-linking the "Close to Distinguished" preset (`?preset=`) looked like "just
+add `preset` to the codec." But the preset is **not a column filter** — it's a
+separate pipeline step (R11) layered on top of the already-filtered rows, and
+`filterStateToParams` never emits it. So folding `preset` into
+`FILTER_PARAM_KEYS` would mean the reconcile **deletes** `preset` on _every_
+filter change and never re-adds it — the deep link would silently evaporate the
+moment the user touched any other filter.
+
+## The principle
+
+**A param that the wholesale-reconcile codec doesn't itself emit must not live
+in that codec's delete-list.** A "delete-all-then-re-emit-present" reconcile is
+only safe for params the reconcile fully owns (reads _and_ writes). A param that
+represents a concept the codec doesn't model — a preset toggle, a view mode, a
+selection that sits beside the filters rather than among them — needs its **own
+single-writer handler** with a disjoint key, exactly like the page's existing
+`sort`/`dir` seam: own `setSearchParams(prev => …)`, `{ replace: true }`,
+read-once-on-mount for the initial value, live state owned downstream and pushed
+back via a callback (R3). Disjoint keys + distinct user gestures ⇒ the two
+writers never co-occur in one batch, so there is no lesson-070 race to fix.
+
+This is the **inverse** of lesson 070: 070 says _fold sibling writes into one
+reconcile_ to dodge the same-batch clobber; 144 says _don't fold a param the
+reconcile can't round-trip_ — give it a separate writer instead. The deciding
+question is not "is it filter-ish?" but "does the reconcile both read AND
+emit it?" If not, it belongs outside `FILTER_PARAM_KEYS`.
+
+## How to apply
+
+- Before adding a key to a `DELETE_KEYS`/`FILTER_PARAM_KEYS`-style reconcile
+  list, confirm the reconcile's writer actually emits it. If the writer can't
+  produce the key, the delete-list will strip it and nothing will restore it.
+- Lock the contract with a test that asserts the param is **not** in the
+  reconcile set (here: `clubFilterUrl.test.ts` — `expect(FILTER_PARAM_KEYS).not
+.toContain(PRESET_PARAM)`), so a future "tidy-up" that folds it in goes red.
+- Keep the param's name/value/parse in the same codec _module_ (one URL
+  contract, no parallel scheme) even while keeping it out of the reconcile
+  _list_ — module membership and delete-list membership are different things.
+
+## Related
+
+- [[070-setSearchParams-prev-races-in-batched-updates]] — the same-batch
+  clobber this reconcile exists to dodge; 145 is its inverse (when NOT to fold).
+- [[124-validate-url-synced-range-state-at-the-page-not-the-picker]] — the page
+  owns URL state and validates it; the preset's single writer lives there too.
+- `frontend/src/utils/clubFilterUrl.ts`, `frontend/src/pages/DistrictClubsPage.tsx`
+  (`handlePresetChange`, disjoint from `handleFilterChange`).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -120,4 +120,5 @@
 - **142** [css, frontend, verification, tests, accessibility] — 142-a-new-component-stylesheet-must-be-wired-into-the-import-graph-tests-wont-catch-an-orphan
 - **143** [automation, sprint-runner, verification, tdd, bash] — A probe whose production feed was deferred reports UNKNOWN forever; the verification sprint is where you drive it end-to-end against the real feed (#932, #933)
 - **144** [router, react, frontend, scope, verification] — A cap (or any invariant) enforced only on the mutation path is bypassed the moment the value becomes URL-seedable (#978, #969)
+- **145** [router, react, hooks, frontend, scope] — A URL param that's a pipeline step layered on the filtered set must NOT join the wholesale filter-reconcile key set (#979, #969)
 - **145** [cls, performance, frontend, react, verification, ci] — An incidental post-data re-render can be load-bearing for CLS; a "cleanup" that removes it regresses layout only on the CI font environment (#978, #969)


### PR DESCRIPTION
Part of epic #969 (deep links for everything). Sprint 3 — work item #979 (closed manually after the epic checkbox is ticked, per L106).

## What changed
Two interactive controls that were lost on reload now encode their state in the URL:

| Page | Control | Before | After |
|---|---|---|---|
| `/district/:id/clubs` | "Close to Distinguished" preset chip | component `useState` | `?preset=close-to-distinguished` |
| `/regions` | RegionFinder selection | component `useState` | `?region=<id>` |

Both survive **reload, back button, and shared links**.

## Design
- **Clubs preset** — param contract added to the existing `clubFilterUrl` codec module (`PRESET_PARAM`, `paramsToPresetActive`), satisfying the "no parallel param scheme" guardrail. The preset is a separate pipeline step (R11), **not** a column filter, so it's deliberately kept OUT of `FILTER_PARAM_KEYS` (the filter reconcile deletes those keys then re-emits column filters — including `preset` there would wipe it on every filter change). It gets its own single-writer handler on the page, mirroring the proven `sort`/`dir` seam: disjoint key, no shared-batch trigger, so no Lesson-070 race. The page owns the param (R3); ClubsTable seeds its live toggle from `initialPresetActive` and notifies via `onPresetChange`.
- **RegionsPage** — `selectedRegion` swapped from `useState` to the shared `useUrlState` hook (guardrail met). Module-level options keep a stable reference so the value memo isn't busted. Page-level validation preserved (Lesson 124): an unknown `?region=99` self-heals to "All" at render, never a stranded empty grid.
- Preset toggle stays `aria-pressed`, not `role=tab` (Lesson 128); RegionFinder already was.

## Tests (TDD, all Red-verified first)
- `clubFilterUrl.test.ts` — preset codec read + the FILTER_PARAM_KEYS-exclusion guard.
- `ClubsTable.test.tsx` — `initialPresetActive` seeding + `onPresetChange` callback.
- `DistrictClubsPage.test.tsx` — `?preset=` round-trip (load / write / clear).
- `RegionsPage.test.tsx` — `?region=` round-trip (load / write / clear) + unknown-id self-heal.

Full suite: 3173 passing, 0 regressions. /simplify (clean) + fresh-context /review (APPROVE) run pre-push.

## Reviewer note (Low nit, intended)
"Clear all filters" intentionally does **not** clear the preset — the preset is a separate pipeline step, not a column filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)