### PR TITLE
docs(adr): revise ADR-008 — thin local MCP, no compute, drop Phase 0 (#1009)

### DIFF
--- a/docs/architecture-decisions/008-ai-enable-toast-stats.md
+++ b/docs/architecture-decisions/008-ai-enable-toast-stats.md
@@ -1,17 +1,30 @@
-# ADR-008: AI-enable Toast Stats — read-only MCP server over the public snapshot CDN
+# ADR-008: AI-enable Toast Stats — thin **local** MCP server over the public snapshot CDN
 
 ## Status
 
-**Proposed** (2026-05-31). Research spike → recommendation. No build is committed by this
-ADR; the operator reviews the recommendation before any build epic is filed.
-Epic [#1009](https://github.com/taverns-red/toast-stats/issues/1009) (Sprint 1, #1018).
+**Accepted** (revised 2026-05-31). Originally **Proposed** as a remote MCP server gated
+behind a "Phase 0" deep-link library; **revised** after operator review to a **thin, local
+(self-installed) MCP server that reads the CDN and performs no computation**, and a build
+epic is filed. Epic [#1009](https://github.com/taverns-red/toast-stats/issues/1009)
+(spike, #1018) → build epic (see _Decision_).
 
-> **Filename note.** Epic #1009 templated the path as
-> `docs/strategy/decisions/NNNN-…-2026-MM-DD.md` — that is the **ops** repo's ADR
-> convention (`taverns-red/ops`). This repo's established convention is
-> `docs/architecture-decisions/NNN-slug.md` (see ADR-001…007 + the directory
-> [README](README.md)). To avoid fragmenting ADRs across two directories, this ADR
-> follows the repo convention; the date lives in this header, not the filename.
+> **Revision note (2026-05-31).** The first cut of this ADR recommended a **remote** MCP
+> server, sequenced behind a zero-cost **Phase 0** "ask/deep-link library." Operator review
+> rejected both:
+>
+> - **Phase 0 is dropped entirely.** It was a curated link list wearing an "AI-native"
+>   costume — it answers only pre-curated questions and does not advance the open-ended brief.
+>   It is not in scope and will not be built.
+> - **Remote → local.** The remote server's only material cost was an always-on hosted
+>   surface a one-operator org must keep up (this ADR's original #1 objection). A **local,
+>   self-installed** MCP server deletes that cost: it runs on the user's machine, so there is
+>   **no hosting, no on-call, and CORS/auth are moot** (local process reading public data).
+> - **Thin, no computation.** The server exposes the **pre-computed snapshot fields** the
+>   pipeline already writes (e.g. `recognitionState`, `regionAdvisorVisitMet`); it does **not**
+>   import `analytics-core` or re-derive any rule. This makes it strictly a
+>   _retrieval-and-explain_ surface whose answers are the same bytes the website shows — the
+>   strongest possible grounding claim, and it removes the recognition-rule single-sourcing
+>   precondition (#799) a "fat"/compute design would have required.
 
 ## Context
 
@@ -27,29 +40,36 @@ The decision is shaped by four facts that are authoritative for this repo:
    on a CDN (`cdn.taverns.red`), written by a scheduled GCS→CDN pipeline at daily-ish
    cadence ([ADR-007](007-data-serving-gcs-cdn-lb-over-firebase.md),
    [ADR-001](001-cdn-only-frontend.md)). The data is pre-aggregated to exactly the
-   club / area / division / district granularity the example questions need.
+   club / area / division / district granularity the example questions need. **Verified
+   2026-05-31:** `GET https://cdn.taverns.red/v1/latest.json` → `200`,
+   `application/json`, `cache-control: public,max-age=300`; the path is `v1/`-namespaced
+   so a tool pinned to `v1` is contract-stable across pipeline changes.
 2. **The two motivating questions are answerable from existing computed fields** — no
    new pipeline computation is required. Charter risk → `club-health-status` +
    `charterPayments` / chartered counts; round-2 visits → `regionAdvisorVisitMet` and the
    visit-qualifying fields ([#974](https://github.com/taverns-red/toast-stats/issues/974)).
+   Because these are **pre-computed**, a thin reader can answer them without deriving anything.
 3. **There is no existing AI/MCP surface in the org** — verified empty in `taverns-red/ops`
    and `red-vote`, and no prior thoughts in Open Brain. This is greenfield, and whatever
    primitive we pick becomes the org's first AI pattern across the 5-product Red Taverns
-   ecosystem (shared Clerk auth available).
+   ecosystem.
 4. **Two distinct user segments.** The **in-app district leader** (the product spec's named
-   primary user) who uses the React SPA and never opens a Claude client; and the **Claude
-   power-user** (the operator, plus any Claude-using leaders) who lives in MCP-capable clients.
+   primary user) who uses the React SPA and never opens a Claude client; and the **Claude /
+   MCP power-user** (the operator, plus any MCP-using leaders) who lives in MCP-capable
+   clients. The local MCP serves the second segment; the first is explicitly **out of scope
+   for this ADR** and is addressed, if ever, by a future BYO-key in-app panel (see
+   _Future consumers_).
 
 The architecture's core virtue today is that the read path is **static**: GCS→CDN→SPA with
-no live backend, which is why it is cheap and never pages anyone. Any recommendation must
-weigh new standing surface against delivered user value — this is a one-operator, "no-build"
-org by default.
+no live backend, which is why it is cheap and never pages anyone. A **local** MCP preserves
+that virtue exactly — it adds **no standing server** to the org.
 
 ## The queryable data surface (the AI's corpus)
 
-This inventory IS the corpus any AI option would query. All datasets are JSON, keyed by
-`districtId` (e.g. `"42"`, `"F"`) and optionally `date` (YYYY-MM-DD) or `programYear`,
-validated by Zod schemas in `packages/shared-contracts/src/`.
+This inventory IS the corpus the MCP tools read. All datasets are JSON, keyed by
+`districtId` (e.g. `"61"`, `"F"`) and optionally `date` (YYYY-MM-DD) or `programYear`,
+validated by Zod schemas in `packages/shared-contracts/src/` — the MCP reuses these as
+**read-schemas**, not as a computation dependency.
 
 **Discovery / routing**
 
@@ -61,7 +81,7 @@ validated by Zod schemas in `packages/shared-contracts/src/`.
 | Latest-successful pointer | `snapshots/latest-successful.json`    | fast constant-time latest lookup |
 | Club→district index       | `config/club-index.json`              | resolve a club to its district   |
 
-**Core analytics**
+**Core analytics (all pre-computed; the MCP reads these fields verbatim)**
 
 | Dataset                      | CDN path                                            | Key queryable fields                                                                                                                                                     | Schema                                          |
 | ---------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
@@ -76,9 +96,9 @@ validated by Zod schemas in `packages/shared-contracts/src/`.
 | Snapshot metadata / manifest | `snapshots/{date}/metadata.json`, `…/manifest.json` | run status, successful/failed districts                                                                                                                                  | `snapshot-metadata`, `snapshot-manifest`        |
 
 **Implication for AI design:** the data is small, structured, schema-versioned, and already
-aggregated to decision granularity. That fact drives the decision below — it rewards a
-**typed, deterministic** access surface and penalizes anything that re-indexes or
-embeds it.
+aggregated to decision granularity. A **thin reader** that surfaces these fields — and refuses
+to invent anything not present — captures the open-ended-query value at the lowest possible
+liability.
 
 ## Options evaluated
 
@@ -86,138 +106,143 @@ Scored across: freshness vs cadence, auth/privacy (data is public → low), cost
 build+maintenance effort, primary user served, grounding/hallucination risk, GCS→CDN fit,
 ecosystem reuse.
 
-| #   | Option                                      | Cost                                                                      | Effort                                                       | Serves                                              | Grounding risk                                     | Ecosystem reuse                              | Verdict                                               |
-| --- | ------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------- | -------------------------------------------------- | -------------------------------------------- | ----------------------------------------------------- |
-| 1   | **Read-only MCP server** over the snapshots | Very low (no model hosting — user's own Claude infers; CDN absorbs reads) | Low–moderate (Zod contracts map ~1:1 to MCP tools/resources) | Claude power-user (**not** the in-app leader alone) | **Lowest** — typed rows from schematized snapshots | **Highest** — first reusable org MCP pattern | **Recommend (as the AI-native primitive)**            |
-| 2   | In-app NL chat panel                        | Highest recurring (per-query inference)                                   | Highest (full React feature + eval harness)                  | In-app leader                                       | Moderate — must build grounding yourself           | Low — bespoke per product                    | Secondary / phase-2                                   |
-| 3   | Prompt / "ask" deep-link library            | ≈0 (static config)                                                        | Lowest (days)                                                | In-app leader                                       | **Zero** (no LLM in the numeric path)              | Low–moderate (UX pattern)                    | **Ship first as baseline** (not AI-native on its own) |
-| 4   | Structured query + RAG API                  | High (vector store + re-embed per snapshot)                               | Highest infra                                                | Neither without a client on top                     | Moderate–high, self-inflicted                      | Over-engineered for tabular data             | **Reject**                                            |
+| #   | Option                                             | Cost                                                  | Effort                                             | Serves                   | Grounding risk                                                         | Standing liability     | Verdict                                     |
+| --- | -------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------- | ---------------------- | ------------------------------------------- |
+| 1   | **Thin _local_ MCP** (reads CDN, no compute)       | ~0 (user's own Claude infers; user's machine runs it) | Low (Zod read-schemas map ~1:1 to MCP tools)       | Claude/MCP power-user    | **Lowest** — returns the same pre-computed bytes the site shows        | **None** — no hosting  | **Recommend (build)**                       |
+| 1b  | _Fat_ local MCP (imports analytics-core, computes) | ~0 hosting                                            | Higher — + recognition-rule single-sourcing (#799) | same                     | Higher — read-path vs compute-path can diverge (the #800 class of bug) | None                   | Deferred — revisit if what-ifs are demanded |
+| 2   | Remote MCP server                                  | Low box cost, but **always-on**                       | Moderate                                           | same                     | Lowest                                                                 | **Yes — on-call**      | Rejected for now (hosting liability)        |
+| 3   | In-app NL chat panel (org-funded model)            | Highest recurring (per-query inference)               | Highest (full React feature + eval harness)        | in-app leader            | Moderate                                                               | Yes (live LLM backend) | Deferred (see _Future consumers_)           |
+| 4   | Structured query + RAG                             | High (vector store + re-embed per snapshot)           | Highest infra                                      | neither without a client | Moderate–high, self-inflicted                                          | Yes                    | **Reject**                                  |
 
 **Why RAG is rejected outright:** embeddings/vector retrieval earn their keep on large
 unstructured corpora. This data is small, structured, and query-ready as files; RAG would
 manufacture a re-indexing staleness layer, recurring infra cost, and retrieval-hallucination
-risk that a typed query eliminates. For _"clubs in Division B…"_ a deterministic typed query
-beats semantic retrieval every time.
+risk that a direct typed read eliminates.
+
+**Why thin beats fat (for now):** a fat MCP that computes would need recognition logic
+single-sourced in `analytics-core` first (#799 — still unconsolidated; frontend
+`divisionStatus.ts` / `divisionGapAnalysis.ts` hold parallel copies, the #800 root cause), and
+would introduce a read-path-vs-compute-path divergence risk — the exact failure class that has
+recurred in this repo. A thin reader has **one** answer for each field: the pre-computed one.
+The cost is that it can only answer what the pipeline already wrote (no what-ifs) — accepted,
+because the motivating questions are pre-computed fields, and a wave of unanswerable what-ifs
+would be the _evidence_ to justify the fat layer later.
 
 ## Decision
 
-**Recommend a read-only remote MCP server (option 1) as the AI-native primitive — but
-sequence it behind a zero-cost ask/deep-link library (option 3) shipped first, and gate the
-MCP build on two falsifiable demand signals.**
+**Build a thin, local (self-installed) read-only MCP server over the public snapshot CDN. No
+computation, no `analytics-core` dependency, no hosting. Drop the originally-proposed Phase 0
+deep-link library entirely.**
 
 Rationale, in order of weight:
 
-1. **Only option 1 is genuinely AI-native.** The brief is _open-ended_ questions. The ask
-   library answers only pre-curated questions; MCP lets any Claude client compose arbitrary
-   queries over the typed datasets. Options 2 and 4 are AI-native too but at far higher cost,
-   effort, and grounding risk.
-2. **The data's shape decides it.** Public, versioned, file-addressable, Zod-schematized,
-   pre-aggregated. A read-only MCP server wraps the existing contracts almost 1:1
-   (`list-districts`, `get-club-health`, `query-rankings`, `get-time-series`) and touches
-   the pipeline **not at all** — the `v1/latest.json → dates → per-district JSON` layout is
-   already a de-facto resource tree.
-3. **Lowest grounding risk of the LLM options.** The model receives exact typed rows;
-   tool-shaped responses keep it on rails. (See the honest caveat in _Falsification_ below.)
-4. **It serves the operator's actual center of gravity** — a Claude/MCP-heavy workflow with
-   zero existing AI surface — and seeds the reusable org-wide pattern (read-only remote MCP
-   over public CDN data) that Red Vote / Red Club can clone.
+1. **Local deletes the only real objection.** The original ADR gated the MCP build on an
+   on-call/maintenance condition because it assumed a _remote_ server. A local server has no
+   standing surface to maintain — it runs on the user's machine. The build gate is therefore
+   removed; there is no always-on liability to gate against.
+2. **Thin = strongest grounding + zero rule-drift.** The server returns the pre-computed field
+   the pipeline already wrote (`recognitionState`, tier, visit-met). The agent's numeric
+   answer is the same byte the website shows, so the MCP cannot contradict the site, and there
+   is no second implementation of any rule to drift (no #799 precondition, no #800-class risk).
+3. **The data's shape decides it.** Public, versioned, file-addressable, Zod-schematized,
+   pre-aggregated. The read tools wrap the existing CDN layout (`v1/latest.json → dates →
+per-district JSON`) and `shared-contracts` read-schemas almost 1:1, touching the pipeline
+   **not at all**.
+4. **It serves the operator's center of gravity** (a Claude/MCP-heavy workflow) and seeds the
+   reusable org pattern (thin local MCP over public CDN data) that Red Vote / Red Club can
+   clone — without committing any product to a hosted service.
 
-**Sequencing (this is the falsification-driven part):**
+**Non-negotiable design rules for the build:**
 
-- **Phase 0 — ship the ask/deep-link library first.** It is a static JSON/markdown artifact
-  pointing at views that **already exist** (the app already ships `?regions=`, `?q=`,
-  `?pinned=`, `?sort=&dir=`, the "Close to Distinguished" preset, and deep-linkable
-  division/area/analytics/trends routes — #969, #974). It serves the **majority in-app
-  leader** natively, costs ≈0, adds no hosting, and has structurally zero hallucination risk.
-  It also doubles as the **demand probe** for the MCP layer.
-- **Phase 1 — thin MCP POC** over 2–3 datasets, gated on the conditions below.
+- **Read-only, no computation.** Tools fetch CDN JSON, validate with `shared-contracts`
+  read-schemas, and return fields. They never derive a tier, threshold, or recognition state.
+- **No `analytics-core` import.** If a question requires computation the snapshot doesn't
+  already answer, the tool returns _"not available for this date/field"_ — it never guesses.
+- **Pin to `v1/`** for contract stability; surface the snapshot `date` in every response.
+- **Cite the source.** Every tool result includes the exact CDN URL it read, so a human can
+  verify against the live site.
 
-## POC plan (scoped — the recommended option, not a build commitment)
+## Build plan (the filed epic)
 
-**Phase 0 — ask library (days).** Curate ~10 parameterized deep-link templates keyed to the
-example questions ("clubs close to Distinguished in my division", "areas missing a round-2
-visit", "fastest-declining clubs this program year"). Static artifact + a small launcher UI
-reusing existing route/preset state. No backend. Validates whether leaders want guided
-answers and surfaces which open-ended questions the templates _can't_ express — that gap is
-the MCP demand signal.
+A thin local MCP server, distributed as an installable package (e.g. `npx`-runnable / MCP
+client config entry), exposing read-only tools over the corpus above, typed from
+`shared-contracts`. Indicative tools: `list-districts`, `get-latest-date`,
+`get-district-snapshot`, `query-rankings`, `get-club-health`, `get-time-series`,
+`resolve-club`. Success = the two motivating questions answered end-to-end from a Claude
+client against the live CDN, each answer carrying the source URL.
 
-**Phase 1 — read-only MCP POC (1–2 weeks, gated).** A stateless remote MCP server (HTTP/SSE
-transport) on the existing Cloud Run footprint, exposing **read-only** tools over 2–3 datasets
-to start (rankings, district snapshot, club-health), typed from `shared-contracts`. No
-writes, no inference hosting, no new pipeline stage. Public data ⇒ no auth needed for
-correctness; shared Clerk available later for optional rate-limiting. Success = the two
-motivating questions answered end-to-end from a Claude client against staging CDN data, with
-every answer carrying a deterministic deep link back to the source view for human verification.
+The epic and its sprints are tracked in GitHub and wired into META-EPIC #606.
 
-**Build-gate conditions (must hold before Phase 1):**
+## Future consumers (explicitly deferred, not part of this build)
 
-1. Evidence that Claude-using district leaders exist in **non-trivial numbers** (not a
-   population of ~1), OR a sibling product (Red Vote / Red Club) **commits** to consuming the
-   same MCP pattern so the ecosystem-reuse value stops being speculative.
-2. The operator can commit to maintaining a new always-on remote service alongside the
-   existing pipeline/runner on-call.
+The thin read layer is designed so these can be added later **without** re-litigating grounding:
 
-If neither holds, **ship Phase 0 only** and revisit.
+- **BYO-key in-app chat panel.** A browser chat where the leader supplies their own model API
+  key; the SPA feeds it CDN data it already fetches (CORS verified: `cdn.taverns.red` echoes
+  `access-control-allow-origin: https://ts.taverns.red`). $0 inference for the org. Serves the
+  in-app leader segment the local MCP does not. Power-user feature (requires a key); deferred
+  until demand is shown.
+- **Remote MCP.** Only if a sibling product commits to consuming it or a non-trivial cohort
+  needs zero-install access — at which point the hosting/on-call cost becomes justified.
+- **Fat / compute MCP.** Only if leaders demand what-if questions the pre-computed fields
+  can't answer; requires the #799 recognition-logic consolidation first.
 
-## Falsification (the MCP-leading hypothesis was attacked, not assumed)
+## Falsification
 
-Per the epic DoD, the MCP-leading hypothesis was adversarially tested. It **survives as the
-AI-native primitive** but the attack changed the recommendation's _shape_ (hence Phase 0
-first). The strongest counter-arguments, recorded honestly:
+The thin-local recommendation was reached by attacking the prior remote/fat/Phase-0 design:
 
-- **Primary-user inversion.** The product spec names "Toastmasters district leaders" as the
-  primary user and has previously rejected complexity-without-user-value (the "real-time
-  updates" decision). MCP serves the Claude power-user; the in-app leader who never opens a
-  Claude client "is unaddressed by this option alone" (option-1's own admission). Optimizing
-  purely on the scored columns risks favoring builder ergonomics + ecosystem speculation over
-  delivered leader value. **Mitigation:** Phase 0 ships leader value first and gates MCP on
-  real demand.
-- **Standing-liability mismatch.** A one-operator no-build org's core virtue is a static read
-  path. "Very low cost" prices the box, not the on-call — a server must never be down and is
-  maintained by the same single operator. **Mitigation:** the build-gate's on-call condition.
-- **Grounding risk is understated by framing.** Typed tools constrain _retrieval_, not the
-  natural-language _claim_ built on top ("District X is at charter risk"). For decision-grade
-  numbers, any LLM-mediated answer has a confidently-wrong tail a deterministic view does not.
-  **Mitigation:** every MCP answer pairs with a deterministic deep link to the source view.
+- **"Phase 0 advances the brief."** Rejected — it answers only pre-curated questions; the brief
+  is open-ended. Dropped.
+- **"Remote is needed for reach."** Rejected for now — local serves the power-user segment with
+  zero hosting; reach (zero-install) is a future-remote trigger, not a launch requirement.
+- **"Fat MCP gives better answers."** Rejected for now — compute introduces a second answer
+  path (the #800/#799 risk) for marginal gain on questions nobody has yet asked. Thin first;
+  fat on evidence.
+- **Honest residual risk:** thin can only answer pre-computed fields. If real usage produces a
+  steady stream of unanswerable what-ifs, that is the signal to build the fat/compute layer
+  (after #799). Tracked, not pre-built.
 
-**Conditions to revisit this ADR:** flip toward "ask-library-only" if no measured Claude-using
-leader cohort emerges and no sibling commits; flip fully toward MCP-first if usage telemetry /
-leader interviews show a growing conversational-query cohort, a sibling product adopts the
-pattern, or the ask library ships and leaders explicitly request free-form questions the
-templates can't express.
+**Conditions to revisit:** add the BYO-key in-app panel if the in-app leader segment asks for
+conversational access; add remote MCP if a sibling commits or zero-install demand appears; add
+the fat/compute layer if what-if demand is measured.
 
 ## Consequences
 
 ### Positive
 
-- AI-native open-ended querying with **no pipeline change** and no new computation.
-- Leader value this sprint via Phase 0 at ≈0 cost.
-- Seeds a reusable, public-data, read-only MCP pattern for the Red Taverns ecosystem.
-- Grounding risk minimized by typed tools + mandatory deep-link-to-source.
+- AI-native open-ended querying with **no pipeline change, no computation, and no hosting**.
+- Strongest grounding of any LLM option — answers are the pipeline's own bytes; the MCP cannot
+  disagree with the website.
+- No recognition-rule single-sourcing precondition (#799) and no #800-class divergence risk.
+- Seeds a reusable, public-data, thin local MCP pattern for the Red Taverns ecosystem.
 
 ### Negative
 
-- Phase 1 adds the org's first always-on hosted read surface — a maintenance/on-call
-  liability for a one-operator org (gated, not unconditional).
-- MCP alone does not serve the in-app-only leader; that segment is served by Phase 0 (and a
-  future in-app chat panel built _on_ the MCP layer, if ever justified).
+- Serves the Claude/MCP power-user, **not** the in-app-only leader (deferred to a future
+  BYO-key panel).
+- Cannot answer what-if / derived questions the snapshots don't pre-compute — by design.
+- A published package to version (mitigated: `v1/` contract pinning; no server to operate).
+- Local install = no central usage telemetry; demand signals come from direct operator/leader
+  feedback rather than logs.
 
 ## Alternatives Considered
 
-- **In-app NL chat panel (option 2)** — the only option that natively serves the in-app
-  leader, but highest cost (per-query inference, org-funded), highest effort (full React
-  feature + eval harness), and couples the deliberately-static SPA to a live LLM backend.
-  Deferred as a phase-2 secondary built _on top of_ the MCP data layer if leader demand proves out.
-- **Prompt / ask library (option 3)** — adopted as **Phase 0**, but rejected as _the_
-  AI-native answer because it only addresses pre-curated questions and fails the open-ended brief.
-- **Structured query + RAG (option 4)** — rejected: embeddings/RAG are mismatched to small,
-  schematized, aggregated tabular data; they add cost, staleness, and self-inflicted
-  retrieval-hallucination risk that typed MCP queries eliminate.
+- **Phase 0 deep-link library** — **dropped.** Pre-curated only; fails the open-ended brief.
+- **Remote MCP** — deferred; reintroduces the always-on hosting/on-call liability a local
+  server avoids.
+- **Fat / compute MCP** — deferred; needs #799 consolidation and adds read-vs-compute
+  divergence risk.
+- **In-app org-funded NL chat (option 2)** — deferred; per-query inference cost + live-LLM
+  coupling to a deliberately static SPA. A BYO-key variant ($0 to the org) is the preferred
+  future form.
+- **Structured query + RAG (option 4)** — rejected; mismatched to small, schematized,
+  aggregated tabular data.
 
 ## Related
 
 - [ADR-001](001-cdn-only-frontend.md) — CDN-only frontend (the static read path this preserves)
 - [ADR-007](007-data-serving-gcs-cdn-lb-over-firebase.md) — GCS + Cloud CDN data serving (the corpus host)
 - Epic [#1009](https://github.com/taverns-red/toast-stats/issues/1009) — AI-native Toast Stats spike; Sprint 1 [#1018](https://github.com/taverns-red/toast-stats/issues/1018)
-- `packages/shared-contracts/src/schemas/` — the Zod contracts that map ~1:1 onto MCP tools/resources
+- #799 / #800 — recognition-logic single-sourcing (the precondition a _fat_ MCP would need; not required by this thin design)
+- `packages/shared-contracts/src/schemas/` — the Zod read-schemas the MCP reuses
 - `frontend/src/services/cdn.ts`, `frontend/src/services/cdnTimeSeries.ts` — the read surface inventoried above

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -28,7 +28,7 @@ Each ADR follows this template:
 | [005](005-district-subpage-ia-and-secondary-nav.md)   | District subpage IA map + secondary route-nav              | Accepted                                                           | May 2026 |
 | [006](006-data-table-page-layout-and-column-model.md) | Data-table page layout & column-model standard             | Accepted                                                           | May 2026 |
 | [007](007-data-serving-gcs-cdn-lb-over-firebase.md)   | Serve data via GCS + Cloud CDN + LB (not Firebase Hosting) | Accepted                                                           | May 2026 |
-| [008](008-ai-enable-toast-stats.md)                   | AI-enable Toast Stats — read-only MCP server over the CDN  | Proposed                                                           | May 2026 |
+| [008](008-ai-enable-toast-stats.md)                   | AI-enable Toast Stats — thin local MCP server over the CDN | Accepted (revised — thin local MCP, no compute; Phase 0 dropped)   | May 2026 |
 
 ## When to Write an ADR
 


### PR DESCRIPTION
## What
Revise **ADR-008** from *Proposed (remote MCP, gated behind a Phase-0 deep-link library)* to **Accepted (thin, local, no-compute MCP)**, and file the build epic.

## Why (operator review, 2026-05-31)
- **Drop Phase 0 entirely** — a curated deep-link list that answers only pre-curated questions; fails the open-ended brief.
- **Remote → local.** A self-installed MCP server has **no hosting and no on-call** — which was the original ADR's #1 objection. CORS/auth are moot for a local process reading public data.
- **Thin, no computation.** Reads the **pre-computed** snapshot fields the pipeline already writes (`recognitionState`, `regionAdvisorVisitMet`, distinguished tiers). No `analytics-core` import, no rule re-derivation. Grounding is the strongest possible — the agent's numbers are the same bytes the website shows — and it removes the #799 recognition-rule single-sourcing precondition and the #800-class read-vs-compute divergence risk a "fat" design would carry.
- **Future consumers** (BYO-key in-app chat, remote MCP, fat/compute MCP) are explicitly deferred, designed to consume the same thin read layer without re-litigating grounding.

Verified during review: `cdn.taverns.red` is public (`200`, `application/json`), `v1/`-namespaced (contract-stable), and echoes `access-control-allow-origin: https://ts.taverns.red` (relevant only to the future in-app panel).

## Changes
- `008-ai-enable-toast-stats.md` — revised recommendation, options table, decision, build plan, falsification, consequences; revision banner at top.
- `README.md` — ADR-008 index row → title + status updated.

Docs-only (Lightweight DoD). Refs #1009. Build epic wired into META-EPIC #606 (see issue links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)