### PR TITLE
feat(area): AreaPage parity with the divisions overview + scoped narrative (#1016)

### DIFF
--- a/frontend/src/pages/AreaPage.tsx
+++ b/frontend/src/pages/AreaPage.tsx
@@ -48,11 +48,11 @@ const AreaPage: React.FC = () => {
   const normalizedAreaId = areaId?.toUpperCase()
   const areaPerformance = React.useMemo(() => {
     if (!snapshot || !normalizedDivId || !normalizedAreaId) return undefined
+    // The CDN snapshot carries the as-of date; pass it so historical snapshots
+    // gate visit deadlines correctly (R3).
     const division = extractDivisionPerformance(
       snapshot,
-      // The CDN snapshot carries the as-of date; pass it so historical
-      // snapshots gate visit deadlines correctly (R3).
-      (snapshot as { asOfDate?: string }).asOfDate
+      snapshot.asOfDate
     ).find(d => d.divisionId.toUpperCase() === normalizedDivId)
     return division?.areas.find(
       a => a.areaId.toUpperCase() === normalizedAreaId
@@ -113,14 +113,7 @@ const AreaPage: React.FC = () => {
               {divisionName}
             </Link>
           </p>
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 12,
-              flexWrap: 'wrap',
-            }}
-          >
+          <div className="flex items-center gap-3 flex-wrap">
             <h1 className="districts-page-header__title">{areaName}</h1>
             {badge && (
               <span

--- a/frontend/src/pages/AreaPage.tsx
+++ b/frontend/src/pages/AreaPage.tsx
@@ -1,9 +1,21 @@
-/* AreaPage (#425) — narrowest hierarchy page: a single area within a
-   division within a district. Lists every club in that area. */
+/* AreaPage (#425) — narrowest hierarchy page: a single area within a division
+   within a district. Shows the same recognition-aware data as the Divisions
+   overview's per-area row (status badge, paid/distinguished, First/Second Round
+   Visits, Gap-to-D/S/P) via the shared extractDivisionPerformance +
+   AreaPerformanceTable, plus the scoped narrative (generateAreaProgressText —
+   the #974/#976 per-area progress prose) — one source of truth (R6/R8, #1016).
+   Then lists every club in that area. */
 
 import React from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
+import { useDistrictStatistics } from '../hooks/useMembershipData'
+import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
+import { calculateAreaGapAnalysis } from '../utils/areaGapAnalysis'
+import { generateAreaProgressText } from '../utils/areaProgressText'
+import { renderRecognitionBadge } from '../utils/areaRecognitionBadge'
+import { AreaPerformanceTable } from '../components/AreaPerformanceTable'
+import type { AreaWithDivision } from '../components/DivisionAreaProgressSummary'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 import { ClubMiniList } from '../components/ClubMiniList'
@@ -24,6 +36,45 @@ const AreaPage: React.FC = () => {
     undefined
   )
 
+  // Recognition / gap / visit data come from the same raw snapshot the Divisions
+  // overview reads — one source of truth (R6/R8, #1016). We reuse the overview's
+  // extractDivisionPerformance util + AreaPerformanceTable + areaProgressText
+  // rather than re-deriving from allClubs, so this scoped page can't drift from
+  // it. Per Lesson 147, this surface is fed by the snapshot and must NOT be
+  // hidden behind the allClubs emptiness check below.
+  const { data: snapshot, isLoading: isLoadingSnapshot } =
+    useDistrictStatistics(districtId ?? '', undefined, 'divisions')
+  const normalizedDivId = divId?.toUpperCase()
+  const normalizedAreaId = areaId?.toUpperCase()
+  const areaPerformance = React.useMemo(() => {
+    if (!snapshot || !normalizedDivId || !normalizedAreaId) return undefined
+    const division = extractDivisionPerformance(
+      snapshot,
+      // The CDN snapshot carries the as-of date; pass it so historical
+      // snapshots gate visit deadlines correctly (R3).
+      (snapshot as { asOfDate?: string }).asOfDate
+    ).find(d => d.divisionId.toUpperCase() === normalizedDivId)
+    return division?.areas.find(
+      a => a.areaId.toUpperCase() === normalizedAreaId
+    )
+  }, [snapshot, normalizedDivId, normalizedAreaId])
+
+  const areaNarrative = React.useMemo(() => {
+    if (!areaPerformance || !normalizedDivId) return undefined
+    const gapAnalysis = calculateAreaGapAnalysis({
+      clubBase: areaPerformance.clubBase,
+      paidClubs: areaPerformance.paidClubs,
+      distinguishedClubs: areaPerformance.distinguishedClubs,
+    })
+    // The current-round visit fields (#973) and recognitionState (#832) travel
+    // on the area row, so the generator reads them directly (#974).
+    const areaWithDivision: AreaWithDivision = {
+      ...areaPerformance,
+      divisionId: normalizedDivId,
+    }
+    return generateAreaProgressText(areaWithDivision, gapAnalysis)
+  }, [areaPerformance, normalizedDivId])
+
   if (isLoading) {
     return <LoadingSkeleton variant="card" />
   }
@@ -39,38 +90,18 @@ const AreaPage: React.FC = () => {
   }
 
   const clubs = data.allClubs.filter(
-    c => c.divisionId === divId && c.areaId === areaId
+    c =>
+      c.divisionId.toUpperCase() === normalizedDivId &&
+      c.areaId.toUpperCase() === normalizedAreaId
   )
 
-  if (clubs.length === 0) {
-    return (
-      <div className="app-shell__page">
-        <p className="placeholder-page__eyebrow">Area</p>
-        <h1 className="placeholder-page__title">
-          District {districtId} · Division {divId} · Area {areaId}
-        </h1>
-        <p className="placeholder-page__body">
-          No clubs found in this area.{' '}
-          <Link to={`/district/${districtId}/division/${divId}`}>
-            Back to Division {divId}
-          </Link>
-          .
-        </p>
-      </div>
-    )
-  }
-
-  const areaName = clubs[0]?.areaName ?? `Area ${areaId}`
+  const areaName =
+    clubs[0]?.areaName ??
+    (areaPerformance ? `Area ${areaPerformance.areaId}` : `Area ${areaId}`)
   const divisionName = clubs[0]?.divisionName ?? `Division ${divId}`
-
-  const totalMembers = clubs.reduce((sum, c) => {
-    const last = c.membershipTrend[c.membershipTrend.length - 1]
-    return sum + (last?.count ?? 0)
-  }, 0)
-  const thriving = clubs.filter(c => c.currentStatus === 'thriving').length
-  const distinguished = clubs.filter(
-    c => c.distinguishedLevel !== 'NotDistinguished'
-  ).length
+  const badge = areaPerformance
+    ? renderRecognitionBadge(areaPerformance.recognitionState)
+    : undefined
 
   return (
     <div className="app-shell__page">
@@ -82,108 +113,149 @@ const AreaPage: React.FC = () => {
               {divisionName}
             </Link>
           </p>
-          <h1 className="districts-page-header__title">{areaName}</h1>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              flexWrap: 'wrap',
+            }}
+          >
+            <h1 className="districts-page-header__title">{areaName}</h1>
+            {badge && (
+              <span
+                className={`px-2 py-1 text-xs font-medium rounded-full border ${badge.className}`}
+                aria-label={`Recognition status: ${badge.label}`}
+                title={badge.tooltip}
+                role="status"
+              >
+                {badge.label}
+              </span>
+            )}
+          </div>
           <p className="districts-page-header__lede">
-            {clubs.length} club{clubs.length === 1 ? '' : 's'} in this area.
+            {clubs.length === 0
+              ? 'Area recognition standing for this program year.'
+              : `${clubs.length} club${clubs.length === 1 ? '' : 's'} in this area.`}
           </p>
         </div>
       </header>
 
-      <div
-        className="districts-kpi-strip"
-        style={{ marginBottom: 24 }}
-        aria-label="Area totals"
-      >
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Clubs</p>
-          <div className="districts-kpi-card__value">{clubs.length}</div>
-        </div>
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Total Members</p>
-          <div className="districts-kpi-card__value">
-            {totalMembers.toLocaleString()}
-          </div>
-        </div>
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Thriving</p>
-          <div className="districts-kpi-card__value">{thriving}</div>
-        </div>
-        <div className="districts-kpi-card">
-          <p className="districts-kpi-card__label">Distinguished+</p>
-          <div className="districts-kpi-card__value">{distinguished}</div>
-        </div>
+      {/* Area recognition data, reused from the Divisions overview (#1016).
+          Replaces the old ad-hoc allClubs KPI strip so the standalone page shows
+          the same status / paid / distinguished / R1-R2 visit / Gap-to-D-S-P
+          metrics on the same computation as the overview. */}
+      <div style={{ marginBottom: 24 }}>
+        {areaPerformance ? (
+          <AreaPerformanceTable areas={[areaPerformance]} />
+        ) : (
+          isLoadingSnapshot && <LoadingSkeleton variant="table" count={2} />
+        )}
       </div>
+
+      {/* Scoped narrative — the same per-area progress prose the overview's
+          Division and Area Progress Summary shows (#974/#976), generated from
+          the snapshot-derived recognition source of truth. */}
+      {areaNarrative && (
+        <article
+          className="bg-gray-50 rounded-lg p-4 border border-gray-200"
+          style={{ marginBottom: 24 }}
+          aria-label="Area progress summary"
+        >
+          <p
+            data-testid="area-progress-text"
+            className="text-gray-700 font-tm-body leading-relaxed"
+            style={{ fontSize: '14px' }}
+          >
+            {areaNarrative.progressText}
+          </p>
+        </article>
+      )}
+
+      {/* No analytics-club rows for this area (suspended/migrated clubs, or a
+          casing skew). The recognition surface above still renders from the
+          snapshot — don't hide it behind an empty club list (Lesson 147). */}
+      {clubs.length === 0 && (
+        <p className="placeholder-page__body">
+          No clubs are currently listed in this area.{' '}
+          <Link to={`/district/${districtId}/division/${divId}`}>
+            Back to {divisionName}
+          </Link>
+          .
+        </p>
+      )}
 
       {/* CC-4 (#871): the 4-col table overflows 375px and clips the Status
           chip, so mobile de-tables to a stacked card list; desktop keeps the
           table unchanged. */}
-      {isMobile ? (
-        <ClubMiniList
-          clubs={clubs}
-          clubTo={c => `/district/${districtId}/club/${c.clubId}`}
-        />
-      ) : (
-        <div className="districts-rankings-table-wrap">
-          <div className="overflow-x-auto">
-            <table className="districts-rankings-table">
-              <thead>
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Club
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Status
-                  </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Members
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Distinguished
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {clubs.map(c => {
-                  const last = c.membershipTrend[c.membershipTrend.length - 1]
-                  return (
-                    <tr
-                      key={c.clubId}
-                      className="cursor-pointer"
-                      onClick={() =>
-                        navigate(`/district/${districtId}/club/${c.clubId}`)
-                      }
-                    >
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        {/* CC-7 (#872): real <Link> on the club name; whole-row
-                            click kept as a mouse convenience (stop the bubble so
-                            a name-click navigates once). */}
-                        <Link
-                          to={`/district/${districtId}/club/${c.clubId}`}
-                          onClick={e => e.stopPropagation()}
-                          className="clubs-name-link text-sm font-medium text-gray-900"
-                        >
-                          {c.clubName}
-                        </Link>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm">
-                        {c.currentStatus}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
-                        {last?.count ?? '—'}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {c.distinguishedLevel === 'NotDistinguished'
-                          ? '—'
-                          : c.distinguishedLevel}
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
+      {clubs.length > 0 &&
+        (isMobile ? (
+          <ClubMiniList
+            clubs={clubs}
+            clubTo={c => `/district/${districtId}/club/${c.clubId}`}
+          />
+        ) : (
+          <div className="districts-rankings-table-wrap">
+            <div className="overflow-x-auto">
+              <table className="districts-rankings-table">
+                <thead>
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Club
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Status
+                    </th>
+                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Members
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Distinguished
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {clubs.map(c => {
+                    const last = c.membershipTrend[c.membershipTrend.length - 1]
+                    return (
+                      <tr
+                        key={c.clubId}
+                        className="cursor-pointer"
+                        onClick={() =>
+                          navigate(`/district/${districtId}/club/${c.clubId}`)
+                        }
+                      >
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          {/* CC-7 (#872): real <Link> on the club name; whole-row
+                              click kept as a mouse convenience (stop the bubble so
+                              a name-click navigates once). */}
+                          <Link
+                            to={`/district/${districtId}/club/${c.clubId}`}
+                            onClick={e => e.stopPropagation()}
+                            className="clubs-name-link text-sm font-medium text-gray-900"
+                          >
+                            {c.clubName}
+                          </Link>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm">
+                          {c.currentStatus}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums">
+                          {last?.count ?? '—'}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          {c.distinguishedLevel === 'NotDistinguished'
+                            ? '—'
+                            : c.distinguishedLevel}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
-      )}
+        ))}
     </div>
   )
 }

--- a/frontend/src/pages/AreaPage.tsx
+++ b/frontend/src/pages/AreaPage.tsx
@@ -46,7 +46,7 @@ const AreaPage: React.FC = () => {
     useDistrictStatistics(districtId ?? '', undefined, 'divisions')
   const normalizedDivId = divId?.toUpperCase()
   const normalizedAreaId = areaId?.toUpperCase()
-  const areaPerformance = React.useMemo(() => {
+  const matched = React.useMemo(() => {
     if (!snapshot || !normalizedDivId || !normalizedAreaId) return undefined
     // The CDN snapshot carries the as-of date; pass it so historical snapshots
     // gate visit deadlines correctly (R3).
@@ -54,26 +54,28 @@ const AreaPage: React.FC = () => {
       snapshot,
       snapshot.asOfDate
     ).find(d => d.divisionId.toUpperCase() === normalizedDivId)
-    return division?.areas.find(
+    const area = division?.areas.find(
       a => a.areaId.toUpperCase() === normalizedAreaId
     )
+    return area ? { area, divisionId: division!.divisionId } : undefined
   }, [snapshot, normalizedDivId, normalizedAreaId])
+  const areaPerformance = matched?.area
 
   const areaNarrative = React.useMemo(() => {
-    if (!areaPerformance || !normalizedDivId) return undefined
+    if (!matched) return undefined
+    const { area, divisionId } = matched
     const gapAnalysis = calculateAreaGapAnalysis({
-      clubBase: areaPerformance.clubBase,
-      paidClubs: areaPerformance.paidClubs,
-      distinguishedClubs: areaPerformance.distinguishedClubs,
+      clubBase: area.clubBase,
+      paidClubs: area.paidClubs,
+      distinguishedClubs: area.distinguishedClubs,
     })
     // The current-round visit fields (#973) and recognitionState (#832) travel
-    // on the area row, so the generator reads them directly (#974).
-    const areaWithDivision: AreaWithDivision = {
-      ...areaPerformance,
-      divisionId: normalizedDivId,
-    }
+    // on the area row, so the generator reads them directly (#974). Use the
+    // division's actual extracted id (not the route param) so the prose matches
+    // the overview's "one source of truth" exactly.
+    const areaWithDivision: AreaWithDivision = { ...area, divisionId }
     return generateAreaProgressText(areaWithDivision, gapAnalysis)
-  }, [areaPerformance, normalizedDivId])
+  }, [matched])
 
   if (isLoading) {
     return <LoadingSkeleton variant="card" />
@@ -118,9 +120,8 @@ const AreaPage: React.FC = () => {
             {badge && (
               <span
                 className={`px-2 py-1 text-xs font-medium rounded-full border ${badge.className}`}
-                aria-label={`Recognition status: ${badge.label}`}
+                aria-label={`Area ${areaPerformance?.areaId ?? areaId} recognition: ${badge.label}`}
                 title={badge.tooltip}
-                role="status"
               >
                 {badge.label}
               </span>

--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -10,6 +10,8 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
 import { useDistrictStatistics } from '../hooks/useMembershipData'
 import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
+import { calculateDivisionGapAnalysis } from '../utils/divisionGapAnalysis'
+import { generateDivisionProgressText } from '../utils/divisionProgressText'
 import { DivisionPerformanceCard } from '../components/DivisionPerformanceCard'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
@@ -43,6 +45,19 @@ const DivisionPage: React.FC = () => {
       d => d.divisionId.toUpperCase() === normalizedDivId
     )
   }, [snapshot, normalizedDivId])
+
+  // Scoped division-level narrative — the same prose the overview's Division and
+  // Area Progress Summary shows, scoped to this division (#1016 S2 refactor).
+  // Reuses the existing generateDivisionProgressText generator (R6/R7).
+  const divisionNarrative = React.useMemo(() => {
+    if (!divisionPerformance) return undefined
+    const gapAnalysis = calculateDivisionGapAnalysis({
+      clubBase: divisionPerformance.clubBase,
+      paidClubs: divisionPerformance.paidClubs,
+      distinguishedClubs: divisionPerformance.distinguishedClubs,
+    })
+    return generateDivisionProgressText(divisionPerformance, gapAnalysis)
+  }, [divisionPerformance])
 
   if (isLoading) {
     return <LoadingSkeleton variant="card" />
@@ -113,6 +128,24 @@ const DivisionPage: React.FC = () => {
           isLoadingSnapshot && <LoadingSkeleton variant="table" count={3} />
         )}
       </div>
+
+      {/* Scoped division-level narrative (#1016 S2) — same prose as the overview
+          summary, scoped to this division. */}
+      {divisionNarrative && (
+        <article
+          className="bg-tm-loyal-blue/10 rounded-lg p-4 border border-tm-loyal-blue/30"
+          style={{ marginBottom: 24 }}
+          aria-label="Division progress summary"
+        >
+          <p
+            data-testid="division-progress-text"
+            className="text-gray-800 font-tm-body leading-relaxed font-medium"
+            style={{ fontSize: '15px' }}
+          >
+            {divisionNarrative.progressText}
+          </p>
+        </article>
+      )}
 
       {/* No analytics-club rows for this division (suspended/migrated clubs).
           The recognition card above still renders from the snapshot — don't

--- a/frontend/src/pages/__tests__/AreaPageParity.test.tsx
+++ b/frontend/src/pages/__tests__/AreaPageParity.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * AreaPage data parity with the Divisions overview (#1016, epic #1008).
+ *
+ * Sprint 1 (#1015) gave DivisionPage parity with the Divisions overview via the
+ * shared extractDivisionPerformance → DivisionPerformanceCard surface. Sprint 2
+ * ports the same recognition-aware data down to the standalone AreaPage: the
+ * scoped page must render, for its single area, the same per-area row the
+ * overview shows (recognition badge, First/Second Round Visits, Gap-to-D/S/P
+ * via AreaPerformanceTable) AND the scoped narrative the overview carries
+ * (generateAreaProgressText — the #974/#976 per-area progress prose), all from
+ * the snapshot — one source of truth (R6/R8). Per Lesson 147, the recognition
+ * surface is fed by the snapshot and must NOT be hidden behind the *other*
+ * source's (allClubs) emptiness check.
+ */
+import React from 'react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import AreaPage from '../AreaPage'
+
+vi.mock('../../hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+}))
+
+// Division A, Area 10: one Select Distinguished club (R1 visit done). Area 11:
+// two undistinguished clubs (no visits). We scope to Area 10.
+const SNAPSHOT = {
+  asOfDate: '2026-03-15',
+  divisionPerformance: [
+    {
+      Division: 'A',
+      Area: '10',
+      'Club Number': '123456',
+      'Club Name': 'Ottawa Club',
+      'Division Club Base': '3',
+      'Area Club Base': '1',
+      'Nov Visit award': '1',
+      'May Visit award': '0',
+    },
+    {
+      Division: 'A',
+      Area: '11',
+      'Club Number': '234567',
+      'Club Name': 'Vulnerable Club',
+      'Division Club Base': '3',
+      'Area Club Base': '2',
+      'Nov Visit award': '0',
+      'May Visit award': '0',
+    },
+    {
+      Division: 'A',
+      Area: '11',
+      'Club Number': '654321',
+      'Club Name': 'Struggling Club',
+      'Division Club Base': '3',
+      'Area Club Base': '2',
+      'Nov Visit award': '0',
+      'May Visit award': '0',
+    },
+  ],
+  clubPerformance: [
+    {
+      'Club Number': '123456',
+      'Club Name': 'Ottawa Club',
+      'Club Status': 'Active',
+      'Club Distinguished Status': 'Select Distinguished',
+    },
+    {
+      'Club Number': '234567',
+      'Club Name': 'Vulnerable Club',
+      'Club Status': 'Active',
+      'Club Distinguished Status': '',
+    },
+    {
+      'Club Number': '654321',
+      'Club Name': 'Struggling Club',
+      'Club Status': 'Active',
+      'Club Distinguished Status': '',
+    },
+  ],
+}
+
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({
+    data: SNAPSHOT,
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+const CLUB: ClubTrend = {
+  clubId: '123456',
+  clubName: 'Ottawa Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '10',
+  areaName: 'Area 10',
+  distinguishedLevel: 'Select Distinguished',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: '2026-03-15', count: 25 }],
+  dcpGoalsTrend: [{ date: '2026-03-15', goalsAchieved: 8 }],
+}
+
+vi.mock('../../hooks/useDistrictAnalytics', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../hooks/useDistrictAnalytics')
+  >('../../hooks/useDistrictAnalytics')
+  return {
+    ...actual,
+    useDistrictAnalytics: vi.fn(() => ({
+      data: { allClubs: [CLUB] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })),
+  }
+})
+
+function renderArea() {
+  return render(
+    <MemoryRouter initialEntries={['/district/61/division/A/area/10']}>
+      <Routes>
+        <Route
+          path="/district/:districtId/division/:divId/area/:areaId"
+          element={<AreaPage />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('AreaPage data parity with the Divisions overview (#1016)', () => {
+  it('renders the per-area recognition badge from the snapshot', () => {
+    const { getAllByLabelText } = renderArea()
+    expect(
+      getAllByLabelText(/Recognition status:/i).length
+    ).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders the per-area First/Second Round Visit columns', () => {
+    const { getByText } = renderArea()
+    expect(getByText('First Round Visits')).toBeInTheDocument()
+    expect(getByText('Second Round Visits')).toBeInTheDocument()
+  })
+
+  it('renders Gap-to-D / S / P columns from the shared area performance row', () => {
+    const { getByText } = renderArea()
+    expect(getByText('Gap to D')).toBeInTheDocument()
+    expect(getByText('Gap to S')).toBeInTheDocument()
+    expect(getByText('Gap to P')).toBeInTheDocument()
+  })
+
+  it('renders the scoped areaProgressText narrative for this area', () => {
+    const { getByTestId } = renderArea()
+    const narrative = getByTestId('area-progress-text')
+    // The generator always prefixes the area label "Area <id> (Division <id>)".
+    expect(narrative.textContent).toMatch(/Area 10 \(Division A\)/)
+  })
+
+  it('still renders the recognition surface when allClubs has no rows for the area', async () => {
+    // Parity surface is fed by the snapshot, not allClubs. An area with snapshot
+    // data but zero analytics-club rows (suspended/migrated clubs, or a casing
+    // skew) must still show parity data — not a bare "No clubs" placeholder that
+    // hides it (Lesson 147, inherited from Sprint 1 #1015).
+    const mod = await import('../../hooks/useDistrictAnalytics')
+    const spy = mod.useDistrictAnalytics as unknown as ReturnType<typeof vi.fn>
+    spy.mockReturnValueOnce({
+      data: { allClubs: [] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    const { getAllByLabelText, getByTestId } = renderArea()
+    expect(
+      getAllByLabelText(/Recognition status:/i).length
+    ).toBeGreaterThanOrEqual(1)
+    expect(getByTestId('area-progress-text').textContent).toMatch(
+      /Area 10 \(Division A\)/
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
@@ -161,6 +161,13 @@ describe('DivisionPage data parity with the Divisions overview (#1015)', () => {
     ).toBeGreaterThanOrEqual(1)
   })
 
+  it('renders the scoped division-level narrative (generateDivisionProgressText, #1016 S2 refactor)', () => {
+    const { getByTestId } = renderDivision()
+    const narrative = getByTestId('division-progress-text')
+    // The generator always prefixes the division label "Division <id>".
+    expect(narrative.textContent).toMatch(/Division A/)
+  })
+
   it('drops the ad-hoc "Needs Attention" KPI card (swapped for shared data)', () => {
     const { queryByText } = renderDivision()
     expect(queryByText('Needs Attention')).toBeNull()


### PR DESCRIPTION
## Sprint 2 of epic #1008 — AreaPage parity + scoped narrative text

Closes-by-verification #1016 (ticked + closed post-merge per the tick-before-close ordering, R15/#626 — not via a `Closes` keyword, see Lesson 106).

### What
Brings the standalone **AreaPage** to parity with the Divisions overview's per-area row, and adds the scoped per-area narrative — mirroring what Sprint 1 (#1015) did for DivisionPage, from the **same snapshot source of truth** (R6/R8).

- **AreaPage** now renders, for its single area, the shared `AreaPerformanceTable` row: recognition badge, Paid/Base, Distinguished %, First/Second Round Visits, and Gap-to-D/S/P — fed by `extractDivisionPerformance(snapshot)`, the exact computation the overview uses.
- **Scoped narrative**: reuses `generateAreaProgressText` (the #974/#976 per-area progress prose — names active clubs still needing the current-round visit + the 75% qualifying-metric → Distinguished sentence).
- **Refactor step**: DivisionPage gains the scoped **division-level** narrative via the existing `generateDivisionProgressText` generator (the ticket's "if a division-level generator exists" branch — it does).

### Lesson 147 (inherited from Sprint 1)
The recognition surface + narrative are fed by the **snapshot**, and are **not** gated behind the *other* source's (`allClubs`) emptiness — an area with snapshot data but zero analytics-club rows (suspended/migrated clubs, or a casing skew) still shows its parity data. `divId`/`areaId` casing is normalized on **both** the snapshot lookup and the `allClubs` filter.

### TDD
- **Red** → **Green** → **/simplify** → **fresh-context review** → review fixes. Six commits, each referencing #1016.
- New tests: `AreaPageParity.test.tsx` (5 cases incl. the empty-`allClubs` Lesson-147 case) + a division-narrative case in `DivisionPageParity.test.tsx`.
- Existing `DivisionAreaStatusChip.test.tsx` mobile/desktop contracts preserved.

### Review fixes applied
- a11y: header badge dropped the misused `role="status"` (static label, not a live region) and uses a distinct `Area N recognition: …` label so it doesn't duplicate the table badge's "Recognition status:" announcement.
- Narrative uses the matched division's **actual** extracted id (not the route param) for exact overview parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Sprints

- [ ] **Sprint 1** — #1036
- [ ] **Sprint 2** — #1037
