### PR TITLE
feat(ux): deep-link disclosure & expand-collapse state across routes (#980)

### DIFF
--- a/frontend/src/components/ChartSparklineExpand.tsx
+++ b/frontend/src/components/ChartSparklineExpand.tsx
@@ -28,21 +28,6 @@ export interface ChartSparklineExpandProps {
   urlId?: string
 }
 
-/**
- * Sparkline-then-expand wrapper (epic #876 / CC-3). At and above `breakpoint`
- * the desktop chart renders directly — zero added chrome, so desktop layout is
- * untouched. Below it, the multi-series chart (unreadable at 375px) collapses
- * to its headline numbers + a sparkline behind a tap target; tapping opens a
- * full-screen `ChartExpandSheet` with the full desktop chart.
- *
- * The collapse is width-driven (`useIsMobile` → matchMedia), NOT scroll/visibility
- * gated, so the collapsed view is present on mount in every context including
- * non-scroll capture (Lesson 113). In JSDOM `useIsMobile` resolves to false, so
- * desktop tests and existing consumers see the bare chart unchanged.
- *
- * This sprint (#874) ships only the reusable wrapper; #875 applies it to the
- * District Trends, Club detail, Rankings Progression and Awards charts.
- */
 type ViewProps = Omit<ChartSparklineExpandProps, 'breakpoint' | 'urlId'> & {
   isOpen: boolean
   setOpen: (open: boolean) => void
@@ -116,6 +101,20 @@ const LocalChartSparklineExpand: React.FC<
   )
 }
 
