### PR TITLE
feat(divisions): surface per-area current-round missing club-visit list on AreaPerformance (#973)

### DIFF
--- a/frontend/src/test-utils/generators/divisionPerformance.ts
+++ b/frontend/src/test-utils/generators/divisionPerformance.ts
@@ -275,6 +275,12 @@ export const areaPerformanceArb = (options?: {
               // confirmed/provisional/not-distinguished states.
               snapshotDate: '2026-03-15',
             }),
+            // #973: the area arb models aggregate visit status, not per-club
+            // rows, so there are no enumerable missing clubs. snapshotDate
+            // '2026-03-15' (March) ⇒ round 2.
+            currentRound: 2 as const,
+            clubsMissingCurrentRoundVisit: [],
+            clubsMissingCurrentRoundVisitIneligible: [],
           }
         })
     })

--- a/frontend/src/utils/__tests__/areaRecognitionState.test.ts
+++ b/frontend/src/utils/__tests__/areaRecognitionState.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from 'vitest'
 import {
   deriveAreaRecognitionState,
   getAreaVisitDeadlines,
+  getCurrentVisitRound,
   type AreaRecognitionInput,
 } from '../areaRecognitionState'
 
@@ -35,6 +36,42 @@ function input(
     ...overrides,
   }
 }
+
+describe('getCurrentVisitRound (snapshot-date → active visit round)', () => {
+  // R1 window: Jul–Nov (due Nov 30). R2 window: Dec–Jun (due May 31).
+  it('returns round 1 for the start of the program year (Jul 1)', () => {
+    expect(getCurrentVisitRound('2025-07-01')).toBe(1)
+  })
+
+  it('returns round 1 mid first-round window (Sep)', () => {
+    expect(getCurrentVisitRound('2025-09-15')).toBe(1)
+  })
+
+  it('returns round 1 on the R1 deadline day itself (Nov 30)', () => {
+    expect(getCurrentVisitRound('2025-11-30')).toBe(1)
+  })
+
+  it('flips to round 2 the day after the R1 deadline (Dec 1)', () => {
+    expect(getCurrentVisitRound('2025-12-01')).toBe(2)
+  })
+
+  it('returns round 2 in the new calendar year (Jan)', () => {
+    expect(getCurrentVisitRound('2026-01-15')).toBe(2)
+  })
+
+  it('returns round 2 on the R2 deadline day itself (May 31)', () => {
+    expect(getCurrentVisitRound('2026-05-31')).toBe(2)
+  })
+
+  it('returns round 2 on the last day of the program year (Jun 30)', () => {
+    expect(getCurrentVisitRound('2026-06-30')).toBe(2)
+  })
+
+  it('tolerates a full ISO timestamp (slices to date)', () => {
+    expect(getCurrentVisitRound('2025-11-30T15:00:00Z')).toBe(1)
+    expect(getCurrentVisitRound('2025-12-01T00:00:00Z')).toBe(2)
+  })
+})
 
 describe('getAreaVisitDeadlines (program-year anchoring)', () => {
   it('anchors deadlines to the snapshot date program year (Aug 2026 → PY 2026-2027)', () => {

--- a/frontend/src/utils/__tests__/extractDivisionPerformance.test.ts
+++ b/frontend/src/utils/__tests__/extractDivisionPerformance.test.ts
@@ -3922,3 +3922,111 @@ describe('countVisitCompletions', () => {
     })
   })
 })
