### PR TITLE
feat(a11y): deep-link Methodology sections + fragment-on-mount auto-expand (#981)

### DIFF
--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -1,9 +1,16 @@
-import React, { useCallback, useState } from 'react'
-import { Link } from 'react-router-dom'
+import React, { useCallback, useEffect, useMemo } from 'react'
+import { Link, useLocation } from 'react-router-dom'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useUrlState } from '../hooks/useUrlState'
 import CollapsibleSection from '../components/CollapsibleSection'
 import JumpToChip from '../components/JumpToChip'
+import {
+  OPEN_SECTIONS_PARAM,
+  parseOpenSections,
+  serializeOpenSections,
+  sectionFromHash,
+} from '../utils/methodologyUrl'
 
 /* Methodology page (#368). Authored fresh from analytics-core as the
    source of truth — Borda formula, DCP thresholds, club health
@@ -32,6 +39,15 @@ const SECTIONS: ReadonlyArray<{ id: string; num: string; title: string }> = [
   { id: 'changelog', num: '10', title: 'Changelog' },
 ]
 
+// Module-scope so the codec's parse/serialize identity is stable — keeps
+// useUrlState's memoised value and setter stable across renders.
+const SECTION_ID_SET: ReadonlySet<string> = new Set(SECTIONS.map(s => s.id))
+const EMPTY_OPEN: ReadonlyArray<string> = []
+const OPEN_SECTIONS_OPTS = {
+  parse: parseOpenSections(SECTION_ID_SET),
+  serialize: serializeOpenSections,
+}
+
 const MethodologyPage: React.FC = () => {
   useDocumentTitle('Methodology')
 
@@ -39,22 +55,59 @@ const MethodologyPage: React.FC = () => {
   // (useIsMobile is false in jsdom too, so the static-content tests still
   // see the full page). #877.
   const isMobile = useIsMobile()
-  const [openIds, setOpenIds] = useState<ReadonlySet<string>>(() => new Set())
 
-  const toggle = useCallback((id: string) => {
-    setOpenIds(prev => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
+  // Which sections are open is URL state (#981): `?openSections=a,b` round-trips
+  // through reload / back / share. The parse whitelists ids against
+  // SECTION_ID_SET, so a hand-edited/shared URL can't seed a phantom open id
+  // (Lesson 144 — the seed path bypasses the toggle's own guards).
+  const [openSections, setOpenSections] = useUrlState<string[]>(
+    OPEN_SECTIONS_PARAM,
+    EMPTY_OPEN as string[],
+    OPEN_SECTIONS_OPTS
+  )
+  const openIds = useMemo(() => new Set(openSections), [openSections])
+
+  const toggle = useCallback(
+    (id: string) => {
+      setOpenSections(prev =>
+        prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
+      )
+    },
+    [setOpenSections]
+  )
+
+  // A TOC anchor (and the fragment-on-mount directive below) must reveal its
+  // target — otherwise the jump lands on a collapsed heading and the reader
+  // sees nothing below it. Idempotent: re-expanding an open section is a no-op.
+  const expand = useCallback(
+    (id: string) => {
+      setOpenSections(prev => (prev.includes(id) ? prev : [...prev, id]))
+    },
+    [setOpenSections]
+  )
+
+  // Fragment as an on-mount directive: a shared `/methodology#borda-count` link
+  // expands that section and scrolls to it. The whitelist in sectionFromHash
+  // means an unknown `#bogus` is a no-op. setOpenSections is this page's only
+  // URL writer, so there's no same-batch sibling to race (Lesson 070 N/A here).
+  // Keyed on the hash so a deep-link mount fires exactly once per fragment.
+  const { hash } = useLocation()
+  useEffect(() => {
+    const id = sectionFromHash(hash, SECTION_ID_SET)
+    if (!id) return
+    expand(id)
+    // Scroll after the expand paints. scrollIntoView (unlike the native locked
+    // hash scroll) honours scroll-margin-top on .methodology-section, so the
+    // heading clears the sticky chip bar (Lessons 138/139). Double rAF lets the
+    // newly-revealed content lay out first.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document
+          .getElementById(id)
+          ?.scrollIntoView?.({ behavior: 'auto', block: 'start' })
+      })
     })
-  }, [])
-
-  // A TOC anchor must reveal its target — otherwise the jump lands on a
-  // collapsed heading and the reader sees nothing below it.
-  const expand = useCallback((id: string) => {
-    setOpenIds(prev => (prev.has(id) ? prev : new Set(prev).add(id)))
-  }, [])
+  }, [hash, expand])
 
   return (
     <div className="methodology-page">

--- a/frontend/src/pages/__tests__/MethodologyPage.deeplink.test.tsx
+++ b/frontend/src/pages/__tests__/MethodologyPage.deeplink.test.tsx
@@ -1,0 +1,128 @@
+/* /methodology deep-link open-section state (#981, epic #969 Sprint 5).
+
+   The section expand/collapse state is encoded in the URL so reload / back /
+   share preserve it:
+     - `?openSections=a,b` seeds the open set on mount (round-trips through the
+       toggle), and
+     - `#section` auto-expands its target on mount (a shared anchor link).
+
+   These mount the page AT the URL (Lesson 144 — the seed path bypasses every
+   guard the click path enforces, so it must be exercised directly), not just by
+   driving the controls. useIsMobile is forced true so sections are collapsible
+   and `aria-expanded` is observable. */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+
+const mockIsMobile = vi.fn()
+vi.mock('../../hooks/useIsMobile', () => ({
+  useIsMobile: () => mockIsMobile(),
+}))
+
+import MethodologyPage from '../MethodologyPage'
+
+// Surfaces the live router location so assertions can read the URL the page
+// writes back (the round-trip half of the contract).
+const LocationProbe: React.FC = () => {
+  const loc = useLocation()
+  return (
+    <div data-testid="loc">
+      {loc.pathname}
+      {loc.search}
+      {loc.hash}
+    </div>
+  )
+}
+
+const renderAt = (url: string) =>
+  render(
+    <MemoryRouter initialEntries={[url]}>
+      <MethodologyPage />
+      <LocationProbe />
+    </MemoryRouter>
+  )
+
+const toggleFor = (name: RegExp) => screen.getByRole('button', { name })
+
+describe('MethodologyPage — ?openSections seed (#981)', () => {
+  beforeEach(() => mockIsMobile.mockReturnValue(true))
+
+  it('expands the sections named in ?openSections on mount', () => {
+    renderAt('/methodology?openSections=borda-count,glossary')
+    expect(toggleFor(/Borda count scoring/i)).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+    expect(toggleFor(/Glossary/i)).toHaveAttribute('aria-expanded', 'true')
+    // An unlisted section stays collapsed.
+    expect(toggleFor(/Refresh cadence/i)).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+  })
+
+  it('ignores an unknown id in ?openSections (no phantom expand)', () => {
+    renderAt('/methodology?openSections=bogus,borda-count')
+    expect(toggleFor(/Borda count scoring/i)).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+    // Exactly one section open — the bogus id seeded nothing.
+    const open = screen
+      .getAllByRole('button')
+      .filter(b => b.getAttribute('aria-expanded') === 'true')
+    expect(open).toHaveLength(1)
+  })
+
+  it('round-trips: toggling a section closed updates ?openSections', async () => {
+    renderAt('/methodology?openSections=borda-count,glossary')
+    await userEvent.click(toggleFor(/Borda count scoring/i))
+    expect(toggleFor(/Borda count scoring/i)).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+    // The remaining open section is reflected in the URL; the closed one is gone.
+    const loc = screen.getByTestId('loc').textContent || ''
+    expect(loc).toContain('openSections=glossary')
+    expect(loc).not.toContain('borda-count')
+  })
+
+  it('round-trips: opening a section adds it to ?openSections', async () => {
+    renderAt('/methodology')
+    await userEvent.click(toggleFor(/Caveats/i))
+    const loc = screen.getByTestId('loc').textContent || ''
+    expect(loc).toContain('openSections=caveats')
+  })
+})
+
+describe('MethodologyPage — #fragment auto-expand on mount (#981)', () => {
+  beforeEach(() => mockIsMobile.mockReturnValue(true))
+
+  it('auto-expands the section named in the location hash', () => {
+    renderAt('/methodology#borda-count')
+    expect(toggleFor(/Borda count scoring/i)).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+  })
+
+  it('ignores an unknown fragment', () => {
+    renderAt('/methodology#bogus')
+    const open = screen
+      .getAllByRole('button')
+      .filter(b => b.getAttribute('aria-expanded') === 'true')
+    expect(open).toHaveLength(0)
+  })
+
+  it('expands the fragment target even when ?openSections lists others', () => {
+    renderAt('/methodology?openSections=glossary#borda-count')
+    expect(toggleFor(/Glossary/i)).toHaveAttribute('aria-expanded', 'true')
+    expect(toggleFor(/Borda count scoring/i)).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+  })
+})

