### PR TITLE
feat(error-page): route-aware smart recovery — suggest valid destinations for malformed /district/:id (#1012)

### DIFF
--- a/frontend/src/__tests__/integration/errorPage.test.tsx
+++ b/frontend/src/__tests__/integration/errorPage.test.tsx
@@ -14,17 +14,43 @@
  */
 import React from 'react'
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider, Outlet } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import ErrorPage from '../../components/ErrorPage'
+import type { DistrictsResponse } from '../../types/districts'
 
 /** A child route that always throws at render — exercises the runtime path. */
 function Boom(): React.JSX.Element {
   throw new Error('kaboom from a child route')
 }
 
+/**
+ * Build a QueryClient with the `['districts']` cache pre-seeded so
+ * `useDistricts()` (which ErrorPage now calls for route-aware recovery)
+ * resolves synchronously with no network. Pass `undefined` to leave it
+ * unseeded (the districts-not-loaded path).
+ */
+function makeClient(districts?: DistrictsResponse['districts']) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  if (districts) {
+    client.setQueryData<DistrictsResponse>(['districts'], { districts })
+  }
+  return client
+}
+
+const D61_DISTRICTS = [
+  { id: '61', name: 'District 61' },
+  { id: '42', name: 'District 42' },
+]
+
 /** Mount a router shaped like App's: root with errorElement, throwing child. */