+
+describe('AreaPerformance — per-area current-round missing club-visit list (#973)', () => {
+  /**
+   * Build a single-area snapshot. Each `club` entry is merged into both the
+   * divisionPerformance row (carries the visit-award fields) and a matching
+   * clubPerformance row (carries Club Status). Field name for the visit award
+   * is the caller's responsibility so we can exercise R1 vs R2.
+   */
+  function snapshotWithClubs(
+    clubs: Array<{
+      number: string
+      name: string
+      status: string
+      novVisit?: string
+      mayVisit?: string
+      mayVisitLower?: string
+    }>
+  ) {
+    return {
+      divisionPerformance: clubs.map(c => ({
+        Division: 'A',
+        Area: '01',
+        'Area Club Base': String(clubs.length),
+        'Club Number': c.number,
+        'Club Name': c.name,
+        ...(c.novVisit !== undefined ? { 'Nov Visit award': c.novVisit } : {}),
+        ...(c.mayVisit !== undefined ? { 'May Visit award': c.mayVisit } : {}),
+        ...(c.mayVisitLower !== undefined
+          ? { 'May visit award': c.mayVisitLower }
+          : {}),
+      })),
+      clubPerformance: clubs.map(c => ({
+        'Club Number': c.number,
+        'Club Name': c.name,
+        'Club Status': c.status,
+        'Club Distinguished Status': '',
+      })),
+    }
+  }
+
+  it('exposes currentRound derived from the snapshot date (R1 window)', () => {
+    const snapshot = snapshotWithClubs([
+      { number: '1', name: 'Alpha', status: 'Active', novVisit: '1' },
+    ])
+    const area = extractDivisionPerformance(snapshot, '2025-09-15')[0].areas[0]
+    expect(area.currentRound).toBe(1)
+  })
+
+  it('exposes currentRound derived from the snapshot date (R2 window)', () => {
+    const snapshot = snapshotWithClubs([
+      { number: '1', name: 'Alpha', status: 'Active', mayVisit: '1' },
+    ])
+    const area = extractDivisionPerformance(snapshot, '2026-02-15')[0].areas[0]
+    expect(area.currentRound).toBe(2)
+  })
+
+  it('lists ACTIVE clubs missing the R1 visit, by number+name, sorted', () => {
+    const snapshot = snapshotWithClubs([
+      { number: '2', name: 'Bravo', status: 'Active', novVisit: '1' }, // done
+      { number: '1', name: 'Alpha', status: 'Active', novVisit: '0' }, // missing
+      { number: '3', name: 'Charlie', status: 'Active' }, // missing (field absent)
+    ])
+    const area = extractDivisionPerformance(snapshot, '2025-09-15')[0].areas[0]
+    expect(area.clubsMissingCurrentRoundVisit).toEqual([
+      { clubNumber: '1', clubName: 'Alpha' },
+      { clubNumber: '3', clubName: 'Charlie' },
+    ])
+    expect(area.clubsMissingCurrentRoundVisitIneligible).toEqual([])
+  })
+
+  it('flags suspended/ineligible clubs separately, excluding them from the active list', () => {
+    const snapshot = snapshotWithClubs([
+      { number: '1', name: 'Alpha', status: 'Active', novVisit: '0' },
+      { number: '2', name: 'Bravo', status: 'Suspended', novVisit: '0' },
+      { number: '3', name: 'Charlie', status: 'Ineligible', novVisit: '0' },
+    ])
+    const area = extractDivisionPerformance(snapshot, '2025-09-15')[0].areas[0]
+    expect(area.clubsMissingCurrentRoundVisit).toEqual([
+      { clubNumber: '1', clubName: 'Alpha' },
+    ])
+    expect(area.clubsMissingCurrentRoundVisitIneligible).toEqual([
+      { clubNumber: '2', clubName: 'Bravo', status: 'Suspended' },
+      { clubNumber: '3', clubName: 'Charlie', status: 'Ineligible' },
+    ])
+  })
+
+  it('uses the R2 visit field and honours the lowercase "May visit award" fallback (#268)', () => {
+    const snapshot = snapshotWithClubs([
+      { number: '1', name: 'Alpha', status: 'Active', mayVisitLower: '1' }, // done via lowercase
+      { number: '2', name: 'Bravo', status: 'Active', mayVisitLower: '0' }, // missing
+    ])
+    const area = extractDivisionPerformance(snapshot, '2026-02-15')[0].areas[0]
+    expect(area.currentRound).toBe(2)
+    expect(area.clubsMissingCurrentRoundVisit).toEqual([
+      { clubNumber: '2', clubName: 'Bravo' },
+    ])
+  })
+
+  it('returns empty lists when every active club has the current-round visit', () => {
+    const snapshot = snapshotWithClubs([
+      { number: '1', name: 'Alpha', status: 'Active', novVisit: '1' },
+      { number: '2', name: 'Bravo', status: 'Active', novVisit: '1' },
+    ])
+    const area = extractDivisionPerformance(snapshot, '2025-09-15')[0].areas[0]
+    expect(area.clubsMissingCurrentRoundVisit).toEqual([])
+    expect(area.clubsMissingCurrentRoundVisitIneligible).toEqual([])
+  })
+})

