### PR TITLE
feat: link club names in the What-Changed feed (#1013)

### DIFF
--- a/frontend/src/components/ChangeGroup.tsx
+++ b/frontend/src/components/ChangeGroup.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import type {
+  DiffEvent,
+  DiffEventCategory,
+} from '@toastmasters/shared-contracts'
+
+/* District "What Changed" feed group (#1013, epic #1007 — club links).
+   Extracted from DistrictChangesPage so the link logic can be unit-tested
+   directly without a full page mount (R22). Every DiffEvent.label is a
+   pre-rendered sentence that BEGINS with the club name (see diffSnapshots:
+   membership/dcp/distinguished labels are `${name} …`; roster labels are
+   `${name} (${status}) joined/left the roster`). We link just that leading
+   club-name token to the club's detail page and keep the rest of the sentence
+   as plain text — only the name is the link, not the whole prose. districtId
+   is the route param the page owns and passes down (R3) — never re-derived
+   from event data; only clubId comes from each event. */
+
+/** One change line: club name linked, the rest of the label as plain text.
+    Falls back to plain text for a club-less (district-level) event, or when a
+    label unexpectedly doesn't begin with the club name — so a link is only
+    ever rendered when it points somewhere real. */
+const ChangeLabel: React.FC<{ event: DiffEvent; districtId: string }> = ({
+  event,
+  districtId,
+}) => {
+  const { clubId, clubName, label } = event
+  const linkable =
+    !!clubId && !!clubName && !!districtId && label.startsWith(clubName)
+
+  if (!linkable) return <>{label}</>
+
+  const rest = label.slice(clubName.length)
+  return (
+    <>
+      <Link
+        to={`/district/${districtId}/club/${clubId}`}
+        className="clubs-name-link"
+      >
+        {clubName}
+      </Link>
+      {rest}
+    </>
+  )
+}
+
+export const ChangeGroup: React.FC<{
+  category: DiffEventCategory
+  heading: string
+  events: DiffEvent[]
+  /** Route district id, owned by the page and passed down (R3). */
+  districtId: string
+  /** Groups are open by default; collapsed when listed in ?expandChanges (#980). */
+  collapsed: boolean
+  onToggle: (category: DiffEventCategory, open: boolean) => void
+}> = ({ category, heading, events, districtId, collapsed, onToggle }) => {
+  if (events.length === 0) return null
+  return (
+    <details
+      className="changes-group"
+      open={!collapsed}
+      onToggle={e => onToggle(category, e.currentTarget.open)}
+    >
+      <summary className="changes-group__summary">
+        {heading}{' '}
+        <span className="changes-group__count">({events.length})</span>
+      </summary>
+      <ul className="changes-group__list">
+        {events.map(e => (
+          <li key={`${e.category}-${e.clubId}`} className="changes-group__item">
+            <ChangeLabel event={e} districtId={districtId} />
+          </li>
+        ))}
+      </ul>
+    </details>
+  )
+}

--- a/frontend/src/components/__tests__/ChangeGroup.test.tsx
+++ b/frontend/src/components/__tests__/ChangeGroup.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ChangeGroup } from '../ChangeGroup'
+import type { DiffEvent } from '@toastmasters/shared-contracts'
+
+/* Unit test for the District "What Changed" feed group (#1013, epic #1007).
+   Every club-scoped change line links the club name to that club's detail page
+   (/district/:districtId/club/:clubId). A club-less event (empty clubId) still
+   renders as plain text — no broken/empty link. Tested directly, no page mount
+   (R22); districtId is passed as a prop (R3), clubId comes from the event. */
+
+const renderGroup = (events: DiffEvent[], districtId = '61') =>
+  render(
+    <MemoryRouter>
+      <ChangeGroup
+        category="membership"
+        heading="Membership changes"
+        events={events}
+        districtId={districtId}
+        collapsed={false}
+        onToggle={() => {}}
+      />
+    </MemoryRouter>
+  )
+
+const event = (over: Partial<DiffEvent> = {}): DiffEvent => ({
+  category: 'membership',
+  clubId: '123',
+  clubName: 'Acme Club',
+  label: 'Acme Club gained 5 members',
+  magnitude: 5,
+  ...over,
+})
+
+describe('ChangeGroup club links (#1013)', () => {
+  it('links the club name to its detail page for a club-scoped event', () => {
+    renderGroup([event()], '61')
+
+    const link = screen.getByRole('link', { name: /Acme Club/ })
+    expect(link).toHaveAttribute('href', '/district/61/club/123')
+    // The prose remainder stays as text; only the name is the link.
+    expect(screen.getByText(/gained 5 members/)).toBeInTheDocument()
+  })
+
+  it('renders plain text with no link for a district-level (club-less) event', () => {
+    renderGroup(
+      [
+        event({
+          clubId: '',
+          clubName: '',
+          label: 'District membership shifted by 5',
+        }),
+      ],
+      '61'
+    )
+
+    expect(
+      screen.getByText('District membership shifted by 5')
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('builds the href from the districtId prop, not from event data (R3)', () => {
+    renderGroup(
+      [
+        event({
+          clubId: '999',
+          clubName: 'Beta Club',
+          label: 'Beta Club lost 2 members',
+        }),
+      ],
+      '42'
+    )
+
+    expect(screen.getByRole('link', { name: /Beta Club/ })).toHaveAttribute(
+      'href',
+      '/district/42/club/999'
+    )
+  })
+
+  it('links the roster-move label whose name is followed by a "(Active)" suffix', () => {
+    renderGroup(
+      [
+        event({
+          category: 'club-added',
+          clubId: '28680300',
+          clubName: 'iA Montreal Toastmasters',
+          label: 'iA Montreal Toastmasters (Active) joined the roster',
+        }),
+      ],
+      '61'
+    )
+
+    const link = screen.getByRole('link', { name: /iA Montreal Toastmasters/ })
+    expect(link).toHaveAttribute('href', '/district/61/club/28680300')
+    expect(screen.getByText(/joined the roster/)).toBeInTheDocument()
+  })
+
+  it('renders nothing when the group has no events', () => {
+    const { container } = renderGroup([])
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/pages/DistrictChangesPage.tsx
+++ b/frontend/src/pages/DistrictChangesPage.tsx
@@ -12,6 +12,7 @@ import { DatePairPicker } from '../components/DatePairPicker'
 import { KpiDeltaCard } from '../components/KpiDeltaCard'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import ErrorBoundary from '../components/ErrorBoundary'
+import { ChangeGroup } from '../components/ChangeGroup'
 import type {
   DiffEvent,
   DiffEventCategory,
@@ -43,36 +44,6 @@ const CATEGORY_GROUPS: { category: DiffEventCategory; heading: string }[] = [
   { category: 'membership', heading: 'Membership changes' },
   { category: 'dcp-goals', heading: 'DCP goal changes' },
 ]
-
-const ChangeGroup: React.FC<{
-  category: DiffEventCategory
-  heading: string
-  events: DiffEvent[]
-  /** Groups are open by default; collapsed when listed in ?expandChanges (#980). */
-  collapsed: boolean
-  onToggle: (category: DiffEventCategory, open: boolean) => void
-}> = ({ category, heading, events, collapsed, onToggle }) => {
-  if (events.length === 0) return null
-  return (
-    <details
-      className="changes-group"
-      open={!collapsed}
-      onToggle={e => onToggle(category, e.currentTarget.open)}
-    >
-      <summary className="changes-group__summary">
-        {heading}{' '}
-        <span className="changes-group__count">({events.length})</span>
-      </summary>
-      <ul className="changes-group__list">
-        {events.map(e => (
-          <li key={`${e.category}-${e.clubId}`} className="changes-group__item">
-            {e.label}
-          </li>
-        ))}
-      </ul>
-    </details>
-  )
-}
 
 const DistrictChangesPage: React.FC = () => {
   const { districtId } = useParams<{ districtId: string }>()
@@ -252,6 +223,7 @@ const DistrictChangesPage: React.FC = () => {
                         category={category}
                         heading={heading}
                         events={eventsByCategory.get(category) ?? []}
+                        districtId={districtId}
                         collapsed={collapsedGroups.includes(category)}
                         onToggle={handleGroupToggle}
                       />

--- a/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
@@ -95,9 +95,12 @@ describe('DistrictChangesPage', () => {
     expect(screen.getAllByTestId('kpi-delta-card')).toHaveLength(4)
     expect(screen.getByTestId('changes-list')).toBeInTheDocument()
     expect(screen.getByText(/Clubs that joined/)).toBeInTheDocument()
+    // The club name is now a link to the club detail page (#1013); the prose
+    // remainder of the roster-move label stays as plain text alongside it.
     expect(
-      screen.getByText('iA Montreal Toastmasters (Active) joined the roster')
-    ).toBeInTheDocument()
+      screen.getByRole('link', { name: 'iA Montreal Toastmasters' })
+    ).toHaveAttribute('href', '/district/61/club/28680300')
+    expect(screen.getByText(/\(Active\) joined the roster/)).toBeInTheDocument()
   })
 
   it('renders the date-pair picker when at least two snapshots exist (#794)', () => {


### PR DESCRIPTION
## What

Every club name rendered in the District Changes ("What Changed") feed is now a working link to that club's detail page (`/district/:districtId/club/:clubId`). Refs #1013 (epic #1007).

## How

- Extracted the inline `ChangeGroup` out of `DistrictChangesPage` into its own component (`frontend/src/components/ChangeGroup.tsx`) so the link logic can be unit-tested directly without a full page mount (R22).
- Each `DiffEvent.label` is a pre-rendered sentence that begins with the club name (see `diffSnapshots` — membership/dcp/distinguished are `${name} …`; roster labels are `${name} (${status}) joined/left the roster`). A new `ChangeLabel` renders the **leading club-name token** as a `<Link>` and keeps the rest of the sentence as plain text — only the name is linked, not the whole sentence.
- `districtId` is sourced from the route param the page already owns and passed down as a prop (**R3** — never re-derived from API/event data). `clubId` comes from each `DiffEvent`.
- A club-less event (empty `clubId`) or a label that does not begin with the club name falls back to plain text — no broken/empty link.
- Reuses the existing dark-mode-aware `.clubs-name-link` styling (the same affordance the clubs table uses), so the link is keyboard-focusable and legible in both themes. No CSS change needed.

## Tests

New unit test `frontend/src/components/__tests__/ChangeGroup.test.tsx`:
- club-scoped event -> `<Link href="/district/61/club/123">`
- club-less event -> plain text, no link
- href built from the `districtId` prop, not event data (R3)
- roster-move label with `(Active)` suffix still links the name
- empty group renders nothing

Full workspace suite green (151 files / 1771 frontend tests + all packages); lint clean (0 errors); typecheck clean; `test:no-page-mounts:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)