--- a/frontend/src/utils/__tests__/methodologyUrl.test.ts
+++ b/frontend/src/utils/__tests__/methodologyUrl.test.ts
@@ -1,0 +1,87 @@
+/* methodologyUrl codec — the URL contract for /methodology open-section state
+   (#981, epic #969 Sprint 5). The parse is the chokepoint every entry path
+   (typed URL, shared link, back button) flows through, so the whitelist /
+   dedup invariants are asserted here, not only at the handler (Lesson 144). */
+
+import { describe, it, expect } from 'vitest'
+import {
+  OPEN_SECTIONS_PARAM,
+  parseOpenSections,
+  serializeOpenSections,
+  sectionFromHash,
+} from '../methodologyUrl'
+
+const VALID = new Set(['borda-count', 'glossary', 'caveats'])
+const parse = parseOpenSections(VALID)
+
+describe('methodologyUrl — parseOpenSections', () => {
+  it('keeps only whitelisted section ids', () => {
+    expect(parse('borda-count,bogus,glossary')).toEqual([
+      'borda-count',
+      'glossary',
+    ])
+  })
+
+  it('drops an entirely unknown value to an empty list (no phantom seed)', () => {
+    expect(parse('not-a-section')).toEqual([])
+  })
+
+  it('de-dups repeated ids, preserving first-seen order', () => {
+    expect(parse('glossary,borda-count,glossary')).toEqual([
+      'glossary',
+      'borda-count',
+    ])
+  })
+
+  it('trims whitespace and ignores empty segments', () => {
+    expect(parse(' borda-count , , glossary ')).toEqual([
+      'borda-count',
+      'glossary',
+    ])
+  })
+
+  it('returns an empty list for an empty string', () => {
+    expect(parse('')).toEqual([])
+  })
+})
+
+describe('methodologyUrl — serializeOpenSections', () => {
+  it('joins ids with commas', () => {
+    expect(serializeOpenSections(['borda-count', 'glossary'])).toBe(
+      'borda-count,glossary'
+    )
+  })
+
+  it('serializes an empty list to the empty string (the clean-URL default)', () => {
+    expect(serializeOpenSections([])).toBe('')
+  })
+
+  it('round-trips through parse', () => {
+    const ids = ['glossary', 'caveats']
+    expect(parse(serializeOpenSections(ids))).toEqual(ids)
+  })
+})
+
+describe('methodologyUrl — sectionFromHash', () => {
+  it('resolves a leading-# fragment to a known id', () => {
+    expect(sectionFromHash('#borda-count', VALID)).toBe('borda-count')
+  })
+
+  it('resolves a bare id too', () => {
+    expect(sectionFromHash('glossary', VALID)).toBe('glossary')
+  })
+
+  it('returns null for an unknown fragment', () => {
+    expect(sectionFromHash('#bogus', VALID)).toBeNull()
+  })
+
+  it('returns null for an empty hash', () => {
+    expect(sectionFromHash('', VALID)).toBeNull()
+  })
+})
+
+describe('methodologyUrl — constants', () => {
+  it('uses a stable search-param key', () => {
+    expect(OPEN_SECTIONS_PARAM).toBe('openSections')
+  })
+})

