### PR TITLE
feat(divisions): area text — name clubs still needing a visit + state visit qualifying metric & Distinguished impact (#974)

### DIFF
--- a/frontend/src/components/DivisionAreaProgressSummary.tsx
+++ b/frontend/src/components/DivisionAreaProgressSummary.tsx
@@ -36,7 +36,6 @@ import { renderRecognitionBadge } from '../utils/areaRecognitionBadge'
 import {
   generateAreaProgressText,
   AreaProgressText,
-  ClubVisitInfo,
 } from '../utils/areaProgressText'
 import {
   calculateDivisionGapAnalysis,
@@ -203,24 +202,17 @@ export const DivisionAreaProgressSummary: React.FC<
           distinguishedClubs: area.distinguishedClubs,
         })
 
-        // Extract club visit info from area data
-        const visitInfo: ClubVisitInfo = {
-          firstRoundCompleted: area.firstRoundVisits.completed,
-          secondRoundCompleted: area.secondRoundVisits.completed,
-          totalClubs: area.clubBase,
-        }
-
-        // Create area with division context for progress text generation
+        // Create area with division context for progress text generation.
+        // The current-round visit fields (#973) and recognitionState (#832)
+        // travel on `area`, so the generator reads them directly (#974).
         const areaWithDivision: AreaWithDivision = {
           ...area,
           divisionId: division.divisionId,
         }
 
-        // Generate progress text with actual visit data
         const progressText = generateAreaProgressText(
           areaWithDivision,
-          gapAnalysis,
-          visitInfo
+          gapAnalysis
         )
 
         return {

--- a/frontend/src/components/__tests__/AreaProgressSummary.test.tsx
+++ b/frontend/src/components/__tests__/AreaProgressSummary.test.tsx
@@ -59,6 +59,10 @@ const createArea = (
       percentage: 50,
       meetsThreshold: false,
     },
+    // Mid-PY snapshot (2026-03-15) ⇒ current round is 2 (#973/#974).
+    currentRound: 2,
+    clubsMissingCurrentRoundVisit: [],
+    clubsMissingCurrentRoundVisitIneligible: [],
     status: 'distinguished',
     isQualified: true,
     ...overrides,
@@ -960,6 +964,10 @@ describe('AreaProgressSummary', () => {
               percentage: 50,
               meetsThreshold: false,
             },
+            clubsMissingCurrentRoundVisit: [
+              { clubNumber: '111', clubName: 'North Grenville' },
+              { clubNumber: '222', clubName: 'Manotick' },
+            ],
           }),
           divisionId: 'A',
         },
@@ -967,8 +975,11 @@ describe('AreaProgressSummary', () => {
 
       renderWithProviders(<DivisionAreaProgressSummary divisions={divisions} />)
 
-      // Club visit status should show progress toward 75% threshold
-      expect(screen.getByText(/Club visits:/)).toBeInTheDocument()
+      // Current-round visit status names the active clubs still missing a visit
+      // and states the 75% qualifying metric (#974).
+      expect(
+        screen.getByText(/Round 2 club visits:.*North Grenville.*Manotick/)
+      ).toBeInTheDocument()
       expect(screen.getByText(/75%/)).toBeInTheDocument()
     })
 
