### PR TITLE
feat(error-page): branded root errorElement — 404 + runtime boundary (#1011)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { ProgramYearProvider } from './contexts/ProgramYearContext'
 import { DarkModeProvider } from './contexts/DarkModeContext'
 import DistrictsPage from './pages/DistrictsPage'
 import AppShell from './components/AppShell'
+import ErrorPage from './components/ErrorPage'
 
 // Code-split: DistrictDetailPage (816 lines + recharts) loads on navigation (#169)
 const DistrictDetailPage = React.lazy(
@@ -86,6 +87,11 @@ const router = createBrowserRouter(
     {
       path: '/',
       element: <AppShell />,
+      // Branded root boundary (#1011): catches unmatched routes (404 bubbles to
+      // the nearest errorElement) and any child render throw, so React Router's
+      // raw developer default is never reached. Distinguishes 404 vs runtime
+      // error via useRouteError/isRouteErrorResponse.
+      errorElement: <ErrorPage />,
       children: [
         {
           index: true,

--- a/frontend/src/__tests__/integration/errorPage.test.tsx
+++ b/frontend/src/__tests__/integration/errorPage.test.tsx
@@ -1,0 +1,108 @@
+/* Branded error boundary (#1011, epic #1010 Sprint 1).
+ *
+ * Verifies the root `errorElement` replaces React Router's raw developer
+ * default ("Unexpected Application Error! 404 Not Found · Hey developer 👋…")
+ * for BOTH failure modes:
+ *   - an unmatched route (404 ErrorResponse bubbles to the nearest errorElement)
+ *   - a child route that throws at render (runtime error)
+ * Both render the same branded ErrorPage chrome (testid `error-page`) with
+ * distinct, human copy and Home + Back recovery — no framework jargon leaks.
+ *
+ * Lives in the integration project (not the fast unit gate): it full-mounts a
+ * RouterProvider with the real errorElement wiring (R22 spirit — router mounts
+ * route off the pre-push unit gate).
+ */
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider, Outlet } from 'react-router-dom'
+import ErrorPage from '../../components/ErrorPage'
+
+/** A child route that always throws at render — exercises the runtime path. */
+function Boom(): React.JSX.Element {
+  throw new Error('kaboom from a child route')
+}
+
+/** Mount a router shaped like App's: root with errorElement, throwing child. */
+function renderWithRouter(initialPath: string) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <Outlet />,
+        errorElement: <ErrorPage />,
+        children: [
+          { index: true, element: <div>home</div> },
+          { path: 'boom', element: <Boom /> },
+        ],
+      },
+    ],
+    { initialEntries: [initialPath] }
+  )
+  return render(<RouterProvider router={router} />)
+}
+
+describe('Branded error boundary (#1011)', () => {
+  describe('unmatched route (404)', () => {
+    it('renders the branded ErrorPage, not React Router default', () => {
+      renderWithRouter('/this-route-does-not-exist')
+      expect(screen.getByTestId('error-page')).toBeInTheDocument()
+      // RR's raw default leaks this exact phrase — it must be unreachable.
+      expect(
+        screen.queryByText(/Unexpected Application Error/i)
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows 404-variant human copy (no framework jargon)', () => {
+      renderWithRouter('/this-route-does-not-exist')
+      const page = screen.getByTestId('error-page')
+      expect(page).toHaveAttribute('data-error-variant', 'not-found')
+      // Human, not "errorElement" / "Hey developer".
+      expect(page.textContent).not.toMatch(/errorElement|Hey developer/i)
+      expect(
+        screen.getByRole('heading', { name: /page not found/i })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('thrown runtime error', () => {
+    it('renders the same branded ErrorPage with error-variant copy', () => {
+      renderWithRouter('/boom')
+      const page = screen.getByTestId('error-page')
+      expect(page).toBeInTheDocument()
+      expect(page).toHaveAttribute('data-error-variant', 'error')
+      expect(
+        screen.queryByText(/Unexpected Application Error/i)
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('heading', { name: /something went wrong/i })
+      ).toBeInTheDocument()
+    })
+
+    it('does not leak the raw error message as page chrome jargon', () => {
+      renderWithRouter('/boom')
+      const page = screen.getByTestId('error-page')
+      expect(page.textContent).not.toMatch(/errorElement|Hey developer/i)
+    })
+  })
+
+  describe('recovery affordances (both variants)', () => {
+    it('offers a Home link to the landing page', () => {
+      renderWithRouter('/this-route-does-not-exist')
+      const home = screen.getByRole('link', { name: /home|go home|landing/i })
+      expect(home).toHaveAttribute('href', '/')
+    })
+
+    it('offers a Back action', () => {
+      renderWithRouter('/boom')
+      expect(
+        screen.getByRole('button', { name: /back|go back/i })
+      ).toBeInTheDocument()
+    })
+
+    it('announces the error to assistive tech (role=alert)', () => {
+      renderWithRouter('/this-route-does-not-exist')
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/__tests__/integration/errorPage.test.tsx
+++ b/frontend/src/__tests__/integration/errorPage.test.tsx
@@ -86,6 +86,24 @@ describe('Branded error boundary (#1011)', () => {
     })
   })
 
+  describe('error thrown by the root element itself', () => {
+    // In App the root route's element is <AppShell />; the errorElement
+    // replaces it when AppShell (or anything in its slot) throws. This proves
+    // the boundary still renders standalone — the chrome is not re-mounted.
+    it('replaces the root element with the branded page', () => {
+      const router = createMemoryRouter(
+        [{ path: '/', element: <Boom />, errorElement: <ErrorPage /> }],
+        { initialEntries: ['/'] }
+      )
+      render(<RouterProvider router={router} />)
+      const page = screen.getByTestId('error-page')
+      expect(page).toHaveAttribute('data-error-variant', 'error')
+      expect(
+        screen.getByRole('heading', { name: /something went wrong/i })
+      ).toBeInTheDocument()
+    })
+  })
+
   describe('recovery affordances (both variants)', () => {
     it('offers a Home link to the landing page', () => {
       renderWithRouter('/this-route-does-not-exist')

--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+
+/** Stub — real branded error boundary lands in the Green step (#1011). */
+const ErrorPage: React.FC = () => {
+  return <div>error</div>
+}
+
+export default ErrorPage

--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -1,8 +1,121 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
+import {
+  Link,
+  useNavigate,
+  useRouteError,
+  isRouteErrorResponse,
+} from 'react-router-dom'
+import { logger } from '../utils/logger'
 
-/** Stub — real branded error boundary lands in the Green step (#1011). */
+/**
+ * Root `errorElement` for the router (#1011, epic #1010 Sprint 1).
+ *
+ * Replaces React Router's raw developer default ("Unexpected Application
+ * Error! … Hey developer 👋 You can provide a way better UX…") with a calm,
+ * branded page for the two failure modes that bubble to the root route:
+ *   - an unmatched route → a 404 `ErrorResponse` (no route matched)
+ *   - any child route that throws at render → a runtime error
+ *
+ * `useRouteError()` + `isRouteErrorResponse()` distinguish the two: a 404 gets
+ * "page not found" copy, anything else gets "something went wrong". Both share
+ * the same chrome and the same Home + Back recovery. It renders standalone
+ * (the errorElement replaces `AppShell`, so the shell — which could itself be
+ * what threw — is not re-mounted); the dark-mode-aware tokens + `redesign-panel`
+ * surface give it the product look without rebuilding the nav.
+ *
+ * Route-aware smart recovery for malformed `/district/:id` is Sprint 2 (#1012).
+ */
 const ErrorPage: React.FC = () => {
-  return <div>error</div>
+  const error = useRouteError()
+  const navigate = useNavigate()
+  const headingRef = useRef<HTMLHeadingElement>(null)
+
+  const is404 = isRouteErrorResponse(error) && error.status === 404
+  const variant = is404 ? 'not-found' : 'error'
+
+  // Log genuine runtime errors for telemetry; a 404 is expected user navigation
+  // (mistyped URL / dead link), not an error worth recording.
+  useEffect(() => {
+    if (!is404) {
+      logger.error('Route error boundary caught:', error)
+    }
+  }, [error, is404])
+
+  // Move focus to the heading on mount so screen-reader and keyboard users land
+  // on the error context immediately rather than at the top of a replaced tree.
+  useEffect(() => {
+    headingRef.current?.focus()
+  }, [])
+
+  const heading = is404 ? 'Page not found' : 'Something went wrong'
+  const message = is404
+    ? "We couldn't find the page you're looking for. It may have moved, or the link you followed may be broken."
+    : 'An unexpected error stopped this page from loading. You can go back to the previous page, or head home and start again.'
+
+  // Surface technical detail only in development — never leak a stack trace or
+  // framework internals to real users in production.
+  const detail = import.meta.env.DEV
+    ? isRouteErrorResponse(error)
+      ? `${error.status} ${error.statusText}`
+      : error instanceof Error
+        ? error.message
+        : null
+    : null
+
+  return (
+    <div
+      className="error-page"
+      data-testid="error-page"
+      data-error-variant={variant}
+    >
+      <div className="error-page__panel redesign-panel" role="alert">
+        <div className="error-page__badge" aria-hidden="true">
+          {is404 ? (
+            <span className="error-page__code">404</span>
+          ) : (
+            <svg
+              className="error-page__glyph"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+          )}
+        </div>
+
+        <h1 ref={headingRef} tabIndex={-1} className="error-page__heading">
+          {heading}
+        </h1>
+
+        <p className="error-page__message">{message}</p>
+
+        {detail && (
+          <p className="error-page__detail" data-testid="error-page-detail">
+            {detail}
+          </p>
+        )}
+
+        <div className="error-page__actions">
+          <Link to="/" className="tm-btn-primary error-page__action">
+            Go home
+          </Link>
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="tm-btn-secondary error-page__action"
+          >
+            Go back
+          </button>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default ErrorPage

--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -68,38 +68,43 @@ const ErrorPage: React.FC = () => {
       data-testid="error-page"
       data-error-variant={variant}
     >
-      <div className="error-page__panel redesign-panel" role="alert">
-        <div className="error-page__badge" aria-hidden="true">
-          {is404 ? (
-            <span className="error-page__code">404</span>
-          ) : (
-            <svg
-              className="error-page__glyph"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-              />
-            </svg>
+      <div className="error-page__panel redesign-panel">
+        {/* role=alert announces the error context on mount; scope it to the
+            message region so the recovery buttons below aren't read as part of
+            the live region (they're separately focusable affordances). */}
+        <div role="alert">
+          <div className="error-page__badge" aria-hidden="true">
+            {is404 ? (
+              <span className="error-page__code">404</span>
+            ) : (
+              <svg
+                className="error-page__glyph"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+            )}
+          </div>
+
+          <h1 ref={headingRef} tabIndex={-1} className="error-page__heading">
+            {heading}
+          </h1>
+
+          <p className="error-page__message">{message}</p>
+
+          {detail && (
+            <p className="error-page__detail" data-testid="error-page-detail">
+              {detail}
+            </p>
           )}
         </div>
-
-        <h1 ref={headingRef} tabIndex={-1} className="error-page__heading">
-          {heading}
-        </h1>
-
-        <p className="error-page__message">{message}</p>
-
-        {detail && (
-          <p className="error-page__detail" data-testid="error-page-detail">
-            {detail}
-          </p>
-        )}
 
         <div className="error-page__actions">
           <Link to="/" className="tm-btn-primary error-page__action">

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -5027,4 +5027,104 @@
     padding: 0 4px;
     margin: 0 1px;
   }
+
+  /* Branded root error boundary (#1011, epic #1010). Replaces RR's raw
+     developer default for 404s + thrown render errors. It renders standalone
+     (the errorElement replaces AppShell), so it owns a full-viewport,
+     token-driven canvas that themes for dark mode automatically (--bg/--ink),
+     with the product amber accent (--rt-stats) on the 404 numerals. */
+  .error-page {
+    min-height: 100vh;
+    background-color: var(--bg);
+    color: var(--ink);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 16px;
+  }
+
+  .error-page__panel {
+    max-width: 30rem;
+    width: 100%;
+    text-align: center;
+    padding: 32px 24px;
+  }
+
+  .error-page__badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 16px;
+    color: var(--rt-stats, #d4873f);
+  }
+
+  .error-page__code {
+    font-family: var(--serif, var(--rt-font-display));
+    font-weight: 700;
+    font-size: 56px;
+    line-height: 1;
+    letter-spacing: -0.02em;
+  }
+
+  .error-page__glyph {
+    width: 48px;
+    height: 48px;
+  }
+
+  .error-page__heading {
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 22px;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    margin: 0 0 8px;
+  }
+
+  /* Focus lands here on mount (a11y); the panel already signals the error,
+     so suppress the default focus ring on this non-interactive heading. */
+  .error-page__heading:focus {
+    outline: none;
+  }
+
+  .error-page__message {
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.5;
+    color: var(--ink-2);
+    margin: 0 auto 24px;
+    max-width: 26rem;
+  }
+
+  .error-page__detail {
+    font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+    font-size: 12px;
+    color: var(--ink-3);
+    background-color: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-sm, 6px);
+    padding: 8px 10px;
+    margin: 0 0 24px;
+    word-break: break-word;
+  }
+
+  .error-page__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+  }
+
+  .error-page__action {
+    text-decoration: none;
+  }
+
+  @media (max-width: 400px) {
+    .error-page__actions {
+      flex-direction: column;
+    }
+
+    .error-page__action {
+      width: 100%;
+    }
+  }
 }

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -5059,7 +5059,7 @@
   }
 
   .error-page__code {
-    font-family: var(--serif, var(--rt-font-display));
+    font-family: var(--serif);
     font-weight: 700;
     font-size: 56px;
     line-height: 1;

--- a/tasks/lessons/146-a-root-errorelement-renders-outside-the-app-context-providers.md
+++ b/tasks/lessons/146-a-root-errorelement-renders-outside-the-app-context-providers.md
@@ -1,0 +1,77 @@
+---
+id: '146'
+category: lesson
+tags: [router, react, frontend, architecture, error-handling]
+auto_load: true
+date: 2026-05-31
+issues: [1011, 1010]
+---
+
+# Lesson 146 — A router `errorElement` renders OUTSIDE the app's context providers; it can only use router hooks + CSS tokens
+
+**Date:** 2026-05-31
+**Issue:** #1011 (epic #1010 Sprint 1 — branded root error boundary)
+**PR:** [#1019](https://github.com/taverns-red/toast-stats/pull/1019)
+
+## What happened
+
+The app nests providers OUTSIDE the router:
+
+```
+QueryClientProvider → ProgramYearProvider → DarkModeProvider → RouterProvider
+```
+
+An `errorElement` on the root route renders **inside `RouterProvider` but
+inside no other provider** — and, critically, it **replaces** the route's own
+`element` (here `<AppShell />`) rather than rendering within it. So when the
+boundary fires:
+
+- ✅ Router hooks work: `useRouteError`, `isRouteErrorResponse`, `useNavigate`,
+  `<Link>`.
+- ❌ App-context hooks do **not**: `useQuery`/`useQueryClient`, `useProgramYear`,
+  the dark-mode hook — they'd throw "no provider" _inside the error boundary_,
+  turning a handled error into a blank crash.
+- ❌ The chrome (`AppShell` top bar / footer) is gone, because the errorElement
+  took its slot — which is actually the **right** behaviour: AppShell may be the
+  thing that threw, so re-mounting it would re-throw.
+
+The branded error page therefore has to be **self-sufficient**: it reads
+`import.meta.env.DEV` directly (not a context flag), themes via CSS custom
+properties (`--bg`/`--ink`/`--surface`/`--rt-stats`) that resolve from the
+`[data-theme]` attribute already on `<html>` — not via the dark-mode _hook_ —
+and ships its own Home/Back recovery instead of leaning on nav chrome.
+
+## The transferable principle
+
+**An error/fallback component that sits at a different point in the provider
+tree than the normal app cannot assume the app's contexts exist.** Before a
+boundary component calls any hook, ask "is its provider an ancestor of _this_
+render position, or only of the normal tree it's replacing?" For a root
+`errorElement` the answer for every non-router provider is **no**. Make the
+boundary depend only on what is guaranteed at its position: router hooks, the
+build-time env, and CSS variables (which cascade from `<html>` regardless of
+React context). If a future feature genuinely needs a context (e.g. "retry with
+the current program year"), the fix is to move the boundary _inside_ that
+provider — or lift the provider above the router — not to call the hook and hope.
+
+## How to apply
+
+- Putting a boundary at the router root? Restrict it to `react-router` hooks +
+  `import.meta.env` + CSS tokens. No `useQuery`, no app contexts.
+- Theme a replaced-chrome surface with CSS custom properties keyed off the
+  `[data-theme]` attribute, not the dark-mode hook — the attribute is on
+  `<html>` and survives the missing provider; the hook does not.
+- Want the boundary _inside_ chrome/contexts instead of replacing them? Put the
+  `errorElement` on the **child** routes (renders in `AppShell`'s `<Outlet/>`),
+  and accept that a throw in `AppShell` itself then has no handler. Root-level =
+  standalone + provider-free; child-level = in-chrome + context-available. Pick
+  per what can throw.
+
+## Related
+
+- [[124-validate-url-synced-range-state-at-the-page-not-the-picker]] — the page
+  owns router-derived state; the boundary likewise owns only what its position
+  guarantees.
+- `frontend/src/components/ErrorPage.tsx`, `frontend/src/App.tsx`
+  (`errorElement` on the root route). Sprint 2 (#1012) adds route-aware recovery
+  — if it needs app data it must reckon with this provider boundary.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -123,4 +123,5 @@
 - **144** [router, react, frontend, scope, verification] — A cap (or any invariant) enforced only on the mutation path is bypassed the moment the value becomes URL-seedable (#978, #969)
 - **145** [router, react, hooks, frontend, scope] — A URL param that's a pipeline step layered on the filtered set must NOT join the wholesale filter-reconcile key set (#979, #969)
 - **145** [cls, performance, frontend, react, verification, ci] — An incidental post-data re-render can be load-bearing for CLS; a "cleanup" that removes it regresses layout only on the CI font environment (#978, #969)
+- **146** [router, react, frontend, architecture, error-handling] — A router `errorElement` renders OUTSIDE the app's context providers; it can only use router hooks + CSS tokens (#1011, #1010)
 - **146** [testing, vitest, flake, ci, performance, runner-fleet] — An "aggressively low" testTimeout is a latent flake source the moment the same machine runs concurrent workloads (#1003)


### PR DESCRIPTION
## Sprint 1 of epic #1010 — closes #1011

Stops React Router's raw developer default ("Unexpected Application Error! … Hey developer 👋…") from ever reaching users. Adds a root `errorElement` that distinguishes a **404** (unmatched route) from a **thrown runtime error**, with Home + Back recovery and full theming.

### What changed
- **`frontend/src/components/ErrorPage.tsx`** (new) — branded boundary. `useRouteError()` + `isRouteErrorResponse()` branch 404 vs runtime. `data-error-variant="not-found"|"error"`, distinct human copy, no framework jargon. Technical detail gated on `import.meta.env.DEV` — **no prod stack-trace leak**. Focus moves to the heading on mount; `role="alert"` scoped to the message region (recovery buttons stay separate affordances).
- **`frontend/src/App.tsx`** — `errorElement: <ErrorPage />` on the root route. Catches unmatched routes (404 bubbles to nearest errorElement) **and** any child render throw, including a throw in the root `element` (AppShell) slot — it renders standalone, so the chrome that may have thrown isn't re-mounted.
- **`app-shell.css`** — `.error-page` rules inside the existing `@layer brand` (no new stylesheet → no orphan-import risk; lesson 142). Dark-mode-aware via `--bg/--ink/--surface/--line`; product amber accent `--rt-stats` on the 404 numerals; responsive (stacks actions <400px).

### Tests (`src/__tests__/integration/errorPage.test.tsx`, 8 cases)
404 path, thrown-runtime path, root-element throw, both-variant recovery (Home `href="/"` + Back), `role=alert` announce, and absence of RR's raw default text. Integration project (router mount routes off the fast unit gate, R22).

### Verification plan (per sprint protocol)
Dual-engine Playwright on the PR preview: 404 + thrown-error at 375/768/1280 + dark mode, screenshots attached on the issue.

### Scope
Route-aware smart recovery for malformed `/district/:id` is **Sprint 2 (#1012)** — out of scope here.

### Reviewer notes (Low, triaged)
- `navigate(-1)` has no history fallback on a fresh-tab deep link — Home is the always-works affordance; smarter recovery is Sprint 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)