### PR TITLE
chore(test): raise vitest testTimeout 5s→15s for runner-fleet load (#1003)

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -26,9 +26,14 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/__tests__/setup.ts',
-    // Set aggressive timeout limits for fast test execution
-    testTimeout: 5000, // 5 seconds max per test
-    hookTimeout: 5000, // 5 seconds max for setup/teardown hooks
+    // Timeouts carry headroom for machine saturation: the red-barkeep sprint-runner
+    // fleet runs several builds/test-suites concurrently, and a correct fast test
+    // (CollapsibleSection, normally ~ms) was observed taking 8.3s under that
+    // contention. 5s flaked correct tests at the pre-push gate; 15s — matching the
+    // heavy-journey override in 03-DcpProgressFlow — absorbs the load without
+    // masking real hangs (these tests pass in <1s un-contended). #1003 / #473 / L53
+    testTimeout: 15000,
+    hookTimeout: 15000,
     // Worker-count policy lives in vitest.shared.mjs so the guard test can't
     // drift from it (V8, #914). Local: fixed 3 forks (a busy dev machine
     // saturates at one-fork-per-core and blows the 5s timeout — #473 / Lesson


### PR DESCRIPTION
Closes #1003

## What
Raise the global `testTimeout`/`hookTimeout` in `frontend/vitest.config.ts` from **5000ms → 15000ms**.

## Why
The red-barkeep sprint-runner fleet runs several builds/test-suites concurrently on the dev machine. Under that saturation, **correct fast tests blow past the 5s cap** at the pre-push gate — `CollapsibleSection` (a trivial render, normally ~ms) was observed running **8340ms** under contention. These are load-induced flakes, not perf or logic bugs.

15s matches the existing in-repo precedent (`03-DcpProgressFlow.test.tsx` already overrides to `vi.setConfig({ testTimeout: 15000 })`) and the config's own #473/L53 note that a busy machine blows the 5s cap. Global rather than per-file because the flake is load-induced and test-agnostic — per-file overrides would whack-a-mole.

## Evidence it's not masking a real bug
CollapsibleSection passes all 6 tests in **1.78s** tests-phase un-contended; agenda-pdf (sibling fix in red-vote) passes in ~0.7s/test. The bump only absorbs load variance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)