### PR TITLE
feat(pipeline): value-aware promote gate for full-range re-derive (#1034)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -1299,15 +1299,19 @@ jobs:
           echo "Overlap dates to value-compare: ${OVERLAP_COUNT}"
 
           # Pull each overlap date's all-districts-rankings.json from both buckets.
+          # Parallelized (xargs -P): ~2 cp/date sequentially over ~100 dates is
+          # ~200 round-trips dominated by gsutil startup; running them concurrently
+          # cuts wall time markedly. Each cp is fail-soft (a missing file just drops
+          # that date from the compare — loadDateDigests skips dirs without the file).
           rm -rf /tmp/vd && mkdir -p /tmp/vd/staging /tmp/vd/prod
-          while IFS= read -r d; do
-            [ -z "$d" ] && continue
+          xargs -P 16 -I {} bash -c '
+            d="$1"; sb="$2"; pb="$3"
             mkdir -p "/tmp/vd/staging/${d}" "/tmp/vd/prod/${d}"
-            gsutil -q cp "gs://${GCS_BUCKET}/snapshots/${d}/all-districts-rankings.json" \
+            gsutil -q cp "gs://${sb}/snapshots/${d}/all-districts-rankings.json" \
               "/tmp/vd/staging/${d}/all-districts-rankings.json" 2>/dev/null || true
-            gsutil -q cp "gs://${GCS_BUCKET_PRODUCTION}/snapshots/${d}/all-districts-rankings.json" \
+            gsutil -q cp "gs://${pb}/snapshots/${d}/all-districts-rankings.json" \
               "/tmp/vd/prod/${d}/all-districts-rankings.json" 2>/dev/null || true
-          done < /tmp/overlap-dates.txt
+          ' _ {} "${GCS_BUCKET}" "${GCS_BUCKET_PRODUCTION}" < /tmp/overlap-dates.txt
 
           ALLOW_FLAG=""
           if [ "${ALLOW_VALUE_CHANGES:-false}" = "true" ]; then

--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: boolean
         default: false
+      allow_value_changes:
+        description: 'Promote even if re-derived VALUES changed vs prod (review the value-diff first). For re-derive runs.'
+        required: false
+        type: boolean
+        default: false
 
 # Prevent overlapping pipeline runs
 concurrency:
@@ -1268,10 +1273,77 @@ jobs:
           fi
 
           echo "promote=${PROMOTE}" >> "$GITHUB_OUTPUT"
-          echo "- **Promotion**: $([ "$PROMOTE" = "true" ] && echo '✅ Safe (additive)' || echo '❌ Blocked (subtractive change detected)')" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Promotion (count gate)**: $([ "$PROMOTE" = "true" ] && echo '✅ Safe (additive)' || echo '❌ Blocked (subtractive change detected)')" >> "$GITHUB_STEP_SUMMARY"
+
+      # Value-aware gate (#1034, epic #1031). The count gate above is blind to a
+      # re-derive that keeps the same dates/districts but changes VALUES (F2).
+      # This step compares per-date district values over the overlap set and
+      # blocks promotion until an operator reviews them (allow_value_changes).
+      # Fail-closed: any error leaves value_promote=false.
+      - name: Value diff staging vs production (#1034)
+        id: valuediff
+        if: steps.mode.outputs.mode != 'prune'
+        env:
+          ALLOW_VALUE_CHANGES: ${{ inputs.allow_value_changes }}
+        run: |
+          set -uo pipefail
+          VALUE_PROMOTE="false"
+
+          # Overlap = dates present in BOTH staging and prod indexes.
+          gsutil cat "gs://${GCS_BUCKET}/v1/dates.json" 2>/dev/null \
+            | jq -r '.dates[]?' | sort > /tmp/staging-dates.txt || true
+          gsutil cat "gs://${GCS_BUCKET_PRODUCTION}/v1/dates.json" 2>/dev/null \
+            | jq -r '.dates[]?' | sort > /tmp/prod-dates.txt || true
+          comm -12 /tmp/staging-dates.txt /tmp/prod-dates.txt > /tmp/overlap-dates.txt || true
+          OVERLAP_COUNT=$(wc -l < /tmp/overlap-dates.txt | tr -d ' ')
+          echo "Overlap dates to value-compare: ${OVERLAP_COUNT}"
+
+          # Pull each overlap date's all-districts-rankings.json from both buckets.
+          rm -rf /tmp/vd && mkdir -p /tmp/vd/staging /tmp/vd/prod
+          while IFS= read -r d; do
+            [ -z "$d" ] && continue
+            mkdir -p "/tmp/vd/staging/${d}" "/tmp/vd/prod/${d}"
+            gsutil -q cp "gs://${GCS_BUCKET}/snapshots/${d}/all-districts-rankings.json" \
+              "/tmp/vd/staging/${d}/all-districts-rankings.json" 2>/dev/null || true
+            gsutil -q cp "gs://${GCS_BUCKET_PRODUCTION}/snapshots/${d}/all-districts-rankings.json" \
+              "/tmp/vd/prod/${d}/all-districts-rankings.json" 2>/dev/null || true
+          done < /tmp/overlap-dates.txt
+
+          ALLOW_FLAG=""
+          if [ "${ALLOW_VALUE_CHANGES:-false}" = "true" ]; then
+            ALLOW_FLAG="--allow-value-changes"
+          fi
+
+          # R4: structured JSON on stdout, logs on stderr. Parse .promote from JSON
+          # rather than the exit code so this step stays green and the gate flows
+          # through the step output.
+          npx collector-cli value-diff \
+            --staging-dir /tmp/vd/staging \
+            --prod-dir /tmp/vd/prod \
+            ${ALLOW_FLAG} > /tmp/value-diff.json 2>/tmp/value-diff.log || true
+
+          echo "## 🔬 Value Diff (staging vs production)" >> "$GITHUB_STEP_SUMMARY"
+          if jq -e . /tmp/value-diff.json >/dev/null 2>&1; then
+            VALUE_PROMOTE=$(jq -r '.promote' /tmp/value-diff.json)
+            ADDED=$(jq -r '.report.added | length' /tmp/value-diff.json)
+            REMOVED=$(jq -r '.report.removed | length' /tmp/value-diff.json)
+            CHANGED=$(jq -r '.report.changed | length' /tmp/value-diff.json)
+            echo "- Overlap dates: ${OVERLAP_COUNT}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Added: ${ADDED} · Removed: ${REMOVED} · **Changed: ${CHANGED}**" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Value-gate promote: ${VALUE_PROMOTE}" >> "$GITHUB_STEP_SUMMARY"
+            jq -r '.reasons[]? | "  - " + .' /tmp/value-diff.json >> "$GITHUB_STEP_SUMMARY" || true
+            jq -r '.report.changed[]? | "  - changed " + .date + " (" + (.changedDistricts | length | tostring) + " districts)"' \
+              /tmp/value-diff.json >> "$GITHUB_STEP_SUMMARY" || true
+          else
+            echo "::warning::value-diff produced no parseable output — failing closed (no promote)"
+            echo "- ⚠️ value-diff failed to produce output — **failing closed**" >> "$GITHUB_STEP_SUMMARY"
+            cat /tmp/value-diff.log || true
+          fi
+
+          echo "value_promote=${VALUE_PROMOTE}" >> "$GITHUB_OUTPUT"
 
       - name: Promote staging to production
-        if: steps.diff.outputs.promote == 'true' && steps.mode.outputs.mode != 'prune'
+        if: steps.diff.outputs.promote == 'true' && steps.valuediff.outputs.value_promote == 'true' && steps.mode.outputs.mode != 'prune'
         run: |
           echo "Promoting staging → production..."
 
@@ -1294,12 +1366,14 @@ jobs:
           echo "Staging data synced to production bucket." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Promotion blocked
-        if: steps.diff.outputs.promote == 'false' && steps.mode.outputs.mode != 'prune'
+        if: (steps.diff.outputs.promote == 'false' || steps.valuediff.outputs.value_promote == 'false') && steps.mode.outputs.mode != 'prune'
         run: |
-          echo "::error::Promotion BLOCKED — subtractive changes detected in staging. Production data unchanged."
+          echo "::error::Promotion BLOCKED — count gate or value gate refused. Production data unchanged."
           echo "## ❌ Promotion Blocked" >> "$GITHUB_STEP_SUMMARY"
-          echo "Subtractive changes detected. Production data is **unchanged**." >> "$GITHUB_STEP_SUMMARY"
-          echo "Review the diff above and manually promote if safe." >> "$GITHUB_STEP_SUMMARY"
+          echo "- Count gate (additive): **${{ steps.diff.outputs.promote }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Value gate: **${{ steps.valuediff.outputs.value_promote }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "Production data is **unchanged**. Review the diffs above." >> "$GITHUB_STEP_SUMMARY"
+          echo "For a reviewed re-derive, re-run with **allow_value_changes = true**." >> "$GITHUB_STEP_SUMMARY"
 
       # ── Summary ──
       - name: Pipeline summary

--- a/docs/architecture-decisions/009-full-range-rederive-promote-semantics.md
+++ b/docs/architecture-decisions/009-full-range-rederive-promote-semantics.md
@@ -1,0 +1,129 @@
+# ADR-009: Full-range re-derive promote semantics (value-aware gate + seed-from-prod)
+
+**Status**: Accepted
+**Date**: 2026-05-31
+**Issue**: #1034 (epic #1031 — rerun pipeline 2017→now; Sprint 1 investigation #1033)
+
+## Context
+
+Epic #1031 wants to re-run the data pipeline for every month-end from Jan 2017
+to now, **re-deriving** snapshots + analytics from the raw-csv already in GCS,
+**validate-first** (rebuild to a staging bucket → diff vs prod → promote). Sprint 1
+([`docs/investigations/2017-rerun-raw-csv-coverage.md`](../investigations/2017-rerun-raw-csv-coverage.md))
+established the ground truth and surfaced two findings that the existing
+staging→diff→promote path (`data-pipeline.yml`) cannot handle:
+
+- **F1 — A wholesale rebuild-from-raw-csv CANNOT promote today.** raw-csv yields
+  ~99 collection months; prod has **152** snapshot dates (55 are daily 2026
+  snapshots; 3 prod-only months — `2017-01`, `2022-07`, `2026-05` — have no
+  raw-csv source). The promote gate is count-monotonic
+  (`STAGING_DATES >= PROD_DATES`), so a pure raw-csv rebuild trips it and blocks.
+  This is the gate **correctly** refusing a subtractive change — not a bug.
+
+- **F2 — The gate cannot validate a re-derivation.** It compares aggregate
+  **counts**, never **values**. The epic's "re-derive after logic changes" intent
+  produces identical dates/districts with corrected values ⇒ counts match ⇒
+  `promote=true` unconditionally ⇒ prod overwritten with **unvalidated** values.
+  "Validate-first" was a count check, not a value check.
+
+Two questions follow, and this ADR records the decisions so Sprint 3 (the
+operator-attended execution) builds on them rather than relitigating:
+
+1. **How do we detect a wrong re-derive before it reaches prod?** (the F2 gap)
+2. **How does a partial-range rebuild promote without destroying the prod-only
+   dates it never regenerated?** (the F1 gap)
+
+## Decision
+
+### D1 — Add a value-aware diff gate (implemented this sprint)
+
+A new `collector-cli value-diff` command computes a per-date **value digest** over
+each district's data fields in `all-districts-rankings.json` for the set of dates
+present in **both** staging and prod (the overlap), and classifies every overlap
+date as `unchanged` or `changed` (plus `added` / `removed` by date-set). The digest:
+
+- is **order-independent** (districts sorted before combining), so a reordering
+  is not a false "changed";
+- **excludes volatile metadata** (`calculatedAt`, `csvFetchedAt`, `fromCache`,
+  version stamps) — those change every run without the data changing, which would
+  make every date falsely "changed" and render the gate useless.
+
+`evaluatePromote` then decides:
+
+| Diff shape                                      | promote                                    | rationale                                           |
+| ----------------------------------------------- | ------------------------------------------ | --------------------------------------------------- |
+| additive-only (`added`/`unchanged`)             | ✅ true                                    | new dates, nothing regressed                        |
+| any `removed` (date in prod, absent in staging) | ❌ false                                   | subtractive — always blocks, even with the override |
+| any `changed` (overlap values differ)           | ❌ false → ✅ with `--allow-value-changes` | a re-derive must be **reviewed** before it promotes |
+
+The gate is **fail-closed**: if the snapshots cannot be read or compared, the
+verdict is "do not promote." It is **ANDed with** the existing count gate in
+`data-pipeline.yml` (`steps.diff`) — it does not replace it (R11). A new
+`allow_value_changes` workflow_dispatch input maps to `--allow-value-changes`,
+so the operator promotes a re-derive only after reviewing the surfaced changed
+dates in the run summary.
+
+### D2 — Partial-range rebuild seeds staging from prod, then overlays the rebuild
+
+For the full-range execution (Sprint 3), **seed the staging bucket from prod
+first, then run the rebuild over it** (rebuild writes only raw-csv-backed dates).
+The consequence:
+
+- the 3 prod-only months (no raw-csv source) and the 55 daily 2026 snapshots
+  **survive** in staging because they were copied from prod and the rebuild never
+  touches them;
+- staging's date **count never regresses** below prod, so the count gate (D1's
+  AND-partner) passes and stops vetoing the whole run on F1;
+- the **value gate does the real work** — it flags exactly the overlap dates
+  whose re-derived values differ, which is precisely what the operator must review.
+
+This is preferred over the alternative of a scoped per-date promote (see below)
+because it requires **no new promote machinery** — the existing
+`gsutil -m rsync` promote step (additive, no `-d`) already does the right thing
+once staging is a superset of prod, and the safety logic lives entirely in the
+two gates rather than in a bespoke per-date rsync loop.
+
+## Consequences
+
+**Easier**
+
+- A re-derive that silently corrupts values is now caught before prod: the value
+  gate blocks by default and names the changed dates for review.
+- The full-range rebuild can promote (F1 unblocked) without a gate loosening —
+  staging becomes a superset of prod via the seed step, so "additive" stays true.
+- The decision is reversible and observable: the gates emit to the run summary,
+  and reverting the workflow step restores the prior count-only behavior.
+
+**More difficult / cost**
+
+- The value gate downloads each overlap date's `all-districts-rankings.json` from
+  both buckets (≈2 × overlap small JSON reads). Acceptable inside the 240-min
+  rebuild job; it would be too heavy for the 30-min daily job, but the gate runs
+  for all non-prune modes and the daily overlap is tiny.
+- The seed-from-prod step (Sprint 3) adds a one-time `gsutil -m rsync prod→staging`
+  before the rebuild. Staging then diverges from "pure rebuild output"; that is
+  intended — staging models _what prod would become after promotion_, which is the
+  correct thing to diff.
+- The digest covers `all-districts-rankings.json` only. Per-district snapshot
+  files, time-series, and club-trends are **not** value-diffed yet (a follow-up if
+  the rankings digest proves insufficient as a re-derive canary).
+
+## Alternatives Considered
+
+- **Loosen the count gate to allow `STAGING_DATES < PROD_DATES`.** Rejected — it
+  removes the only protection against an accidental subtractive rebuild, the exact
+  failure F1 describes the gate correctly catching.
+- **Scoped per-date promote** (never rewrite `v1/dates.json` downward; rsync only
+  the rebuilt dates). Viable and avoids the seed copy, but needs bespoke
+  per-date promote logic and a careful manifest-merge (regenerate `dates.json`
+  from the union, not staging alone). More moving parts and more ways to corrupt
+  the prod index than D2's "make staging a superset, let the existing additive
+  rsync run." Kept as a fallback if the seed copy proves too slow/expensive.
+- **Value-diff every snapshot artifact** (per-district files + time-series +
+  club-trends). Rejected for now as over-scoped — `all-districts-rankings.json` is
+  the rolled-up output of the per-district compute, so a change upstream surfaces
+  there. Revisit if a re-derive changes a per-district file without moving the
+  rollup.
+- **Gate on a tolerance** (promote if values changed by < ε). Rejected — a
+  re-derive is deterministic; any value change is either intended (logic fix, then
+  review + `--allow-value-changes`) or a bug. A tolerance would hide small bugs.

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -29,6 +29,7 @@ Each ADR follows this template:
 | [006](006-data-table-page-layout-and-column-model.md) | Data-table page layout & column-model standard             | Accepted                                                           | May 2026 |
 | [007](007-data-serving-gcs-cdn-lb-over-firebase.md)   | Serve data via GCS + Cloud CDN + LB (not Firebase Hosting) | Accepted                                                           | May 2026 |
 | [008](008-ai-enable-toast-stats.md)                   | AI-enable Toast Stats — thin local MCP server over the CDN | Accepted (revised — thin local MCP, no compute; Phase 0 dropped)   | May 2026 |
+| [009](009-full-range-rederive-promote-semantics.md)   | Full-range re-derive promote semantics (value-aware gate)  | Accepted                                                           | May 2026 |
 
 ## When to Write an ADR
 

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -1488,5 +1488,82 @@ export function createCLI(): Command {
       }
     )
 
