### PR TITLE
docs(adr): ADR-002 partially superseded — frontend flow → ADR-003/004, data flow live (#1031)

### DIFF
--- a/docs/architecture-decisions/002-staging-environment.md
+++ b/docs/architecture-decisions/002-staging-environment.md
@@ -1,7 +1,17 @@
 # ADR-002: Staging Environment and Deployment Flow
 
-**Status**: Accepted
+**Status**: Partially superseded (2026-05)
 **Date**: 2026-04-10
+
+> **⚠️ Partially superseded — read this first.** This ADR bundled two flows that have since diverged:
+>
+> - **Data-promotion flow (§"How each change type flows" b, §"Data Promotion", §"Rollback" data) — STILL IN FORCE.** The daily `data-pipeline.yml` writes to the staging bucket `gs://toast-stats-data-staging` (`GCS_BUCKET`), diffs staging vs production (additive→promote / subtractive→block), and `rsync`s staging→production on an additive-only diff (#316). This is the current production data architecture and the authoritative reference for any pipeline rerun/backfill (see #1031).
+> - **Frontend deployment flow (§a/c/d — deploy to `staging.ts.taverns.red` → Playwright smoke → auto-promote to prod) — SUPERSEDED.** Replaced by:
+>   - **[ADR-003](003-staging-bucket-cors-preview-channels.md)** — per-PR **Firebase preview channels** (`pr-preview.yml`) replaced the persistent staging _site_ for verification. The `staging-toast-stats` Firebase target now only hosts ephemeral preview channels, not a smoke-test-and-promote pipeline.
+>   - **[ADR-004](004-release-gated-production-deploy.md)** — frontend prod deploys are now **release-gated** (fire on a release-please release via `deploy.yml`), not auto-promoted after a staging smoke test. There is no workflow performing the §a/c/d staging-site→smoke→auto-promote flow.
+>
+> Net: the **data half is live**, the **frontend half is dead**. The original text below is preserved for historical record.
+
 **Context**: The site is in production, shared with all Toastmasters district directors worldwide. Every commit to main deploys directly to production via Firebase Hosting. Multiple incidents have reached users before detection: closing period data corruption (#309), Distinguished count discrepancy (#311), lighthouse CI failures, stale dates in dropdown. Most incidents were **pipeline data bugs**, not frontend bugs — CI catches code issues but can't catch bad data.
 
 ## Decision

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -19,16 +19,16 @@ Each ADR follows this template:
 
 ## Index
 
-| ADR                                                   | Title                                                      | Status   | Date     |
-| ----------------------------------------------------- | ---------------------------------------------------------- | -------- | -------- |
-| [001](001-cdn-only-frontend.md)                       | CDN-only frontend (no API server)                          | Accepted | Jan 2026 |
-| [002](002-staging-environment.md)                     | Staging environment and deployment flow                    | Accepted | Apr 2026 |
-| [003](003-staging-bucket-cors-preview-channels.md)    | Staging bucket CORS for Firebase previews                  | Accepted | May 2026 |
-| [004](004-release-gated-production-deploy.md)         | Release-gated production deploys                           | Accepted | May 2026 |
-| [005](005-district-subpage-ia-and-secondary-nav.md)   | District subpage IA map + secondary route-nav              | Accepted | May 2026 |
-| [006](006-data-table-page-layout-and-column-model.md) | Data-table page layout & column-model standard             | Accepted | May 2026 |
-| [007](007-data-serving-gcs-cdn-lb-over-firebase.md)   | Serve data via GCS + Cloud CDN + LB (not Firebase Hosting) | Accepted | May 2026 |
-| [008](008-ai-enable-toast-stats.md)                   | AI-enable Toast Stats — read-only MCP server over the CDN  | Proposed | May 2026 |
+| ADR                                                   | Title                                                      | Status                                                             | Date     |
+| ----------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------ | -------- |
+| [001](001-cdn-only-frontend.md)                       | CDN-only frontend (no API server)                          | Accepted                                                           | Jan 2026 |
+| [002](002-staging-environment.md)                     | Staging environment and deployment flow                    | Partially superseded (data flow live; frontend flow → ADR-003/004) | Apr 2026 |
+| [003](003-staging-bucket-cors-preview-channels.md)    | Staging bucket CORS for Firebase previews                  | Accepted                                                           | May 2026 |
+| [004](004-release-gated-production-deploy.md)         | Release-gated production deploys                           | Accepted                                                           | May 2026 |
+| [005](005-district-subpage-ia-and-secondary-nav.md)   | District subpage IA map + secondary route-nav              | Accepted                                                           | May 2026 |
+| [006](006-data-table-page-layout-and-column-model.md) | Data-table page layout & column-model standard             | Accepted                                                           | May 2026 |
+| [007](007-data-serving-gcs-cdn-lb-over-firebase.md)   | Serve data via GCS + Cloud CDN + LB (not Firebase Hosting) | Accepted                                                           | May 2026 |
+| [008](008-ai-enable-toast-stats.md)                   | AI-enable Toast Stats — read-only MCP server over the CDN  | Proposed                                                           | May 2026 |
 
 ## When to Write an ADR
 


### PR DESCRIPTION
## What
Re-status **ADR-002 (Staging Environment and Deployment Flow)** from *Accepted* to **Partially superseded (2026-05)** and add a "read this first" banner explaining the split.

## Why
ADR-002 bundled two flows that have since diverged:

- **Data-promotion flow** (daily pipeline writes to `gs://toast-stats-data-staging` → diff staging vs prod → additive-only `rsync` promote, #316) — **STILL IN FORCE.** It is the current production data architecture and the authoritative reference for the Jan-2017→now pipeline rerun (#1031).
- **Frontend deployment flow** (deploy to `staging.ts.taverns.red` → Playwright smoke → auto-promote to prod) — **SUPERSEDED.** Replaced by:
  - **ADR-003** — per-PR Firebase preview channels replaced the persistent staging *site* for verification.
  - **ADR-004** — frontend prod deploys are release-gated (release-please), not auto-promoted after a staging smoke test. No workflow performs the old staging-site→smoke→auto-promote flow.

Discovered while reviewing ADR-002 for obsolescence (it's half-obsolete, not fully) and verified against `data-pipeline.yml`, `deploy.yml`, `pr-preview.yml`, and `.firebaserc`.

## Changes
- `002-staging-environment.md` — status banner + re-status; original text preserved for historical record.
- `README.md` — ADR index status updated.

Docs-only (Lightweight DoD). Refs #1031.

🤖 Generated with [Claude Code](https://claude.com/claude-code)