--- a/frontend/src/utils/methodologyUrl.ts
+++ b/frontend/src/utils/methodologyUrl.ts
@@ -1,0 +1,58 @@
+/**
+ * methodologyUrl — URL contract for the /methodology page's open-section state
+ * (#981, epic #969 Sprint 5 — deep-link Methodology sections).
+ *
+ * Two entry points encode "which sections are open" so reload / back / share
+ * all preserve it:
+ *   - `?openSections=borda-count,glossary` — the persistent multi-section state,
+ *     round-tripped through `useUrlState`.
+ *   - `#borda-count` fragment — an on-mount directive to expand + scroll to one
+ *     section (the natural shape of a shared anchor link).
+ *
+ * Both are adversarial input: a hand-edited or shared URL is a write path that
+ * bypasses every guard on the toggle handler (Lesson 144). So the parse here is
+ * the chokepoint — it whitelists ids against the page's known section list and
+ * de-dups, exactly so `?openSections=bogus` or `#bogus` can never seed a phantom
+ * open id.
+ */
+
+/** URL search-param key for the persistent multi-section open state. */
+export const OPEN_SECTIONS_PARAM = 'openSections'
+
+/**
+ * Parse `?openSections=` into a de-duped, whitelisted, order-preserving id list.
+ *
+ * Curried on the valid-id set so the page can build a module-scope `parse` with
+ * stable identity (keeps `useUrlState`'s memoised value/setter stable).
+ */
+export const parseOpenSections =
+  (validIds: ReadonlySet<string>) =>
+  (raw: string): string[] => {
+    const seen = new Set<string>()
+    const out: string[] = []
+    for (const part of raw.split(',')) {
+      const id = part.trim()
+      if (id && validIds.has(id) && !seen.has(id)) {
+        seen.add(id)
+        out.push(id)
+      }
+    }
+    return out
+  }
+
+/** Serialize an open-section id list back to the `?openSections=` value. */
+export const serializeOpenSections = (ids: ReadonlyArray<string>): string =>
+  ids.join(',')
+
+/**
+ * Resolve a location hash (`#borda-count`) to a known section id, or null when
+ * the fragment is empty / unknown. Whitelisted for the same reason as parse —
+ * a shared `#bogus` must not drive an expand/scroll.
+ */
+export const sectionFromHash = (
+  hash: string,
+  validIds: ReadonlySet<string>
+): string | null => {
+  const id = hash.replace(/^#/, '').trim()
+  return id && validIds.has(id) ? id : null
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       }
     },
     "frontend": {
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.0",


### PR DESCRIPTION
Part of epic #969 (Sprint 5). Closes #981.

## What
Wire the `/methodology` section expand/collapse state to the URL so **reload, back, and shared links** all preserve it.

- **`?openSections=a,b`** — the persistent multi-section open set, round-tripped through `useUrlState` (replaces the local `useState` `openIds`). Toggling a section adds/removes its id; URL stays clean when empty.
- **`#section` fragment** — an on-mount directive: expand the named section and `scrollIntoView`. Uses `scrollIntoView` (not the native locked hash scroll) so the heading honours `scroll-margin-top` and clears the sticky chip bar (Lessons 138/139).

New `utils/methodologyUrl.ts` codec **whitelists** ids against the known section list on parse, so a hand-edited/shared `?openSections=bogus` or `#bogus` can't seed a phantom open id — the seed path is exercised directly in tests because it bypasses the toggle's own guard (Lesson 144).

## Tests (TDD)
- `utils/__tests__/methodologyUrl.test.ts` — parse whitelist/dedup/trim, serialize, `sectionFromHash`, round-trip (13).
- `pages/__tests__/MethodologyPage.deeplink.test.tsx` — mounts **at** the URL: `?openSections=` seed, unknown-id rejection, open/close round-trip to the URL, `#fragment` auto-expand, unknown-fragment no-op, fragment + query coexistence (7).
- Full frontend suite green (3231 passed); no-page-mounts guard passes (page test lives in `pages/__tests__/`).

## Acceptance
- [x] `/methodology#<section>` auto-expands & scrolls on load
- [x] survives reload / back / share (via `?openSections=`)
- [x] round-trip test
- [x] suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)