+  // Value-aware staging→production diff for the full-range re-derive promote
+  // gate (#1034, epic #1031). Complements the count-only gate in
+  // data-pipeline.yml: detects re-derived VALUE changes the count gate is blind
+  // to, and blocks promotion until an operator reviews them. Fail-closed.
+  program
+    .command('value-diff')
+    .description(
+      'Compare staging vs production snapshot values and decide if promotion is safe (#1034)'
+    )
+    .requiredOption(
+      '--staging-dir <dir>',
+      'Directory of staging snapshots ({dir}/{date}/all-districts-rankings.json)'
+    )
+    .requiredOption(
+      '--prod-dir <dir>',
+      'Directory of production snapshots (same layout)'
+    )
+    .option(
+      '--allow-value-changes',
+      'Operator override: promote re-derived value changes after reviewing the diff',
+      false
+    )
+    .option('-v, --verbose', 'Enable detailed logging output', false)
+    .action(
+      async (options: {
+        stagingDir: string
+        prodDir: string
+        allowValueChanges: boolean
+        verbose: boolean
+      }) => {
+        const { runValueDiff } =
+          await import('./services/SnapshotValueDiffLoader.js')
+
+        let result
+        try {
+          result = runValueDiff({
+            stagingDir: options.stagingDir,
+            prodDir: options.prodDir,
+            allowValueChanges: options.allowValueChanges,
+          })
+        } catch (err) {
+          // Fail-closed: if we cannot read/compare the snapshots, do NOT promote.
+          const message = err instanceof Error ? err.message : String(err)
+          console.error(`[ERROR] value-diff failed: ${message}`)
+          console.log(
+            JSON.stringify(
+              {
+                promote: false,
+                requiresReview: true,
+                reasons: [`value-diff failed: ${message}`],
+              },
+              null,
+              2
+            )
+          )
+          process.exit(ExitCode.PARTIAL_FAILURE)
+        }
+
+        const { report, decision } = result
+        if (options.verbose) {
+          console.error(
+            `[INFO] overlap=${report.overlap} added=${report.added.length} removed=${report.removed.length} changed=${report.changed.length} unchanged=${report.unchanged.length}`
+          )
+          for (const reason of decision.reasons) {
+            console.error(`[INFO] ${reason}`)
+          }
+        }
+
+        // Structured JSON to stdout (R4: logs to stderr only).
+        console.log(JSON.stringify({ ...decision, report }, null, 2))
+
+        process.exit(
+          decision.promote ? ExitCode.SUCCESS : ExitCode.PARTIAL_FAILURE
+        )
+      }
+    )
+
   return program
 }

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -1559,9 +1559,8 @@ export function createCLI(): Command {
         // Structured JSON to stdout (R4: logs to stderr only).
         console.log(JSON.stringify({ ...decision, report }, null, 2))
 
-        process.exit(
-          decision.promote ? ExitCode.SUCCESS : ExitCode.PARTIAL_FAILURE
-        )
+        // result.exitCode is the single source of truth (0 promote / 1 blocked).
+        process.exit(result.exitCode)
       }
     )
 

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -1,0 +1,85 @@
+/**
+ * SnapshotValueDiff — value-aware comparison of two snapshot sets (staging vs
+ * production) for the full-range re-derive promote gate (epic #1031, Sprint 2).
+ *
+ * The existing promote gate (`data-pipeline.yml` `steps.diff`) compares only
+ * aggregate COUNTS — date count and ranked-district count. That is monotonic
+ * protection against a SUBTRACTIVE change, but it gives ZERO protection for the
+ * epic's "re-derive after logic changes" intent: same dates/districts ⇒ counts
+ * identical ⇒ auto-promote, even if every value was recomputed wrong (F2 in
+ * docs/investigations/2017-rerun-raw-csv-coverage.md).
+ *
+ * This module adds a per-date VALUE digest over each district's data fields and
+ * classifies the overlap set as added / removed / changed / unchanged, so a
+ * re-derive must be reviewed (validate-first) before it can promote.
+ *
+ * NOTE: stub bodies — implemented in the GREEN commit. Kept typed so the failing
+ * test compiles (the assertions are what fail in RED, not the import).
+ */
+import type {
+  AllDistrictsRankingsData,
+  DistrictRanking,
+} from '@toastmasters/shared-contracts'
+
+export interface DateDigest {
+  date: string
+  totalDistricts: number
+  /** districtId → stable digest of that district's data fields */
+  districtDigests: Record<string, string>
+  /** order-independent digest of the whole date */
+  combined: string
+}
+
+export interface ChangedDate {
+  date: string
+  changedDistricts: string[]
+}
+
+export interface ValueDiffReport {
+  /** dates present in staging but not prod (additive) */
+  added: string[]
+  /** dates present in prod but not staging (subtractive) */
+  removed: string[]
+  /** overlap dates whose values differ */
+  changed: ChangedDate[]
+  /** overlap dates whose values are identical */
+  unchanged: string[]
+  /** number of dates present in both sets */
+  overlap: number
+}
+
+export interface PromoteDecision {
+  promote: boolean
+  requiresReview: boolean
+  reasons: string[]
+}
+
+export interface PromoteOptions {
+  /** operator override: promote a reviewed value re-derive despite changed dates */
+  allowValueChanges?: boolean
+}
+
+export function digestDistrict(_district: DistrictRanking): string {
+  return ''
+}
+
+export function digestDate(
+  date: string,
+  _data: AllDistrictsRankingsData
+): DateDigest {
+  return { date, totalDistricts: 0, districtDigests: {}, combined: '' }
+}
+
+export function diffSnapshots(
+  _staging: DateDigest[],
+  _prod: DateDigest[]
+): ValueDiffReport {
+  return { added: [], removed: [], changed: [], unchanged: [], overlap: 0 }
+}
+
+export function evaluatePromote(
+  _report: ValueDiffReport,
+  _opts: PromoteOptions = {}
+): PromoteDecision {
+  return { promote: true, requiresReview: false, reasons: [] }
+}

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -12,9 +12,6 @@
  * This module adds a per-date VALUE digest over each district's data fields and
  * classifies the overlap set as added / removed / changed / unchanged, so a
  * re-derive must be reviewed (validate-first) before it can promote.