-function renderWithRouter(initialPath: string) {
+function renderWithRouter(
+  initialPath: string,
+  districts: DistrictsResponse['districts'] | undefined = D61_DISTRICTS
+) {
   const router = createMemoryRouter(
     [
       {
@@ -39,7 +65,11 @@ function renderWithRouter(initialPath: string) {
     ],
     { initialEntries: [initialPath] }
   )
-  return render(<RouterProvider router={router} />)
+  return render(
+    <QueryClientProvider client={makeClient(districts)}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  )
 }
 
 describe('Branded error boundary (#1011)', () => {
@@ -95,7 +125,11 @@ describe('Branded error boundary (#1011)', () => {
         [{ path: '/', element: <Boom />, errorElement: <ErrorPage /> }],
         { initialEntries: ['/'] }
       )
-      render(<RouterProvider router={router} />)
+      render(
+        <QueryClientProvider client={makeClient(D61_DISTRICTS)}>
+          <RouterProvider router={router} />
+        </QueryClientProvider>
+      )
       const page = screen.getByTestId('error-page')
       expect(page).toHaveAttribute('data-error-variant', 'error')
       expect(
@@ -121,6 +155,55 @@ describe('Branded error boundary (#1011)', () => {
     it('announces the error to assistive tech (role=alert)', () => {
       renderWithRouter('/this-route-does-not-exist')
       expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  // Route-aware smart recovery (#1012, Sprint 2). A malformed /district/:id URL
+  // is a 404; the page detects the bad path (via useLocation) and the valid
+  // district set (via useDistricts) and offers contextual destinations.
+  describe('route-aware smart recovery (#1012)', () => {
+    it('suggests the district subpages for a malformed /district/:id (valid id)', () => {
+      renderWithRouter('/district/61/dude')
+      const region = screen.getByTestId('error-page-suggestions')
+      // Every suggested link is a REAL subpage of the valid district 61.
+      const overview = within(region).getByRole('link', { name: /overview/i })
+      expect(overview).toHaveAttribute('href', '/district/61')
+      const clubs = within(region).getByRole('link', { name: /clubs/i })
+      expect(clubs).toHaveAttribute('href', '/district/61/clubs')
+    })
+
+    it('suggests the districts index for an unknown district id', () => {
+      renderWithRouter('/district/zzz/whatever')
+      const region = screen.getByTestId('error-page-suggestions')
+      const all = within(region).getByRole('link', { name: /all districts/i })
+      expect(all).toHaveAttribute('href', '/')
+      // No district-subpage links for an id we can't resolve.
+      expect(
+        within(region).queryByRole('link', { name: /clubs/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('falls back to the districts index when districts have not loaded', () => {
+      renderWithRouter('/district/61/dude', undefined)
+      const region = screen.getByTestId('error-page-suggestions')
+      expect(
+        within(region).getByRole('link', { name: /all districts/i })
+      ).toHaveAttribute('href', '/')
+    })
+
+    it('shows NO suggestion region for a runtime error (only Home + Back)', () => {
+      renderWithRouter('/boom')
+      expect(screen.getByTestId('error-page')).toBeInTheDocument()
+      expect(
+        screen.queryByTestId('error-page-suggestions')
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows NO suggestion region for a non-district 404', () => {
+      renderWithRouter('/totally/unknown')
+      expect(
+        screen.queryByTestId('error-page-suggestions')
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/__tests__/integration/errorPage.test.tsx
+++ b/frontend/src/__tests__/integration/errorPage.test.tsx
@@ -28,16 +28,18 @@ function Boom(): React.JSX.Element {
 /**
  * Build a QueryClient with the `['districts']` cache pre-seeded so
  * `useDistricts()` (which ErrorPage now calls for route-aware recovery)
- * resolves synchronously with no network. Pass `undefined` to leave it
- * unseeded (the districts-not-loaded path).
+ * resolves synchronously with NO network. `staleTime: Infinity` stops a
+ * background refetch (default staleTime 0 would otherwise hit the real CDN and
+ * make these tests network-flaky); we always seed, so the queryFn never runs.
+ * An empty array models the "districts unresolved" path deterministically.
  */
-function makeClient(districts?: DistrictsResponse['districts']) {
+function makeClient(districts: DistrictsResponse['districts']) {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
+    },
   })
-  if (districts) {
-    client.setQueryData<DistrictsResponse>(['districts'], { districts })
-  }
+  client.setQueryData<DistrictsResponse>(['districts'], { districts })
   return client
 }
 
@@ -49,7 +51,7 @@ const D61_DISTRICTS = [
 /** Mount a router shaped like App's: root with errorElement, throwing child. */
 function renderWithRouter(
   initialPath: string,
-  districts: DistrictsResponse['districts'] | undefined = D61_DISTRICTS
+  districts: DistrictsResponse['districts'] = D61_DISTRICTS
 ) {
   const router = createMemoryRouter(
     [
@@ -183,8 +185,8 @@ describe('Branded error boundary (#1011)', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('falls back to the districts index when districts have not loaded', () => {
-      renderWithRouter('/district/61/dude', undefined)
+    it('falls back to the districts index when the district set is unresolved', () => {
+      renderWithRouter('/district/61/dude', [])
       const region = screen.getByTestId('error-page-suggestions')
       expect(
         within(region).getByRole('link', { name: /all districts/i })

--- a/frontend/src/components/DistrictSubnav.tsx
+++ b/frontend/src/components/DistrictSubnav.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 import { NavLink } from 'react-router-dom'
+import {
+  DISTRICT_SECTIONS,
+  buildDistrictSectionUrl,
+} from '../config/districtSections'
 
 /* #678 (epic #674 Sprint 4) — District secondary route-nav primitive.
 
@@ -23,30 +27,10 @@ import { NavLink } from 'react-router-dom'
    scroll container needs no role="region" (cf. Lesson 105, which applies to
    non-focusable table scrolls). */
 
-export interface DistrictSection {
-  /** Visible label. */
-  label: string
-  /** Path segment appended after /district/:id. '' = the Overview hub. */
-  segment: string
-}
-
-/* The canonical, ordered section list. ADR-005 §2 + the epic's AC1 require
-   every item to be a REAL route — a destination-less nav item is the exact
-   tab-like fiction the no-tabs decision rejects. `/trends` and `/analytics`
-   joined in Sprint 6 (#680); order follows ADR-005 §3
-   (Overview · Clubs · Divisions · Trends · Analytics · Rankings). This const
-   is the single extension point. */
-export const DISTRICT_SECTIONS: readonly DistrictSection[] = [
-  { label: 'Overview', segment: '' },
-  // 'What Changed' (#793, epic #797) — a real route, sits next to Overview as
-  // the "since I last looked" companion to the current-state hub.
-  { label: 'What Changed', segment: 'changes' },
-  { label: 'Clubs', segment: 'clubs' },
-  { label: 'Divisions', segment: 'divisions' },
-  { label: 'Trends', segment: 'trends' },
-  { label: 'Analytics', segment: 'analytics' },
-  { label: 'Rankings', segment: 'rankings' },
-]
+/* The canonical section list (`DISTRICT_SECTIONS`) and its URL builder now live
+   in `config/districtSections` — the single source of truth shared with the
+   route-aware error recovery (#1012), so a util no longer imports from this
+   component. */
 
 interface DistrictSubnavProps {
   districtId: string
@@ -63,9 +47,7 @@ export const DistrictSubnav: React.FC<DistrictSubnavProps> = ({
     >
       <ul className="district-subnav__list">
         {DISTRICT_SECTIONS.map(({ label, segment }) => {
-          const to = segment
-            ? `/district/${districtId}/${segment}`
-            : `/district/${districtId}`
+          const to = buildDistrictSectionUrl(districtId, segment)
           return (
             <li key={label} className="district-subnav__item">
               <NavLink

--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -3,9 +3,12 @@ import {
   Link,
   useNavigate,
   useRouteError,
+  useLocation,
   isRouteErrorResponse,
 } from 'react-router-dom'
 import { logger } from '../utils/logger'
+import { useDistricts } from '../hooks/useDistricts'
+import { resolveRouteRecovery } from '../utils/errorRecovery'
 
 /**
  * Root `errorElement` for the router (#1011, epic #1010 Sprint 1).
@@ -23,15 +26,33 @@ import { logger } from '../utils/logger'
  * what threw — is not re-mounted); the dark-mode-aware tokens + `redesign-panel`
  * surface give it the product look without rebuilding the nav.
  *
- * Route-aware smart recovery for malformed `/district/:id` is Sprint 2 (#1012).
+ * Sprint 2 (#1012) adds route-aware smart recovery: for a malformed
+ * `/district/:id` 404 it suggests that district's real subpages (valid id) or
+ * the districts index (unknown id). See `utils/errorRecovery.ts`.
  */
 const ErrorPage: React.FC = () => {
   const error = useRouteError()
   const navigate = useNavigate()
+  const location = useLocation()
   const headingRef = useRef<HTMLHeadingElement>(null)
 
   const is404 = isRouteErrorResponse(error) && error.status === 404
   const variant = is404 ? 'not-found' : 'error'
+
+  // Route-aware smart recovery (#1012). useRouteError exposes no attempted URL,
+  // so we read the unmatched path from useLocation and validate the district id
+  // against the known set (useDistricts). Only meaningful for a 404 — a runtime
+  // error fired from a route that DID match needs generic Home + Back, not
+  // "did you mean these subpages". ErrorPage is always rendered under App's
+  // QueryClientProvider, so useDistricts is safe here.
+  const { data: districtsData } = useDistricts()
+  const recovery = is404
+    ? resolveRouteRecovery(
+        location.pathname,
+        districtsData?.districts.map(d => d.id) ?? []
+      )
+    : { kind: 'none' as const, suggestions: [] }
+  const hasSuggestions = recovery.suggestions.length > 0
 
   // Log genuine runtime errors for telemetry; a 404 is expected user navigation
   // (mistyped URL / dead link), not an error worth recording.
@@ -105,6 +126,29 @@ const ErrorPage: React.FC = () => {
             </p>
           )}
         </div>
+
+        {hasSuggestions && (
+          <nav
+            className="error-page__suggestions"
+            data-testid="error-page-suggestions"
+            aria-label="Suggested destinations"
+          >
+            <p className="error-page__suggestions-lead">
+              {recovery.kind === 'district-subpages'
+                ? `Did you mean one of District ${recovery.districtId}'s pages?`
+                : 'Try browsing from the districts list:'}
+            </p>
+            <ul className="error-page__suggestions-list">
+              {recovery.suggestions.map(({ label, to }) => (
+                <li key={to} className="error-page__suggestions-item">
+                  <Link to={to} className="error-page__suggestion-link">
+                    {label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
 
         <div className="error-page__actions">
           <Link to="/" className="tm-btn-primary error-page__action">

--- a/frontend/src/components/__tests__/DistrictSubnav.test.tsx
+++ b/frontend/src/components/__tests__/DistrictSubnav.test.tsx
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { axe, toHaveNoViolations } from 'jest-axe'
-import { DistrictSubnav, DISTRICT_SECTIONS } from '../DistrictSubnav'
+import { DistrictSubnav } from '../DistrictSubnav'
+import { DISTRICT_SECTIONS } from '../../config/districtSections'
 
 expect.extend(toHaveNoViolations)
 

--- a/frontend/src/config/districtSections.ts
+++ b/frontend/src/config/districtSections.ts
@@ -1,0 +1,39 @@
+/* The canonical, ordered list of district section routes, plus the single
+   builder for their URLs. Lives in config (not a component) so both the UI
+   that renders the nav (DistrictSubnav) and non-UI consumers (errorRecovery's
+   route-aware smart recovery, #1012) share one source of truth without a util
+   importing from a component. */
+
+export interface DistrictSection {
+  /** Visible label. */
+  label: string
+  /** Path segment appended after /district/:id. '' = the Overview hub. */
+  segment: string
+}
+
+/* ADR-005 §2 + epic #674 AC1 require every item to be a REAL route — a
+   destination-less nav item is the exact tab-like fiction the no-tabs decision
+   rejects. `/trends` and `/analytics` joined in Sprint 6 (#680); order follows
+   ADR-005 §3 (Overview · Clubs · Divisions · Trends · Analytics · Rankings).
+   This const is the single extension point. */
+export const DISTRICT_SECTIONS: readonly DistrictSection[] = [
+  { label: 'Overview', segment: '' },
+  // 'What Changed' (#793, epic #797) — a real route, sits next to Overview as
+  // the "since I last looked" companion to the current-state hub.
+  { label: 'What Changed', segment: 'changes' },
+  { label: 'Clubs', segment: 'clubs' },
+  { label: 'Divisions', segment: 'divisions' },
+  { label: 'Trends', segment: 'trends' },
+  { label: 'Analytics', segment: 'analytics' },
+  { label: 'Rankings', segment: 'rankings' },
+]
+
+/** Build the URL for a district section. Empty segment = the Overview hub. */
+export function buildDistrictSectionUrl(
+  districtId: string,
+  segment: string
+): string {
+  return segment
+    ? `/district/${districtId}/${segment}`
+    : `/district/${districtId}`
+}

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -5107,6 +5107,52 @@
     word-break: break-word;
   }
 
+  /* Route-aware smart recovery (#1012). Contextual destinations between the
+     message and the generic Home + Back actions. Token-driven so it themes for
+     dark mode automatically (--ink-2/--line/--link). */
+  .error-page__suggestions {
+    margin: 0 auto 24px;
+    max-width: 26rem;
+    text-align: left;
+    border-top: 1px solid var(--line);
+    padding-top: 20px;
+  }
+
+  .error-page__suggestions-lead {
+    font-family: var(--sans);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink-2);
+    margin: 0 0 10px;
+  }
+
+  .error-page__suggestions-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .error-page__suggestion-link {
+    display: inline-block;
+    font-family: var(--sans);
+    font-size: 14px;
+    color: var(--link, #2563eb);
+    text-decoration: none;
+    padding: 6px 12px;
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-sm, 6px);
+    background-color: var(--surface-2);
+  }
+
+  .error-page__suggestion-link:hover,
+  .error-page__suggestion-link:focus-visible {
+    text-decoration: underline;
+    border-color: var(--link, #2563eb);
+  }
+
   .error-page__actions {
     display: flex;
     flex-wrap: wrap;

--- a/frontend/src/utils/__tests__/errorRecovery.test.ts
+++ b/frontend/src/utils/__tests__/errorRecovery.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { resolveRouteRecovery } from '../errorRecovery'
+import { DISTRICT_SECTIONS } from '../../components/DistrictSubnav'
+
+/* Route-aware smart recovery resolver (#1012, epic #1010 Sprint 2).
+ *
+ * Pure function: given the attempted (unmatched) pathname and the set of valid
+ * district ids, decide what destinations to suggest on the branded error page.
+ * Kept pure + unit-tested here (no page mount → R22) so the rendering layer in
+ * ErrorPage stays a thin consumer. */
+
+const D61 = ['61', '42', '7']
+
+describe('resolveRouteRecovery', () => {
+  describe('malformed /district/:id with a VALID id', () => {
+    it("suggests the district's real subpages", () => {
+      const r = resolveRouteRecovery('/district/61/dude', D61)
+      expect(r.kind).toBe('district-subpages')
+      expect(r.districtId).toBe('61')
+      // Every suggestion is a REAL route built from the canonical section list
+      // (no invented destinations — same single source DistrictSubnav uses).
+      const expected = DISTRICT_SECTIONS.map(({ label, segment }) => ({
+        label,
+        to: segment ? `/district/61/${segment}` : '/district/61',
+      }))
+      expect(r.suggestions).toEqual(expected)
+    })
+
+    it('points the Overview suggestion at the bare hub URL', () => {
+      const r = resolveRouteRecovery('/district/42/nonsense', D61)
+      const overview = r.suggestions.find(s => s.label === 'Overview')
+      expect(overview?.to).toBe('/district/42')
+    })
+  })
+
+  describe('malformed /district/:id with an UNKNOWN id', () => {
+    it('suggests the districts index, not subpages', () => {
+      const r = resolveRouteRecovery('/district/zzz/whatever', D61)
+      expect(r.kind).toBe('districts-index')
+      expect(r.suggestions).toEqual([{ label: 'All districts', to: '/' }])
+    })
+  })
+
+  describe('districts not loaded yet (empty valid set)', () => {
+    it('falls back to the districts index (cannot confirm the id)', () => {
+      const r = resolveRouteRecovery('/district/61/dude', [])
+      expect(r.kind).toBe('districts-index')
+      expect(r.suggestions).toEqual([{ label: 'All districts', to: '/' }])
+    })
+  })
+
+  describe('a /district path with no id segment', () => {
+    it('treats /district/ as the districts index', () => {
+      const r = resolveRouteRecovery('/district/', D61)
+      expect(r.kind).toBe('districts-index')
+    })
+  })
+
+  describe('a non-district path', () => {
+    it('returns kind=none with no suggestions (Home + Back only)', () => {
+      const r = resolveRouteRecovery('/totally/unknown', D61)
+      expect(r.kind).toBe('none')
+      expect(r.suggestions).toEqual([])
+    })
+
+    it('does not treat the landing path as a district recovery', () => {
+      const r = resolveRouteRecovery('/', D61)
+      expect(r.kind).toBe('none')
+    })
+  })
+})

--- a/frontend/src/utils/__tests__/errorRecovery.test.ts
+++ b/frontend/src/utils/__tests__/errorRecovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { resolveRouteRecovery } from '../errorRecovery'
-import { DISTRICT_SECTIONS } from '../../components/DistrictSubnav'
+import { DISTRICT_SECTIONS } from '../../config/districtSections'
 
 /* Route-aware smart recovery resolver (#1012, epic #1010 Sprint 2).
  *

--- a/frontend/src/utils/errorRecovery.ts
+++ b/frontend/src/utils/errorRecovery.ts
@@ -1,0 +1,80 @@
+import { DISTRICT_SECTIONS } from '../components/DistrictSubnav'
+
+/**
+ * Route-aware smart recovery resolver (#1012, epic #1010 Sprint 2).
+ *
+ * Sprint 1 (#1011) gave the branded error page generic Home + Back recovery.
+ * This adds *contextual* recovery for the most common dead end: a malformed
+ * `/district/:id/…` URL (e.g. `/district/61/dude`), which React Router treats
+ * as an unmatched route (404). `useRouteError()` exposes no attempted URL, so
+ * ErrorPage feeds us `useLocation().pathname` and the known district ids.
+ *
+ * Pure on purpose — all branching is unit-tested without a page mount (R22),
+ * and ErrorPage stays a thin consumer (R3: the page owns the data, the
+ * resolver only decides).
+ */
+
+export interface RecoverySuggestion {
+  /** Visible link text. */
+  label: string
+  /** Destination path. */
+  to: string
+}
+
+export type RecoveryKind = 'district-subpages' | 'districts-index' | 'none'
+
+export interface RouteRecovery {
+  kind: RecoveryKind
+  /** The district id parsed from the path, when one was present. */
+  districtId?: string
+  suggestions: RecoverySuggestion[]
+}
+
+/** Matches `/district/<id>` optionally followed by `/<anything>`. */
+const DISTRICT_PATH = /^\/district\/([^/]+)(?:\/.*)?$/
+
+const DISTRICTS_INDEX: RouteRecovery = {
+  kind: 'districts-index',
+  suggestions: [{ label: 'All districts', to: '/' }],
+}
+
+/**
+ * Decide what destinations to surface on the error page for an unmatched path.
+ *
+ * - A `/district/:id/…` path whose `:id` is a known district → links to that
+ *   district's real subpages (built from the canonical {@link DISTRICT_SECTIONS}
+ *   list, so no destination is ever invented — same source the subnav uses).
+ * - A `/district/:id/…` path whose `:id` is unknown — or any `/district` path
+ *   while the district list is still empty/unloaded — → the districts index
+ *   (the safe place to find a valid district).
+ * - Anything else → `none`; the page keeps its generic Home + Back affordances.
+ */
+export function resolveRouteRecovery(
+  pathname: string,
+  validDistrictIds: readonly string[]
+): RouteRecovery {
+  const match = DISTRICT_PATH.exec(pathname)
+  if (!match) {
+    // Not a district path at all (incl. `/district` with no id, and `/`).
+    return pathname.startsWith('/district/') || pathname === '/district'
+      ? DISTRICTS_INDEX
+      : { kind: 'none', suggestions: [] }
+  }
+
+  const districtId = match[1] ?? ''
+  if (!districtId || !validDistrictIds.includes(districtId)) {
+    // Unknown id, or we can't confirm it yet (empty list). Either way the
+    // districts index is the honest, useful destination.
+    return DISTRICTS_INDEX
+  }
+
+  const suggestions: RecoverySuggestion[] = DISTRICT_SECTIONS.map(
+    ({ label, segment }) => ({
+      label,
+      to: segment
+        ? `/district/${districtId}/${segment}`
+        : `/district/${districtId}`,
+    })
+  )
+  return { kind: 'district-subpages', districtId, suggestions }
+}

--- a/frontend/src/utils/errorRecovery.ts
+++ b/frontend/src/utils/errorRecovery.ts
@@ -1,4 +1,7 @@
-import { DISTRICT_SECTIONS } from '../components/DistrictSubnav'
+import {
+  DISTRICT_SECTIONS,
+  buildDistrictSectionUrl,
+} from '../config/districtSections'
 
 /**
  * Route-aware smart recovery resolver (#1012, epic #1010 Sprint 2).
@@ -61,8 +64,10 @@ export function resolveRouteRecovery(
       : { kind: 'none', suggestions: [] }
   }
 
+  // `[^/]+` guarantees a non-empty capture; `?? ''` only satisfies the
+  // noUncheckedIndexedAccess type, it is never the empty string at runtime.
   const districtId = match[1] ?? ''
-  if (!districtId || !validDistrictIds.includes(districtId)) {
+  if (!validDistrictIds.includes(districtId)) {
     // Unknown id, or we can't confirm it yet (empty list). Either way the
     // districts index is the honest, useful destination.
     return DISTRICTS_INDEX
@@ -71,9 +76,7 @@ export function resolveRouteRecovery(
   const suggestions: RecoverySuggestion[] = DISTRICT_SECTIONS.map(
     ({ label, segment }) => ({
       label,
-      to: segment
-        ? `/district/${districtId}/${segment}`
-        : `/district/${districtId}`,
+      to: buildDistrictSectionUrl(districtId, segment),
     })
   )
   return { kind: 'district-subpages', districtId, suggestions }

--- a/frontend/src/utils/errorRecovery.ts
+++ b/frontend/src/utils/errorRecovery.ts
@@ -58,8 +58,10 @@ export function resolveRouteRecovery(
 ): RouteRecovery {
   const match = DISTRICT_PATH.exec(pathname)
   if (!match) {
-    // Not a district path at all (incl. `/district` with no id, and `/`).
-    return pathname.startsWith('/district/') || pathname === '/district'
+    // The regex requires an id (`[^/]+`), so a district-shaped path that still
+    // fails to match has no usable id — `/district`, `/district/`, `/district//x`.
+    // Point those at the index; any non-district path keeps Home + Back.
+    return pathname === '/district' || pathname.startsWith('/district/')
       ? DISTRICTS_INDEX
       : { kind: 'none', suggestions: [] }
   }

--- a/tasks/lessons/146-a-root-errorelement-renders-outside-the-app-context-providers.md
+++ b/tasks/lessons/146-a-root-errorelement-renders-outside-the-app-context-providers.md
@@ -4,10 +4,42 @@ category: lesson
 tags: [router, react, frontend, architecture, error-handling]
 auto_load: true
 date: 2026-05-31
-issues: [1011, 1010]
+issues: [1011, 1010, 1012]
 ---
 
-# Lesson 146 — A router `errorElement` renders OUTSIDE the app's context providers; it can only use router hooks + CSS tokens
+# Lesson 146 — A router `errorElement` inherits contexts provided ABOVE `RouterProvider`, but NOT those provided inside the subtree it replaces
+
+> **Correction (Sprint 2, #1012 — empirically verified live).** The original
+> Sprint-1 framing below ("renders outside the app's context providers; it can
+> only use router hooks") is **too strong and partly wrong**. A root
+> `errorElement` renders _within_ `RouterProvider`'s React subtree, so it
+> inherits every provider that wraps `RouterProvider` — in this app that is
+> `QueryClientProvider`, `ProgramYearProvider`, **and** `DarkModeProvider`
+> (`App.tsx`: `QueryClientProvider → … → RouterProvider`). Sprint 2 calls
+> `useDistricts()` (a `useQuery` hook) inside `ErrorPage` and it resolves fine —
+> proven by the integration tests (which mirror App's nesting) **and** a
+> dual-engine Playwright drive of `/district/61/dude` on the live PR-1021
+> preview (the district's real subpages rendered, which only happens if the
+> query resolved). What a root `errorElement` genuinely _loses_ is any context
+> a provider rendered **inside `AppShell` or a route element** — i.e. below
+> `RouterProvider` — because the errorElement _replaces_ that subtree. The
+> original lesson conflated "replaces AppShell's subtree" with "outside all
+> providers"; the generalization broke because the Sprint-1 unit test mounted
+> `ErrorPage` under a _bare_ `RouterProvider` (no `QueryClientProvider`), so the
+> hook threw _there_ and the conclusion was over-extended to the real app.
+>
+> **Corrected rule:** before a boundary calls a hook, ask "is this provider an
+> ancestor of `RouterProvider`, or only of the subtree the boundary replaces?"
+> Ancestors of `RouterProvider` → available. Providers inside the replaced
+> subtree → gone. (Keeping the page self-sufficient on CSS tokens + `env.DEV`
+> is still a fine _defensive_ choice; it just isn't _forced_.)
+>
+> Bonus (#1012): `useRouteError()` exposes **no attempted URL** for a 404 — read
+> the unmatched path from `useLocation().pathname` instead.
+
+---
+
+# Lesson 146 (original framing) — A router `errorElement` renders OUTSIDE the app's context providers; it can only use router hooks + CSS tokens
 
 **Date:** 2026-05-31
 **Issue:** #1011 (epic #1010 Sprint 1 — branded root error boundary)

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -123,5 +123,5 @@
 - **144** [router, react, frontend, scope, verification] — A cap (or any invariant) enforced only on the mutation path is bypassed the moment the value becomes URL-seedable (#978, #969)
 - **145** [router, react, hooks, frontend, scope] — A URL param that's a pipeline step layered on the filtered set must NOT join the wholesale filter-reconcile key set (#979, #969)
 - **145** [cls, performance, frontend, react, verification, ci] — An incidental post-data re-render can be load-bearing for CLS; a "cleanup" that removes it regresses layout only on the CI font environment (#978, #969)
-- **146** [router, react, frontend, architecture, error-handling] — A router `errorElement` renders OUTSIDE the app's context providers; it can only use router hooks + CSS tokens (#1011, #1010)
+- **146** [router, react, frontend, architecture, error-handling] — A router `errorElement` inherits contexts provided ABOVE `RouterProvider`, but NOT those provided inside the subtree it replaces (#1011, #1010, #1012)
 - **146** [testing, vitest, flake, ci, performance, runner-fleet] — An "aggressively low" testTimeout is a latent flake source the moment the same machine runs concurrent workloads (#1003)


### PR DESCRIPTION
## What & why

Epic #1010 Sprint 2 (#1012). Sprint 1 (#1019) gave the branded error page generic Home + Back recovery. This adds **contextual** recovery for the most common dead end — a malformed `/district/:id/…` URL (e.g. `/district/61/dude`), which React Router treats as a 404.

- **Valid district id** → suggest that district's real subpages (Overview, What Changed, Clubs, Divisions, Trends, Analytics, Rankings).
- **Unknown id** (or district list still unresolved) → suggest the districts index.
- **Non-district 404 or runtime error** → unchanged (Home + Back only).

## How

- New pure resolver `frontend/src/utils/errorRecovery.ts` — `resolveRouteRecovery(pathname, validDistrictIds)`. `useRouteError()` exposes no attempted URL, so `ErrorPage` feeds it `useLocation().pathname` + the known ids from `useDistricts()`. Suggestions are gated to 404s.
- Single source of truth: `DISTRICT_SECTIONS` + a new `buildDistrictSectionUrl()` helper moved to `frontend/src/config/districtSections.ts` (was exported from `DistrictSubnav.tsx`). This fixes a util→component import direction, removes a duplicated URL pattern, and clears a stale react-refresh lint warning. `DistrictSubnav` + both tests updated.
- Token-driven CSS (`.error-page__suggestions`) — dark-mode auto, responsive.

## Tests (TDD)

- Unit: `errorRecovery.test.ts` (pure, no page mount → R22) — valid id, unknown id, empty set, `/district/` no-id, non-district, landing.
- Integration: `errorPage.test.tsx` extended — seeds the `['districts']` cache with `staleTime: Infinity` (deterministic, no network) and asserts D61 subpage suggestions for `/district/61/dude`, districts-index for unknown id, and no suggestion region for runtime errors / non-district 404s.
- Full suite: 3281 passing.

## Re: Lesson 146

Lesson 146 (from Sprint 1) states `useQuery` throws inside the root `errorElement`. In this app `QueryClientProvider` wraps `RouterProvider` (`App.tsx:242`), so the errorElement **is** a React descendant of it and `useDistricts()` resolves fine — confirmed by the integration tests (which mirror App's nesting) and verified live on the preview below. Will correct the lesson with that evidence.

## Verification

Dual-engine Playwright on the PR preview (driving `/district/61/dude`), screenshots in the evidence comment.

Epic #1010 · Sprint 2 of 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)