### PR TITLE
feat(changes): area & division status-transition events in the What-Changed feed (#1014)

### DIFF
--- a/frontend/src/components/ChangeGroup.tsx
+++ b/frontend/src/components/ChangeGroup.tsx
@@ -5,39 +5,66 @@ import type {
   DiffEventCategory,
 } from '@toastmasters/shared-contracts'
 
-/* District "What Changed" feed group (#1013, epic #1007 — club links).
+/* District "What Changed" feed group (#1013/#1014, epic #1007 — entity links).
    Extracted from DistrictChangesPage so the link logic can be unit-tested
    directly without a full page mount (R22). Every DiffEvent.label is a
-   pre-rendered sentence that BEGINS with the club name (see diffSnapshots:
-   membership/dcp/distinguished labels are `${name} …`; roster labels are
-   `${name} (${status}) joined/left the roster`). We link just that leading
-   club-name token to the club's detail page and keep the rest of the sentence
-   as plain text — only the name is the link, not the whole prose. districtId
-   is the route param the page owns and passes down (R3) — never re-derived
-   from event data; only clubId comes from each event. */
+   pre-rendered sentence that BEGINS with its entity's display name — the club
+   name for club events (membership/dcp/distinguished/roster), or `entityName`
+   ("Division G" / "Area 2") for area/division status events (#1014). We link
+   just that leading name token to the entity's scoped route and keep the rest
+   of the sentence as plain text. districtId is the route param the page owns
+   and passes down (R3); the entity id/name come from each event. */
 
-/** One change line: club name linked, the rest of the label as plain text.
-    Falls back to plain text for a club-less (district-level) event, or when a
-    label unexpectedly doesn't begin with the club name — so a link is only
+/** The display name + scoped route for an event's entity, or null when the
+    event has no linkable target (an aggregate/district-level line, or an area
+    event missing its division ref — degrade gracefully to text, never a broken
+    link). */
+function resolveEntity(
+  event: DiffEvent,
+  districtId: string
+): { name: string; href: string } | null {
+  if (!districtId) return null
+  const { clubId, clubName, divisionId, areaId, entityName } = event
+
+  // Club-scoped event (the Phase-1 default).
+  if (clubId && clubName) {
+    return { name: clubName, href: `/district/${districtId}/club/${clubId}` }
+  }
+  // Area status event → division-scoped area route (#1008). Needs both refs.
+  if (event.category === 'area-status' && areaId && divisionId && entityName) {
+    return {
+      name: entityName,
+      href: `/district/${districtId}/division/${divisionId}/area/${areaId}`,
+    }
+  }
+  // Division status event → division-scoped route (#1008).
+  if (event.category === 'division-status' && divisionId && entityName) {
+    return {
+      name: entityName,
+      href: `/district/${districtId}/division/${divisionId}`,
+    }
+  }
+  return null
+}
+
+/** One change line: the leading entity name linked, the rest of the label as
+    plain text. Falls back to plain text for an entity-less event, or when a
+    label unexpectedly doesn't begin with the entity name — so a link is only
     ever rendered when it points somewhere real. */
 const ChangeLabel: React.FC<{ event: DiffEvent; districtId: string }> = ({
   event,
   districtId,
 }) => {
-  const { clubId, clubName, label } = event
-  const linkable =
-    !!clubId && !!clubName && !!districtId && label.startsWith(clubName)
+  const { label } = event
+  const entity = resolveEntity(event, districtId)
 
-  if (!linkable) return <>{label}</>
+  if (!entity || !label.startsWith(entity.name)) return <>{label}</>
 
-  const rest = label.slice(clubName.length)
+  const rest = label.slice(entity.name.length)
   return (
     <>
-      <Link
-        to={`/district/${districtId}/club/${clubId}`}
-        className="clubs-name-link"
-      >
-        {clubName}
+      <Link to={entity.href} className="clubs-name-link">
+        {entity.name}
       </Link>
       {rest}
     </>
@@ -67,7 +94,10 @@ export const ChangeGroup: React.FC<{
       </summary>
       <ul className="changes-group__list">
         {events.map(e => (
-          <li key={`${e.category}-${e.clubId}`} className="changes-group__item">
+          <li
+            key={`${e.category}-${e.clubId || e.divisionId || ''}-${e.areaId ?? ''}`}
+            className="changes-group__item"
+          >
             <ChangeLabel event={e} districtId={districtId} />
           </li>
         ))}

--- a/frontend/src/components/__tests__/ChangeGroup.test.tsx
+++ b/frontend/src/components/__tests__/ChangeGroup.test.tsx
@@ -102,3 +102,71 @@ describe('ChangeGroup club links (#1013)', () => {
     expect(container).toBeEmptyDOMElement()
   })
 })
+
+describe('ChangeGroup area/division links (#1014)', () => {
+  it('links a division-status entity to its scoped division route', () => {
+    renderGroup(
+      [
+        event({
+          category: 'division-status',
+          clubId: '',
+          clubName: '',
+          divisionId: 'G',
+          entityName: 'Division G',
+          label: 'Division G moved to Select Distinguished',
+        }),
+      ],
+      '61'
+    )
+
+    const link = screen.getByRole('link', { name: /Division G/ })
+    expect(link).toHaveAttribute('href', '/district/61/division/G')
+    expect(
+      screen.getByText(/moved to Select Distinguished/)
+    ).toBeInTheDocument()
+  })
+
+  it('links an area-status entity to its division-scoped area route', () => {
+    renderGroup(
+      [
+        event({
+          category: 'area-status',
+          clubId: '',
+          clubName: '',
+          divisionId: 'B',
+          areaId: '2',
+          entityName: 'Area 2',
+          label: 'Area 2 moved to Confirmed Distinguished',
+        }),
+      ],
+      '61'
+    )
+
+    const link = screen.getByRole('link', { name: /Area 2/ })
+    expect(link).toHaveAttribute('href', '/district/61/division/B/area/2')
+    expect(
+      screen.getByText(/moved to Confirmed Distinguished/)
+    ).toBeInTheDocument()
+  })
+
+  it('renders an area entity as plain text when its division ref is missing', () => {
+    renderGroup(
+      [
+        event({
+          category: 'area-status',
+          clubId: '',
+          clubName: '',
+          areaId: '2',
+          entityName: 'Area 2',
+          label: 'Area 2 lost Distinguished status',
+        }),
+      ],
+      '61'
+    )
+
+    expect(
+      screen.getByText('Area 2 lost Distinguished status')
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/hooks/__tests__/useSnapshotDiff.test.tsx
+++ b/frontend/src/hooks/__tests__/useSnapshotDiff.test.tsx
@@ -112,6 +112,66 @@ describe('useSnapshotDiff', () => {
     expect(result.current.data?.to.date).toBe('2026-05-26')
   })
 
+  it('merges area/division recognition-status events into the club diff (#1014)', async () => {
+    // Division G earns Select in `to` (paid 4 → 5 at base 4) while staying
+    // Distinguished in `from` — a division-status transition that the
+    // analytics-core club diff never produces. clubPerformance carries the
+    // raw rows extractDivisionPerformance needs.
+    const gClub = (
+      num: string,
+      distinguished: boolean,
+      extra: Record<string, unknown> = {}
+    ) => ({
+      'Club Number': num,
+      'Club Status': 'Active',
+      'Club Distinguished Status': distinguished ? 'Distinguished' : '',
+      Division: 'G',
+      Area: '1',
+      'Division Club Base': '4',
+      'Area Club Base': '10',
+      'Nov Visit award': '0',
+      'May Visit award': '0',
+      ...extra,
+    })
+    const divPerf = (withFifth: boolean) => {
+      const rows = [
+        gClub('g1', true),
+        gClub('g2', true),
+        gClub('g3', false),
+        gClub('g4', false),
+      ]
+      if (withFifth) rows.push(gClub('g5', false))
+      return rows
+    }
+    const snap = (date: string, withFifth: boolean): PerDistrictData => {
+      const base = wrapper(date, 20)
+      base.data.divisionPerformance = divPerf(withFifth)
+      base.data.clubPerformance = divPerf(withFifth)
+      return base
+    }
+
+    mockedFetch.mockImplementation(
+      (date: string) =>
+        Promise.resolve(
+          snap(date, date === '2026-05-26') as unknown
+        ) as Promise<unknown>
+    )
+
+    const { result } = renderHook(
+      () => useSnapshotDiff('61', '2026-05-25', '2026-05-26'),
+      { wrapper: makeWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const divEvent = result.current.data?.events.find(
+      e => e.category === 'division-status'
+    )
+    expect(divEvent).toMatchObject({
+      divisionId: 'G',
+      label: 'Division G moved to Select Distinguished',
+    })
+  })
+
   it('is disabled (does not fetch) when from or to is missing', () => {
     renderHook(() => useSnapshotDiff('61', undefined, '2026-05-26'), {
       wrapper: makeWrapper(),

--- a/frontend/src/hooks/useSnapshotDiff.ts
+++ b/frontend/src/hooks/useSnapshotDiff.ts
@@ -5,6 +5,7 @@ import type {
   PerDistrictData,
   SnapshotDiff,
 } from '@toastmasters/shared-contracts'
+import { diffAreaDivisionStatus } from '../utils/diffAreaDivisionStatus'
 
 /**
  * Resolve the default "since the previous recorded date" pair from a district's
@@ -47,7 +48,12 @@ export function useSnapshotDiff(
         fetchCdnDistrictSnapshot<PerDistrictData>(from!, districtId!),
         fetchCdnDistrictSnapshot<PerDistrictData>(to!, districtId!),
       ])
-      return diffSnapshots(fromSnap.data, toSnap.data)
+      // Club-scoped diff (analytics-core engine) + area/division recognition
+      // transitions (frontend source-of-truth, #1014). The page buckets events
+      // by category, so the two streams coexist in one flat `events` list.
+      const diff = diffSnapshots(fromSnap.data, toSnap.data)
+      const areaDivision = diffAreaDivisionStatus(fromSnap.data, toSnap.data)
+      return { ...diff, events: [...diff.events, ...areaDivision] }
     },
     enabled: !!districtId && !!from && !!to,
     staleTime: 5 * 60 * 1000,

--- a/frontend/src/pages/DistrictChangesPage.tsx
+++ b/frontend/src/pages/DistrictChangesPage.tsx
@@ -36,11 +36,15 @@ function fmtDate(iso: string): string {
 }
 
 /* Display order + headings for the grouped change list. Roster moves first
-   (most material), then recognition, then the per-club metric churn. */
+   (most material), then club / division / area recognition, then the per-club
+   metric churn. Division & area status changes (#1014) sit with the club
+   distinguished group as the "recognition" band. */
 const CATEGORY_GROUPS: { category: DiffEventCategory; heading: string }[] = [
   { category: 'club-added', heading: 'Clubs that joined' },
   { category: 'club-removed', heading: 'Clubs that left' },
   { category: 'distinguished', heading: 'Distinguished status changes' },
+  { category: 'division-status', heading: 'Division status changes' },
+  { category: 'area-status', heading: 'Area status changes' },
   { category: 'membership', heading: 'Membership changes' },
   { category: 'dcp-goals', heading: 'DCP goal changes' },
 ]

--- a/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
@@ -64,6 +64,25 @@ function diffFixture(over: Partial<SnapshotDiff> = {}): SnapshotDiff {
         label: 'Club 00002959 became Distinguished',
         magnitude: 1,
       },
+      {
+        category: 'division-status',
+        clubId: '',
+        clubName: '',
+        divisionId: 'G',
+        entityName: 'Division G',
+        label: 'Division G moved to Select Distinguished',
+        magnitude: 1,
+      },
+      {
+        category: 'area-status',
+        clubId: '',
+        clubName: '',
+        divisionId: 'B',
+        areaId: '2',
+        entityName: 'Area 2',
+        label: 'Area 2 moved to Confirmed Distinguished',
+        magnitude: 1,
+      },
     ],
     ...over,
   }
@@ -101,6 +120,30 @@ describe('DistrictChangesPage', () => {
       screen.getByRole('link', { name: 'iA Montreal Toastmasters' })
     ).toHaveAttribute('href', '/district/61/club/28680300')
     expect(screen.getByText(/\(Active\) joined the roster/)).toBeInTheDocument()
+  })
+
+  it('renders division and area status groups with entities linked to scoped routes (#1014)', () => {
+    mockedDates.mockReturnValue({
+      data: { dates: ['2026-05-25', '2026-05-26'] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDistrictCachedDates>)
+    mockedDiff.mockReturnValue({
+      data: diffFixture(),
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useSnapshotDiff>)
+
+    renderPage()
+    expect(screen.getByText(/Division status changes/)).toBeInTheDocument()
+    expect(screen.getByText(/Area status changes/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Division G' })).toHaveAttribute(
+      'href',
+      '/district/61/division/G'
+    )
+    expect(screen.getByRole('link', { name: 'Area 2' })).toHaveAttribute(
+      'href',
+      '/district/61/division/B/area/2'
+    )
   })
 
   it('renders the date-pair picker when at least two snapshots exist (#794)', () => {

--- a/frontend/src/utils/__tests__/diffAreaDivisionStatus.test.ts
+++ b/frontend/src/utils/__tests__/diffAreaDivisionStatus.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest'
+import { diffAreaDivisionStatus } from '../diffAreaDivisionStatus'
+import type { DistrictStatisticsFile } from '@toastmasters/shared-contracts'
+
+/* Pure diff helper for area/division recognition-status transitions (#1014,
+   epic #1007 Sprint 2). It runs the verified frontend recognition
+   source-of-truth (`extractDivisionPerformance`) on both dated snapshots and
+   emits a `division-status` / `area-status` DiffEvent wherever a recognition
+   tier (division) or a recognition-state descriptor (area: Provisional /
+   Confirmed / Not Distinguished) changes. Computed in the frontend, NOT
+   analytics-core — #799 removed tier logic there to avoid divergence
+   (Lesson 117). No page mount (R22). */
+
+/** A single club row pair: divisionPerformance row + matching clubPerformance row. */
+function club(o: {
+  division: string
+  area: string
+  num: string
+  divBase: string
+  areaBase: string
+  nov: string
+  may: string
+  distinguished?: boolean
+}) {
+  return {
+    dp: {
+      Division: o.division,
+      Area: o.area,
+      'Club Number': o.num,
+      'Division Club Base': o.divBase,
+      'Area Club Base': o.areaBase,
+      'Nov Visit award': o.nov,
+      'May Visit award': o.may,
+    },
+    cp: {
+      'Club Number': o.num,
+      'Club Status': 'Active',
+      'Club Distinguished Status': o.distinguished ? 'Distinguished' : '',
+    },
+  }
+}
+
+function snapshot(
+  snapshotDate: string,
+  pairs: ReturnType<typeof club>[]
+): DistrictStatisticsFile {
+  return {
+    districtId: '61',
+    snapshotDate,
+    divisionPerformance: pairs.map(p => p.dp),
+    clubPerformance: pairs.map(p => p.cp),
+  } as unknown as DistrictStatisticsFile
+}
+
+/* Division G (base 4): 2 distinguished + paid goes 4 → 5, so Distinguished
+   (paid≥base) → Select (paid≥base+1). Its area "1" carries an inflated Area
+   Club Base (10) so it is perpetually net-loss → Not Distinguished in BOTH
+   snapshots and emits no area event — isolating the division transition. */
+function divisionGClubs(extraPaidClub: boolean) {
+  const base = [
+    club({ division: 'G', area: '1', num: 'g1', divBase: '4', areaBase: '10', nov: '0', may: '0', distinguished: true }), // prettier-ignore
+    club({ division: 'G', area: '1', num: 'g2', divBase: '4', areaBase: '10', nov: '0', may: '0', distinguished: true }), // prettier-ignore
+    club({
+      division: 'G',
+      area: '1',
+      num: 'g3',
+      divBase: '4',
+      areaBase: '10',
+      nov: '0',
+      may: '0',
+    }),
+    club({
+      division: 'G',
+      area: '1',
+      num: 'g4',
+      divBase: '4',
+      areaBase: '10',
+      nov: '0',
+      may: '0',
+    }),
+  ]
+  if (extraPaidClub) {
+    base.push(
+      club({ division: 'G', area: '1', num: 'g5', divBase: '4', areaBase: '10', nov: '0', may: '0' }) // prettier-ignore
+    )
+  }
+  return base
+}
+
+/* Division B (base 4): paid 4, distinguished 2 in BOTH snapshots → Distinguished
+   throughout (no division event). Its area "2" (base 4) earns Distinguished on
+   club metrics; round-1 visits are met in both, round-2 visits flip 0 → met,
+   so the area moves Provisional → Confirmed in a March snapshot (R2 deadline
+   May 31 not yet passed). */
+function divisionBClubs(round2Met: boolean) {
+  const may = round2Met ? '1' : '0'
+  return [
+    club({ division: 'B', area: '2', num: 'b1', divBase: '4', areaBase: '4', nov: '1', may, distinguished: true }), // prettier-ignore
+    club({ division: 'B', area: '2', num: 'b2', divBase: '4', areaBase: '4', nov: '1', may, distinguished: true }), // prettier-ignore
+    club({
+      division: 'B',
+      area: '2',
+      num: 'b3',
+      divBase: '4',
+      areaBase: '4',
+      nov: '1',
+      may,
+    }),
+    club({
+      division: 'B',
+      area: '2',
+      num: 'b4',
+      divBase: '4',
+      areaBase: '4',
+      nov: '1',
+      may,
+    }),
+  ]
+}
+
+describe('diffAreaDivisionStatus (#1014)', () => {
+  it('emits a division-status event when a division moves Distinguished → Select', () => {
+    const from = snapshot('2026-03-10', [
+      ...divisionGClubs(false),
+      ...divisionBClubs(false),
+    ])
+    const to = snapshot('2026-03-20', [
+      ...divisionGClubs(true),
+      ...divisionBClubs(false),
+    ])
+
+    const events = diffAreaDivisionStatus(from, to)
+    const div = events.filter(e => e.category === 'division-status')
+
+    expect(div).toHaveLength(1)
+    expect(div[0]).toMatchObject({
+      category: 'division-status',
+      divisionId: 'G',
+      entityName: 'Division G',
+      label: 'Division G moved to Select Distinguished',
+    })
+    expect(div[0].clubId).toBe('')
+    expect(div[0].areaId).toBeUndefined()
+  })
+
+  it('emits an area-status event when an area moves Provisional → Confirmed', () => {
+    const from = snapshot('2026-03-10', [
+      ...divisionGClubs(false),
+      ...divisionBClubs(false),
+    ])
+    const to = snapshot('2026-03-20', [
+      ...divisionGClubs(false),
+      ...divisionBClubs(true),
+    ])
+
+    const events = diffAreaDivisionStatus(from, to)
+    const area = events.filter(e => e.category === 'area-status')
+
+    expect(area).toHaveLength(1)
+    expect(area[0]).toMatchObject({
+      category: 'area-status',
+      areaId: '2',
+      divisionId: 'B',
+      entityName: 'Area 2',
+      label: 'Area 2 moved to Confirmed Distinguished',
+    })
+    // The area carries its division so the feed can build the scoped route.
+    expect(area[0].clubId).toBe('')
+  })
+
+  it('emits nothing when the two snapshots are identical', () => {
+    const from = snapshot('2026-03-10', [
+      ...divisionGClubs(false),
+      ...divisionBClubs(false),
+    ])
+    const to = snapshot('2026-03-20', [
+      ...divisionGClubs(false),
+      ...divisionBClubs(false),
+    ])
+
+    expect(diffAreaDivisionStatus(from, to)).toEqual([])
+  })
+})

--- a/frontend/src/utils/diffAreaDivisionStatus.ts
+++ b/frontend/src/utils/diffAreaDivisionStatus.ts
@@ -1,0 +1,197 @@
+/**
+ * Area/division recognition-status diff (#1014, epic #1007 Sprint 2).
+ *
+ * Pure helper that derives `area-status` / `division-status` change events
+ * between two dated district snapshots, to enrich the "What Changed" feed
+ * beyond its club-scoped events.
+ *
+ * It runs the **verified recognition source-of-truth**
+ * (`extractDivisionPerformance`) on each snapshot and compares:
+ *   - per **division**: the DDP recognition tier (`DistinguishedStatus`);
+ *   - per **area**: the snapshot-date-aware recognition *descriptor* — the
+ *     `recognitionState` collapsed to Not Distinguished / Provisional <tier> /
+ *     Confirmed <tier> (the visit-qualifying gate, #832).
+ *
+ * Computed in the frontend, NOT the analytics-core `diffSnapshots` engine:
+ * #799 deliberately removed recognition-tier logic from analytics-core because
+ * it diverged from this source-of-truth (Lesson 117). Keeping the derivation
+ * here means one implementation feeds both the rendered tables and this diff.
+ *
+ * Each emitted `DiffEvent` sets `divisionId` (and `areaId` for areas) plus an
+ * `entityName` the `label` begins with, so the feed can link the entity to its
+ * scoped route exactly as club events link the club name (#1013).
+ *
+ * @module diffAreaDivisionStatus
+ */
+
+import type {
+  DistrictStatisticsFile,
+  DiffEvent,
+} from '@toastmasters/shared-contracts'
+import { extractDivisionPerformance } from './extractDivisionPerformance'
+import type {
+  DivisionPerformance,
+  AreaPerformance,
+  DistinguishedStatus,
+} from './divisionStatus'
+
+/** Human tier names shared by area + division labels. */
+const TIER_LABEL: Record<string, string> = {
+  distinguished: 'Distinguished',
+  'select-distinguished': 'Select Distinguished',
+  'presidents-distinguished': "President's Distinguished",
+  // area recognition-LEVEL codes (areaRecognitionState.level)
+  select: 'Select Distinguished',
+  presidents: "President's Distinguished",
+}
+
+function tierLabel(code: string): string {
+  return TIER_LABEL[code] ?? 'Distinguished'
+}
+
+/** A division is distinguished at any tier above the floor. */
+function isDivisionDistinguished(status: DistinguishedStatus): boolean {
+  return status !== 'not-distinguished' && status !== 'not-qualified'
+}
+
+/** Sort rank for a division tier (higher = stronger recognition). */
+function divisionRank(status: DistinguishedStatus): number {
+  switch (status) {
+    case 'presidents-distinguished':
+      return 3
+    case 'select-distinguished':
+      return 2
+    case 'distinguished':
+      return 1
+    default:
+      return 0
+  }
+}
+
+/**
+ * Collapse an area's `recognitionState` to the human descriptor the feed
+ * surfaces: "Not Distinguished", or "<Provisional|Confirmed> <tier>".
+ */
+function areaDescriptor(area: AreaPerformance): string {
+  const { level, status } = area.recognitionState
+  if (level === 'none' || status === 'not-distinguished') {
+    return 'Not Distinguished'
+  }
+  const prefix = status === 'confirmed' ? 'Confirmed' : 'Provisional'
+  return `${prefix} ${tierLabel(level)}`
+}
+
+function areaIsDistinguished(area: AreaPerformance): boolean {
+  return (
+    area.recognitionState.level !== 'none' &&
+    area.recognitionState.status !== 'not-distinguished'
+  )
+}
+
+/** Sort rank for an area state: tier weight, with Confirmed above Provisional. */
+function areaRank(area: AreaPerformance): number {
+  const { level, status } = area.recognitionState
+  if (level === 'none' || status === 'not-distinguished') return 0
+  const tier = level === 'presidents' ? 3 : level === 'select' ? 2 : 1
+  return tier * 2 + (status === 'confirmed' ? 1 : 0)
+}
+
+/** Build the became/lost/moved label fragment shared by both entity kinds. */
+function transitionLabel(
+  name: string,
+  fromDist: boolean,
+  toDist: boolean,
+  toDescriptor: string
+): string | null {
+  if (!fromDist && toDist) return `${name} became ${toDescriptor}`
+  if (fromDist && !toDist) return `${name} lost Distinguished status`
+  if (fromDist && toDist) return `${name} moved to ${toDescriptor}`
+  return null // both not-distinguished: no recognition change to surface
+}
+
+function divisionsById(
+  snapshot: DistrictStatisticsFile
+): Map<string, DivisionPerformance> {
+  const perf = extractDivisionPerformance(snapshot, snapshot.snapshotDate)
+  return new Map(perf.map(d => [d.divisionId, d]))
+}
+
+/**
+ * Compute area/division recognition-status transition events between two dated
+ * snapshots. Only entities present in BOTH snapshots are diffed (a freshly
+ * added/removed division surfaces via club roster events, not a phantom
+ * status flip). Returns events sorted by descending magnitude.
+ */
+export function diffAreaDivisionStatus(
+  from: DistrictStatisticsFile,
+  to: DistrictStatisticsFile
+): DiffEvent[] {
+  const fromDivs = divisionsById(from)
+  const toDivs = divisionsById(to)
+  const events: DiffEvent[] = []
+
+  for (const [divisionId, toDiv] of toDivs) {
+    const fromDiv = fromDivs.get(divisionId)
+    if (!fromDiv) continue
+
+    // Division tier transition.
+    if (fromDiv.status !== toDiv.status) {
+      const name = `Division ${divisionId}`
+      const label = transitionLabel(
+        name,
+        isDivisionDistinguished(fromDiv.status),
+        isDivisionDistinguished(toDiv.status),
+        tierLabel(toDiv.status)
+      )
+      if (label) {
+        events.push({
+          category: 'division-status',
+          clubId: '',
+          clubName: '',
+          divisionId,
+          entityName: name,
+          label,
+          magnitude: divisionRank(toDiv.status) - divisionRank(fromDiv.status),
+        })
+      }
+    }
+
+    // Area transitions within the division.
+    const fromAreas = new Map(fromDiv.areas.map(a => [a.areaId, a]))
+    for (const toArea of toDiv.areas) {
+      const fromArea = fromAreas.get(toArea.areaId)
+      if (!fromArea) continue
+      const fromDesc = areaDescriptor(fromArea)
+      const toDesc = areaDescriptor(toArea)
+      if (fromDesc === toDesc) continue
+
+      const name = `Area ${toArea.areaId}`
+      const label = transitionLabel(
+        name,
+        areaIsDistinguished(fromArea),
+        areaIsDistinguished(toArea),
+        toDesc
+      )
+      if (!label) continue
+      events.push({
+        category: 'area-status',
+        clubId: '',
+        clubName: '',
+        divisionId,
+        areaId: toArea.areaId,
+        entityName: name,
+        label,
+        magnitude: areaRank(toArea) - areaRank(fromArea),
+      })
+    }
+  }
+
+  // Biggest absolute recognition swing first; stable tie-break by entity name.
+  events.sort((a, b) => {
+    const byMag = Math.abs(b.magnitude) - Math.abs(a.magnitude)
+    if (byMag !== 0) return byMag
+    return (a.entityName ?? '').localeCompare(b.entityName ?? '')
+  })
+
+  return events
+}

--- a/packages/shared-contracts/src/__tests__/snapshot-diff.schema.test.ts
+++ b/packages/shared-contracts/src/__tests__/snapshot-diff.schema.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DiffEventCategorySchema,
+  DiffEventSchema,
+} from '../schemas/snapshot-diff.schema.js'
+
+/* Schema contract for the area/division status-transition events (#1014,
+   epic #1007 Sprint 2). The diff event vocabulary gains two entity-scoped
+   categories and optional area/division refs so a single DiffEvent can carry
+   a club, an area, OR a division — the existing club-scoped events keep their
+   exact shape (clubId/clubName required-but-emptyable, no new fields needed). */
+
+describe('DiffEventCategorySchema (#1014)', () => {
+  it.each([
+    'membership',
+    'dcp-goals',
+    'distinguished',
+    'club-added',
+    'club-removed',
+    'area-status',
+    'division-status',
+  ])('accepts the %s category', category => {
+    expect(DiffEventCategorySchema.parse(category)).toBe(category)
+  })
+
+  it('rejects an unknown category', () => {
+    expect(() => DiffEventCategorySchema.parse('region-status')).toThrow()
+  })
+})
+
+describe('DiffEventSchema entity refs (#1014)', () => {
+  it('parses a division-status event with a divisionId + entityName', () => {
+    const event = {
+      category: 'division-status',
+      clubId: '',
+      clubName: '',
+      divisionId: 'G',
+      entityName: 'Division G',
+      label: 'Division G moved to Select Distinguished',
+      magnitude: 1,
+    }
+    expect(DiffEventSchema.parse(event)).toMatchObject({
+      category: 'division-status',
+      divisionId: 'G',
+      entityName: 'Division G',
+    })
+  })
+
+  it('parses an area-status event carrying both areaId and divisionId', () => {
+    const event = {
+      category: 'area-status',
+      clubId: '',
+      clubName: '',
+      divisionId: 'B',
+      areaId: 'B2',
+      entityName: 'Area B2',
+      label: 'Area B2 moved to Confirmed Distinguished',
+      magnitude: 1,
+    }
+    expect(DiffEventSchema.parse(event)).toMatchObject({
+      areaId: 'B2',
+      divisionId: 'B',
+    })
+  })
+
+  it('still parses a club-scoped event with no entity refs (back-compat)', () => {
+    const event = {
+      category: 'membership',
+      clubId: '123',
+      clubName: 'Acme Club',
+      label: 'Acme Club gained 5 members',
+      magnitude: 5,
+    }
+    const parsed = DiffEventSchema.parse(event)
+    expect(parsed.areaId).toBeUndefined()
+    expect(parsed.divisionId).toBeUndefined()
+  })
+})

--- a/packages/shared-contracts/src/schemas/snapshot-diff.schema.ts
+++ b/packages/shared-contracts/src/schemas/snapshot-diff.schema.ts
@@ -26,6 +26,13 @@ export type AggregateDelta = z.infer<typeof AggregateDeltaSchema>
 /**
  * Category of a single change event. Payments is intentionally aggregate-only
  * in Phase 1 (per-club payment churn would double the membership noise).
+ *
+ * `area-status` / `division-status` (#1014) carry recognition-tier transitions
+ * for areas/divisions instead of clubs — derived in the frontend from the
+ * verified recognition source-of-truth (`extractDivisionPerformance`), NOT the
+ * analytics-core engine (which deliberately dropped tier logic in #799 to avoid
+ * divergence — Lesson 117). Such events set `areaId`/`divisionId` rather than a
+ * `clubId`.
  */
 export const DiffEventCategorySchema = z.enum([
   'membership',
@@ -33,6 +40,8 @@ export const DiffEventCategorySchema = z.enum([
   'distinguished',
   'club-added',
   'club-removed',
+  'area-status',
+  'division-status',
 ])
 export type DiffEventCategory = z.infer<typeof DiffEventCategorySchema>
 
@@ -70,11 +79,26 @@ export const ClubPresenceSchema = z.object({
 })
 export type ClubPresence = z.infer<typeof ClubPresenceSchema>
 
-/** A narrative-ready, categorized change event. `magnitude` is signed (sort key). */
+/**
+ * A narrative-ready, categorized change event. `magnitude` is signed (sort key).
+ *
+ * `clubId`/`clubName` identify a club-scoped event (the Phase-1 default; both
+ * empty for an entity-less aggregate line). `areaId`/`divisionId`/`entityName`
+ * (#1014) identify an area- or division-scoped recognition transition — the
+ * frontend links the entity to its scoped route from these. `label` always
+ * BEGINS with the entity display name (club name or `entityName`) so the feed
+ * can link just that leading token, matching the club-link contract (#1013).
+ */
 export const DiffEventSchema = z.object({
   category: DiffEventCategorySchema,
   clubId: z.string(),
   clubName: z.string(),
+  /** Division ref — set for `division-status` and (with `areaId`) `area-status`. */
+  divisionId: z.string().optional(),
+  /** Area ref — set for `area-status` events. */
+  areaId: z.string().optional(),
+  /** Display name the label begins with for an area/division event (e.g. "Area B2"). */
+  entityName: z.string().optional(),
   label: z.string(),
   magnitude: z.number(),
 })


### PR DESCRIPTION
Closes-after-verify: #1014 (epic #1007 Sprint 2). _Not_ auto-closing via `Closes #` — the runner ticks the epic before closing the sub-issue (R15 / Lesson 106).

## What
Surfaces **area & division recognition-status transitions** in the District "What Changed" feed (`/district/:id/changes`), alongside the existing club-scoped events. Status-transitions only — no per-visit detail (operator decision in #1014).

- "Division G moved to Select Distinguished", "Area 2 moved to Confirmed Distinguished", became/lost variants.
- Each entity links to its scoped route (#1008): division → `/district/:d/division/:divId`; area → `/district/:d/division/:divId/area/:areaId`.

## Architecture decision (operator-confirmed this session)
The issue suggested extending `diffSnapshots` in **analytics-core**. But **#799 deliberately removed** recognition-tier logic from analytics-core because it diverged from the frontend's verified source-of-truth (`divisionGapAnalysis`/`areaGapAnalysis`/`areaRecognitionState`, DDP/DAP manual item 1490) — re-adding it would reintroduce exactly that divergence (Lesson 117). So the diff is computed in the **frontend** via a new pure helper `diffAreaDivisionStatus`, reusing `extractDivisionPerformance` (the same code that renders the division/area tables). One implementation, zero divergence. The shared **schema** (`DiffEventCategory` + optional `areaId`/`divisionId`/`entityName`) is still extended as specified.

Trade-off accepted: these events are frontend-derived, so a future Phase-4 collector pre-compute would need them ported. Noted for follow-up.

## Changes
- `shared-contracts`: `DiffEventCategory` gains `area-status`/`division-status`; `DiffEvent` gains optional `divisionId`/`areaId`/`entityName`.
- `frontend/utils/diffAreaDivisionStatus.ts` (new, pure): diff division tier + area recognition-descriptor (Not Distinguished / Provisional <tier> / Confirmed <tier>).
- `useSnapshotDiff`: merges these events into the club diff.
- `ChangeGroup`: generalised entity-linking (club | division | area), graceful text fallback.
- `DistrictChangesPage`: two new category groups in the recognition band.

## TDD / tests
Red→Green→Refactor per surface, each commit refs #1014. New tests: schema (11), pure diff helper (3), hook merge (1), ChangeGroup links (3), page groups (1). Full suite green: frontend 3295, shared 145, analytics 791, collector 737. R22 page-mount guard passes.

## Verification
Live preview verification on `/district/61/changes` (dual-engine Playwright) to follow on the PR preview channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)