- *
- * NOTE: stub bodies — implemented in the GREEN commit. Kept typed so the failing
- * test compiles (the assertions are what fail in RED, not the import).
  */
 import type {
   AllDistrictsRankingsData,
@@ -59,27 +56,163 @@ export interface PromoteOptions {
   allowValueChanges?: boolean
 }
 
-export function digestDistrict(_district: DistrictRanking): string {
-  return ''
+/**
+ * Deterministic JSON serialization with recursively sorted object keys, so that
+ * a digest depends only on values, never on key insertion order. `undefined`
+ * values (absent optional fields) are dropped consistently by JSON.stringify.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`
+  }
+  const obj = value as Record<string, unknown>
+  const keys = Object.keys(obj)
+    .filter(k => obj[k] !== undefined)
+    .sort()
+  return `{${keys
+    .map(k => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(',')}}`
 }
 
+/**
+ * Stable digest of a single district's data. Captures EVERY field of the
+ * ranking (metrics, ranks, scores, the optional #329/#330/#336 fields) so any
+ * re-derived difference is detected — but is independent of object key order.
+ */
+export function digestDistrict(district: DistrictRanking): string {
+  return stableStringify(district)
+}
+
+/**
+ * Per-date digest. Deliberately EXCLUDES `metadata` (calculatedAt, csvFetchedAt,
+ * fromCache, version stamps) — those change on every run without the underlying
+ * data changing, which would make every date falsely read as "changed".
+ */
 export function digestDate(
   date: string,
-  _data: AllDistrictsRankingsData
+  data: AllDistrictsRankingsData
 ): DateDigest {
-  return { date, totalDistricts: 0, districtDigests: {}, combined: '' }
+  const districtDigests: Record<string, string> = {}
+  for (const district of data.rankings) {
+    districtDigests[district.districtId] = digestDistrict(district)
+  }
+  // Order-independent: sort by districtId before combining.
+  const combined = stableStringify(
+    Object.keys(districtDigests)
+      .sort()
+      .map(id => [id, districtDigests[id]])
+  )
+  return {
+    date,
+    totalDistricts: data.rankings.length,
+    districtDigests,
+    combined,
+  }
+}
+
+function byDate(digests: DateDigest[]): Map<string, DateDigest> {
+  const map = new Map<string, DateDigest>()
+  for (const d of digests) map.set(d.date, d)
+  return map
+}
+
+/** Districts whose per-district digest differs (or is present in only one set). */
+function changedDistricts(a: DateDigest, b: DateDigest): string[] {
+  const ids = new Set([
+    ...Object.keys(a.districtDigests),
+    ...Object.keys(b.districtDigests),
+  ])
+  const changed: string[] = []
+  for (const id of ids) {
+    if (a.districtDigests[id] !== b.districtDigests[id]) changed.push(id)
+  }
+  return changed.sort()
 }
 
 export function diffSnapshots(
-  _staging: DateDigest[],
-  _prod: DateDigest[]
+  staging: DateDigest[],
+  prod: DateDigest[]
 ): ValueDiffReport {
-  return { added: [], removed: [], changed: [], unchanged: [], overlap: 0 }
+  const stagingMap = byDate(staging)
+  const prodMap = byDate(prod)
+
+  const added: string[] = []
+  const removed: string[] = []
+  const changed: ChangedDate[] = []
+  const unchanged: string[] = []
+  let overlap = 0
+
+  for (const date of stagingMap.keys()) {
+    if (!prodMap.has(date)) added.push(date)
+  }
+  for (const date of prodMap.keys()) {
+    if (!stagingMap.has(date)) removed.push(date)
+  }
+  for (const [date, stagingDigest] of stagingMap) {
+    const prodDigest = prodMap.get(date)
+    if (!prodDigest) continue
+    overlap++
+    if (stagingDigest.combined === prodDigest.combined) {
+      unchanged.push(date)
+    } else {
+      changed.push({
+        date,
+        changedDistricts: changedDistricts(stagingDigest, prodDigest),
+      })
+    }
+  }
+
+  return {
+    added: added.sort(),
+    removed: removed.sort(),
+    changed: changed.sort((x, y) => x.date.localeCompare(y.date)),
+    unchanged: unchanged.sort(),
+    overlap,
+  }
 }
 
+/**
+ * Promote gate (validate-first). A SUBTRACTIVE change (date removed from prod)
+ * always blocks. A value re-derive (changed overlap dates) requires explicit
+ * operator review — it blocks unless `allowValueChanges` is set, signalling the
+ * operator has reviewed the value diff. A purely additive change promotes.
+ */
 export function evaluatePromote(
-  _report: ValueDiffReport,
-  _opts: PromoteOptions = {}
+  report: ValueDiffReport,
+  opts: PromoteOptions = {}
 ): PromoteDecision {
-  return { promote: true, requiresReview: false, reasons: [] }
+  const reasons: string[] = []
+  let promote = true
+  let requiresReview = false
+
+  if (report.removed.length > 0) {
+    promote = false
+    reasons.push(
+      `subtractive: ${report.removed.length} date(s) present in production are missing from staging (${report.removed.join(', ')})`
+    )
+  }
+
+  if (report.changed.length > 0) {
+    requiresReview = true
+    reasons.push(
+      `changed: ${report.changed.length} overlap date(s) have re-derived values differing from production`
+    )
+    if (!opts.allowValueChanges) {
+      promote = false
+      reasons.push(
+        'value changes require operator review — re-run with --allow-value-changes to promote after reviewing the diff'
+      )
+    }
+  }
+
+  if (promote && reasons.length === 0) {
+    reasons.push(
+      `additive-only: ${report.added.length} new date(s), ${report.unchanged.length} unchanged`
+    )
+  }
+
+  return { promote, requiresReview, reasons }
 }

--- a/packages/collector-cli/src/services/SnapshotValueDiffLoader.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiffLoader.ts
@@ -1,0 +1,47 @@
+/**
+ * SnapshotValueDiffLoader — fs glue for {@link SnapshotValueDiff}. Loads per-date
+ * digests from a snapshots directory tree (`{root}/{date}/all-districts-rankings.json`)
+ * and orchestrates the diff + promote decision for the CLI `value-diff` command.
+ *
+ * The pure comparison logic lives in SnapshotValueDiff.ts (unit-tested without fs);
+ * this module owns only the reading + orchestration.
+ *
+ * NOTE: stub bodies — implemented in the GREEN commit.
+ */
+import {
+  digestDate,
+  diffSnapshots,
+  evaluatePromote,
+  type DateDigest,
+  type PromoteDecision,
+  type ValueDiffReport,
+} from './SnapshotValueDiff.js'
+
+export interface RunValueDiffOptions {
+  stagingDir: string
+  prodDir: string
+  allowValueChanges?: boolean
+}
+
+export interface RunValueDiffResult {
+  report: ValueDiffReport
+  decision: PromoteDecision
+  /** 0 when promotion is safe, 1 (PARTIAL_FAILURE) when blocked / requires review */
+  exitCode: number
+}
+
+export function loadDateDigests(_root: string): DateDigest[] {
+  return []
+}
+
+export function runValueDiff(_opts: RunValueDiffOptions): RunValueDiffResult {
+  // referenced so the imports are not flagged unused in the stub
+  void digestDate
+  void diffSnapshots
+  void evaluatePromote
+  return {
+    report: { added: [], removed: [], changed: [], unchanged: [], overlap: 0 },
+    decision: { promote: true, requiresReview: false, reasons: [] },
+    exitCode: 0,
+  }
+}

--- a/packages/collector-cli/src/services/SnapshotValueDiffLoader.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiffLoader.ts
@@ -8,7 +8,7 @@
  */
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { AllDistrictsRankingsDataSchema } from '@toastmasters/shared-contracts'
+import { validateAllDistrictsRankings } from '@toastmasters/shared-contracts'
 import {
   digestDate,
   diffSnapshots,
@@ -47,12 +47,12 @@ export function loadDateDigests(root: string): DateDigest[] {
     if (!entry.isDirectory()) continue
     const file = join(root, entry.name, RANKINGS_FILE)
     if (!existsSync(file)) continue
-    const parsed = AllDistrictsRankingsDataSchema.safeParse(
+    const parsed = validateAllDistrictsRankings(
       JSON.parse(readFileSync(file, 'utf8'))
     )
-    if (!parsed.success) {
+    if (!parsed.success || !parsed.data) {
       throw new Error(
-        `Invalid ${RANKINGS_FILE} for ${entry.name}: ${parsed.error.message}`
+        `Invalid ${RANKINGS_FILE} for ${entry.name}: ${parsed.error}`
       )
     }
     digests.push(digestDate(entry.name, parsed.data))

--- a/packages/collector-cli/src/services/SnapshotValueDiffLoader.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiffLoader.ts
@@ -5,9 +5,10 @@
  *
  * The pure comparison logic lives in SnapshotValueDiff.ts (unit-tested without fs);
  * this module owns only the reading + orchestration.
- *
- * NOTE: stub bodies — implemented in the GREEN commit.
  */
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { AllDistrictsRankingsDataSchema } from '@toastmasters/shared-contracts'
 import {
   digestDate,
   diffSnapshots,
@@ -16,6 +17,8 @@ import {
   type PromoteDecision,
   type ValueDiffReport,
 } from './SnapshotValueDiff.js'
+
+const RANKINGS_FILE = 'all-districts-rankings.json'
 
 export interface RunValueDiffOptions {
   stagingDir: string
@@ -30,18 +33,39 @@ export interface RunValueDiffResult {
   exitCode: number
 }
 
-export function loadDateDigests(_root: string): DateDigest[] {
-  return []
+/**
+ * Load one {@link DateDigest} per date directory under `root` that contains an
+ * `all-districts-rankings.json`. The file is schema-validated (fail-closed: a
+ * malformed snapshot throws rather than silently skipping a date — a safety gate
+ * must not pass on data it could not read). A missing root yields `[]`.
+ */
+export function loadDateDigests(root: string): DateDigest[] {
+  if (!existsSync(root)) return []
+
+  const digests: DateDigest[] = []
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const file = join(root, entry.name, RANKINGS_FILE)
+    if (!existsSync(file)) continue
+    const parsed = AllDistrictsRankingsDataSchema.safeParse(
+      JSON.parse(readFileSync(file, 'utf8'))
+    )
+    if (!parsed.success) {
+      throw new Error(
+        `Invalid ${RANKINGS_FILE} for ${entry.name}: ${parsed.error.message}`
+      )
+    }
+    digests.push(digestDate(entry.name, parsed.data))
+  }
+  return digests
 }
 
-export function runValueDiff(_opts: RunValueDiffOptions): RunValueDiffResult {
-  // referenced so the imports are not flagged unused in the stub
-  void digestDate
-  void diffSnapshots
-  void evaluatePromote
-  return {
-    report: { added: [], removed: [], changed: [], unchanged: [], overlap: 0 },
-    decision: { promote: true, requiresReview: false, reasons: [] },
-    exitCode: 0,
-  }
+export function runValueDiff(opts: RunValueDiffOptions): RunValueDiffResult {
+  const staging = loadDateDigests(opts.stagingDir)
+  const prod = loadDateDigests(opts.prodDir)
+  const report = diffSnapshots(staging, prod)
+  const decision = evaluatePromote(report, {
+    allowValueChanges: opts.allowValueChanges,
+  })
+  return { report, decision, exitCode: decision.promote ? 0 : 1 }
 }

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiff.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiff.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest'
+import type {
+  AllDistrictsRankingsData,
+  DistrictRanking,
+} from '@toastmasters/shared-contracts'
+import {
+  digestDistrict,
+  digestDate,
+  diffSnapshots,
+  evaluatePromote,
+} from '../SnapshotValueDiff.js'
+
+/* Minimal fixtures — only the fields the digest reads. Built from the real
+   AllDistrictsRankingsData shape (packages/shared-contracts). */
+
+function district(overrides: Partial<DistrictRanking> = {}): DistrictRanking {
+  return {
+    districtId: '61',
+    districtName: 'District 61',
+    region: 'Region 7',
+    paidClubs: 100,
+    paidClubBase: 98,
+    clubGrowthPercent: 2.04,
+    totalPayments: 5000,
+    paymentBase: 4800,
+    paymentGrowthPercent: 4.17,
+    activeClubs: 95,
+    distinguishedClubs: 30,
+    selectDistinguished: 10,
+    presidentsDistinguished: 5,
+    distinguishedPercent: 30,
+    clubsRank: 3,
+    paymentsRank: 4,
+    distinguishedRank: 2,
+    aggregateScore: 88.5,
+    overallRank: 3,
+    ...overrides,
+  }
+}
+
+function rankings(
+  districts: DistrictRanking[],
+  metaOverrides: Partial<AllDistrictsRankingsData['metadata']> = {}
+): AllDistrictsRankingsData {
+  return {
+    metadata: {
+      snapshotId: '2024-06-30',
+      calculatedAt: '2024-07-01T00:00:00.000Z',
+      schemaVersion: '1.0.0',
+      calculationVersion: '1.0.0',
+      rankingVersion: '1.0.0',
+      sourceCsvDate: '2024-06-30',
+      csvFetchedAt: '2024-07-01T00:00:00.000Z',
+      totalDistricts: districts.length,
+      fromCache: false,
+      ...metaOverrides,
+    },
+    rankings: districts,
+  }
+}
+
+describe('digestDistrict', () => {
+  it('produces an identical digest for identical data fields', () => {
+    expect(digestDistrict(district())).toBe(digestDistrict(district()))
+  })
+
+  it('changes when any data metric changes', () => {
+    expect(digestDistrict(district())).not.toBe(
+      digestDistrict(district({ totalPayments: 5001 }))
+    )
+  })
+})
+
+describe('digestDate', () => {
+  it('ignores volatile metadata (calculatedAt / csvFetchedAt / fromCache)', () => {
+    const a = digestDate('2024-06-30', rankings([district()]))
+    const b = digestDate(
+      '2024-06-30',
+      rankings([district()], {
+        calculatedAt: '2025-01-01T12:00:00.000Z',
+        csvFetchedAt: '2025-01-01T12:00:00.000Z',
+        fromCache: true,
+      })
+    )
+    expect(a.combined).toBe(b.combined)
+  })
+
+  it('is order-independent across the rankings array', () => {
+    const d61 = district({ districtId: '61' })
+    const d42 = district({ districtId: '42', aggregateScore: 70 })
+    const a = digestDate('2024-06-30', rankings([d61, d42]))
+    const b = digestDate('2024-06-30', rankings([d42, d61]))
+    expect(a.combined).toBe(b.combined)
+  })
+
+  it('changes when a district metric changes', () => {
+    const a = digestDate('2024-06-30', rankings([district()]))
+    const b = digestDate(
+      '2024-06-30',
+      rankings([district({ totalPayments: 5001 })])
+    )
+    expect(a.combined).not.toBe(b.combined)
+  })
+})
+
+describe('diffSnapshots', () => {
+  const base = (date: string, ds: DistrictRanking[]) =>
+    digestDate(date, rankings(ds))
+
+  it('classifies added / removed / unchanged dates by date set', () => {
+    const staging = [
+      base('2024-06-30', [district()]),
+      base('2024-07-31', [district()]), // added (staging only)
+    ]
+    const prod = [
+      base('2024-06-30', [district()]),
+      base('2024-05-31', [district()]), // removed (prod only)
+    ]
+    const report = diffSnapshots(staging, prod)
+    expect(report.added).toEqual(['2024-07-31'])
+    expect(report.removed).toEqual(['2024-05-31'])
+    expect(report.unchanged).toEqual(['2024-06-30'])
+    expect(report.changed).toEqual([])
+    expect(report.overlap).toBe(1)
+  })
+
+  it('flags an overlap date whose values changed, naming the district', () => {
+    const staging = [base('2024-06-30', [district({ totalPayments: 5001 })])]
+    const prod = [base('2024-06-30', [district({ totalPayments: 5000 })])]
+    const report = diffSnapshots(staging, prod)
+    expect(report.changed).toHaveLength(1)
+    expect(report.changed[0].date).toBe('2024-06-30')
+    expect(report.changed[0].changedDistricts).toContain('61')
+    expect(report.unchanged).toEqual([])
+  })
+})
+
+describe('evaluatePromote', () => {
+  const digest = (date: string, ds: DistrictRanking[]) =>
+    digestDate(date, rankings(ds))
+
+  it('promotes a purely additive change', () => {
+    const report = diffSnapshots(
+      [digest('2024-06-30', [district()]), digest('2024-07-31', [district()])],
+      [digest('2024-06-30', [district()])]
+    )
+    const decision = evaluatePromote(report)
+    expect(decision.promote).toBe(true)
+    expect(decision.requiresReview).toBe(false)
+  })
+
+  it('blocks a subtractive change (date removed from prod)', () => {
+    const report = diffSnapshots(
+      [digest('2024-06-30', [district()])],
+      [digest('2024-06-30', [district()]), digest('2024-05-31', [district()])]
+    )
+    const decision = evaluatePromote(report)
+    expect(decision.promote).toBe(false)
+    expect(decision.reasons.join(' ')).toMatch(/subtractive/i)
+  })
+
+  it('blocks a value re-derive by default (requires review)', () => {
+    const report = diffSnapshots(
+      [digest('2024-06-30', [district({ totalPayments: 5001 })])],
+      [digest('2024-06-30', [district({ totalPayments: 5000 })])]
+    )
+    const decision = evaluatePromote(report)
+    expect(decision.promote).toBe(false)
+    expect(decision.requiresReview).toBe(true)
+    expect(decision.reasons.join(' ')).toMatch(/changed/i)
+  })
+
+  it('promotes a reviewed value re-derive when allowValueChanges is set', () => {
+    const report = diffSnapshots(
+      [digest('2024-06-30', [district({ totalPayments: 5001 })])],
+      [digest('2024-06-30', [district({ totalPayments: 5000 })])]
+    )
+    const decision = evaluatePromote(report, { allowValueChanges: true })
+    expect(decision.promote).toBe(true)
+    expect(decision.requiresReview).toBe(true)
+  })
+
+  it('still blocks a subtractive change even with allowValueChanges set', () => {
+    const report = diffSnapshots(
+      [digest('2024-06-30', [district()])],
+      [digest('2024-06-30', [district()]), digest('2024-05-31', [district()])]
+    )
+    const decision = evaluatePromote(report, { allowValueChanges: true })
+    expect(decision.promote).toBe(false)
+  })
+})

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffLoader.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffLoader.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { AllDistrictsRankingsData } from '@toastmasters/shared-contracts'
+import {
+  loadDateDigests,
+  runValueDiff,
+} from '../SnapshotValueDiffLoader.js'
+
+function rankings(
+  date: string,
+  totalPayments: number
+): AllDistrictsRankingsData {
+  return {
+    metadata: {
+      snapshotId: date,
+      calculatedAt: '2024-07-01T00:00:00.000Z',
+      schemaVersion: '1.0.0',
+      calculationVersion: '1.0.0',
+      rankingVersion: '1.0.0',
+      sourceCsvDate: date,
+      csvFetchedAt: '2024-07-01T00:00:00.000Z',
+      totalDistricts: 1,
+      fromCache: false,
+    },
+    rankings: [
+      {
+        districtId: '61',
+        districtName: 'District 61',
+        region: 'Region 7',
+        paidClubs: 100,
+        paidClubBase: 98,
+        clubGrowthPercent: 2.04,
+        totalPayments,
+        paymentBase: 4800,
+        paymentGrowthPercent: 4.17,
+        activeClubs: 95,
+        distinguishedClubs: 30,
+        selectDistinguished: 10,
+        presidentsDistinguished: 5,
+        distinguishedPercent: 30,
+        clubsRank: 3,
+        paymentsRank: 4,
+        distinguishedRank: 2,
+        aggregateScore: 88.5,
+        overallRank: 3,
+      },
+    ],
+  }
+}
+
+function writeSnapshot(
+  root: string,
+  date: string,
+  data: AllDistrictsRankingsData
+) {
+  const dir = join(root, date)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'all-districts-rankings.json'),
+    JSON.stringify(data, null, 2)
+  )
+}
+
+let tmp: string
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'svd-'))
+})
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('loadDateDigests', () => {
+  it('loads one digest per date dir that has all-districts-rankings.json', () => {
+    const root = join(tmp, 'staging')
+    writeSnapshot(root, '2024-06-30', rankings('2024-06-30', 5000))
+    writeSnapshot(root, '2024-07-31', rankings('2024-07-31', 5100))
+    mkdirSync(join(root, 'not-a-snapshot')) // skipped: no rankings file
+    const digests = loadDateDigests(root)
+    expect(digests.map(d => d.date).sort()).toEqual(['2024-06-30', '2024-07-31'])
+  })
+
+  it('returns [] for a missing root', () => {
+    expect(loadDateDigests(join(tmp, 'does-not-exist'))).toEqual([])
+  })
+})
+
+describe('runValueDiff', () => {
+  it('promotes (exit 0) when staging is additive-only', () => {
+    const staging = join(tmp, 'staging')
+    const prod = join(tmp, 'prod')
+    writeSnapshot(prod, '2024-06-30', rankings('2024-06-30', 5000))
+    writeSnapshot(staging, '2024-06-30', rankings('2024-06-30', 5000))
+    writeSnapshot(staging, '2024-07-31', rankings('2024-07-31', 5100)) // new
+    const { decision, exitCode } = runValueDiff({
+      stagingDir: staging,
+      prodDir: prod,
+    })
+    expect(decision.promote).toBe(true)
+    expect(exitCode).toBe(0)
+  })
+
+  it('blocks (exit 1) a value re-derive unless allowValueChanges', () => {
+    const staging = join(tmp, 'staging')
+    const prod = join(tmp, 'prod')
+    writeSnapshot(prod, '2024-06-30', rankings('2024-06-30', 5000))
+    writeSnapshot(staging, '2024-06-30', rankings('2024-06-30', 5001)) // changed
+    const blocked = runValueDiff({ stagingDir: staging, prodDir: prod })
+    expect(blocked.decision.promote).toBe(false)
+    expect(blocked.decision.requiresReview).toBe(true)
+    expect(blocked.exitCode).toBe(1)
+
+    const allowed = runValueDiff({
+      stagingDir: staging,
+      prodDir: prod,
+      allowValueChanges: true,
+    })
+    expect(allowed.decision.promote).toBe(true)
+    expect(allowed.exitCode).toBe(0)
+  })
+})

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffLoader.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffLoader.test.ts
@@ -3,10 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import type { AllDistrictsRankingsData } from '@toastmasters/shared-contracts'
-import {
-  loadDateDigests,
-  runValueDiff,
-} from '../SnapshotValueDiffLoader.js'
+import { loadDateDigests, runValueDiff } from '../SnapshotValueDiffLoader.js'
 
 function rankings(
   date: string,
@@ -78,7 +75,10 @@ describe('loadDateDigests', () => {
     writeSnapshot(root, '2024-07-31', rankings('2024-07-31', 5100))
     mkdirSync(join(root, 'not-a-snapshot')) // skipped: no rankings file
     const digests = loadDateDigests(root)
-    expect(digests.map(d => d.date).sort()).toEqual(['2024-06-30', '2024-07-31'])
+    expect(digests.map(d => d.date).sort()).toEqual([
+      '2024-06-30',
+      '2024-07-31',
+    ])
   })
 
   it('returns [] for a missing root', () => {


### PR DESCRIPTION
## Sprint 2 of epic #1031 — harden full-range staging reprocess

Sprint sub-issue: #1034 (closed post-merge after the epic checkbox ticks — Lesson 106 ordering). Implements the re-scope Sprint 1 (#1033) handed us (investigation doc §5): a **value-aware promote gate**, an **ADR** on partial-range promote semantics, and the **dashboard-reachability probe** for the PY2021-22 hole (recorded on #1031).

### Problem (from Sprint 1)
The existing staging→promote gate (`data-pipeline.yml`) compares only aggregate **counts**. For the epic's "re-derive after logic changes" intent (same dates/districts, corrected values) the counts are identical ⇒ `promote=true` unconditionally ⇒ prod overwritten with **unvalidated** values (finding F2). "Validate-first" was a count check, not a value check.

### What this PR adds
- **`SnapshotValueDiff.ts`** (pure, unit-tested): per-date **value digest** over each district's data fields in `all-districts-rankings.json`, classifying the staging∩prod overlap as `unchanged` / `changed` (+ `added` / `removed` by date-set). Digest is **order-independent** and **excludes volatile metadata** (`calculatedAt`/`csvFetchedAt`/`fromCache`/version stamps) so a re-derive isn't falsely flagged "changed".
- **`evaluatePromote`**: subtractive (`removed`) **always blocks**; a value re-derive (`changed`) **requires operator review** — blocks unless `--allow-value-changes`. Purely additive promotes. **Fail-closed.**
- **`value-diff` CLI command** (`collector-cli`): JSON decision on stdout, logs on stderr (R4), exit 1 when blocked.
- **`data-pipeline.yml`**: a value-diff step **ANDed into** the existing count gate (R11 — does not replace it); new `allow_value_changes` dispatch input. Per-date fetches parallelized (`xargs -P 16`).
- **ADR-009**: records D1 (value gate, this sprint) + D2 (Sprint 3: seed staging from prod, then overlay the rebuild, so the count gate passes and the value gate does the real work). Alternatives weighed.

### Verification
TDD (RED→GREEN commits). 753 collector-cli tests pass incl. 16 new. `lint:yaml` green. **No live preview** — this PR touches only `packages/collector-cli`, `.github/workflows`, and `docs` (none match `pr-preview.yml`'s `frontend/**` path filter), so verification is the full test suite + code-proof of the gate logic + the end-to-end CLI smoke (blocked→exit 1, `--allow-value-changes`→exit 0). Does **not** touch prod (staging-only by design).

**Daily-mode note (review):** the gate runs on all non-prune modes incl. the daily cron, but daily runs scrape only today's new date and never recompute prior month-end snapshots, so overlap stays byte-identical ⇒ `value_promote=true` (no-op). It only blocks if a historical value actually changed — the intended safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)