@@ -1002,9 +1013,10 @@ describe('AreaProgressSummary', () => {
 
       renderWithProviders(<DivisionAreaProgressSummary divisions={divisions} />)
 
-      // Should show both rounds meet 75% threshold for President's Distinguished
+      // Current round (R2) met ⇒ states the visit requirement is satisfied and
+      // won't block Distinguished recognition (#974, recognitionState-driven).
       expect(
-        screen.getByText(/club visits meeting 75% threshold/)
+        screen.getByText(/won't block Distinguished recognition/)
       ).toBeInTheDocument()
     })
 

--- a/frontend/src/test-utils/areaFixture.ts
+++ b/frontend/src/test-utils/areaFixture.ts
@@ -9,14 +9,36 @@
  * preserving pre-#832 "tier name appears in badge" assertions.
  */
 import type { AreaPerformance } from '../utils/divisionStatus'
-import { deriveAreaRecognitionState } from '../utils/areaRecognitionState'
+import {
+  deriveAreaRecognitionState,
+  getCurrentVisitRound,
+} from '../utils/areaRecognitionState'
+
+/**
+ * The Sprint-1 (#973) current-round visit fields a component fixture must carry
+ * for the area-progress presenter (#974) to render without re-deriving the
+ * round. Defaulted here so callers that only care about recognition badges
+ * don't have to spell them out; pass them explicitly when a test asserts on the
+ * named missing-club clause.
+ */
+type VisitFields = Pick<
+  AreaPerformance,
+  | 'currentRound'
+  | 'clubsMissingCurrentRoundVisit'
+  | 'clubsMissingCurrentRoundVisitIneligible'
+>
 
 export function withRecognitionState(
-  fixture: Omit<AreaPerformance, 'recognitionState'>,
+  fixture: Omit<AreaPerformance, 'recognitionState' | keyof VisitFields> &
+    Partial<VisitFields>,
   snapshotDate = '2026-03-15'
 ): AreaPerformance {
   return {
     ...fixture,
+    currentRound: fixture.currentRound ?? getCurrentVisitRound(snapshotDate),
+    clubsMissingCurrentRoundVisit: fixture.clubsMissingCurrentRoundVisit ?? [],
+    clubsMissingCurrentRoundVisitIneligible:
+      fixture.clubsMissingCurrentRoundVisitIneligible ?? [],
     recognitionState: deriveAreaRecognitionState({
       clubBase: fixture.clubBase,
       paidClubs: fixture.paidClubs,

--- a/frontend/src/utils/__tests__/areaProgressText.test.ts
+++ b/frontend/src/utils/__tests__/areaProgressText.test.ts
@@ -11,20 +11,34 @@
  * - Distinguished with incremental gaps to Select and President's
  * - Not distinguished with all gaps described incrementally
  * - Net club loss scenario with eligibility explanation
- * - Club visit status display (complete, partial, unknown)
+ * - Current-round club-visit text: named missing clubs + Distinguished impact (#974)
  * - Edge cases (0 clubs, 1 club)
  *
  * Requirements: 5.1, 5.2, 5.3, 5.6, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7
  */
 
 import { describe, it, expect } from 'vitest'
-import { generateAreaProgressText, ClubVisitInfo } from '../areaProgressText'
+import { generateAreaProgressText } from '../areaProgressText'
 import { AreaWithDivision } from '../../components/DivisionAreaProgressSummary'
 import { calculateAreaGapAnalysis } from '../areaGapAnalysis'
-import { DistinguishedStatus } from '../divisionStatus'
+import {
+  DistinguishedStatus,
+  calculateVisitStatus,
+  MissingVisitClub,
+  IneligibleMissingVisitClub,
+} from '../divisionStatus'
+import {
+  deriveAreaRecognitionState,
+  getCurrentVisitRound,
+  type AreaRecognitionState,
+} from '../areaRecognitionState'
 
 /**
- * Helper function to create an AreaWithDivision object for testing
+ * Build an AreaWithDivision for the gap/level tests. Visit data defaults to
+ * "all clubs visited" with a snapshot-derived `recognitionState`, so the
+ * (Sprint 1 #973) current-round fields are consistent without each test
+ * having to spell them out. Current-round visit *behaviour* is exercised
+ * separately via `createRoundArea` below.
  */
 function createArea(
   areaId: string,
@@ -33,7 +47,17 @@ function createArea(
   paidClubs: number,
   distinguishedClubs: number
 ): AreaWithDivision {
-  // Determine status based on metrics
+  const snapshotDate = '2026-05-15' // PY 2025-26, round 2 in progress
+  const allVisited = calculateVisitStatus(clubBase, clubBase)
+  const recognitionState = deriveAreaRecognitionState({
+    clubBase,
+    paidClubs,
+    distinguishedClubs,
+    firstRoundVisitMet: allVisited.meetsThreshold,
+    secondRoundVisitMet: allVisited.meetsThreshold,
+    snapshotDate,
+  })
+
   let status: DistinguishedStatus = 'not-distinguished'
   if (paidClubs < clubBase) {
     status = 'not-qualified'
@@ -47,35 +71,14 @@ function createArea(
     distinguishedClubs,
     netGrowth: paidClubs - clubBase,
     requiredDistinguishedClubs: Math.ceil(clubBase * 0.5),
-    firstRoundVisits: {
-      completed: 0,
-      required: Math.ceil(clubBase * 0.75),
-      percentage: 0,
-      meetsThreshold: false,
-    },
-    secondRoundVisits: {
-      completed: 0,
-      required: Math.ceil(clubBase * 0.75),
-      percentage: 0,
-      meetsThreshold: false,
-    },
+    firstRoundVisits: allVisited,
+    secondRoundVisits: allVisited,
     status,
     isQualified: paidClubs >= clubBase,
-  }
-}
-
-/**
- * Helper function to create ClubVisitInfo for testing
- */
-function createVisitInfo(
-  firstRoundCompleted: number,
-  secondRoundCompleted: number,
-  totalClubs: number
-): ClubVisitInfo {
-  return {
-    firstRoundCompleted,
-    secondRoundCompleted,
-    totalClubs,
+    recognitionState,
+    currentRound: getCurrentVisitRound(snapshotDate),
+    clubsMissingCurrentRoundVisit: [],
+    clubsMissingCurrentRoundVisitIneligible: [],
   }
 }
 
@@ -85,7 +88,7 @@ describe('generateAreaProgressText', () => {
    * no further gaps should be mentioned.
    */
   describe("President's Distinguished achieved", () => {
-    it('should describe achievement when both visit rounds meet 75% threshold', () => {
+    it('describes achievement and confirms visits do not block recognition', () => {
       // 4 clubs, 5 paid (club base + 1), 3 distinguished (50% + 1 = 3)
       const area = createArea('A1', 'A', 4, 5, 3)
       const gapAnalysis = calculateAreaGapAnalysis({
@@ -93,54 +96,37 @@ describe('generateAreaProgressText', () => {
         paidClubs: 5,
         distinguishedClubs: 3,
       })
-      // 75% of 4 = 3, so 3+ visits meets threshold
-      const visitInfo = createVisitInfo(3, 3, 4)
 
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.currentLevel).toBe('presidents')
       expect(result.areaLabel).toBe('Area A1 (Division A)')
       expect(result.progressText).toContain("President's Distinguished")
-      expect(result.progressText).toContain('club visits meeting 75% threshold')
+      expect(result.progressText).toContain(
+        "visits won't block Distinguished recognition"
+      )
       // Should NOT mention any gaps
       expect(result.progressText).not.toContain('For Select')
       expect(result.progressText).not.toContain('For Distinguished')
     })
 
-    it('should describe achievement with partial club visits', () => {
+    it('includes the current-round visit clause', () => {
       const area = createArea('B2', 'B', 4, 5, 3)
       const gapAnalysis = calculateAreaGapAnalysis({
         clubBase: 4,
         paidClubs: 5,
         distinguishedClubs: 3,
       })
-      const visitInfo = createVisitInfo(4, 2, 4)
 
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.currentLevel).toBe('presidents')
       expect(result.progressText).toContain("President's Distinguished")
-      expect(result.progressText).toContain('Club visits:')
-      // Should NOT mention any gaps
+      expect(result.progressText).toContain('Round 2 club visits:')
       expect(result.progressText).not.toContain('For Select')
     })
 
-    it('should describe achievement with unknown club visits', () => {
-      const area = createArea('C3', 'C', 4, 5, 3)
-      const gapAnalysis = calculateAreaGapAnalysis({
-        clubBase: 4,
-        paidClubs: 5,
-        distinguishedClubs: 3,
-      })
-
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
-
-      expect(result.currentLevel).toBe('presidents')
-      expect(result.progressText).toContain("President's Distinguished")
-      expect(result.progressText).toContain('Club visits: status unknown')
-    })
-
-    it('should include all metrics in the text', () => {
+    it('should mention the achievement', () => {
       const area = createArea('D4', 'D', 4, 5, 3)
       const gapAnalysis = calculateAreaGapAnalysis({
         clubBase: 4,
@@ -148,10 +134,8 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 3,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
-      // President's Distinguished doesn't show metrics in parentheses
-      // but should mention the achievement
       expect(result.progressText).toContain("President's Distinguished status")
     })
   })
@@ -170,9 +154,8 @@ describe('generateAreaProgressText', () => {
         paidClubs: 4,
         distinguishedClubs: 3,
       })
-      const visitInfo = createVisitInfo(3, 2, 4)
 
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.currentLevel).toBe('select')
       expect(result.progressText).toContain('Select Distinguished status')
@@ -185,18 +168,17 @@ describe('generateAreaProgressText', () => {
       expect(result.progressText).not.toContain('For Distinguished')
     })
 
-    it('should include club visit status', () => {
+    it('includes the current-round visit clause', () => {
       const area = createArea('B2', 'B', 4, 4, 3)
       const gapAnalysis = calculateAreaGapAnalysis({
         clubBase: 4,
         paidClubs: 4,
         distinguishedClubs: 3,
       })
-      const visitInfo = createVisitInfo(4, 4, 4)
 
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
-      expect(result.progressText).toContain('Club visits:')
+      expect(result.progressText).toContain('Round 2 club visits:')
     })
   })
 
@@ -207,16 +189,14 @@ describe('generateAreaProgressText', () => {
   describe('Distinguished with incremental gaps to Select and Presidents', () => {
     it('should describe achievement and incremental gaps', () => {
       // 4 clubs, 4 paid (no net loss), 2 distinguished (50% = 2)
-      // Distinguished achieved, Select needs 1 more distinguished, Presidents needs 1 more distinguished + 1 paid
       const area = createArea('A1', 'A', 4, 4, 2)
       const gapAnalysis = calculateAreaGapAnalysis({
         clubBase: 4,
         paidClubs: 4,
         distinguishedClubs: 2,
       })
-      const visitInfo = createVisitInfo(2, 1, 4)
 
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.currentLevel).toBe('distinguished')
       expect(result.progressText).toContain('Distinguished status')
@@ -236,32 +216,23 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 2,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
-      // The text should build incrementally
-      // Select gap mentions distinguished clubs needed
-      // President's gap should mention "also" to indicate building on previous
       expect(result.progressText).toContain('Select Distinguished')
       expect(result.progressText).toContain("President's Distinguished")
     })
 
-    it('should include club visit status showing visits needed for 75%', () => {
+    it('includes the current-round visit clause', () => {
       const area = createArea('C3', 'C', 4, 4, 2)
       const gapAnalysis = calculateAreaGapAnalysis({
         clubBase: 4,
         paidClubs: 4,
         distinguishedClubs: 2,
       })
-      // 75% of 4 = 3, first round has 3 (meets), second has 0 (needs 3)
-      const visitInfo = createVisitInfo(3, 0, 4)
 
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
-      expect(result.progressText).toContain('Club visits:')
-      expect(result.progressText).toContain('first-round meets 75% threshold')
-      expect(result.progressText).toContain(
-        'second-round needs 3 visits for 75%'
-      )
+      expect(result.progressText).toContain('Round 2 club visits:')
     })
   })
 
@@ -278,9 +249,8 @@ describe('generateAreaProgressText', () => {
         paidClubs: 4,
         distinguishedClubs: 1,
       })
-      const visitInfo = createVisitInfo(2, 0, 4)
 
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.currentLevel).toBe('none')
       expect(result.progressText).toContain('not yet distinguished')
@@ -300,27 +270,11 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 0,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
-      // Distinguished needs 2 clubs (50% of 4)
-      // Select needs 3 clubs (50% + 1), so 1 additional beyond Distinguished
-      // President's needs 3 distinguished + 1 paid
       expect(result.progressText).toContain('For Distinguished')
       expect(result.progressText).toContain('For Select Distinguished')
       expect(result.progressText).toContain("President's Distinguished")
-    })
-
-    it('should include club visit status unknown when not provided', () => {
-      const area = createArea('C3', 'C', 4, 4, 1)
-      const gapAnalysis = calculateAreaGapAnalysis({
-        clubBase: 4,
-        paidClubs: 4,
-        distinguishedClubs: 1,
-      })
-
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
-
-      expect(result.progressText).toContain('Club visits: status unknown')
     })
   })
 
@@ -331,16 +285,14 @@ describe('generateAreaProgressText', () => {
   describe('Net club loss scenario with eligibility explanation', () => {
     it('should explain eligibility requirement first (already has enough distinguished)', () => {
       // 4 clubs, 3 paid (net club loss), 2 distinguished
-      // Once eligibility is met, Distinguished requirements would be met (2 = 50% of 4)
       const area = createArea('A1', 'A', 4, 3, 2)
       const gapAnalysis = calculateAreaGapAnalysis({
         clubBase: 4,
         paidClubs: 3,
         distinguishedClubs: 2,
       })
-      const visitInfo = createVisitInfo(3, 1, 4)
 
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.currentLevel).toBe('none')
       expect(result.progressText).toContain('net club loss')
@@ -363,26 +315,12 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 3,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.progressText).toContain('net club loss')
       expect(result.progressText).toContain('7 of 10 clubs paid')
       expect(result.progressText).toContain('To become eligible')
       expect(result.progressText).toContain('3 paid clubs')
-    })
-
-    it('should include club visit status', () => {
-      const area = createArea('C3', 'C', 4, 3, 2)
-      const gapAnalysis = calculateAreaGapAnalysis({
-        clubBase: 4,
-        paidClubs: 3,
-        distinguishedClubs: 2,
-      })
-      const visitInfo = createVisitInfo(3, 0, 4)
-
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
-
-      expect(result.progressText).toContain('Club visits:')
     })
 
     it('should describe Distinguished requirements after eligibility', () => {
@@ -394,7 +332,7 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 0,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.progressText).toContain('To become eligible')
       expect(result.progressText).toContain('2 paid clubs')
@@ -402,95 +340,6 @@ describe('generateAreaProgressText', () => {
       expect(result.progressText).toContain('Then for Distinguished')
       expect(result.progressText).toContain(
         '2 clubs need to become distinguished'
-      )
-    })
-  })
-
-  /**
-   * Requirement 6.7, 6.8, 6.9: Club visit status display in terms of 75% threshold
-   */
-  describe('Club visit status display', () => {
-    it('should show "both rounds meet 75% threshold" when threshold is met', () => {
-      const area = createArea('A1', 'A', 4, 4, 2)
-      const gapAnalysis = calculateAreaGapAnalysis({
-        clubBase: 4,
-        paidClubs: 4,
-        distinguishedClubs: 2,
-      })
-      // 75% of 4 = 3, so 3+ visits meets threshold
-      const visitInfo = createVisitInfo(3, 3, 4)
-
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
-
-      expect(result.progressText).toContain('both rounds meet 75% threshold')
-    })
-
-    it('should show visits needed for 75% when threshold not met', () => {
-      const area = createArea('B2', 'B', 4, 4, 2)
-      const gapAnalysis = calculateAreaGapAnalysis({
-        clubBase: 4,
-        paidClubs: 4,
-        distinguishedClubs: 2,
-      })
-      // 75% of 4 = 3, so 2 visits needs 1 more
-      const visitInfo = createVisitInfo(2, 1, 4)
-
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
-
-      expect(result.progressText).toContain('Club visits:')
-      expect(result.progressText).toContain('first-round')
-      expect(result.progressText).toContain('second-round')
-      expect(result.progressText).toContain('75%')
-    })
-
-    it('should show "status unknown" when visit data unavailable', () => {
-      const area = createArea('C3', 'C', 4, 4, 2)
-      const gapAnalysis = calculateAreaGapAnalysis({
-        clubBase: 4,
-        paidClubs: 4,
-        distinguishedClubs: 2,
-      })
-
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
-
-      expect(result.progressText).toContain('Club visits: status unknown')
-    })
-
-    it('should show visits needed when zero visits completed', () => {
-      const area = createArea('D4', 'D', 4, 4, 2)
-      const gapAnalysis = calculateAreaGapAnalysis({
-        clubBase: 4,
-        paidClubs: 4,
-        distinguishedClubs: 2,
-      })
-      const visitInfo = createVisitInfo(0, 0, 4)
-
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
-
-      // 75% of 4 = 3 visits needed
-      expect(result.progressText).toContain(
-        'first-round needs 3 visits for 75%'
-      )
-      expect(result.progressText).toContain(
-        'second-round needs 3 visits for 75%'
-      )
-    })
-
-    it('should show first-round meets threshold, second-round needs more', () => {
-      const area = createArea('E5', 'E', 4, 4, 2)
-      const gapAnalysis = calculateAreaGapAnalysis({
-        clubBase: 4,
-        paidClubs: 4,
-        distinguishedClubs: 2,
-      })
-      // 75% of 4 = 3, first round has 3 (meets), second has 1 (needs 2 more)
-      const visitInfo = createVisitInfo(3, 1, 4)
-
-      const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
-
-      expect(result.progressText).toContain('first-round meets 75% threshold')
-      expect(result.progressText).toContain(
-        'second-round 1/3 (need 2 more for 75%)'
       )
     })
   })
@@ -508,24 +357,22 @@ describe('generateAreaProgressText', () => {
           distinguishedClubs: 0,
         })
 
-        const result = generateAreaProgressText(area, gapAnalysis, undefined)
+        const result = generateAreaProgressText(area, gapAnalysis)
 
         expect(result.currentLevel).toBe('none')
         expect(result.areaLabel).toBe('Area A1 (Division A)')
-        // Should handle gracefully without errors
         expect(result.progressText).toBeDefined()
       })
 
-      it('should show "no clubs in area" for visit info with 0 clubs', () => {
+      it('should show "no clubs in area" for an area with 0 clubs', () => {
         const area = createArea('B2', 'B', 0, 0, 0)
         const gapAnalysis = calculateAreaGapAnalysis({
           clubBase: 0,
           paidClubs: 0,
           distinguishedClubs: 0,
         })
-        const visitInfo = createVisitInfo(0, 0, 0)
 
-        const result = generateAreaProgressText(area, gapAnalysis, visitInfo)
+        const result = generateAreaProgressText(area, gapAnalysis)
 
         expect(result.progressText).toContain('no clubs in area')
       })
@@ -541,7 +388,7 @@ describe('generateAreaProgressText', () => {
           distinguishedClubs: 1,
         })
 
-        const result = generateAreaProgressText(area, gapAnalysis, undefined)
+        const result = generateAreaProgressText(area, gapAnalysis)
 
         expect(result.currentLevel).toBe('distinguished')
         expect(result.progressText).toContain('Distinguished status')
@@ -558,13 +405,12 @@ describe('generateAreaProgressText', () => {
           distinguishedClubs: 0,
         })
 
-        const result = generateAreaProgressText(area, gapAnalysis, undefined)
+        const result = generateAreaProgressText(area, gapAnalysis)
 
         expect(result.currentLevel).toBe('none')
         expect(result.progressText).toContain('not yet distinguished')
         expect(result.progressText).toContain('1 of 1 clubs paid')
         expect(result.progressText).toContain('0 of 1 distinguished')
-        // Should mention gap to Distinguished (need 1)
         expect(result.progressText).toContain('For Distinguished')
       })
 
@@ -577,7 +423,7 @@ describe('generateAreaProgressText', () => {
           distinguishedClubs: 0,
         })
 
-        const result = generateAreaProgressText(area, gapAnalysis, undefined)
+        const result = generateAreaProgressText(area, gapAnalysis)
 
         expect(result.currentLevel).toBe('none')
         expect(result.progressText).toContain('net club loss')
@@ -587,7 +433,7 @@ describe('generateAreaProgressText', () => {
       })
 
       it('should handle 1 club area at Presidents level', () => {
-        // 1 club, 2 paid (club base + 1), 2 distinguished (50% + 1 = ceil(0.5) + 1 = 2)
+        // 1 club, 2 paid (club base + 1), 2 distinguished
         const area = createArea('D4', 'D', 1, 2, 2)
         const gapAnalysis = calculateAreaGapAnalysis({
           clubBase: 1,
@@ -595,7 +441,7 @@ describe('generateAreaProgressText', () => {
           distinguishedClubs: 2,
         })
 
-        const result = generateAreaProgressText(area, gapAnalysis, undefined)
+        const result = generateAreaProgressText(area, gapAnalysis)
 
         expect(result.currentLevel).toBe('presidents')
         expect(result.progressText).toContain("President's Distinguished")
@@ -615,7 +461,7 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 2,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.areaLabel).toBe('Area A1 (Division A)')
       expect(result.progressText).toContain('Area A1 (Division A)')
@@ -629,7 +475,7 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 2,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.areaLabel).toBe('Area B3 (Division X)')
     })
@@ -647,7 +493,7 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 2,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result).toHaveProperty('areaLabel')
       expect(result).toHaveProperty('currentLevel')
@@ -665,7 +511,7 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 3,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.currentLevel).toBe(gapAnalysis.currentLevel)
     })
@@ -683,7 +529,7 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 2,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.progressText).not.toMatch(/\s{2,}/)
     })
@@ -696,12 +542,12 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 2,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       // Should start with area label
       expect(result.progressText).toMatch(/^Area/)
-      // Should end with a period
-      expect(result.progressText).toMatch(/\.$/)
+      // Should end with a period (or a parenthetical flag)
+      expect(result.progressText).toMatch(/[.)]$/)
     })
   })
 
@@ -710,7 +556,6 @@ describe('generateAreaProgressText', () => {
    */
   describe('Larger area scenarios', () => {
     it('should handle 10 club area at Distinguished', () => {
-      // 10 clubs, 10 paid, 5 distinguished (50% = ceil(5) = 5)
       const area = createArea('A1', 'A', 10, 10, 5)
       const gapAnalysis = calculateAreaGapAnalysis({
         clubBase: 10,
@@ -718,7 +563,7 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 5,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.currentLevel).toBe('distinguished')
       expect(result.progressText).toContain('10 of 10 clubs paid')
@@ -726,7 +571,6 @@ describe('generateAreaProgressText', () => {
     })
 
     it('should handle 10 club area not distinguished', () => {
-      // 10 clubs, 10 paid, 4 distinguished (40% - below 50%)
       const area = createArea('B2', 'B', 10, 10, 4)
       const gapAnalysis = calculateAreaGapAnalysis({
         clubBase: 10,
@@ -734,12 +578,226 @@ describe('generateAreaProgressText', () => {
         distinguishedClubs: 4,
       })
 
-      const result = generateAreaProgressText(area, gapAnalysis, undefined)
+      const result = generateAreaProgressText(area, gapAnalysis)
 
       expect(result.currentLevel).toBe('none')
       expect(result.progressText).toContain('not yet distinguished')
-      // Need 1 more for Distinguished (50% of 10 = 5)
       expect(result.progressText).toContain('For Distinguished')
     })
+  })
+})
+
+/**
+ * Sprint 2 (#974): the area progress text must NAME the active clubs still
+ * needing the current-round visit and STATE the qualifying-metric →
+ * Distinguished impact, driven by the Sprint 1 (#973) source-of-truth fields
+ * (`currentRound`, `clubsMissingCurrentRoundVisit`,
+ * `clubsMissingCurrentRoundVisitIneligible`) and the #832 `recognitionState`.
+ */
+function createRoundArea(opts: {
+  clubBase: number
+  paidClubs: number
+  distinguishedClubs: number
+  currentRound: 1 | 2
+  roundCompleted: number
+  missing?: MissingVisitClub[]
+  ineligible?: IneligibleMissingVisitClub[]
+  recognitionState: AreaRecognitionState
+}): AreaWithDivision {
+  const {
+    clubBase,
+    paidClubs,
+    distinguishedClubs,
+    currentRound,
+    roundCompleted,
+  } = opts
+  const roundStatus = calculateVisitStatus(roundCompleted, clubBase)
+  const otherStatus = calculateVisitStatus(0, clubBase)
+  return {
+    areaId: 'A1',
+    divisionId: 'A',
+    clubBase,
+    paidClubs,
+    distinguishedClubs,
+    netGrowth: paidClubs - clubBase,
+    requiredDistinguishedClubs: Math.ceil(clubBase * 0.5),
+    firstRoundVisits: currentRound === 1 ? roundStatus : otherStatus,
+    secondRoundVisits: currentRound === 2 ? roundStatus : otherStatus,
+    status: 'not-distinguished',
+    isQualified: false,
+    recognitionState: opts.recognitionState,
+    currentRound,
+    clubsMissingCurrentRoundVisit: opts.missing ?? [],
+    clubsMissingCurrentRoundVisitIneligible: opts.ineligible ?? [],
+  }
+}
+
+describe('generateAreaProgressText — current-round visit text (#974)', () => {
+  it('all-visited: names no clubs and confirms visits do not block recognition', () => {
+    const area = createRoundArea({
+      clubBase: 4,
+      paidClubs: 5,
+      distinguishedClubs: 3,
+      currentRound: 2,
+      roundCompleted: 4,
+      missing: [],
+      recognitionState: {
+        level: 'presidents',
+        status: 'confirmed',
+        pendingRounds: [],
+        failureReason: null,
+      },
+    })
+    const gapAnalysis = calculateAreaGapAnalysis({
+      clubBase: 4,
+      paidClubs: 5,
+      distinguishedClubs: 3,
+    })
+
+    const result = generateAreaProgressText(area, gapAnalysis)
+
+    expect(result.progressText).toContain(
+      'Round 2 club visits: all clubs visited.'
+    )
+    expect(result.progressText).toContain(
+      'met the Round 2 visit requirement (75%+)'
+    )
+    expect(result.progressText).toContain(
+      "visits won't block Distinguished recognition"
+    )
+  })
+
+  it('some-missing/provisional: names the active clubs and states the Provisional impact', () => {
+    const area = createRoundArea({
+      clubBase: 5,
+      paidClubs: 5,
+      distinguishedClubs: 3,
+      currentRound: 2,
+      roundCompleted: 1,
+      missing: [
+        { clubNumber: '1', clubName: 'North Grenville' },
+        { clubNumber: '2', clubName: 'Manotick' },
+        { clubNumber: '3', clubName: 'Smiths Falls' },
+        { clubNumber: '4', clubName: 'Stittsville' },
+      ],
+      recognitionState: {
+        level: 'distinguished',
+        status: 'provisional',
+        pendingRounds: [{ round: 2, deadline: '2026-05-31' }],
+        failureReason: null,
+      },
+    })
+    const gapAnalysis = calculateAreaGapAnalysis({
+      clubBase: 5,
+      paidClubs: 5,
+      distinguishedClubs: 3,
+    })
+
+    const result = generateAreaProgressText(area, gapAnalysis)
+
+    expect(result.progressText).toContain(
+      'Round 2 club visits: 1 of 5 complete — 4 active clubs still need a visit report: North Grenville, Manotick, Smiths Falls, Stittsville.'
+    )
+    expect(result.progressText).toContain('can only be Provisional')
+    // 75% of 5 = 4 required; 1 done → 3 more needed
+    expect(result.progressText).toContain('needs 3 more visits by May 31')
+  })
+
+  it('flags suspended/ineligible clubs separately from the active list', () => {
+    const area = createRoundArea({
+      clubBase: 4,
+      paidClubs: 4,
+      distinguishedClubs: 2,
+      currentRound: 1,
+      roundCompleted: 1,
+      missing: [{ clubNumber: '10', clubName: 'Kanata' }],
+      ineligible: [
+        { clubNumber: '20', clubName: 'Orleans', status: 'Suspended' },
+        { clubNumber: '21', clubName: 'Nepean', status: 'Suspended' },
+      ],
+      recognitionState: {
+        level: 'distinguished',
+        status: 'provisional',
+        pendingRounds: [{ round: 1, deadline: '2025-11-30' }],
+        failureReason: null,
+      },
+    })
+    const gapAnalysis = calculateAreaGapAnalysis({
+      clubBase: 4,
+      paidClubs: 4,
+      distinguishedClubs: 2,
+    })
+
+    const result = generateAreaProgressText(area, gapAnalysis)
+
+    expect(result.progressText).toContain('still needs a visit report: Kanata.')
+    expect(result.progressText).toContain(
+      '(2 suspended/ineligible clubs excluded.)'
+    )
+    expect(result.progressText).toContain('by Nov 30')
+  })
+
+  it('missed-deadline: states the area cannot be Distinguished this year', () => {
+    const area = createRoundArea({
+      clubBase: 4,
+      paidClubs: 4,
+      distinguishedClubs: 1,
+      currentRound: 2,
+      roundCompleted: 1,
+      missing: [{ clubNumber: '5', clubName: 'Carleton Place' }],
+      recognitionState: {
+        level: 'none',
+        status: 'not-distinguished',
+        pendingRounds: [],
+        failureReason: 'missed-deadline',
+      },
+    })
+    const gapAnalysis = calculateAreaGapAnalysis({
+      clubBase: 4,
+      paidClubs: 4,
+      distinguishedClubs: 1,
+    })
+
+    const result = generateAreaProgressText(area, gapAnalysis)
+
+    expect(result.progressText).toContain(
+      'still needs a visit report: Carleton Place.'
+    )
+    expect(result.progressText).toContain(
+      'Round 2 visit deadline (May 31) passed without 75%'
+    )
+    expect(result.progressText).toContain('cannot be Distinguished this year')
+  })
+
+  it('net-loss: still names the missing clubs for the current round', () => {
+    const area = createRoundArea({
+      clubBase: 5,
+      paidClubs: 4,
+      distinguishedClubs: 2,
+      currentRound: 2,
+      roundCompleted: 1,
+      missing: [
+        { clubNumber: '7', clubName: 'Almonte' },
+        { clubNumber: '8', clubName: 'Perth' },
+      ],
+      recognitionState: {
+        level: 'none',
+        status: 'not-distinguished',
+        pendingRounds: [],
+        failureReason: 'net-loss',
+      },
+    })
+    const gapAnalysis = calculateAreaGapAnalysis({
+      clubBase: 5,
+      paidClubs: 4,
+      distinguishedClubs: 2,
+    })
+
+    const result = generateAreaProgressText(area, gapAnalysis)
+
+    expect(result.progressText).toContain('net club loss')
+    expect(result.progressText).toContain(
+      'still need a visit report: Almonte, Perth.'
+    )
   })
 })

--- a/frontend/src/utils/areaProgressText.ts
+++ b/frontend/src/utils/areaProgressText.ts
@@ -16,6 +16,7 @@
 
 import { AreaWithDivision } from '../components/DivisionAreaProgressSummary'
 import { GapAnalysis, RecognitionLevel } from './areaGapAnalysis'
+import type { MissingVisitClub } from './divisionStatus'
 
 /**
  * Result of generating progress text for an area
@@ -27,21 +28,6 @@ export interface AreaProgressText {
   currentLevel: RecognitionLevel
   /** Concise paragraph describing progress and gaps */
   progressText: string
-}
-
-/**
- * Club visit information for an area
- *
- * When visit data is available, contains completion counts.
- * When unavailable, the entire object should be undefined.
- */
-export interface ClubVisitInfo {
-  /** Number of first-round visits completed */
-  firstRoundCompleted: number
-  /** Number of second-round visits completed */
-  secondRoundCompleted: number
-  /** Total clubs in the area (club base) */
-  totalClubs: number
 }
 
 /**
@@ -84,73 +70,144 @@ function generateMetricsDescription(area: AreaWithDivision): string {
 }
 
 /**
- * Generate club visit status text in terms of qualification requirements
- *
- * Club visits require 75% of club base for each round to qualify for distinguished status.
- * This function communicates progress toward that threshold.
- *
- * Requirements: 6.7, 6.8, 6.9
- *
- * @param visitInfo - Club visit information (undefined if unavailable)
- * @returns Club visit status text describing qualification progress
+ * Fixed Distinguished Area Program visit deadline label for a round (item 1490):
+ * R1 is due Nov 30, R2 is due May 31. The month/day is invariant across program
+ * years, so a static label is correct and matches the operator's wording (#974).
  */
-function generateClubVisitText(visitInfo: ClubVisitInfo | undefined): string {
-  // Requirement 6.9: When visit data unavailable, show "status unknown"
-  if (visitInfo === undefined) {
-    return 'Club visits: status unknown.'
-  }
+function visitDeadlineLabel(round: 1 | 2): string {
+  return round === 1 ? 'Nov 30' : 'May 31'
+}
 
-  const { firstRoundCompleted, secondRoundCompleted, totalClubs } = visitInfo
+/** Join club names for prose display: "A, B, C". */
+function formatMissingClubNames(clubs: MissingVisitClub[]): string {
+  return clubs.map(club => club.clubName).join(', ')
+}
 
-  // Handle edge case of zero clubs
-  if (totalClubs === 0) {
-    return 'Club visits: no clubs in area.'
-  }
+/**
+ * Describe the area's CURRENT-round club-visit progress, naming the active
+ * clubs that still need a visit report and flagging any suspended/ineligible
+ * clubs separately. Reads the snapshot-derived source-of-truth fields added in
+ * Sprint 1 (#973) — the round is never re-derived here (R3).
+ *
+ * Requirements: 6.7, 6.8 (#974)
+ */
+function generateMissingVisitClause(area: AreaWithDivision): string {
+  const round = area.currentRound
+  const roundVisits =
+    round === 1 ? area.firstRoundVisits : area.secondRoundVisits
+  const missing = area.clubsMissingCurrentRoundVisit
+  const ineligible = area.clubsMissingCurrentRoundVisitIneligible
 
-  // Calculate 75% threshold (required for qualification)
-  const requiredVisits = Math.ceil(totalClubs * 0.75)
-
-  // Check if thresholds are met
-  const firstRoundMet = firstRoundCompleted >= requiredVisits
-  const secondRoundMet = secondRoundCompleted >= requiredVisits
-
-  // Both rounds meet threshold
-  if (firstRoundMet && secondRoundMet) {
-    return 'Club visits: both rounds meet 75% threshold.'
-  }
-
-  // Build status text describing progress toward 75% threshold
-  const parts: string[] = []
-
-  // First round status
-  if (firstRoundMet) {
-    parts.push('first-round meets 75% threshold')
+  let clause: string
+  if (area.clubBase === 0) {
+    clause = `Round ${round} club visits: no clubs in area.`
+  } else if (missing.length === 0) {
+    clause = `Round ${round} club visits: all clubs visited.`
   } else {
-    const firstRoundNeeded = requiredVisits - firstRoundCompleted
-    if (firstRoundCompleted === 0) {
-      parts.push(`first-round needs ${requiredVisits} visits for 75%`)
-    } else {
-      parts.push(
-        `first-round ${firstRoundCompleted}/${requiredVisits} (need ${firstRoundNeeded} more for 75%)`
+    const clubWord = missing.length === 1 ? 'active club' : 'active clubs'
+    const verb = missing.length === 1 ? 'needs' : 'need'
+    clause =
+      `Round ${round} club visits: ${roundVisits.completed} of ${area.clubBase} complete` +
+      ` — ${missing.length} ${clubWord} still ${verb} a visit report: ${formatMissingClubNames(missing)}.`
+  }
+
+  if (ineligible.length > 0) {
+    const clubWord = ineligible.length === 1 ? 'club' : 'clubs'
+    clause += ` (${ineligible.length} suspended/ineligible ${clubWord} excluded.)`
+  }
+
+  return clause
+}
+
+/**
+ * State whether the area has met the current round's qualifying visit metric
+ * and what that means for Distinguished recognition. Driven entirely by the
+ * #832 `recognitionState` source of truth — no deadline logic is re-derived
+ * here (R3). The "needs N more" count is presentation arithmetic against the
+ * round's own 75% threshold, not a re-derivation of recognition.
+ *
+ * Requirements: 6.7 (#974)
+ */
+function generateVisitRecognitionImpact(area: AreaWithDivision): string {
+  if (area.clubBase === 0) {
+    return ''
+  }
+
+  const round = area.currentRound
+  const roundVisits =
+    round === 1 ? area.firstRoundVisits : area.secondRoundVisits
+  const { status, pendingRounds, failureReason } = area.recognitionState
+
+  if (status === 'confirmed') {
+    return (
+      `The area has met the Round ${round} visit requirement (75%+), ` +
+      `so visits won't block Distinguished recognition.`
+    )
+  }
+
+  if (status === 'provisional') {
+    const currentPending = pendingRounds.find(r => r.round === round)
+    if (currentPending) {
+      const remaining = Math.max(
+        0,
+        roundVisits.required - roundVisits.completed
+      )
+      const visitWord = remaining === 1 ? 'visit' : 'visits'
+      return (
+        `The Round ${round} visit requirement (75%) is not yet met; ` +
+        `until it is, the area can only be Provisional — needs ${remaining} more ` +
+        `${visitWord} by ${visitDeadlineLabel(round)}.`
       )
     }
-  }
-
-  // Second round status
-  if (secondRoundMet) {
-    parts.push('second-round meets 75% threshold')
-  } else {
-    const secondRoundNeeded = requiredVisits - secondRoundCompleted
-    if (secondRoundCompleted === 0) {
-      parts.push(`second-round needs ${requiredVisits} visits for 75%`)
-    } else {
-      parts.push(
-        `second-round ${secondRoundCompleted}/${requiredVisits} (need ${secondRoundNeeded} more for 75%)`
+    // The current round is met; a different round keeps the area Provisional.
+    const otherPending = pendingRounds[0]
+    if (otherPending) {
+      return (
+        `The area has met the Round ${round} visit requirement (75%), but ` +
+        `remains Provisional until Round ${otherPending.round} is met by ` +
+        `${visitDeadlineLabel(otherPending.round)}.`
       )
     }
+    return `The area has met the Round ${round} visit requirement (75%).`
   }
 
-  return `Club visits: ${parts.join(', ')}.`
+  // status === 'not-distinguished'
+  if (failureReason === 'missed-deadline') {
+    // Attribute the miss to the current round when it is the unmet one; else to
+    // the other (already-passed) round.
+    const curMet =
+      round === 1
+        ? area.firstRoundVisits.meetsThreshold
+        : area.secondRoundVisits.meetsThreshold
+    const missedRound: 1 | 2 = curMet ? (round === 1 ? 2 : 1) : round
+    return (
+      `The Round ${missedRound} visit deadline (${visitDeadlineLabel(missedRound)}) ` +
+      `passed without 75%, so the area cannot be Distinguished this year.`
+    )
+  }
+
+  if (failureReason === 'net-loss') {
+    // Net club loss is the headline blocker (stated earlier); the visit metric
+    // is informational only here.
+    return roundVisits.meetsThreshold
+      ? `The Round ${round} visit requirement (75%) is met.`
+      : ''
+  }
+
+  // insufficient-distinguished (or null): visits are not the gating shortfall.
+  return roundVisits.meetsThreshold
+    ? `The Round ${round} visit requirement (75%) is met; the remaining gap is in distinguished clubs, not visits.`
+    : `Meeting the Round ${round} visit requirement (75%) is one of the remaining requirements for Distinguished.`
+}
+
+/**
+ * Compose the full current-round club-visit text: the named missing-clubs
+ * clause followed by the qualifying-metric → Distinguished-impact sentence.
+ */
+function generateCurrentRoundVisitText(area: AreaWithDivision): string {
+  const clause = generateMissingVisitClause(area)
+  const impact = generateVisitRecognitionImpact(area)
+  return impact ? `${clause} ${impact}` : clause
 }
 
 /**
@@ -322,37 +379,24 @@ function generateNetLossText(
  *
  * @param area - Area performance data
  * @param gapAnalysis - Gap analysis for the area
- * @param visitInfo - Club visit information (undefined if unavailable)
  * @returns Text describing achievement and any remaining gaps
  */
 function generateAchievedText(
   area: AreaWithDivision,
-  gapAnalysis: GapAnalysis,
-  visitInfo: ClubVisitInfo | undefined
+  gapAnalysis: GapAnalysis
 ): string {
   const levelLabel = getRecognitionLevelLabel(gapAnalysis.currentLevel)
   const metrics = generateMetricsDescription(area)
+  const visitText = generateCurrentRoundVisitText(area)
 
   // President's Distinguished - no further gaps to mention
   if (gapAnalysis.currentLevel === 'presidents') {
-    const visitText = generateClubVisitText(visitInfo)
-    // Check if both visit rounds meet 75% threshold for special message
-    if (visitInfo) {
-      const requiredVisits = Math.ceil(visitInfo.totalClubs * 0.75)
-      const bothRoundsMet =
-        visitInfo.firstRoundCompleted >= requiredVisits &&
-        visitInfo.secondRoundCompleted >= requiredVisits
-      if (bothRoundsMet) {
-        return `has achieved ${levelLabel} status with club visits meeting 75% threshold.`
-      }
-    }
-    return `has achieved ${levelLabel} status. ${visitText}`
+    return `has achieved ${levelLabel} status (${metrics}). ${visitText}`
   }
 
   // Select Distinguished - mention gap to President's
   if (gapAnalysis.currentLevel === 'select') {
     const presidentsGap = generatePresidentsGapText(gapAnalysis)
-    const visitText = generateClubVisitText(visitInfo)
     return `has achieved ${levelLabel} status (${metrics}). ${presidentsGap} ${visitText}`
   }
 
@@ -360,7 +404,6 @@ function generateAchievedText(
   if (gapAnalysis.currentLevel === 'distinguished') {
     const selectGap = generateSelectGapText(gapAnalysis)
     const presidentsGap = generatePresidentsGapText(gapAnalysis)
-    const visitText = generateClubVisitText(visitInfo)
     return `has achieved ${levelLabel} status (${metrics}). ${selectGap} ${presidentsGap} ${visitText}`
   }
 
@@ -375,20 +418,18 @@ function generateAchievedText(
  *
  * @param area - Area performance data
  * @param gapAnalysis - Gap analysis for the area
- * @param visitInfo - Club visit information (undefined if unavailable)
  * @returns Text describing current status and all gaps
  */
 function generateNotDistinguishedText(
   area: AreaWithDivision,
-  gapAnalysis: GapAnalysis,
-  visitInfo: ClubVisitInfo | undefined
+  gapAnalysis: GapAnalysis
 ): string {
   const metrics = generateMetricsDescription(area)
 
   const distinguishedGap = generateDistinguishedGapText(gapAnalysis)
   const selectGap = generateSelectGapText(gapAnalysis)
   const presidentsGap = generatePresidentsGapText(gapAnalysis)
-  const visitText = generateClubVisitText(visitInfo)
+  const visitText = generateCurrentRoundVisitText(area)
 
   return `is not yet distinguished (${metrics}). ${distinguishedGap} ${selectGap} ${presidentsGap} ${visitText}`
 }
@@ -421,15 +462,14 @@ function generateNotDistinguishedText(
  *
  * Requirements: 5.1, 5.2, 5.3, 5.6, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7
  *
- * @param area - Area with division information
+ * @param area - Area with division information (carries the Sprint 1 #973
+ *   current-round visit fields and the #832 recognitionState)
  * @param gapAnalysis - Gap analysis for the area
- * @param visitInfo - Club visit information (undefined if unavailable)
  * @returns AreaProgressText with label, level, and progress paragraph
  */
 export function generateAreaProgressText(
   area: AreaWithDivision,
-  gapAnalysis: GapAnalysis,
-  visitInfo?: ClubVisitInfo
+  gapAnalysis: GapAnalysis
 ): AreaProgressText {
   const areaLabel = generateAreaLabel(area)
   const currentLevel = gapAnalysis.currentLevel
@@ -440,16 +480,16 @@ export function generateAreaProgressText(
   if (!gapAnalysis.meetsNoNetLossRequirement) {
     const metrics = generateMetricsDescription(area)
     const netLossText = generateNetLossText(area, gapAnalysis)
-    const visitText = generateClubVisitText(visitInfo)
+    const visitText = generateCurrentRoundVisitText(area)
     progressText = `${areaLabel} has a net club loss (${metrics}). ${netLossText} ${visitText}`
   }
   // Handle achieved recognition levels (Requirement 6.5)
   else if (gapAnalysis.currentLevel !== 'none') {
-    progressText = `${areaLabel} ${generateAchievedText(area, gapAnalysis, visitInfo)}`
+    progressText = `${areaLabel} ${generateAchievedText(area, gapAnalysis)}`
   }
   // Handle not yet distinguished (Requirements 5.2, 5.3, 6.2, 6.3, 6.4)
   else {
-    progressText = `${areaLabel} ${generateNotDistinguishedText(area, gapAnalysis, visitInfo)}`
+    progressText = `${areaLabel} ${generateNotDistinguishedText(area, gapAnalysis)}`
   }
 
   // Clean up any double spaces


### PR DESCRIPTION
## Summary
Enhances the existing per-area progress text on `/district/:id/divisions` (issue #974, epic #976 Sprint 2) to:
1. **Name the active clubs** still needing the **current-round** visit report (auto-detected from the snapshot date — R1/Nov 30, R2/May 31), with a separate flag for excluded suspended/ineligible clubs.
2. **State the qualifying-metric → Distinguished impact**, driven entirely by the #832 `recognitionState` (Confirmed / Provisional / cannot-this-year) — no deadline re-derivation (R3).

Replaces the old vague two-round "second-round needs 4 visits for 75%" clause and the now-removed `ClubVisitInfo`/`visitInfo` param; the generator reads the Sprint-1 (#973) `currentRound` / `clubsMissingCurrentRoundVisit[/Ineligible]` fields directly off `area`.

## Changes
- `frontend/src/utils/areaProgressText.ts` — named missing-club clause + `recognitionState`-driven impact; dropped `ClubVisitInfo` and the `visitInfo` parameter.
- `frontend/src/components/DivisionAreaProgressSummary.tsx` — 2-arg call (fields travel on `area`).
- `frontend/src/utils/__tests__/areaProgressText.test.ts` — unit tests for all-visited, some-missing/provisional, suspended-flag, missed-deadline, net-loss.
- `frontend/src/test-utils/areaFixture.ts` + `frontend/src/components/__tests__/AreaProgressSummary.test.tsx` — complete the component-integration fixtures with the now-required Sprint-1 visit fields (latent gap: the old code never read them) and update the two stale visit-text assertions to the new spec.

## Verification
- Unit: `areaProgressText.test.ts` 32/32; component `AreaProgressSummary` + `DivisionAreaRecognitionPanel` 91/91.
- Full frontend suite green except known #917 contention-timeout flakes in unrelated files (RankingCard / HeaderActionsMenu / EndOfYearRankingsPanel), all confirmed green in isolation.
- `typecheck:prod` (CI gate) 0 errors; lint 0 errors.
- Live PR-preview drive at `/district/61/divisions` (Chromium + WebKit) to follow on this PR.

Refs #974 (closed manually after epic checkbox is ticked — Lesson 106/R15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
