### PR TITLE
feat: disambiguate Overview & Trends net-change cards (metric + baseline) (#1023)

### DIFF
--- a/frontend/src/components/DistrictKpiStrip.tsx
+++ b/frontend/src/components/DistrictKpiStrip.tsx
@@ -168,8 +168,8 @@ export const DistrictKpiStrip: React.FC<DistrictKpiStripProps> = ({ kpis }) => {
             <KpiDeltaCard
               title="Net Member Change"
               current={kpis.netMemberChange.current}
-              secondaryLabel="members vs. base year"
-              tooltipContent="Net change in district membership (payments) since the program-year base."
+              secondaryLabel="payments vs. program-year base"
+              tooltipContent="Membership payments minus the program-year payment base (the recognition baseline). This differs from the Trends 'Net Change', which compares member counts against the first snapshot of the year."
             />
           </div>
           <p

--- a/frontend/src/components/MembershipTrendChart.tsx
+++ b/frontend/src/components/MembershipTrendChart.tsx
@@ -330,6 +330,12 @@ export const MembershipTrendChart: React.FC<MembershipTrendChartProps> = ({
             {netChange >= 0 ? '+' : ''}
             {netChange}
           </p>
+          {/* #1023 — name the metric AND baseline so this member-count delta
+              can't be read as the Overview "Net Member Change" (a payments-vs-
+              payment-base figure). Single text node so the copy is assertable. */}
+          <p className="text-xs text-gray-600 mt-1 font-tm-body">
+            {`since first snapshot (${formatLongDate(firstDataPoint.date)}) · member counts`}
+          </p>
         </div>
         <div className="bg-gray-50 rounded-lg p-3 border border-gray-200">
           <p className="text-xs text-gray-700 font-medium font-tm-body">Peak</p>

--- a/frontend/src/components/__tests__/DistrictKpiStrip.test.tsx
+++ b/frontend/src/components/__tests__/DistrictKpiStrip.test.tsx
@@ -4,6 +4,7 @@ import {
   render,
   screen,
   within,
+  waitFor,
   fireEvent,
 } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
@@ -134,5 +135,48 @@ describe('DistrictKpiStrip (#572)', () => {
     expect(
       screen.queryByTestId('district-kpi-strip-legend')
     ).not.toBeInTheDocument()
+  })
+
+  // #1023 — disambiguate the Overview "Net Member Change" (payments vs. payment
+  // base) from the Trends "Net Change" (member counts vs. first PY snapshot).
+  describe('net-change disambiguation (#1023)', () => {
+    it('names the metric AND baseline in the secondary line (payments vs. program-year base)', () => {
+      renderStrip(<DistrictKpiStrip kpis={sampleKpis} />)
+      expect(
+        screen.getByText('payments vs. program-year base')
+      ).toBeInTheDocument()
+    })
+
+    it('tooltip contrasts the payment-base delta with the Trends member-count metric', async () => {
+      renderStrip(<DistrictKpiStrip kpis={sampleKpis} />)
+      const deltaCard = screen.getByTestId('kpi-delta-card')
+      const infoBtn = within(deltaCard).getByRole('button', {
+        name: /more info/i,
+      })
+      fireEvent.focus(infoBtn)
+      const tip = await waitFor(() => within(deltaCard).getByRole('tooltip'))
+      // Overview basis: payments minus the program-year payment base.
+      expect(tip).toHaveTextContent(/payment base/i)
+      // Explicitly distinguished from the Trends "Net Change" member-count metric.
+      expect(tip).toHaveTextContent(/member counts/i)
+      expect(tip).toHaveTextContent(/first snapshot/i)
+    })
+
+    it('drift guard: the card value still derives from the passed delta source', () => {
+      // The page wires netMemberChange.current ← analytics.membershipChange
+      // (DistrictDetailPage.tsx). The strip must render exactly that value,
+      // never re-derive it. −8 is the documented payments−paymentBase delta.
+      renderStrip(
+        <DistrictKpiStrip
+          kpis={{ ...sampleKpis, netMemberChange: { current: -8 } }}
+        />
+      )
+      const strip = screen.getByRole('region', {
+        name: /key district metrics/i,
+      })
+      expect(within(strip).getByTestId('kpi-delta-value')).toHaveTextContent(
+        '−8'
+      )
+    })
   })
 })

--- a/frontend/src/components/__tests__/MembershipTrendChart.methodology.test.tsx
+++ b/frontend/src/components/__tests__/MembershipTrendChart.methodology.test.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import { describe, it, expect } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import { MembershipTrendChart } from '../MembershipTrendChart'
+import { formatLongDate } from '../../utils/dateFormatting'
 
 const TREND = [
   { date: '2025-07-01', count: 100 },
@@ -39,5 +40,25 @@ describe('MembershipTrendChart — methodology surfacing (#438)', () => {
     expect(infoLink.getAttribute('href')).toBe(
       '/methodology#district-membership-trend'
     )
+  })
+})
+
+// #1023 — the Trends "Net Change" measures member counts since the first
+// charted snapshot — a different metric AND baseline from the Overview
+// "Net Member Change" (payments vs. payment base). Make that legible inline.
+describe('MembershipTrendChart — net-change disambiguation (#1023)', () => {
+  it('names the metric AND baseline under the Net Change stat (member counts since first snapshot)', () => {
+    render(<MembershipTrendChart membershipTrend={TREND} />)
+    const expected = `since first snapshot (${formatLongDate('2025-07-01')}) · member counts`
+    expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+
+  it('drift guard: Net Change value stays last − first charted snapshot', () => {
+    // 110 − 100 = +10 member-count delta vs. the first snapshot, NOT a
+    // payments-vs-base delta. This is the documented Trends computation.
+    render(<MembershipTrendChart membershipTrend={TREND} />)
+    const netLabel = screen.getByText('Net Change')
+    const stat = netLabel.closest('div') as HTMLElement
+    expect(within(stat).getByText('+10')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Sprint 1 of epic #1022 — reconcile net-change labels

Two cards on a district both read like "net member change" but show different
numbers because they measure **different metrics against different baselines**.
This sprint makes each card unambiguous about *what* it measures and *vs. what
baseline*. **Labeling only — no computation changed** (per the epic's explicit
constraint).

| | Overview "Net Member Change" | Trends "Net Change" |
|---|---|---|
| Metric | Membership **payments** | **Member counts** |
| Baseline | Program-year **payment base** | **First snapshot** of the charted PY |

### Changes
- **`DistrictKpiStrip.tsx`** — the Net Member Change `KpiDeltaCard`:
  - secondary line → `payments vs. program-year base`
  - tooltip reworded to state the payment-base definition and explicitly contrast
    it with the Trends "Net Change" (member counts vs. first snapshot).
- **`MembershipTrendChart.tsx`** — under the "Net Change" stat, a single-text-node
  `<p>`: `since first snapshot (<date>) · member counts`, using existing
  `formatLongDate`.

### Tests (TDD)
- Assert each card's rendered secondary line names its **metric** and **baseline**.
- Tooltip-content assertion (focus-driven) confirms the Overview tooltip contrasts
  with the Trends metric.
- **Drift guards** kept: Overview value still renders the passed
  `analytics.membershipChange` delta; Trends value stays `last − first` charted
  snapshot. Guards against a future Lesson #185-style regression.

Full frontend suite green (3323 tests). R22 no-page-mounts guard green.

Closes #1023 is intentionally **omitted** (Lesson 106 / R15 — the runner ticks the
epic before closing the sub-issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
