### PR TITLE
feat(division): DivisionPage data parity with the divisions overview (#1015)

### DIFF
--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -6,6 +6,9 @@
 import React from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
+import { useDistrictStatistics } from '../hooks/useMembershipData'
+import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
+import { DivisionPerformanceCard } from '../components/DivisionPerformanceCard'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 import { ClubMiniList } from '../components/ClubMiniList'
@@ -24,6 +27,19 @@ const DivisionPage: React.FC = () => {
     undefined,
     undefined
   )
+
+  // Recognition / gap / visit data come from the same raw snapshot the
+  // Divisions overview reads — one source of truth (R6/R8, #1015). We reuse the
+  // overview's extractDivisionPerformance util + DivisionPerformanceCard rather
+  // than re-deriving from allClubs, so this scoped page can't drift from it.
+  const { data: snapshot, isLoading: isLoadingSnapshot } =
+    useDistrictStatistics(districtId ?? '', undefined, 'divisions')
+  const divisionPerformance = React.useMemo(() => {
+    if (!snapshot || !divId) return undefined
+    return extractDivisionPerformance(snapshot, snapshot.asOfDate).find(
+      d => d.divisionId.toUpperCase() === divId.toUpperCase()
+    )
+  }, [snapshot, divId])
 
   if (isLoading) {
     return <LoadingSkeleton variant="card" />
@@ -60,17 +76,6 @@ const DivisionPage: React.FC = () => {
   }
 
   const divisionName = clubs[0]?.divisionName ?? `Division ${divId}`
-
-  // KPI rollup — counts by health status, total members.
-  const totalMembers = clubs.reduce((sum, c) => {
-    const last = c.membershipTrend[c.membershipTrend.length - 1]
-    return sum + (last?.count ?? 0)
-  }, 0)
-  const thriving = clubs.filter(c => c.currentStatus === 'thriving').length
-  const vulnerable = clubs.filter(c => c.currentStatus === 'vulnerable').length
-  const intervention = clubs.filter(
-    c => c.currentStatus === 'intervention-required'
-  ).length
 
   // Group clubs by area for the table sections.
   const areaGroups = new Map<
@@ -109,42 +114,16 @@ const DivisionPage: React.FC = () => {
         </div>
       </header>
 
-      <div
-        className="districts-kpi-strip"
-        style={{ marginBottom: 24 }}
-        aria-label="Division totals"
-      >
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Clubs</p>
-          <div className="districts-kpi-card__value">{clubs.length}</div>
-        </div>
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Total Members</p>
-          <div className="districts-kpi-card__value">
-            {totalMembers.toLocaleString()}
-          </div>
-        </div>
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Thriving</p>
-          <div
-            className="districts-kpi-card__value"
-            style={{ color: 'var(--green-600, #16a34a)' }}
-          >
-            {thriving}
-          </div>
-        </div>
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Needs Attention</p>
-          <div
-            className="districts-kpi-card__value"
-            style={{
-              color:
-                intervention > 0 ? 'var(--red-600, #dc2626)' : 'var(--ink-2)',
-            }}
-          >
-            {vulnerable + intervention}
-          </div>
-        </div>
+      {/* Division + areas recognition data, reused from the Divisions overview
+          (#1015). Replaces the old ad-hoc allClubs KPI strip so the standalone
+          page shows the same status / Gap-to-D-S-P / per-area visit metrics on
+          the same computation as the overview. */}
+      <div style={{ marginBottom: 24 }}>
+        {divisionPerformance ? (
+          <DivisionPerformanceCard division={divisionPerformance} />
+        ) : (
+          isLoadingSnapshot && <LoadingSkeleton variant="table" count={3} />
+        )}
       </div>
 
       {areas.map(area => (

--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -1,7 +1,9 @@
-/* DivisionPage (#424) — landing for a single division within a
-   district. Lists every club in that division with health status and
-   a small KPI strip. Reuses the shared district analytics React-Query
-   cache. */
+/* DivisionPage (#424) — landing for a single division within a district.
+   Shows the same division + areas recognition data as the Divisions overview
+   (status, Gap-to-D/S/P, per-area visit metrics) via the shared
+   extractDivisionPerformance + DivisionPerformanceCard (#1015), then lists
+   every club in the division by area with health status. Reuses the shared
+   district analytics + snapshot React-Query caches. */
 
 import React from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'

--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -36,12 +36,13 @@ const DivisionPage: React.FC = () => {
   // than re-deriving from allClubs, so this scoped page can't drift from it.
   const { data: snapshot, isLoading: isLoadingSnapshot } =
     useDistrictStatistics(districtId ?? '', undefined, 'divisions')
+  const normalizedDivId = divId?.toUpperCase()
   const divisionPerformance = React.useMemo(() => {
-    if (!snapshot || !divId) return undefined
+    if (!snapshot || !normalizedDivId) return undefined
     return extractDivisionPerformance(snapshot, snapshot.asOfDate).find(
-      d => d.divisionId.toUpperCase() === divId.toUpperCase()
+      d => d.divisionId.toUpperCase() === normalizedDivId
     )
-  }, [snapshot, divId])
+  }, [snapshot, normalizedDivId])
 
   if (isLoading) {
     return <LoadingSkeleton variant="card" />
@@ -57,25 +58,9 @@ const DivisionPage: React.FC = () => {
     )
   }
 
-  const clubs = data.allClubs.filter(c => c.divisionId === divId)
-
-  if (clubs.length === 0) {
-    return (
-      <div className="app-shell__page">
-        <p className="placeholder-page__eyebrow">Division</p>
-        <h1 className="placeholder-page__title">
-          District {districtId} · Division {divId}
-        </h1>
-        <p className="placeholder-page__body">
-          No clubs found in this division.{' '}
-          <Link to={`/district/${districtId}`}>
-            Back to District {districtId}
-          </Link>
-          .
-        </p>
-      </div>
-    )
-  }
+  const clubs = data.allClubs.filter(
+    c => c.divisionId.toUpperCase() === normalizedDivId
+  )
 
   const divisionName = clubs[0]?.divisionName ?? `Division ${divId}`
 
@@ -110,8 +95,9 @@ const DivisionPage: React.FC = () => {
           </p>
           <h1 className="districts-page-header__title">{divisionName}</h1>
           <p className="districts-page-header__lede">
-            {clubs.length} club{clubs.length === 1 ? '' : 's'} across{' '}
-            {areas.length} area{areas.length === 1 ? '' : 's'} in this division.
+            {clubs.length === 0
+              ? 'Division recognition standing for this program year.'
+              : `${clubs.length} club${clubs.length === 1 ? '' : 's'} across ${areas.length} area${areas.length === 1 ? '' : 's'} in this division.`}
           </p>
         </div>
       </header>
@@ -127,6 +113,19 @@ const DivisionPage: React.FC = () => {
           isLoadingSnapshot && <LoadingSkeleton variant="table" count={3} />
         )}
       </div>
+
+      {/* No analytics-club rows for this division (suspended/migrated clubs).
+          The recognition card above still renders from the snapshot — don't
+          hide it behind an empty club list (#1015). */}
+      {clubs.length === 0 && (
+        <p className="placeholder-page__body">
+          No clubs are currently listed in this division.{' '}
+          <Link to={`/district/${districtId}`}>
+            Back to District {districtId}
+          </Link>
+          .
+        </p>
+      )}
 
       {areas.map(area => (
         <section key={area.areaId} style={{ marginBottom: 32 }}>

--- a/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
@@ -23,6 +23,18 @@ vi.mock('../../hooks/useIsMobile', () => ({
   useIsMobile: () => mockUseIsMobile(),
 }))
 
+// DivisionPage now also reads the raw snapshot for the shared
+// DivisionPerformanceCard (#1015). This suite only exercises the club
+// mini-table de-table behaviour, so stub the snapshot query as "no data" —
+// the recognition card is absent and the club list (under test) renders.
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  })),
+}))
+
 const CLUB: ClubTrend = {
   clubId: 'c1',
   clubName: 'Limestone City Club',

--- a/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
@@ -165,4 +165,24 @@ describe('DivisionPage data parity with the Divisions overview (#1015)', () => {
     const { queryByText } = renderDivision()
     expect(queryByText('Needs Attention')).toBeNull()
   })
+
+  it('still renders the recognition card when allClubs has no rows for the division', async () => {
+    // The recognition card is fed by the snapshot, not allClubs. A division
+    // with snapshot data but zero analytics-club rows (suspended/migrated
+    // clubs, or a casing skew) must still show parity data — not a bare
+    // "No clubs found" placeholder that hides it.
+    const mod = await import('../../hooks/useDistrictAnalytics')
+    const spy = mod.useDistrictAnalytics as unknown as ReturnType<typeof vi.fn>
+    spy.mockReturnValueOnce({
+      data: { allClubs: [] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    const { getByRole, queryByText } = renderDivision()
+    expect(
+      getByRole('status', { name: /Division status:/i })
+    ).toBeInTheDocument()
+    expect(queryByText('No clubs found in this division.')).toBeNull()
+  })
 })

--- a/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * DivisionPage data parity with the Divisions overview (#1015, epic #1008).
+ *
+ * The standalone DivisionPage used to render four ad-hoc KPI cards
+ * (Clubs / Total Members / Thriving / Needs Attention) computed from
+ * `allClubs` — a *different* computation than the overview, with no
+ * recognition status, gap analysis, or per-area visit metrics. This test
+ * pins the parity target: the page must render the shared
+ * `extractDivisionPerformance` → `DivisionPerformanceCard` surface for the
+ * scoped division (DivisionSummary status + Gap-to-D/S/P, AreaPerformanceTable
+ * with First/Second Round Visits + recognition badge), so it matches the
+ * overview's division+areas data from one source of truth (R6/R8).
+ */
+import React from 'react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import DivisionPage from '../DivisionPage'
+
+vi.mock('../../hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+}))
+
+// Two clubs in Division A: one Select Distinguished (area 10, R1 visit done),
+// two undistinguished (area 11, no visits). base 3 → required distinguished
+// ceil(3 * 0.45) = 2, so the division sits below Distinguished with a Gap-to-D
+// of 1 and area 10 has a met first-round visit while area 11 does not.
+const SNAPSHOT = {
+  asOfDate: '2026-03-15',
+  divisionPerformance: [
+    {
+      Division: 'A',
+      Area: '10',
+      'Club Number': '123456',
+      'Club Name': 'Ottawa Club',
+      'Division Club Base': '3',
+      'Area Club Base': '1',
+      'Nov Visit award': '1',
+      'May Visit award': '0',
+    },
+    {
+      Division: 'A',
+      Area: '11',
+      'Club Number': '234567',
+      'Club Name': 'Vulnerable Club',
+      'Division Club Base': '3',
+      'Area Club Base': '2',
+      'Nov Visit award': '0',
+      'May Visit award': '0',
+    },
+    {
+      Division: 'A',
+      Area: '11',
+      'Club Number': '654321',
+      'Club Name': 'Struggling Club',
+      'Division Club Base': '3',
+      'Area Club Base': '2',
+      'Nov Visit award': '0',
+      'May Visit award': '0',
+    },
+  ],
+  clubPerformance: [
+    {
+      'Club Number': '123456',
+      'Club Name': 'Ottawa Club',
+      'Club Status': 'Active',
+      'Club Distinguished Status': 'Select Distinguished',
+    },
+    {
+      'Club Number': '234567',
+      'Club Name': 'Vulnerable Club',
+      'Club Status': 'Active',
+      'Club Distinguished Status': '',
+    },
+    {
+      'Club Number': '654321',
+      'Club Name': 'Struggling Club',
+      'Club Status': 'Active',
+      'Club Distinguished Status': '',
+    },
+  ],
+}
+
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({
+    data: SNAPSHOT,
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+const CLUB: ClubTrend = {
+  clubId: '123456',
+  clubName: 'Ottawa Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '10',
+  areaName: 'Area 10',
+  distinguishedLevel: 'Select Distinguished',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: '2026-03-15', count: 25 }],
+  dcpGoalsTrend: [{ date: '2026-03-15', goalsAchieved: 8 }],
+}
+
+vi.mock('../../hooks/useDistrictAnalytics', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../hooks/useDistrictAnalytics')
+  >('../../hooks/useDistrictAnalytics')
+  return {
+    ...actual,
+    useDistrictAnalytics: vi.fn(() => ({
+      data: { allClubs: [CLUB] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })),
+  }
+})
+
+function renderDivision() {
+  return render(
+    <MemoryRouter initialEntries={['/district/61/division/A']}>
+      <Routes>
+        <Route
+          path="/district/:districtId/division/:divId"
+          element={<DivisionPage />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('DivisionPage data parity with the Divisions overview (#1015)', () => {
+  it('renders the division recognition status badge', () => {
+    const { getByRole } = renderDivision()
+    const badge = getByRole('status', { name: /Division status:/i })
+    expect(badge).toBeInTheDocument()
+  })
+
+  it('renders Gap-to-D / S / P indicators from the shared gap analysis', () => {
+    const { container } = renderDivision()
+    expect(container.querySelector('[data-testid="gap-to-d"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="gap-to-s"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="gap-to-p"]')).not.toBeNull()
+  })
+
+  it('renders the per-area First/Second Round Visit columns', () => {
+    const { getByText } = renderDivision()
+    expect(getByText('First Round Visits')).toBeInTheDocument()
+    expect(getByText('Second Round Visits')).toBeInTheDocument()
+  })
+
+  it('renders a per-area recognition badge (source-of-truth #832 gate)', () => {
+    const { getAllByLabelText } = renderDivision()
+    expect(
+      getAllByLabelText(/Recognition status:/i).length
+    ).toBeGreaterThanOrEqual(1)
+  })
+
+  it('drops the ad-hoc "Needs Attention" KPI card (swapped for shared data)', () => {
+    const { queryByText } = renderDivision()
+    expect(queryByText('Needs Attention')).toBeNull()
+  })
+})

--- a/tasks/lessons/147-a-reused-parity-surface-must-render-from-its-own-data-source-not-be-gated-by-a-siblings-emptiness.md
+++ b/tasks/lessons/147-a-reused-parity-surface-must-render-from-its-own-data-source-not-be-gated-by-a-siblings-emptiness.md
@@ -1,0 +1,67 @@
+---
+id: '147'
+category: lesson
+tags: [frontend, react, scope, refactor, verification]
+auto_load: true
+date: 2026-05-31
+issues: [1015, 1008]
+---
+
+# Lesson 147 — A reused "parity" surface must render from its own data source, not sit behind a sibling source's emptiness check
+
+**Date:** 2026-05-31
+**Issue:** #1015 (epic #1008 Sprint 1 — DivisionPage data parity)
+**PR:** #1026
+
+## What happened
+
+The standalone `DivisionPage` showed an ad-hoc KPI strip computed from
+`useDistrictAnalytics().allClubs` — a _different_ computation than the Divisions
+overview, which renders `extractDivisionPerformance(snapshot)` →
+`DivisionPerformanceCard`. The sprint swapped in the shared util + component so
+the scoped page matches the overview from one source of truth (R6/R8).
+
+The trap fresh-context review caught: the recognition card is fed by the
+**snapshot**, but the page still had an early `return` for
+`clubs.length === 0` (from the _other_ source, `allClubs`). So a division with
+real snapshot recognition data but zero analytics-club rows — suspended/migrated
+clubs, or just a casing skew between the two id fields — rendered a bare "No
+clubs found" placeholder and **silently hid the parity card**. The very drift
+the sprint existed to kill, reintroduced one layer down: two independent data
+sources, one gating the visibility of the other.
+
+A second, smaller version of the same skew: the card matched the division id
+case-insensitively while the club filter matched it case-sensitively — so the
+two could disagree about which division "exists."
+
+## The transferable principle
+
+When you reuse a shared component to give a scoped page **parity** with a
+broader view, the reused surface must render from **the same data source the
+original reads**, and its visibility must not be coupled to a _different_
+source's emptiness/loading/validity. Audit every early `return` that sits above
+the reused surface: if the guard keys off source B but the surface is fed by
+source A, the surface vanishes exactly on the rows where A and B disagree —
+which is precisely the population a parity feature is supposed to rescue. Render
+the reused surface in the main layout; let each _secondary_ section degrade on
+its own (here: an inline "no clubs listed" note), not by short-circuiting the
+whole page.
+
+## How to apply
+
+- Map each rendered block to the query that feeds it before adding/keeping any
+  early return. A guard may only gate blocks fed by _its own_ query.
+- When two id fields from two sources are compared, normalize both ends the same
+  way (here: `.toUpperCase()` on both the card lookup and the club filter) — a
+  lenient match on one path and a strict match on the other is a latent
+  divergence.
+- Sprints 2–3 of #1008 port the same parity to `AreaPage`; they inherit this —
+  feed the area recognition surface from the snapshot and don't gate it behind
+  the area's `allClubs` rows.
+
+## Related
+
+- [[117-a-delegate-to-x-ticket-is-a-trap-when-the-two-impls-have-diverged-in-output]]
+  — reuse the proven shared core, but verify the two paths actually agree.
+- [[052-close-to-distinguished-dual-metric]] — two surfaces sharing a label must
+  share a definition; here two surfaces sharing a page must not cross-gate.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -125,3 +125,4 @@
 - **145** [cls, performance, frontend, react, verification, ci] — An incidental post-data re-render can be load-bearing for CLS; a "cleanup" that removes it regresses layout only on the CI font environment (#978, #969)
 - **146** [router, react, frontend, architecture, error-handling] — A router `errorElement` inherits contexts provided ABOVE `RouterProvider`, but NOT those provided inside the subtree it replaces (#1011, #1010, #1012)
 - **146** [testing, vitest, flake, ci, performance, runner-fleet] — An "aggressively low" testTimeout is a latent flake source the moment the same machine runs concurrent workloads (#1003)
+- **147** [frontend, react, scope, refactor, verification] — A reused "parity" surface must render from its own data source, not sit behind a sibling source's emptiness check (#1015, #1008)


### PR DESCRIPTION
**Epic:** #1008 — Division & Area scoped pages: deep data enhancement
**Sprint 1:** #1015 — DivisionPage data parity with the divisions overview

## What
The standalone `DivisionPage` (`/district/:districtId/division/:divId`) rendered four ad-hoc KPI cards (Clubs / Total Members / Thriving / Needs Attention) computed from `allClubs` — a **different computation** than the Divisions overview (`DistrictDivisionsPage`), with no recognition status, gap analysis, or per-area visit metrics (drift risk).

This swaps that ad-hoc strip for the **shared** `extractDivisionPerformance` util + `DivisionPerformanceCard` component, scoped to the division in the URL — the exact path the overview uses. One source of truth (R6/R8), no re-derivation.

## Now shows (matching the overview, same computation)
- **DivisionSummary** — recognition status, paid/base + net growth, distinguished/required, **Gap-to-D / S / P**.
- **AreaPerformanceTable** — per-area paid/base, distinguished, **First/Second Round Visits**, **recognition badge** (#832 deadline-aware gate), per-area gaps.
- Per-area **club tables** (club-level detail the overview lacks) are retained, unchanged (#871 mobile de-table intact).

## Review-driven hardening (fresh-context /review)
- The recognition card is fed by the **snapshot**, not `allClubs`. It no longer hides behind the `clubs.length===0` early return — a division with snapshot data but zero analytics-club rows (suspended/migrated clubs, casing skew) still shows parity data, with an inline "no clubs listed" note.
- Division matched **case-insensitively** in both the card lookup and the club filter (was: lenient card, strict filter) so they can't disagree.

## Tests
- New `DivisionPageParity.test.tsx` (6 tests): status badge, Gap-to-D/S/P, First/Second Round Visit columns, per-area recognition badge, "Needs Attention" KPI removed, and card-renders-with-empty-club-list.
- `DivisionAreaStatusChip.test.tsx` stubs the new snapshot query.
- Full frontend suite: **3301 passing**, typecheck + lint clean.

## Notes / out of scope
- The standalone page has no program-year picker, so it reads the **latest** snapshot (what the overview shows by default). Cross-program-year parity is not in scope for Sprint 1.

TDD: Red `1c61d08b` → Green `15f8ba71` → review fix `c72b8de6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sprints

- [ ] **Sprint 1** — #1028
- [ ] **Sprint 2** — #1029
- [ ] **Sprint 3** — #1030