--- a/frontend/src/utils/areaRecognitionState.ts
+++ b/frontend/src/utils/areaRecognitionState.ts
@@ -93,6 +93,23 @@ function programYearStartYear(dateStr: string): number {
 }
 
 /**
+ * Returns the currently-active visit round for `snapshotDate`.
+ *
+ *   - Round 1: Jul–Nov window (due Nov 30 of the PY start year)
+ *   - Round 2: Dec–Jun window (due May 31 of the PY end year)
+ *
+ * The Nov 30 deadline day itself is still round 1 (the round only flips on
+ * Dec 1); the May 31 deadline day and Jun 30 (last day of the PY) are round 2.
+ * String-slice month parsing mirrors `programYearStartYear` — `new Date()` is
+ * timezone-sensitive and would mis-bucket UTC-midnight dates west of UTC.
+ */
+export function getCurrentVisitRound(snapshotDate: string): 1 | 2 {
+  const iso = toIsoDate(snapshotDate)
+  const month = Number.parseInt(iso.slice(5, 7), 10)
+  return month >= 7 && month <= 11 ? 1 : 2
+}
+
+/**
  * Returns the R1 and R2 deadlines for the program year containing `snapshotDate`.
  */
 export function getAreaVisitDeadlines(snapshotDate: string): {

--- a/frontend/src/utils/divisionStatus.ts
+++ b/frontend/src/utils/divisionStatus.ts
@@ -49,6 +49,27 @@ export interface VisitStatus {
 }
 
 /**
+ * A club in an area that has NOT completed the current round's qualifying
+ * club-visit. Identified by club number + name for direct UI display (#973).
+ */
+export interface MissingVisitClub {
+  /** Club Number (snapshot identifier; falls back to Club Name when absent) */
+  clubNumber: string
+  /** Club Name, for human-readable display */
+  clubName: string
+}
+
+/**
+ * A suspended/ineligible club missing the current-round visit, flagged
+ * separately from the active list so the UI can present it differently
+ * (per operator: "active only, flag others"). Carries the raw `Club Status`.
+ */
+export interface IneligibleMissingVisitClub extends MissingVisitClub {
+  /** Raw `Club Status` from clubPerformance (e.g. "Suspended", "Ineligible") */
+  status: string
+}
+
+/**
  * Performance metrics and status for a single area
  *
  * Contains all data needed to display area performance in the
@@ -85,6 +106,25 @@ export interface AreaPerformance {
    * provisional logic locally.
    */
   recognitionState: AreaRecognitionState
+  /**
+   * Currently-active visit round (1 = Jul–Nov / Nov 30, 2 = Dec–Jun / May 31),
+   * derived from the snapshot date via `getCurrentVisitRound` (#973). Single
+   * source of truth — never re-derive the round from a date in a component.
+   */
+  currentRound: 1 | 2
+  /**
+   * Active clubs in the area that have NOT completed the **current round's**
+   * qualifying club-visit (raw `Nov Visit award` for R1, `May Visit award` /
+   * `May visit award` for R2 ≠ `'1'`). Sorted by club number. Suspended /
+   * ineligible clubs are excluded here and surfaced in the flagged list (#973).
+   */
+  clubsMissingCurrentRoundVisit: MissingVisitClub[]
+  /**
+   * Suspended / ineligible clubs missing the current-round visit, flagged
+   * separately (per operator: "active only, flag others"). Sorted by club
+   * number (#973).
+   */
+  clubsMissingCurrentRoundVisitIneligible: IneligibleMissingVisitClub[]
 }
 
 /**

--- a/frontend/src/utils/extractDivisionPerformance.ts
+++ b/frontend/src/utils/extractDivisionPerformance.ts
@@ -12,6 +12,8 @@ import type {
   DivisionPerformance,
   AreaPerformance,
   VisitStatus,
+  MissingVisitClub,
+  IneligibleMissingVisitClub,
 } from './divisionStatus.js'
 import {
   calculateRequiredDistinguishedClubs,
@@ -22,8 +24,65 @@ import {
   checkAreaQualifying,
 } from './divisionStatus.js'
 import { calculateDivisionDistinguishedRequirement } from './divisionGapAnalysis.js'
-import { deriveAreaRecognitionState } from './areaRecognitionState.js'
+import {
+  deriveAreaRecognitionState,
+  getCurrentVisitRound,
+} from './areaRecognitionState.js'
 import { logger } from './logger'
+
+/**
+ * Raw snapshot field(s) holding the qualifying club-visit award for a round.
+ * R1 → `Nov Visit award`. R2 → `May Visit award`, with the lowercase
+ * `May visit award` fallback the CDN sometimes emits (bug #268).
+ */
+function currentRoundVisitFields(round: 1 | 2): string[] {
+  return round === 1
+    ? ['Nov Visit award']
+    : ['May Visit award', 'May visit award']
+}
+
+/**
+ * A club has completed the round's visit when any candidate field is exactly
+ * `'1'` (string) or `1` (number) — mirrors `countVisitCompletions`.
+ */
+function hasCompletedRoundVisit(
+  club: Record<string, unknown>,
+  fields: string[]
+): boolean {
+  return fields.some(f => {
+    const v = club[f]
+    return v === '1' || v === 1
+  })
+}
+
+/**
+ * A club is flagged ineligible (not part of the "active" missing list) when its
+ * `Club Status` is suspended/closed/ineligible. Active (or unknown/absent
+ * status) clubs go in the primary missing list. Operator rule: "active only,
+ * flag others".
+ */
+function isIneligibleStatus(status: string): boolean {
+  return /suspend|close|ineligib/i.test(status)
+}
+
+/** Resolve a club's display number (falls back to name) from a snapshot row. */
+function clubNumberOf(club: Record<string, unknown>): string {
+  return (
+    (typeof club['Club Number'] === 'string' ||
+    typeof club['Club Number'] === 'number'
+      ? String(club['Club Number'])
+      : '') ||
+    (typeof club['Club'] === 'string' || typeof club['Club'] === 'number'
+      ? String(club['Club'])
+      : '') ||
+    (typeof club['Club Name'] === 'string' ? club['Club Name'] : '')
+  )
+}
+
+/** Resolve a club's display name from a snapshot row. */
+function clubNameOf(club: Record<string, unknown>): string {
+  return typeof club['Club Name'] === 'string' ? club['Club Name'] : ''
+}
 
 /**
  * Fallback snapshot date when none is provided by the caller. Today's date
@@ -682,6 +741,14 @@ function extractAreasForDivision(
     }
     const secondRound = calculateVisitStatus(secondRoundCompleted, clubBase)
 
+    // #973: enumerate the clubs missing the CURRENT round's qualifying visit,
+    // split into active (primary list) vs suspended/ineligible (flagged).
+    const currentRound = getCurrentVisitRound(snapshotDate)
+    const visitFields = currentRoundVisitFields(currentRound)
+    const clubsMissingCurrentRoundVisit: MissingVisitClub[] = []
+    const clubsMissingCurrentRoundVisitIneligible: IneligibleMissingVisitClub[] =
+      []
+
     for (const clubRaw of clubs) {
       const club = clubRaw as Record<string, unknown>
 
@@ -726,7 +793,36 @@ function extractAreasForDivision(
           distinguishedClubs++
         }
       }
+
+      // #973: collect clubs missing the current round's visit. The visit-award
+      // fields live on the divisionPerformance `club` row; `Club Status` is
+      // cross-referenced from clubPerformance (the row that carries it).
+      if (!hasCompletedRoundVisit(club, visitFields)) {
+        const clubStatus =
+          clubPerf && typeof clubPerf['Club Status'] === 'string'
+            ? (clubPerf['Club Status'] as string)
+            : ''
+        const clubNumber = clubNumberOf(club)
+        const clubName = clubNameOf(club)
+        if (isIneligibleStatus(clubStatus)) {
+          clubsMissingCurrentRoundVisitIneligible.push({
+            clubNumber,
+            clubName,
+            status: clubStatus,
+          })
+        } else {
+          clubsMissingCurrentRoundVisit.push({ clubNumber, clubName })
+        }
+      }
     }
+
+    // Stable order for deterministic rendering + tests.
+    clubsMissingCurrentRoundVisit.sort((a, b) =>
+      a.clubNumber.localeCompare(b.clubNumber)
+    )
+    clubsMissingCurrentRoundVisitIneligible.sort((a, b) =>
+      a.clubNumber.localeCompare(b.clubNumber)
+    )
 
     // Calculate derived metrics
     const netGrowth = calculateNetGrowth(paidClubs, clubBase)
@@ -770,6 +866,9 @@ function extractAreasForDivision(
       secondRoundVisits: secondRound,
       isQualified,
       recognitionState,
+      currentRound,
+      clubsMissingCurrentRoundVisit,
+      clubsMissingCurrentRoundVisitIneligible,
     })
   }
 


### PR DESCRIPTION
## Summary
Sprint 1 of epic #976. Extends `AreaPerformance` so the per-area progress text (Sprint 2) can **name** the clubs still needing a club-visit report for the **current round** — today this is aggregated away in `extractDivisionPerformance.ts`.

Pure data/utility sprint — **no UI change** (consumed in Sprint 2).

## Changes
- **`getCurrentVisitRound(snapshotDate)`** (`areaRecognitionState.ts`) — single source of truth for the active round from the snapshot date. R1 window Jul–Nov (Nov 30 day itself is still R1), R2 window Dec–Jun. String-slice month parsing, consistent with `programYearStartYear`.
- **`AreaPerformance`** (`divisionStatus.ts`) gains:
  - `currentRound: 1 | 2`
  - `clubsMissingCurrentRoundVisit: { clubNumber, clubName }[]` — **active** clubs whose current-round visit field (`Nov Visit award` R1, `May Visit award`/`May visit award` R2, ≠ `'1'`) is missing. Sorted by club number.
  - `clubsMissingCurrentRoundVisitIneligible: { clubNumber, clubName, status }[]` — suspended/closed/ineligible clubs missing the visit, flagged separately (operator: "active only, flag others").
- **`extractDivisionPerformance.ts`** populates the three fields, cross-referencing `clubPerformance` `Club Status` for eligibility. The 75% metric / `clubBase` denominator are **unchanged** — this only *enumerates*.

## Acceptance criteria
- [x] `AreaPerformance` exposes `currentRound`, `clubsMissingCurrentRoundVisit`, flagged-ineligible list
- [x] Current-round derivation correct across PY boundary (Nov 30 / Dec 1 / May 31 / Jun 30 / Jul 1) — boundary unit tests
- [x] Missing-club lists match raw `Nov/May Visit award`; suspended excluded from active list (lowercase `May visit award` fallback #268 honoured)
- [x] Existing `extractDivisionPerformance` / `divisionStatus` tests still green; 14 new tests added

## Verification
TDD: 14 RED tests → GREEN. Full frontend suite **3261/3261 pass**; unit project (pre-push hook) **2585/2585**. Typecheck clean. No-page-mounts guard passes. No UI surface to drive on the preview (pure data); verified via code-proof unit tests per the data-sprint convention in `tasks/rules.md`.

Closes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)