+/**
+ * Sparkline-then-expand wrapper (epic #876 / CC-3). At and above `breakpoint`
+ * the desktop chart renders directly — zero added chrome, so desktop layout is
+ * untouched. Below it, the multi-series chart (unreadable at 375px) collapses
+ * to its headline numbers + a sparkline behind a tap target; tapping opens a
+ * full-screen `ChartExpandSheet` with the full desktop chart.
+ *
+ * The collapse is width-driven (`useIsMobile` → matchMedia), NOT scroll/visibility
+ * gated, so the collapsed view is present on mount in every context including
+ * non-scroll capture (Lesson 113). In JSDOM `useIsMobile` resolves to false, so
+ * desktop tests and existing consumers see the bare chart unchanged.
+ *
+ * Pass `urlId` to deep-link the open sheet via `?chartExpanded=<id>` (#980).
+ */
 export const ChartSparklineExpand: React.FC<ChartSparklineExpandProps> = ({
   breakpoint = 768,
   urlId,

--- a/frontend/src/components/ChartSparklineExpand.tsx
+++ b/frontend/src/components/ChartSparklineExpand.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useUrlState } from '../hooks/useUrlState'
 import { Sparkline } from './Sparkline'
 import { ChartExpandSheet } from './ChartExpandSheet'
 
@@ -18,6 +19,13 @@ export interface ChartSparklineExpandProps {
   expandLabel?: string
   /** Class on the collapsed-mobile wrapper (Lesson 077 — override, no variant). */
   className?: string
+  /**
+   * When set, the expand sheet deep-links via `?chartExpanded=<urlId>` (#980).
+   * The param holds WHICH chart is open (the sheet is mutually exclusive), so
+   * multiple charts on one page each pass a distinct id. Requires a router.
+   * When omitted, the sheet uses purely-local state (router-free).
+   */
+  urlId?: string
 }
 
 /**
@@ -35,48 +43,92 @@ export interface ChartSparklineExpandProps {
  * This sprint (#874) ships only the reusable wrapper; #875 applies it to the
  * District Trends, Club detail, Rankings Progression and Awards charts.
  */
-export const ChartSparklineExpand: React.FC<ChartSparklineExpandProps> = ({
+type ViewProps = Omit<ChartSparklineExpandProps, 'breakpoint' | 'urlId'> & {
+  isOpen: boolean
+  setOpen: (open: boolean) => void
+}
+
+/** The collapsed-mobile sparkline + expand sheet. State source is injected. */
+const ChartSparklineExpandView: React.FC<ViewProps> = ({
   title,
   sparklineData,
   headline,
   children,
-  breakpoint = 768,
   expandLabel,
   className,
+  isOpen,
+  setOpen,
+}) => (
+  <div className={className ?? 'chart-spark'}>
+    <button
+      type="button"
+      className="chart-spark__trigger"
+      aria-haspopup="dialog"
+      aria-label={expandLabel ?? `Expand ${title} chart`}
+      onClick={() => setOpen(true)}
+    >
+      <span className="chart-spark__headline">{headline}</span>
+      <Sparkline
+        data={sparklineData}
+        ariaLabel={`${title} sparkline`}
+        className="chart-spark__sparkline"
+      />
+      <span className="chart-spark__hint" aria-hidden="true">
+        Tap to expand
+      </span>
+    </button>
+
+    <ChartExpandSheet
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
+      title={title}
+    >
+      {children}
+    </ChartExpandSheet>
+  </div>
+)
+
+/** URL-synced state source — `?chartExpanded` holds which chart id is open. */
+const UrlSyncedChartSparklineExpand: React.FC<
+  Omit<ChartSparklineExpandProps, 'breakpoint'> & { urlId: string }
+> = ({ urlId, ...viewProps }) => {
+  const [expandedId, setExpandedId] = useUrlState('chartExpanded', '')
+  return (
+    <ChartSparklineExpandView
+      {...viewProps}
+      isOpen={expandedId === urlId}
+      setOpen={open => setExpandedId(open ? urlId : '')}
+    />
+  )
+}
+
+/** Local (router-free) state source — the default. */
+const LocalChartSparklineExpand: React.FC<
+  Omit<ChartSparklineExpandProps, 'breakpoint' | 'urlId'>
+> = viewProps => {
+  const [isOpen, setIsOpen] = useState(false)
+  return (
+    <ChartSparklineExpandView
+      {...viewProps}
+      isOpen={isOpen}
+      setOpen={setIsOpen}
+    />
+  )
+}
+
+export const ChartSparklineExpand: React.FC<ChartSparklineExpandProps> = ({
+  breakpoint = 768,
+  urlId,
+  ...viewProps
 }) => {
   const isMobile = useIsMobile(breakpoint)
-  const [isOpen, setIsOpen] = useState(false)
 
-  if (!isMobile) return <>{children}</>
+  if (!isMobile) return <>{viewProps.children}</>
 
-  return (
-    <div className={className ?? 'chart-spark'}>
-      <button
-        type="button"
-        className="chart-spark__trigger"
-        aria-haspopup="dialog"
-        aria-label={expandLabel ?? `Expand ${title} chart`}
-        onClick={() => setIsOpen(true)}
-      >
-        <span className="chart-spark__headline">{headline}</span>
-        <Sparkline
-          data={sparklineData}
-          ariaLabel={`${title} sparkline`}
-          className="chart-spark__sparkline"
-        />
-        <span className="chart-spark__hint" aria-hidden="true">
-          Tap to expand
-        </span>
-      </button>
-
-      <ChartExpandSheet
-        isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
-        title={title}
-      >
-        {children}
-      </ChartExpandSheet>
-    </div>
+  return urlId ? (
+    <UrlSyncedChartSparklineExpand urlId={urlId} {...viewProps} />
+  ) : (
+    <LocalChartSparklineExpand {...viewProps} />
   )
 }
 

--- a/frontend/src/components/CriteriaExplanation.tsx
+++ b/frontend/src/components/CriteriaExplanation.tsx
@@ -31,6 +31,7 @@
 
 import React, { useState } from 'react'
 import { Card } from './ui/Card/Card'
+import { useUrlBoolean } from '../hooks/useUrlBoolean'
 
 /**
  * Props for the CriteriaExplanation component
@@ -38,6 +39,12 @@ import { Card } from './ui/Card/Card'
 export interface CriteriaExplanationProps {
   /** Whether to show in collapsed/expanded state */
   defaultExpanded?: boolean
+  /**
+   * When set, the expand state deep-links via this URL search param (#980):
+   * `?<urlParam>=1` when open, absent when collapsed. Requires a router in the
+   * tree. When omitted, the panel keeps purely-local `useState` (router-free).
+   */
+  urlParam?: string
 }
 
 /**
@@ -54,15 +61,10 @@ export interface CriteriaExplanationProps {
  * <CriteriaExplanation defaultExpanded={true} />
  * ```
  */
-export const CriteriaExplanation: React.FC<CriteriaExplanationProps> = ({
-  defaultExpanded = false,
-}) => {
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
-
-  const toggleExpanded = () => {
-    setIsExpanded(!isExpanded)
-  }
-
+const CriteriaExplanationView: React.FC<{
+  isExpanded: boolean
+  toggleExpanded: () => void
+}> = ({ isExpanded, toggleExpanded }) => {
   return (
     <Card
       variant="default"
@@ -508,5 +510,47 @@ export const CriteriaExplanation: React.FC<CriteriaExplanationProps> = ({
     </Card>
   )
 }
+
+/** URL-synced state source — only mounted when a urlParam is supplied. */
+const UrlSyncedCriteriaExplanation: React.FC<{
+  urlParam: string
+  defaultExpanded: boolean
+}> = ({ urlParam, defaultExpanded }) => {
+  const [isExpanded, setIsExpanded] = useUrlBoolean(urlParam, {
+    defaultValue: defaultExpanded,
+  })
+  return (
+    <CriteriaExplanationView
+      isExpanded={isExpanded}
+      toggleExpanded={() => setIsExpanded(prev => !prev)}
+    />
+  )
+}
+
+/** Local (router-free) state source — the default. */
+const LocalCriteriaExplanation: React.FC<{ defaultExpanded: boolean }> = ({
+  defaultExpanded,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+  return (
+    <CriteriaExplanationView
+      isExpanded={isExpanded}
+      toggleExpanded={() => setIsExpanded(prev => !prev)}
+    />
+  )
+}
+
+export const CriteriaExplanation: React.FC<CriteriaExplanationProps> = ({
+  defaultExpanded = false,
+  urlParam,
+}) =>
+  urlParam ? (
+    <UrlSyncedCriteriaExplanation
+      urlParam={urlParam}
+      defaultExpanded={defaultExpanded}
+    />
+  ) : (
+    <LocalCriteriaExplanation defaultExpanded={defaultExpanded} />
+  )
 
 export default CriteriaExplanation

--- a/frontend/src/components/DivisionAreaRecognitionPanel.tsx
+++ b/frontend/src/components/DivisionAreaRecognitionPanel.tsx
@@ -211,11 +211,19 @@ export const DivisionAreaRecognitionPanel: React.FC<
         </p>
       </div>
 
-      {/* Division Criteria Explanation - Requirements 10.3: DDP criteria */}
-      <DivisionCriteriaExplanation defaultExpanded={false} />
+      {/* Division Criteria Explanation - Requirements 10.3: DDP criteria.
+          Expand state deep-links via ?expandDivisionCriteria (#980). */}
+      <DivisionCriteriaExplanation
+        defaultExpanded={false}
+        urlParam="expandDivisionCriteria"
+      />
 
-      {/* Area Criteria Explanation - Requirements 2, 3, 4 (DAP) - Requirement 10.4 */}
-      <CriteriaExplanation defaultExpanded={false} />
+      {/* Area Criteria Explanation - Requirements 2, 3, 4 (DAP) - Requirement 10.4.
+          Expand state deep-links via ?expandAreaCriteria (#980). */}
+      <CriteriaExplanation
+        defaultExpanded={false}
+        urlParam="expandAreaCriteria"
+      />
 
       {/* Area Progress Summary - Requirements 5, 6, 10.2, 10.3 */}
       <DivisionAreaProgressSummary divisions={divisions} isLoading={false} />

--- a/frontend/src/components/DivisionCriteriaExplanation.tsx
+++ b/frontend/src/components/DivisionCriteriaExplanation.tsx
@@ -33,6 +33,7 @@
 
 import React, { useState } from 'react'
 import { Card } from './ui/Card/Card'
+import { useUrlBoolean } from '../hooks/useUrlBoolean'
 
 /**
  * Props for the DivisionCriteriaExplanation component
@@ -40,6 +41,12 @@ import { Card } from './ui/Card/Card'
 export interface DivisionCriteriaExplanationProps {
   /** Whether to show in collapsed/expanded state */
   defaultExpanded?: boolean
+  /**
+   * When set, the expand state deep-links via this URL search param (#980):
+   * `?<urlParam>=1` when open, absent when collapsed. Requires a router in the
+   * tree. When omitted, the panel keeps purely-local `useState` (router-free).
+   */
+  urlParam?: string
 }
 
 /**
@@ -56,15 +63,10 @@ export interface DivisionCriteriaExplanationProps {
  * <DivisionCriteriaExplanation defaultExpanded={true} />
  * ```
  */
-export const DivisionCriteriaExplanation: React.FC<
-  DivisionCriteriaExplanationProps
-> = ({ defaultExpanded = false }) => {
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
-
-  const toggleExpanded = () => {
-    setIsExpanded(!isExpanded)
-  }
-
+const DivisionCriteriaExplanationView: React.FC<{
+  isExpanded: boolean
+  toggleExpanded: () => void
+}> = ({ isExpanded, toggleExpanded }) => {
   return (
     <Card
       variant="default"
@@ -531,5 +533,46 @@ export const DivisionCriteriaExplanation: React.FC<
     </Card>
   )
 }
+
+/** URL-synced state source — only mounted when a urlParam is supplied. */
+const UrlSyncedDivisionCriteria: React.FC<{
+  urlParam: string
+  defaultExpanded: boolean
+}> = ({ urlParam, defaultExpanded }) => {
+  const [isExpanded, setIsExpanded] = useUrlBoolean(urlParam, {
+    defaultValue: defaultExpanded,
+  })
+  return (
+    <DivisionCriteriaExplanationView
+      isExpanded={isExpanded}
+      toggleExpanded={() => setIsExpanded(prev => !prev)}
+    />
+  )
+}
+
+/** Local (router-free) state source — the default. */
+const LocalDivisionCriteria: React.FC<{ defaultExpanded: boolean }> = ({
+  defaultExpanded,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+  return (
+    <DivisionCriteriaExplanationView
+      isExpanded={isExpanded}
+      toggleExpanded={() => setIsExpanded(prev => !prev)}
+    />
+  )
+}
+
+export const DivisionCriteriaExplanation: React.FC<
+  DivisionCriteriaExplanationProps
+> = ({ defaultExpanded = false, urlParam }) =>
+  urlParam ? (
+    <UrlSyncedDivisionCriteria
+      urlParam={urlParam}
+      defaultExpanded={defaultExpanded}
+    />
+  ) : (
+    <LocalDivisionCriteria defaultExpanded={defaultExpanded} />
+  )
 
 export default DivisionCriteriaExplanation

--- a/frontend/src/components/MobileDisclosure.tsx
+++ b/frontend/src/components/MobileDisclosure.tsx
@@ -1,11 +1,18 @@
 import React from 'react'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useUrlBoolean } from '../hooks/useUrlBoolean'
 
 export interface MobileDisclosureProps {
   /** Label shown on the collapsed summary row (mobile only). */
   summaryLabel: string
   /** Viewport width (px) below which the content folds. Default 768. */
   breakpoint?: number
+  /**
+   * When set, the mobile open/closed state deep-links via this URL search param
+   * (#980): `?<urlParam>=1` when open, absent when collapsed. Requires a router.
+   * When omitted the disclosure stays uncontrolled (native default — router-free).
+   */
+  urlParam?: string
   children: React.ReactNode
 }
 
@@ -24,14 +31,43 @@ export interface MobileDisclosureProps {
 export const MobileDisclosure: React.FC<MobileDisclosureProps> = ({
   summaryLabel,
   breakpoint = 768,
+  urlParam,
   children,
 }) => {
   const isMobile = useIsMobile(breakpoint)
 
   if (!isMobile) return <>{children}</>
 
+  // URL-synced state source is split into its own component so the uncontrolled
+  // path never calls useSearchParams (no router required — Lesson 473 spirit).
+  if (urlParam) {
+    return (
+      <UrlSyncedDisclosure urlParam={urlParam} summaryLabel={summaryLabel}>
+        {children}
+      </UrlSyncedDisclosure>
+    )
+  }
+
   return (
     <details className="mobile-disclosure">
+      <summary className="mobile-disclosure__summary">{summaryLabel}</summary>
+      <div className="mobile-disclosure__content">{children}</div>
+    </details>
+  )
+}
+
+const UrlSyncedDisclosure: React.FC<{
+  urlParam: string
+  summaryLabel: string
+  children: React.ReactNode
+}> = ({ urlParam, summaryLabel, children }) => {
+  const [open, setOpen] = useUrlBoolean(urlParam)
+  return (
+    <details
+      className="mobile-disclosure"
+      open={open}
+      onToggle={e => setOpen(e.currentTarget.open)}
+    >
       <summary className="mobile-disclosure__summary">{summaryLabel}</summary>
       <div className="mobile-disclosure__content">{children}</div>
     </details>

--- a/frontend/src/components/MobileDisclosure.tsx
+++ b/frontend/src/components/MobileDisclosure.tsx
@@ -39,7 +39,7 @@ export const MobileDisclosure: React.FC<MobileDisclosureProps> = ({
   if (!isMobile) return <>{children}</>
 
   // URL-synced state source is split into its own component so the uncontrolled
-  // path never calls useSearchParams (no router required — Lesson 473 spirit).
+  // path never calls useSearchParams (no router required — #473 spirit).
   if (urlParam) {
     return (
       <UrlSyncedDisclosure urlParam={urlParam} summaryLabel={summaryLabel}>

--- a/frontend/src/components/__tests__/ChartSparklineExpand.test.tsx
+++ b/frontend/src/components/__tests__/ChartSparklineExpand.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 
 import { ChartSparklineExpand } from '../ChartSparklineExpand'
 
@@ -71,5 +73,88 @@ describe('ChartSparklineExpand', () => {
     stubViewport(true)
     renderWrapper()
     expect(document.querySelector('svg')).not.toBeNull()
+  })
+
+  // #980 — when a urlId is supplied, the open sheet deep-links via
+  // ?chartExpanded=<urlId>. The param holds WHICH chart is open (the sheet is
+  // mutually exclusive), so two charts on one page each get a distinct id.
+  describe('URL-synced expand state (#980)', () => {
+    let location = ''
+    const LocationProbe: React.FC = () => {
+      location = useLocation().search
+      return null
+    }
+    const renderMobile = (entry: string, urlId = 'membership') => {
+      stubViewport(true)
+      return render(
+        <MemoryRouter initialEntries={[entry]}>
+          <ChartSparklineExpand
+            title="Membership trend"
+            sparklineData={[1, 3, 2, 5]}
+            headline={<span data-testid="headline">1,234 members</span>}
+            urlId={urlId}
+          >
+            <div data-testid="desktop-chart">desktop chart</div>
+          </ChartSparklineExpand>
+          <LocationProbe />
+        </MemoryRouter>
+      )
+    }
+
+    it('opens the sheet on mount when ?chartExpanded matches the urlId', () => {
+      renderMobile('/?chartExpanded=membership')
+      expect(screen.getByRole('dialog')).toBeTruthy()
+    })
+
+    it('stays collapsed when ?chartExpanded is a different chart id', () => {
+      renderMobile('/?chartExpanded=payments')
+      expect(screen.queryByRole('dialog')).toBeNull()
+    })
+
+    it('stays collapsed when the param is absent', () => {
+      renderMobile('/')
+      expect(screen.queryByRole('dialog')).toBeNull()
+    })
+
+    it('writes ?chartExpanded=<urlId> when the trigger is tapped', () => {
+      renderMobile('/')
+      fireEvent.click(screen.getByRole('button'))
+      expect(new URLSearchParams(location).get('chartExpanded')).toBe(
+        'membership'
+      )
+    })
+
+    it('clears the param when the sheet is closed', () => {
+      renderMobile('/?chartExpanded=membership')
+      fireEvent.click(screen.getByRole('button', { name: /Close chart/i }))
+      expect(new URLSearchParams(location).has('chartExpanded')).toBe(false)
+    })
+
+    it('two charts on one page are mutually exclusive', () => {
+      stubViewport(true)
+      render(
+        <MemoryRouter initialEntries={['/?chartExpanded=membership']}>
+          <ChartSparklineExpand
+            title="Membership trend"
+            sparklineData={[1, 2]}
+            headline={<span>m</span>}
+            urlId="membership"
+          >
+            <div data-testid="chart-membership">membership chart</div>
+          </ChartSparklineExpand>
+          <ChartSparklineExpand
+            title="Payments trend"
+            sparklineData={[3, 4]}
+            headline={<span>p</span>}
+            urlId="payments"
+          >
+            <div data-testid="chart-payments">payments chart</div>
+          </ChartSparklineExpand>
+        </MemoryRouter>
+      )
+      // Only the membership sheet is open.
+      expect(screen.getByTestId('chart-membership')).toBeTruthy()
+      expect(screen.queryByTestId('chart-payments')).toBeNull()
+    })
   })
 })

--- a/frontend/src/components/__tests__/CriteriaExplanation.test.tsx
+++ b/frontend/src/components/__tests__/CriteriaExplanation.test.tsx
@@ -23,6 +23,8 @@
 
 import { describe, it, expect, afterEach } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 
 // Provider-free unit-test render (#473): the component under test
 // uses no router / no React Query, so wrapping each render in a
@@ -453,6 +455,51 @@ describe('CriteriaExplanation', () => {
         name: /Distinguished Area Program Criteria/i,
       })
       expect(toggleButton).toHaveClass('focus-visible:ring-2')
+    })
+  })
+
+  // #980 — when a urlParam is supplied the expand state deep-links via the URL.
+  // Needs a router; the uncontrolled (no urlParam) path above stays router-free.
+  describe('URL-synced expand state (#980)', () => {
+    let location = ''
+    const LocationProbe: React.FC = () => {
+      location = useLocation().search
+      return null
+    }
+    const renderWithRouter = (entry: string) =>
+      render(
+        <MemoryRouter initialEntries={[entry]}>
+          <CriteriaExplanation urlParam="expandAreaCriteria" />
+          <LocationProbe />
+        </MemoryRouter>
+      )
+    const button = () =>
+      screen.getByRole('button', {
+        name: /Distinguished Area Program Criteria/i,
+      })
+
+    it('reads expanded state from the URL param', () => {
+      renderWithRouter('/?expandAreaCriteria=1')
+      expect(button()).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('is collapsed when the param is absent', () => {
+      renderWithRouter('/')
+      expect(button()).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('writes the param to the URL when toggled open', () => {
+      renderWithRouter('/')
+      fireEvent.click(button())
+      expect(new URLSearchParams(location).get('expandAreaCriteria')).toBe('1')
+    })
+
+    it('removes the param from the URL when toggled closed', () => {
+      renderWithRouter('/?expandAreaCriteria=1')
+      fireEvent.click(button())
+      expect(new URLSearchParams(location).has('expandAreaCriteria')).toBe(
+        false
+      )
     })
   })
 })

--- a/frontend/src/components/__tests__/DivisionAreaRecognitionPanel.test.tsx
+++ b/frontend/src/components/__tests__/DivisionAreaRecognitionPanel.test.tsx
@@ -29,11 +29,15 @@
 
 import { describe, it, expect, afterEach } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 
-// Provider-free unit-test render (#473): the component under test
-// uses no router / no React Query, so wrapping each render in a
-// fresh QueryClient + memory router was pure contention amplifier.
-const renderWithProviders = (ui: React.ReactElement) => render(ui)
+// A bare MemoryRouter (NO QueryClient) — the panel's criteria children now
+// deep-link their expand state via useUrlBoolean/useSearchParams (#980), which
+// needs router context. This stays well short of the Lesson 473 contention
+// amplifier (which was the QueryClient + router + perf-wrapper stack).
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>)
 const cleanupAllResources = () => cleanup()
 import '@testing-library/jest-dom'
 import { DivisionAreaRecognitionPanel } from '../DivisionAreaRecognitionPanel'
@@ -924,7 +928,11 @@ describe('DivisionAreaRecognitionPanel', () => {
         createDivisionWithAreas('B', ['B1']),
       ]
 
-      rerender(<DivisionAreaRecognitionPanel divisions={updatedDivisions} />)
+      rerender(
+        <MemoryRouter>
+          <DivisionAreaRecognitionPanel divisions={updatedDivisions} />
+        </MemoryRouter>
+      )
 
       expect(
         screen.getByText(/Showing 3 areas across 2 divisions/)

--- a/frontend/src/components/__tests__/DivisionCriteriaExplanation.test.tsx
+++ b/frontend/src/components/__tests__/DivisionCriteriaExplanation.test.tsx
@@ -21,7 +21,9 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import React from 'react'
 import type { ReactElement } from 'react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import { DivisionCriteriaExplanation } from '../DivisionCriteriaExplanation'
 
 // DivisionCriteriaExplanation is provider-free (useState only). Skipping
@@ -488,6 +490,44 @@ describe('DivisionCriteriaExplanation', () => {
       // Section headings (h4)
       const sectionHeadings = screen.getAllByRole('heading', { level: 4 })
       expect(sectionHeadings.length).toBeGreaterThanOrEqual(3) // Eligibility, No Net Loss, Recognition Levels
+    })
+  })
+
+  // #980 — when a urlParam is supplied the expand state deep-links via the URL.
+  describe('URL-synced expand state (#980)', () => {
+    let location = ''
+    const LocationProbe: React.FC = () => {
+      location = useLocation().search
+      return null
+    }
+    const renderWithRouter = (entry: string) =>
+      render(
+        <MemoryRouter initialEntries={[entry]}>
+          <DivisionCriteriaExplanation urlParam="expandDivisionCriteria" />
+          <LocationProbe />
+        </MemoryRouter>
+      )
+    const button = () =>
+      screen.getByRole('button', {
+        name: /Distinguished Division Program Criteria/i,
+      })
+
+    it('reads expanded state from the URL param', () => {
+      renderWithRouter('/?expandDivisionCriteria=1')
+      expect(button()).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('is collapsed when the param is absent', () => {
+      renderWithRouter('/')
+      expect(button()).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('writes the param to the URL when toggled open', () => {
+      renderWithRouter('/')
+      fireEvent.click(button())
+      expect(new URLSearchParams(location).get('expandDivisionCriteria')).toBe(
+        '1'
+      )
     })
   })
 })

--- a/frontend/src/components/__tests__/MobileDisclosure.test.tsx
+++ b/frontend/src/components/__tests__/MobileDisclosure.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 
 import { MobileDisclosure } from '../MobileDisclosure'
 
@@ -69,5 +71,71 @@ describe('MobileDisclosure (#867)', () => {
       </MobileDisclosure>
     )
     expect(container.querySelector('details')).not.toBeNull()
+  })
+
+  // #980 — when a urlParam is supplied (mobile only), the open state deep-links.
+  describe('URL-synced open state (#980)', () => {
+    let location = ''
+    const LocationProbe: React.FC = () => {
+      location = useLocation().search
+      return null
+    }
+    const renderMobile = (entry: string) => {
+      stubViewport(true)
+      return render(
+        <MemoryRouter initialEntries={[entry]}>
+          <MobileDisclosure
+            summaryLabel="Longest-serving clubs"
+            urlParam="clubsExpanded"
+          >
+            <p data-testid="payload">contents</p>
+          </MobileDisclosure>
+          <LocationProbe />
+        </MemoryRouter>
+      )
+    }
+
+    it('opens the disclosure when the URL param is present', () => {
+      const { container } = renderMobile('/?clubsExpanded=1')
+      expect(container.querySelector('details')?.hasAttribute('open')).toBe(
+        true
+      )
+    })
+
+    it('stays collapsed when the param is absent', () => {
+      const { container } = renderMobile('/')
+      expect(container.querySelector('details')?.hasAttribute('open')).toBe(
+        false
+      )
+    })
+
+    it('writes the param when the user expands the disclosure', () => {
+      const { container } = renderMobile('/')
+      const details = container.querySelector('details') as HTMLDetailsElement
+      details.open = true
+      fireEvent(details, new Event('toggle'))
+      expect(new URLSearchParams(location).get('clubsExpanded')).toBe('1')
+    })
+
+    it('removes the param when the user collapses the disclosure', () => {
+      const { container } = renderMobile('/?clubsExpanded=1')
+      const details = container.querySelector('details') as HTMLDetailsElement
+      details.open = false
+      fireEvent(details, new Event('toggle'))
+      expect(new URLSearchParams(location).has('clubsExpanded')).toBe(false)
+    })
+
+    it('keeps the desktop view chrome-free even with a urlParam', () => {
+      stubViewport(false)
+      const { container } = render(
+        <MemoryRouter>
+          <MobileDisclosure summaryLabel="x" urlParam="clubsExpanded">
+            <p data-testid="payload">contents</p>
+          </MobileDisclosure>
+        </MemoryRouter>
+      )
+      expect(container.querySelector('details')).toBeNull()
+      expect(screen.getByTestId('payload')).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/hooks/__tests__/useUrlBoolean.test.ts
+++ b/frontend/src/hooks/__tests__/useUrlBoolean.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for useUrlBoolean hook (#980)
+ *
+ * A boolean drop-in for useState<boolean>(false) that persists in a URL search
+ * param: `?key=1` when true, param absent when false (the clean default). Built
+ * on useUrlState, so it inherits the prev-callback form that preserves unrelated
+ * params (Lesson 070 / urlConcurrentWrites tripwire).
+ */
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { useUrlBoolean } from '../useUrlBoolean'
+
+function createWrapper(initialEntries: string[] = ['/']) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(MemoryRouter, { initialEntries }, children)
+}
+
+describe('useUrlBoolean', () => {
+  it('defaults to false when the param is absent', () => {
+    const { result } = renderHook(() => useUrlBoolean('expandChanges'), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current[0]).toBe(false)
+  })
+
+  it('reads true from `?key=1`', () => {
+    const { result } = renderHook(() => useUrlBoolean('expandChanges'), {
+      wrapper: createWrapper(['/?expandChanges=1']),
+    })
+    expect(result.current[0]).toBe(true)
+  })
+
+  it('writes `?key=1` to the URL when set true', () => {
+    const { result } = renderHook(
+      () => {
+        const [open, setOpen] = useUrlBoolean('expandChanges')
+        const search = useLocation().search
+        return { open, setOpen, search }
+      },
+      { wrapper: createWrapper() }
+    )
+    act(() => result.current.setOpen(true))
+    expect(result.current.open).toBe(true)
+    expect(
+      new URLSearchParams(result.current.search).get('expandChanges')
+    ).toBe('1')
+  })
+
+  it('removes the param when set back to false (clean default)', () => {
+    const { result } = renderHook(
+      () => {
+        const [open, setOpen] = useUrlBoolean('expandChanges')
+        const search = useLocation().search
+        return { open, setOpen, search }
+      },
+      { wrapper: createWrapper(['/?expandChanges=1']) }
+    )
+    act(() => result.current.setOpen(false))
+    expect(result.current.open).toBe(false)
+    expect(
+      new URLSearchParams(result.current.search).has('expandChanges')
+    ).toBe(false)
+  })
+
+  it('supports a functional updater (toggle)', () => {
+    const { result } = renderHook(() => useUrlBoolean('expandChanges'), {
+      wrapper: createWrapper(),
+    })
+    act(() => result.current[1](prev => !prev))
+    expect(result.current[0]).toBe(true)
+    act(() => result.current[1](prev => !prev))
+    expect(result.current[0]).toBe(false)
+  })
+
+  it('honours a defaultValue of true (param absent ⇒ true, `?key=0` ⇒ false)', () => {
+    const open = renderHook(
+      () => useUrlBoolean('clubsExpanded', { defaultValue: true }),
+      { wrapper: createWrapper() }
+    )
+    expect(open.result.current[0]).toBe(true)
+
+    const closed = renderHook(
+      () => useUrlBoolean('clubsExpanded', { defaultValue: true }),
+      { wrapper: createWrapper(['/?clubsExpanded=0']) }
+    )
+    expect(closed.result.current[0]).toBe(false)
+  })
+
+  it('preserves an unrelated param when toggled', () => {
+    const { result } = renderHook(
+      () => {
+        const [open, setOpen] = useUrlBoolean('expandChanges')
+        const search = useLocation().search
+        return { open, setOpen, search }
+      },
+      { wrapper: createWrapper(['/?from=2026-05-01']) }
+    )
+    act(() => result.current.setOpen(true))
+    const params = new URLSearchParams(result.current.search)
+    expect(params.get('from')).toBe('2026-05-01')
+    expect(params.get('expandChanges')).toBe('1')
+  })
+})

--- a/frontend/src/hooks/__tests__/useUrlStringSet.test.ts
+++ b/frontend/src/hooks/__tests__/useUrlStringSet.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for useUrlStringSet hook (#980)
+ *
+ * A drop-in for useState<string[]>([]) that persists a SET of string keys in a
+ * comma-joined URL param (sorted for a stable URL, deduped, param absent when
+ * empty). Built on useUrlState, so unrelated params survive (Lesson 070).
+ */
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { useUrlStringSet } from '../useUrlStringSet'
+
+function createWrapper(initialEntries: string[] = ['/']) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(MemoryRouter, { initialEntries }, children)
+}
+
+function harness(key: string, entries?: string[]) {
+  return renderHook(
+    () => {
+      const [values, setValues] = useUrlStringSet(key)
+      const search = useLocation().search
+      return { values, setValues, search }
+    },
+    { wrapper: createWrapper(entries) }
+  )
+}
+
+describe('useUrlStringSet', () => {
+  it('defaults to an empty array when the param is absent', () => {
+    const { result } = harness('historyRegions')
+    expect(result.current.values).toEqual([])
+  })
+
+  it('reads a comma-joined set from the URL', () => {
+    const { result } = harness('historyRegions', ['/?historyRegions=12,5'])
+    expect(result.current.values).toEqual(['12', '5'])
+  })
+
+  it('writes a sorted, comma-joined set to the URL', () => {
+    const { result } = harness('historyRegions')
+    act(() => result.current.setValues(['12', '5', '8']))
+    expect(
+      new URLSearchParams(result.current.search).get('historyRegions')
+    ).toBe('12,5,8')
+  })
+
+  it('removes the param when set back to empty (clean default)', () => {
+    const { result } = harness('historyRegions', ['/?historyRegions=12,5'])
+    act(() => result.current.setValues([]))
+    expect(
+      new URLSearchParams(result.current.search).has('historyRegions')
+    ).toBe(false)
+    expect(result.current.values).toEqual([])
+  })
+
+  it('supports a functional updater for toggling membership', () => {
+    const { result } = harness('historyRegions', ['/?historyRegions=12'])
+    act(() =>
+      result.current.setValues(prev =>
+        prev.includes('5') ? prev.filter(r => r !== '5') : [...prev, '5']
+      )
+    )
+    expect(result.current.values).toEqual(['12', '5'])
+  })
+
+  it('dedupes and ignores empties on read', () => {
+    const { result } = harness('historyRegions', ['/?historyRegions=12,,12,5'])
+    expect(result.current.values).toEqual(['12', '5'])
+  })
+
+  it('preserves an unrelated param when written', () => {
+    const { result } = harness('historyRegions', ['/?historyExpanded=1'])
+    act(() => result.current.setValues(['7']))
+    const params = new URLSearchParams(result.current.search)
+    expect(params.get('historyExpanded')).toBe('1')
+    expect(params.get('historyRegions')).toBe('7')
+  })
+})

--- a/frontend/src/hooks/useUrlBoolean.ts
+++ b/frontend/src/hooks/useUrlBoolean.ts
@@ -1,0 +1,40 @@
+/**
+ * useUrlBoolean — boolean URL-synced state (#980)
+ *
+ * A drop-in for `useState<boolean>(false)` that persists in a URL search param:
+ * the param is `1` when the value is the non-default, and absent when it equals
+ * the default (keeping URLs clean). Built on {@link useUrlState}, so it inherits
+ * the prev-callback write form that preserves unrelated params (Lesson 070 /
+ * urlConcurrentWrites tripwire).
+ *
+ * @example
+ * ```tsx
+ * // collapsed by default; `?expandChanges=1` when open
+ * const [open, setOpen] = useUrlBoolean('expandChanges')
+ *
+ * // expanded by default; `?clubsExpanded=0` when collapsed
+ * const [open, setOpen] = useUrlBoolean('clubsExpanded', { defaultValue: true })
+ * ```
+ */
+
+import { useUrlState } from './useUrlState'
+
+interface UseUrlBooleanOptions {
+  /** Value when the param is absent. Default `false`. */
+  defaultValue?: boolean
+}
+
+type SetBooleanAction = boolean | ((prev: boolean) => boolean)
+
+export function useUrlBoolean(
+  key: string,
+  options?: UseUrlBooleanOptions
+): [boolean, (action: SetBooleanAction) => void] {
+  const defaultValue = options?.defaultValue ?? false
+  return useUrlState<boolean>(key, defaultValue, {
+    // Anything that isn't an explicit '0' reads as true; '0' reads as false.
+    // `undefined` would fall back to the default, but '1'/'0' cover both writes.
+    parse: value => value !== '0',
+    serialize: value => (value ? '1' : '0'),
+  })
+}

--- a/frontend/src/hooks/useUrlBoolean.ts
+++ b/frontend/src/hooks/useUrlBoolean.ts
@@ -26,15 +26,21 @@ interface UseUrlBooleanOptions {
 
 type SetBooleanAction = boolean | ((prev: boolean) => boolean)
 
+// Module-scoped so the reference is stable across renders — useUrlState keys its
+// value memo and setter useCallback on `options`, so a fresh object each render
+// would needlessly churn both. Anything that isn't an explicit '0' reads true.
+const BOOLEAN_OPTIONS = {
+  parse: (value: string) => value !== '0',
+  serialize: (value: boolean) => (value ? '1' : '0'),
+}
+
 export function useUrlBoolean(
   key: string,
   options?: UseUrlBooleanOptions
 ): [boolean, (action: SetBooleanAction) => void] {
-  const defaultValue = options?.defaultValue ?? false
-  return useUrlState<boolean>(key, defaultValue, {
-    // Anything that isn't an explicit '0' reads as true; '0' reads as false.
-    // `undefined` would fall back to the default, but '1'/'0' cover both writes.
-    parse: value => value !== '0',
-    serialize: value => (value ? '1' : '0'),
-  })
+  return useUrlState<boolean>(
+    key,
+    options?.defaultValue ?? false,
+    BOOLEAN_OPTIONS
+  )
 }

--- a/frontend/src/hooks/useUrlStringSet.ts
+++ b/frontend/src/hooks/useUrlStringSet.ts
@@ -15,7 +15,6 @@
  * ```
  */
 
-import { useMemo } from 'react'
 import { useUrlState } from './useUrlState'
 
 /** Dedupe, preserving first-seen order, dropping empty entries. */
@@ -25,19 +24,19 @@ function dedupe(values: string[]): string[] {
 
 type SetStringSetAction = string[] | ((prev: string[]) => string[])
 
+// Module-scoped (stable references) so useUrlState's value memo + setter
+// useCallback don't churn each render. With stable options + default, the
+// parsed array useUrlState returns is itself stable when the param is unchanged
+// — so consumers can use it directly in effect/memo deps (no extra memo here).
+const EMPTY: string[] = []
+const STRING_SET_OPTIONS = {
+  parse: (raw: string) => dedupe(raw.split(',')),
+  // Sort on write so the URL is order-stable regardless of click order.
+  serialize: (values: string[]) => dedupe(values).sort().join(','),
+}
+
 export function useUrlStringSet(
   key: string
 ): [string[], (action: SetStringSetAction) => void] {
-  const [value, setValue] = useUrlState<string[]>(key, [], {
-    parse: raw => dedupe(raw.split(',')),
-    // Sort on write so the URL is order-stable regardless of click order.
-    serialize: values => dedupe(values).sort().join(','),
-  })
-
-  // useUrlState returns a fresh array each render; memoize on the joined value
-  // so consumers can safely use the result in effect/memo dependency arrays.
-  const joined = value.join(',')
-  const stable = useMemo(() => (joined ? joined.split(',') : []), [joined])
-
-  return [stable, setValue]
+  return useUrlState<string[]>(key, EMPTY, STRING_SET_OPTIONS)
 }

--- a/frontend/src/hooks/useUrlStringSet.ts
+++ b/frontend/src/hooks/useUrlStringSet.ts
@@ -1,0 +1,43 @@
+/**
+ * useUrlStringSet — set-of-strings URL-synced state (#980)
+ *
+ * A drop-in for `useState<string[]>([])` that persists a SET of string keys in a
+ * comma-joined URL param: sorted for a stable/shareable URL, deduped, empties
+ * dropped, and the param removed entirely when the set is empty (clean default).
+ * Built on {@link useUrlState}, so unrelated params survive (Lesson 070 /
+ * urlConcurrentWrites tripwire).
+ *
+ * @example
+ * ```tsx
+ * const [regions, setRegions] = useUrlStringSet('historyRegions')
+ * // toggle membership
+ * setRegions(prev => (prev.includes(id) ? prev.filter(r => r !== id) : [...prev, id]))
+ * ```
+ */
+
+import { useMemo } from 'react'
+import { useUrlState } from './useUrlState'
+
+/** Dedupe, preserving first-seen order, dropping empty entries. */
+function dedupe(values: string[]): string[] {
+  return [...new Set(values.filter(v => v.length > 0))]
+}
+
+type SetStringSetAction = string[] | ((prev: string[]) => string[])
+
+export function useUrlStringSet(
+  key: string
+): [string[], (action: SetStringSetAction) => void] {
+  const [value, setValue] = useUrlState<string[]>(key, [], {
+    parse: raw => dedupe(raw.split(',')),
+    // Sort on write so the URL is order-stable regardless of click order.
+    serialize: values => dedupe(values).sort().join(','),
+  })
+
+  // useUrlState returns a fresh array each render; memoize on the joined value
+  // so consumers can safely use the result in effect/memo dependency arrays.
+  const joined = value.join(',')
+  const stable = useMemo(() => (joined ? joined.split(',') : []), [joined])
+
+  return [stable, setValue]
+}

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -665,6 +665,7 @@ const ClubDetailPage: React.FC = () => {
               <div className="club-panel__body">
                 {filteredMembershipTrend.length > 0 ? (
                   <ChartSparklineExpand
+                    urlId="membership"
                     title="Membership Trend"
                     sparklineData={membershipSparkline}
                     headline={

--- a/frontend/src/pages/DistrictChangesPage.tsx
+++ b/frontend/src/pages/DistrictChangesPage.tsx
@@ -5,6 +5,7 @@ import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
 import { useSnapshotDiff } from '../hooks/useSnapshotDiff'
 import { useUrlDatePair } from '../hooks/useUrlDatePair'
+import { useUrlStringSet } from '../hooks/useUrlStringSet'
 import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
 import { DistrictSubnav } from '../components/DistrictSubnav'
 import { DatePairPicker } from '../components/DatePairPicker'
@@ -43,13 +44,21 @@ const CATEGORY_GROUPS: { category: DiffEventCategory; heading: string }[] = [
   { category: 'dcp-goals', heading: 'DCP goal changes' },
 ]
 
-const ChangeGroup: React.FC<{ heading: string; events: DiffEvent[] }> = ({
-  heading,
-  events,
-}) => {
+const ChangeGroup: React.FC<{
+  category: DiffEventCategory
+  heading: string
+  events: DiffEvent[]
+  /** Groups are open by default; collapsed when listed in ?expandChanges (#980). */
+  collapsed: boolean
+  onToggle: (category: DiffEventCategory, open: boolean) => void
+}> = ({ category, heading, events, collapsed, onToggle }) => {
   if (events.length === 0) return null
   return (
-    <details className="changes-group" open>
+    <details
+      className="changes-group"
+      open={!collapsed}
+      onToggle={e => onToggle(category, e.currentTarget.open)}
+    >
       <summary className="changes-group__summary">
         {heading}{' '}
         <span className="changes-group__count">({events.length})</span>
@@ -81,6 +90,16 @@ const DistrictChangesPage: React.FC = () => {
   )
   const dates = useMemo(() => cachedDates?.dates ?? [], [cachedDates?.dates])
   const { from, to, setFrom, setTo } = useUrlDatePair(dates)
+
+  // Change-groups are open by default; ?expandChanges lists the categories the
+  // user has COLLAPSED (so an all-default page keeps a clean URL). The page owns
+  // this state and passes it down (R3) — every entry path (typed URL, share,
+  // reload, click) converges here. (#980)
+  const [collapsedGroups, setCollapsedGroups] = useUrlStringSet('expandChanges')
+  const handleGroupToggle = (category: DiffEventCategory, open: boolean) =>
+    setCollapsedGroups(prev =>
+      open ? prev.filter(c => c !== category) : [...prev, category]
+    )
 
   // The pair must be two distinct dates with from strictly before to. Each
   // invalid shape gets its own explicit prompt (R17) and skips the fetch —
@@ -230,8 +249,11 @@ const DistrictChangesPage: React.FC = () => {
                     {CATEGORY_GROUPS.map(({ category, heading }) => (
                       <ChangeGroup
                         key={category}
+                        category={category}
                         heading={heading}
                         events={eventsByCategory.get(category) ?? []}
+                        collapsed={collapsedGroups.includes(category)}
+                        onToggle={handleGroupToggle}
                       />
                     ))}
                   </div>

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -543,7 +543,10 @@ const DistrictDetailPageInner: React.FC = () => {
                 {/* Longest-serving clubs — secondary detail, folded behind a
                     disclosure below 768 px (audit §Epic B, #867). On desktop
                     MobileDisclosure renders the leaderboard directly. */}
-                <MobileDisclosure summaryLabel="Longest-serving clubs">
+                <MobileDisclosure
+                  summaryLabel="Longest-serving clubs"
+                  urlParam="clubsExpanded"
+                >
                   <LongestServingClubsLeaderboard
                     clubs={allClubs}
                     {...(districtId !== undefined && { districtId })}

--- a/frontend/src/pages/DistrictTrendsPage.tsx
+++ b/frontend/src/pages/DistrictTrendsPage.tsx
@@ -207,6 +207,7 @@ const DistrictTrendsPage: React.FC = () => {
               // fixed-height div but do NOT gate rendering on viewport
               // intersection.
               <ChartSparklineExpand
+                urlId="membership"
                 title="Membership trend"
                 sparklineData={membershipSparkline}
                 headline={
@@ -249,6 +250,7 @@ const DistrictTrendsPage: React.FC = () => {
             {/* Membership Payments Chart (#243) */}
             {paymentsTrendData ? (
               <ChartSparklineExpand
+                urlId="payments"
                 title="Payments trend"
                 sparklineData={paymentsSparkline}
                 headline={

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -20,6 +20,8 @@ import { useMyDistrict } from '../hooks/useMyDistrict'
 import { useLastVisit } from '../hooks/useLastVisit'
 import { useUrlSort } from '../hooks/useUrlSort'
 import { useUrlState } from '../hooks/useUrlState'
+import { useUrlBoolean } from '../hooks/useUrlBoolean'
+import { useUrlStringSet } from '../hooks/useUrlStringSet'
 import { useDebounce } from '../hooks/useDebounce'
 import { SortableHeader } from '../components/SortableHeader'
 import { LazyComparisonPanel as ComparisonPanel } from '../components/LazyCharts'
@@ -154,12 +156,13 @@ const DistrictsPage: React.FC = () => {
     setSelectedDate,
   } = useUrlProgramYear()
 
-  // Historical rank tracking state
-  const [selectedRegionsForHistory, setSelectedRegionsForHistory] = useState<
-    string[]
-  >([])
+  // Historical rank tracking state — URL-synced so a shared/reloaded link
+  // restores the selection and its disclosure (#980, R3: the page owns it).
+  const [selectedRegionsForHistory, setSelectedRegionsForHistory] =
+    useUrlStringSet('historyRegions')
   // Mobile-friendly collapsible region filters
-  const [isHistoryRegionExpanded, setIsHistoryRegionExpanded] = useState(false)
+  const [isHistoryRegionExpanded, setIsHistoryRegionExpanded] =
+    useUrlBoolean('historyExpanded')
 
   // Fetch cached dates from CDN snapshot index (#233)
   // Uses the same data source as DistrictDetailPage for consistency

--- a/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
 import DistrictChangesPage from '../DistrictChangesPage'
 import { useDistrictCachedDates } from '../../hooks/useDistrictData'
 import { useSnapshotDiff } from '../../hooks/useSnapshotDiff'
@@ -187,5 +188,81 @@ describe('DistrictChangesPage', () => {
     renderPage()
     expect(screen.getByTestId('changes-single')).toBeInTheDocument()
     expect(screen.queryByTestId('changes-headline')).not.toBeInTheDocument()
+  })
+})
+
+// #980 — change-groups are open by default; a user's collapses persist in
+// ?expandChanges (the value lists the COLLAPSED categories, so an all-default
+// page keeps a clean URL). A shared/reloaded link restores those collapses.
+describe('DistrictChangesPage — deep-linked group collapse (#980)', () => {
+  let location = ''
+  const LocationProbe: React.FC = () => {
+    location = useLocation().search
+    return null
+  }
+  function renderWithDiff(initialEntry: string) {
+    mockedDates.mockReturnValue({
+      data: { dates: ['2026-05-25', '2026-05-26'] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDistrictCachedDates>)
+    mockedDiff.mockReturnValue({
+      data: diffFixture(),
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useSnapshotDiff>)
+    return render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path="/district/:districtId/changes"
+            element={<DistrictChangesPage />}
+          />
+        </Routes>
+        <LocationProbe />
+      </MemoryRouter>
+    )
+  }
+  /** Find the <details> whose summary text matches. */
+  const groupByHeading = (container: HTMLElement, re: RegExp) =>
+    Array.from(container.querySelectorAll('details')).find(d =>
+      d.querySelector('summary')?.textContent?.match(re)
+    ) as HTMLDetailsElement | undefined
+
+  it('opens every group by default (param absent)', () => {
+    const { container } = renderWithDiff('/district/61/changes')
+    expect(groupByHeading(container, /Clubs that joined/)?.open).toBe(true)
+    expect(
+      groupByHeading(container, /Distinguished status changes/)?.open
+    ).toBe(true)
+  })
+
+  it('collapses only the categories named in ?expandChanges', () => {
+    const { container } = renderWithDiff(
+      '/district/61/changes?expandChanges=club-added'
+    )
+    expect(groupByHeading(container, /Clubs that joined/)?.open).toBe(false)
+    expect(
+      groupByHeading(container, /Distinguished status changes/)?.open
+    ).toBe(true)
+  })
+
+  it('writes the category to ?expandChanges when a group is collapsed', () => {
+    const { container } = renderWithDiff('/district/61/changes')
+    const group = groupByHeading(container, /Clubs that joined/)!
+    group.open = false
+    fireEvent(group, new Event('toggle'))
+    expect(new URLSearchParams(location).get('expandChanges')).toBe(
+      'club-added'
+    )
+  })
+
+  it('removes the category from ?expandChanges when a group is re-opened', () => {
+    const { container } = renderWithDiff(
+      '/district/61/changes?expandChanges=club-added'
+    )
+    const group = groupByHeading(container, /Clubs that joined/)!
+    group.open = true
+    fireEvent(group, new Event('toggle'))
+    expect(new URLSearchParams(location).has('expandChanges')).toBe(false)
   })
 })

--- a/frontend/src/pages/__tests__/DistrictsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.test.tsx
@@ -581,6 +581,31 @@ describe('DistrictsPage - Layout Order (#83)', () => {
     }
   })
 
+  // #980 — the historical-rank region selection and its mobile disclosure now
+  // deep-link via the URL, so a shared/reloaded link restores them.
+  it('restores the historical region selection from ?historyRegions', async () => {
+    setupWithData()
+    renderWithProviders(<DistrictsPage />, {
+      initialEntries: ['/?historyRegions=1'],
+    })
+    await screen.findByText('District 1')
+    // Region "1" is pre-selected from the URL → the count reflects it.
+    expect(screen.getByText(/Select Regions \(1 regions,/)).toBeInTheDocument()
+    expect(screen.getByText(/from 1 selected region/i)).toBeInTheDocument()
+  })
+
+  it('restores the history region disclosure open state from ?historyExpanded', async () => {
+    setupWithData()
+    renderWithProviders(<DistrictsPage />, {
+      initialEntries: ['/?historyExpanded=1'],
+    })
+    await screen.findByText('District 1')
+    const selectRegionsButton = screen.getByRole('button', {
+      name: /Select Regions \(/i,
+    })
+    expect(selectRegionsButton).toHaveAttribute('aria-expanded', 'true')
+  })
+
   it('renders the redesign h1 "District Rankings" (#356)', async () => {
     setupWithData()
 

--- a/tasks/lessons/144-a-useurlstate-wrapper-must-hoist-its-options-or-it-busts-the-value-memo-every-render.md
+++ b/tasks/lessons/144-a-useurlstate-wrapper-must-hoist-its-options-or-it-busts-the-value-memo-every-render.md
@@ -1,0 +1,98 @@
+---
+id: '144'
+category: lesson
+tags: [react, frontend, hooks, router, url-state, performance]
+auto_load: true
+date: 2026-05-30
+issues: [980, 969]
+---
+
+# Lesson 144 — A `useUrlState` wrapper must hoist its parse/serialize options, or it silently busts the value-memo (and churns the setter) every render
+
+**Date:** 2026-05-30
+**Issue:** #980 (epic #969 Sprint 4 — deep-link disclosure/expand state)
+
+## What happened
+
+`useUrlState` memoizes the parsed value and `useCallback`s the setter, both keyed
+on `[rawValue, defaultValue, options]` — so that a custom `parse` returning a
+fresh array/object yields a **stable reference** across renders when the param is
+unchanged (that stability guard was itself added to stop a 117-row re-sort on an
+unrelated keystroke). The new boolean/set wrappers first did the natural thing:
+
+```ts
+export function useUrlStringSet(key) {
+  const [value, setValue] = useUrlState(key, [], {
+    // ❌ fresh [] AND fresh
+    parse: raw => dedupe(raw.split(',')), //    options object
+    serialize: vals => dedupe(vals).sort().join(','), //    EVERY render
+  })
+  // …then a SECOND useMemo to re-stabilize what the busted memo no longer did
+}
+```
+
+Every render passed a **new `options` object and a new `[]` default**, so
+`useUrlState`'s `useMemo`/`useCallback` deps changed every render: the value memo
+recomputed (fresh array each time) and the setter identity churned. The wrapper
+then bolted a second `useMemo` on top to re-stabilize the reference — papering
+over the memo it had just defeated one layer down.
+
+## The transferable principle
+
+**When you wrap a hook that memoizes on an `options`/`config` argument, the
+wrapper must pass a reference-stable argument — hoist it to module scope (or
+`useMemo` it) — or every consumer of that hook's memoization silently gets the
+unmemoized path.** A fresh object/array literal in a hook call is invisible at
+the call site but is a dependency-array bust one level down. The fix is to move
+the pure pieces out of render:
+
+```ts
+const EMPTY: string[] = []
+const STRING_SET_OPTIONS = {
+  parse: (raw: string) => dedupe(raw.split(',')),
+  serialize: (vals: string[]) => dedupe(vals).sort().join(','),
+}
+export function useUrlStringSet(key: string) {
+  return useUrlState<string[]>(key, EMPTY, STRING_SET_OPTIONS) // stable → memo holds
+}
+```
+
+With stable options + default, the inner memo does its job and the extra wrapper
+memo disappears entirely. Smell test: **if you add a `useMemo` to re-stabilize a
+value a hook you're calling already promises to stabilize, the bug is an unstable
+argument you're feeding that hook, not a missing memo in your wrapper.**
+
+## Corollary — the router-free opt-in split
+
+A second, separable decision in the same sprint: a leaf component (criteria
+disclosure, `MobileDisclosure`, `ChartSparklineExpand`) that _optionally_
+deep-links via a `urlParam?`/`urlId?` prop must **split its state source into two
+sub-components** — a `UrlSynced*` that calls the URL hook and a `Local*` that
+calls `useState` — and pick between them in the parent's `return`. You cannot
+write `urlParam ? useUrlBoolean(...) : useState(...)` (conditional hook), and an
+_unconditional_ `useUrlBoolean` would call `useSearchParams` and throw for every
+consumer not under a router. The split keeps the no-prop path genuinely
+router-free (the #473 provider-free-unit-test convention stays intact) while the
+opt-in path syncs. This is leaf-level UI state with no API-data derivation, so it
+does **not** owe R3 page-ownership the way program-year/filter state does — but
+when several children must coordinate one param (a collapsed-category _set_, a
+region set + its disclosure), own it at the page and pass it down.
+
+## How to apply
+
+- Wrapping `useUrlState` (or any hook with an `options` dep): module-scope the
+  `parse`/`serialize`/`default`. Never pass an object/array literal inline.
+- After a /simplify pass that "adds a memo to stabilize X," check whether X was
+  already supposed to be stable — fix the upstream argument instead.
+- Opt-in URL sync on a reusable leaf → split `UrlSynced*`/`Local*` sub-components;
+  don't make the router a hard dependency of every consumer.
+
+## Related
+
+- [[070-setSearchParams-prev-races-in-batched-updates]] — the prev-callback write
+  form these wrappers inherit; preserves unrelated params (tripwire-guarded).
+- [[129-render-phase-prop-sync-must-compare-by-value-when-the-parent-rebuilds-the-prop]]
+  — same family: a fresh reference each render silently breaks a downstream
+  identity check / memo.
+- `frontend/src/hooks/useUrlState.ts` (the memo keyed on `options`),
+  `useUrlBoolean.ts` / `useUrlStringSet.ts` (the module-scoped options).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -119,6 +119,7 @@
 - **141** [tests, playwright, e2e, verification, frontend, accessibility] — A page-sweep tripwire passes vacuously on nav chrome; gate each route on a content sentinel, not a bare element count (#887, #888)
 - **142** [css, frontend, verification, tests, accessibility] — 142-a-new-component-stylesheet-must-be-wired-into-the-import-graph-tests-wont-catch-an-orphan
 - **143** [automation, sprint-runner, verification, tdd, bash] — A probe whose production feed was deferred reports UNKNOWN forever; the verification sprint is where you drive it end-to-end against the real feed (#932, #933)
+- **144** [react, frontend, hooks, router, url-state, performance] — A `useUrlState` wrapper must hoist its parse/serialize options, or it silently busts the value-memo (and churns the setter) every render (#980, #969)
 - **144** [router, react, frontend, scope, verification] — A cap (or any invariant) enforced only on the mutation path is bypassed the moment the value becomes URL-seedable (#978, #969)
 - **145** [router, react, hooks, frontend, scope] — A URL param that's a pipeline step layered on the filtered set must NOT join the wholesale filter-reconcile key set (#979, #969)
 - **145** [cls, performance, frontend, react, verification, ci] — An incidental post-data re-render can be load-bearing for CLS; a "cleanup" that removes it regresses layout only on the CI font environment (#978, #969)


### PR DESCRIPTION
Part of epic #969 (Sprint 4). Closes #980 on merge + verification (label-driven, not via `Closes` keyword — see #626/L106).

Makes 6 ephemeral disclosure/expand surfaces survive **reload / back / share** by syncing their state to URL search params, building on the existing `useUrlState` prev-callback form (Lesson 070 — unrelated params preserved; tripwire stays green).

## New shared hooks
- `useUrlBoolean(key, { defaultValue })` — `?key=1` when non-default, param absent at default. Drop-in for `useState<boolean>`.
- `useUrlStringSet(key)` — comma-joined, sorted, deduped set; param absent when empty. Drop-in for `useState<string[]>`.

Both pass **module-scoped** options/defaults so `useUrlState`'s value-memo + setter stay reference-stable (see lesson 144).

## Surfaces wired (param ← control)
| Surface | Param |
|---|---|
| `/district/:id/divisions` area + division criteria toggles | `?expandAreaCriteria`, `?expandDivisionCriteria` |
| `/district/:id` mobile longest-serving-clubs disclosure | `?clubsExpanded` |
| `/` historical-rank disclosure + region selector | `?historyExpanded`, `?historyRegions` |
| `/district/:id/trends` (×2) + `/club/:clubId` mobile chart expand | `?chartExpanded=<chart-id>` |
| `/district/:id/changes` change-group collapse | `?expandChanges` (set of **collapsed** categories — clean URL when all default-open) |

## Design notes
- **Opt-in leaf sync:** reusable leaves (`MobileDisclosure`, `ChartSparklineExpand`, criteria) take an optional `urlParam`/`urlId`; the state source is split into `UrlSynced*`/`Local*` sub-components so the no-prop path never calls `useSearchParams` (stays router-free, #473 spirit). Pages with coordinated multi-child state (`DistrictsPage`, `DistrictChangesPage`) own the hook directly (R3).
- **`?chartExpanded=<id>`** holds *which* chart sheet is open (mutually-exclusive sheet → one param, distinct id per chart on the trends page).

## Testing (TDD, red→green per surface)
- New round-trip unit tests for both hooks + all 6 surfaces (read URL→state, write state→URL, preserve unrelated params, clean-default).
- Full frontend suite green: **3211 passed**. R22 page-mount check, prettier, lint, typecheck all green.
- `/simplify` + fresh-context `/review` (verdict APPROVE, no High/Medium) applied.

Live verification on the PR preview (dual-engine Playwright) to follow in the sprint evidence comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)