### PR TITLE
feat(mcp-server): Sprint 2 — read-only MCP tools over the CDN client (#1044)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1269,6 +1269,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1444,6 +1456,68 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -3005,6 +3079,44 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3053,6 +3165,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
@@ -3261,6 +3412,30 @@
         "node": "*"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -3314,6 +3489,15 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3325,6 +3509,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3490,6 +3690,28 @@
         "node": ">=20"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3510,11 +3732,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3740,6 +3987,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3824,6 +4080,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.332",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.332.tgz",
@@ -3837,6 +4099,15 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -3999,6 +4270,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -4241,6 +4518,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -4255,6 +4541,27 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/expect": {
       "version": "30.3.0",
@@ -4282,6 +4589,101 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/extend": {
@@ -4317,7 +4719,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4333,6 +4734,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -4402,6 +4819,27 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4457,6 +4895,15 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -4469,6 +4916,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/frontend": {
@@ -4738,6 +5194,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -4773,6 +5238,26 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -4814,6 +5299,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -4871,6 +5372,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4917,6 +5436,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4933,7 +5458,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5308,6 +5832,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -5391,6 +5924,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5918,6 +6457,27 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -6021,6 +6581,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -6070,6 +6639,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -6080,6 +6670,18 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -6168,6 +6770,15 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6197,10 +6808,19 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -6227,6 +6847,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -6386,6 +7015,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6412,6 +7054,45 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/react": {
       "version": "19.2.6",
@@ -6579,7 +7260,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6672,6 +7352,22 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6690,6 +7386,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -6724,17 +7426,92 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6747,10 +7524,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -6838,6 +7686,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -7094,6 +7951,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -7173,6 +8039,62 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -7202,6 +8124,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -7270,6 +8201,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/victory-vendor": {
@@ -7514,7 +8454,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7654,6 +8593,15 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "node_modules/zod-validation-error": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
@@ -7761,6 +8709,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@toastmasters/shared-contracts": "^1.0.0",
         "zod": "^4.4.3"
       },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -27,6 +27,7 @@
     "typecheck": "tsc --noEmit --skipLibCheck"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@toastmasters/shared-contracts": "^1.0.0",
     "zod": "^4.4.3"
   },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -4,9 +4,12 @@
   "license": "MIT",
   "private": true,
   "type": "module",
-  "description": "Thin, local, read-only MCP server over the public Toast Stats snapshot CDN (ADR-008). Sprint 1: typed CDN read client only — no MCP tools yet.",
+  "description": "Thin, local, read-only MCP server over the public Toast Stats snapshot CDN (ADR-008). Exposes the pre-computed snapshot fields as MCP tools over stdio — no computation, no analytics-core.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "toast-stats-mcp": "./dist/bin.js"
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/mcp-server/src/__fixtures__/district-snapshot.json
+++ b/packages/mcp-server/src/__fixtures__/district-snapshot.json
@@ -1,0 +1,91 @@
+{
+  "districtId": "61",
+  "districtName": "District 61",
+  "collectedAt": "2026-05-31T10:00:00.000Z",
+  "status": "success",
+  "data": {
+    "districtId": "61",
+    "snapshotDate": "2026-05-31",
+    "clubs": [
+      {
+        "clubId": "00012345",
+        "clubName": "Downtown Speakers",
+        "divisionId": "A",
+        "areaId": "A1",
+        "membershipCount": 24,
+        "paymentsCount": 22,
+        "dcpGoals": 6,
+        "status": "Distinguished",
+        "divisionName": "Division A",
+        "areaName": "Area A1",
+        "octoberRenewals": 18,
+        "aprilRenewals": 0,
+        "newMembers": 4,
+        "membershipBase": 20,
+        "clubStatus": "Active"
+      },
+      {
+        "clubId": "00067890",
+        "clubName": "Harbour Orators",
+        "divisionId": "B",
+        "areaId": "B2",
+        "membershipCount": 9,
+        "paymentsCount": 8,
+        "dcpGoals": 1,
+        "status": "Active",
+        "divisionName": "Division B",
+        "areaName": "Area B2",
+        "octoberRenewals": 6,
+        "aprilRenewals": 0,
+        "newMembers": 1,
+        "membershipBase": 14,
+        "clubStatus": "Low"
+      }
+    ],
+    "divisions": [
+      {
+        "divisionId": "A",
+        "divisionName": "Division A",
+        "clubCount": 1,
+        "membershipTotal": 24,
+        "paymentsTotal": 22
+      },
+      {
+        "divisionId": "B",
+        "divisionName": "Division B",
+        "clubCount": 1,
+        "membershipTotal": 9,
+        "paymentsTotal": 8
+      }
+    ],
+    "areas": [
+      {
+        "areaId": "A1",
+        "areaName": "Area A1",
+        "divisionId": "A",
+        "clubCount": 1,
+        "membershipTotal": 24,
+        "paymentsTotal": 22
+      },
+      {
+        "areaId": "B2",
+        "areaName": "Area B2",
+        "divisionId": "B",
+        "clubCount": 1,
+        "membershipTotal": 9,
+        "paymentsTotal": 8
+      }
+    ],
+    "totals": {
+      "totalClubs": 2,
+      "totalMembership": 33,
+      "totalPayments": 30,
+      "distinguishedClubs": 1,
+      "selectDistinguishedClubs": 0,
+      "presidentDistinguishedClubs": 0
+    },
+    "divisionPerformance": [],
+    "clubPerformance": [],
+    "districtPerformance": []
+  }
+}

--- a/packages/mcp-server/src/__fixtures__/time-series.json
+++ b/packages/mcp-server/src/__fixtures__/time-series.json
@@ -1,0 +1,44 @@
+{
+  "districtId": "61",
+  "programYear": "2025-2026",
+  "startDate": "2025-07-01",
+  "endDate": "2026-06-30",
+  "lastUpdated": "2026-05-31T10:00:00.000Z",
+  "dataPoints": [
+    {
+      "date": "2025-07-31",
+      "snapshotId": "2025-07-31",
+      "membership": 2800,
+      "payments": 2750,
+      "dcpGoals": 120,
+      "distinguishedTotal": 8,
+      "clubCounts": {
+        "total": 160,
+        "thriving": 90,
+        "vulnerable": 50,
+        "interventionRequired": 20
+      }
+    },
+    {
+      "date": "2026-05-31",
+      "snapshotId": "2026-05-31",
+      "membership": 3050,
+      "payments": 2990,
+      "dcpGoals": 410,
+      "distinguishedTotal": 22,
+      "clubCounts": {
+        "total": 162,
+        "thriving": 110,
+        "vulnerable": 38,
+        "interventionRequired": 14
+      }
+    }
+  ],
+  "summary": {
+    "totalDataPoints": 2,
+    "membershipStart": 2800,
+    "membershipEnd": 3050,
+    "membershipPeak": 3050,
+    "membershipLow": 2800
+  }
+}

--- a/packages/mcp-server/src/__tests__/CdnClient.snapshot-timeseries.test.ts
+++ b/packages/mcp-server/src/__tests__/CdnClient.snapshot-timeseries.test.ts
@@ -64,6 +64,46 @@ describe('CdnClient.getDistrictSnapshot', () => {
     expect(res.reason).toMatch(/not available/i)
     expect(res.sourceUrl).toBe(`${BASE}/snapshots/2026-05-31/district_99.json`)
   })
+
+  it('treats a failed-collection snapshot as not-available (never surfaces partial data as available)', async () => {
+    const failedFetch = (async () =>
+      new Response(
+        JSON.stringify({
+          districtId: '61',
+          districtName: 'District 61',
+          collectedAt: '2026-05-31T10:00:00.000Z',
+          status: 'failed',
+          errorMessage: 'scrape timed out',
+          data: {
+            districtId: '61',
+            snapshotDate: '2026-05-31',
+            clubs: [],
+            divisions: [],
+            areas: [],
+            totals: {
+              totalClubs: 0,
+              totalMembership: 0,
+              totalPayments: 0,
+              distinguishedClubs: 0,
+              selectDistinguishedClubs: 0,
+              presidentDistinguishedClubs: 0,
+            },
+            divisionPerformance: [],
+            clubPerformance: [],
+            districtPerformance: [],
+          },
+        }),
+        { status: 200 }
+      )) as typeof fetch
+    const res = await client(failedFetch).getDistrictSnapshot(
+      '61',
+      '2026-05-31'
+    )
+    expect(res.available).toBe(false)
+    if (res.available) return
+    expect(res.reason).toMatch(/failed/i)
+    expect(res.sourceUrl).toBe(`${BASE}/snapshots/2026-05-31/district_61.json`)
+  })
 })
 
 describe('CdnClient.getTimeSeries', () => {

--- a/packages/mcp-server/src/__tests__/CdnClient.snapshot-timeseries.test.ts
+++ b/packages/mcp-server/src/__tests__/CdnClient.snapshot-timeseries.test.ts
@@ -1,13 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
-import { CdnClient } from '../index.js'
-
-const here = dirname(fileURLToPath(import.meta.url))
-const fixtureDir = join(here, '..', '__fixtures__')
-
-const BASE = 'https://cdn.taverns.red'
+import type { CdnClient } from '../index.js'
+import { BASE, makeClient, makeFixtureFetch } from './_fixture-fetch.js'
 
 /**
  * Routes the Sprint-2 read targets — the dated district snapshot and a
@@ -18,21 +11,8 @@ const ROUTES: Record<string, string> = {
   '/time-series/district_61/2025-2026.json': 'time-series.json',
 }
 
-function fixtureFetch(): typeof fetch {
-  return (async (input: string | URL | Request) => {
-    const url = typeof input === 'string' ? input : input.toString()
-    const path = url.replace(BASE, '')
-    const file = ROUTES[path]
-    if (!file) return new Response('not found', { status: 404 })
-    return new Response(readFileSync(join(fixtureDir, file), 'utf8'), {
-      status: 200,
-      headers: { 'content-type': 'application/json' },
-    })
-  }) as typeof fetch
-}
-
-function client(fetchFn: typeof fetch = fixtureFetch()): CdnClient {
-  return new CdnClient({ baseUrl: BASE, fetchFn })
+function client(fetchFn: typeof fetch = makeFixtureFetch(ROUTES)): CdnClient {
+  return makeClient(fetchFn)
 }
 
 describe('CdnClient.getDistrictSnapshot', () => {
@@ -96,9 +76,7 @@ describe('CdnClient.getTimeSeries', () => {
     expect(res.data.dataPoints.length).toBe(2)
     // date is the most recent data point in the series
     expect(res.date).toBe('2026-05-31')
-    expect(res.sourceUrl).toBe(
-      `${BASE}/time-series/district_61/2025-2026.json`
-    )
+    expect(res.sourceUrl).toBe(`${BASE}/time-series/district_61/2025-2026.json`)
   })
 
   it('rejects a malformed program year (YYYY-YYYY required) without fetching', async () => {
@@ -119,8 +97,6 @@ describe('CdnClient.getTimeSeries', () => {
     expect(res.available).toBe(false)
     if (res.available) return
     expect(res.reason).toMatch(/not available/i)
-    expect(res.sourceUrl).toBe(
-      `${BASE}/time-series/district_61/1999-2000.json`
-    )
+    expect(res.sourceUrl).toBe(`${BASE}/time-series/district_61/1999-2000.json`)
   })
 })

--- a/packages/mcp-server/src/__tests__/CdnClient.snapshot-timeseries.test.ts
+++ b/packages/mcp-server/src/__tests__/CdnClient.snapshot-timeseries.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { CdnClient } from '../index.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixtureDir = join(here, '..', '__fixtures__')
+
+const BASE = 'https://cdn.taverns.red'
+
+/**
+ * Routes the Sprint-2 read targets — the dated district snapshot and a
+ * program-year time-series file — to committed fixtures; everything else 404s.
+ */
+const ROUTES: Record<string, string> = {
+  '/snapshots/2026-05-31/district_61.json': 'district-snapshot.json',
+  '/time-series/district_61/2025-2026.json': 'time-series.json',
+}
+
+function fixtureFetch(): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const path = url.replace(BASE, '')
+    const file = ROUTES[path]
+    if (!file) return new Response('not found', { status: 404 })
+    return new Response(readFileSync(join(fixtureDir, file), 'utf8'), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as typeof fetch
+}
+
+function client(fetchFn: typeof fetch = fixtureFetch()): CdnClient {
+  return new CdnClient({ baseUrl: BASE, fetchFn })
+}
+
+describe('CdnClient.getDistrictSnapshot', () => {
+  it('reads snapshots/{date}/district_{id}.json and surfaces the snapshot date + source URL', async () => {
+    const res = await client().getDistrictSnapshot('61', '2026-05-31')
+    expect(res.available).toBe(true)
+    if (!res.available) return
+    expect(res.data.districtId).toBe('61')
+    expect(res.data.data.clubs.length).toBe(2)
+    expect(res.data.data.clubs[0]!.clubName).toBe('Downtown Speakers')
+    // date comes from the inner snapshotDate, not the request arg
+    expect(res.date).toBe('2026-05-31')
+    expect(res.sourceUrl).toBe(`${BASE}/snapshots/2026-05-31/district_61.json`)
+  })
+
+  it('rejects a malformed date without fetching (never builds a junk URL)', async () => {
+    let fetched = false
+    const spyFetch = (async () => {
+      fetched = true
+      return new Response('{}', { status: 200 })
+    }) as typeof fetch
+    const res = await client(spyFetch).getDistrictSnapshot('61', 'not-a-date')
+    expect(fetched).toBe(false)
+    expect(res.available).toBe(false)
+    if (res.available) return
+    expect(res.reason).toMatch(/not available/i)
+  })
+
+  it('rejects a path-traversal district id without fetching', async () => {
+    let fetched = false
+    const spyFetch = (async () => {
+      fetched = true
+      return new Response('{}', { status: 200 })
+    }) as typeof fetch
+    const res = await client(spyFetch).getDistrictSnapshot(
+      '../../etc/passwd',
+      '2026-05-31'
+    )
+    expect(fetched).toBe(false)
+    expect(res.available).toBe(false)
+    if (res.available) return
+    expect(res.reason).toMatch(/not available/i)
+  })
+
+  it('returns typed not-available for a missing snapshot (404), never throws', async () => {
+    const res = await client().getDistrictSnapshot('99', '2026-05-31')
+    expect(res.available).toBe(false)
+    if (res.available) return
+    expect(res.reason).toMatch(/not available/i)
+    expect(res.sourceUrl).toBe(`${BASE}/snapshots/2026-05-31/district_99.json`)
+  })
+})
+
+describe('CdnClient.getTimeSeries', () => {
+  it('reads time-series/district_{id}/{programYear}.json with data points', async () => {
+    const res = await client().getTimeSeries('61', '2025-2026')
+    expect(res.available).toBe(true)
+    if (!res.available) return
+    expect(res.data.districtId).toBe('61')
+    expect(res.data.programYear).toBe('2025-2026')
+    expect(res.data.dataPoints.length).toBe(2)
+    // date is the most recent data point in the series
+    expect(res.date).toBe('2026-05-31')
+    expect(res.sourceUrl).toBe(
+      `${BASE}/time-series/district_61/2025-2026.json`
+    )
+  })
+
+  it('rejects a malformed program year (YYYY-YYYY required) without fetching', async () => {
+    let fetched = false
+    const spyFetch = (async () => {
+      fetched = true
+      return new Response('{}', { status: 200 })
+    }) as typeof fetch
+    const res = await client(spyFetch).getTimeSeries('61', '2025')
+    expect(fetched).toBe(false)
+    expect(res.available).toBe(false)
+    if (res.available) return
+    expect(res.reason).toMatch(/not available/i)
+  })
+
+  it('returns typed not-available for a missing program year (404)', async () => {
+    const res = await client().getTimeSeries('61', '1999-2000')
+    expect(res.available).toBe(false)
+    if (res.available) return
+    expect(res.reason).toMatch(/not available/i)
+    expect(res.sourceUrl).toBe(
+      `${BASE}/time-series/district_61/1999-2000.json`
+    )
+  })
+})

--- a/packages/mcp-server/src/__tests__/_fixture-fetch.ts
+++ b/packages/mcp-server/src/__tests__/_fixture-fetch.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared test helper: a `fetch` stub that serves committed CDN fixtures by path
+ * and 404s everything else, plus a `CdnClient` bound to it. Each test supplies
+ * its own route map (path-after-base → fixture filename), so the stub stays a
+ * single implementation across the CdnClient / tools / server suites.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { CdnClient } from '../cdn/CdnClient.js'
+
+export const BASE = 'https://cdn.taverns.red'
+
+const fixtureDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '__fixtures__'
+)
+
+/** A fetch stub serving `routes` (path → fixture file); all else is a 404. */
+export function makeFixtureFetch(routes: Record<string, string>): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const file = routes[url.replace(BASE, '')]
+    if (!file) return new Response('not found', { status: 404 })
+    return new Response(readFileSync(join(fixtureDir, file), 'utf8'), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as typeof fetch
+}
+
+/** A CdnClient bound to BASE and the given fetch (a fixture stub by default). */
+export function makeClient(fetchFn: typeof fetch): CdnClient {
+  return new CdnClient({ baseUrl: BASE, fetchFn })
+}

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -1,36 +1,16 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { CdnClient } from '../cdn/CdnClient.js'
 import { createServer } from '../server.js'
+import { BASE, makeClient, makeFixtureFetch } from './_fixture-fetch.js'
 
-const here = dirname(fileURLToPath(import.meta.url))
-const fixtureDir = join(here, '..', '__fixtures__')
-const BASE = 'https://cdn.taverns.red'
-
-function fixtureClient(): CdnClient {
-  const fetchFn = (async (input: string | URL | Request) => {
-    const url = typeof input === 'string' ? input : input.toString()
-    if (url === `${BASE}/v1/latest.json`) {
-      return new Response(
-        readFileSync(join(fixtureDir, 'latest.json'), 'utf8'),
-        {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        }
-      )
-    }
-    return new Response('not found', { status: 404 })
-  }) as typeof fetch
-  return new CdnClient({ baseUrl: BASE, fetchFn })
+const ROUTES: Record<string, string> = {
+  '/v1/latest.json': 'latest.json',
 }
 
 /** Wire a real MCP client to the server over an in-memory transport pair. */
 async function connectedClient(): Promise<Client> {
-  const server = createServer(fixtureClient())
+  const server = createServer(makeClient(makeFixtureFetch(ROUTES)))
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair()
   await server.connect(serverTransport)

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { CdnClient } from '../cdn/CdnClient.js'
+import { createServer } from '../server.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixtureDir = join(here, '..', '__fixtures__')
+const BASE = 'https://cdn.taverns.red'
+
+function fixtureClient(): CdnClient {
+  const fetchFn = (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url === `${BASE}/v1/latest.json`) {
+      return new Response(
+        readFileSync(join(fixtureDir, 'latest.json'), 'utf8'),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }
+      )
+    }
+    return new Response('not found', { status: 404 })
+  }) as typeof fetch
+  return new CdnClient({ baseUrl: BASE, fetchFn })
+}
+
+/** Wire a real MCP client to the server over an in-memory transport pair. */
+async function connectedClient(): Promise<Client> {
+  const server = createServer(fixtureClient())
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair()
+  await server.connect(serverTransport)
+  const client = new Client({ name: 'test-client', version: '0.0.0' })
+  await client.connect(clientTransport)
+  return client
+}
+
+describe('MCP server (end-to-end over in-memory transport)', () => {
+  it('lists all 8 read-only tools to a connected client', async () => {
+    const client = await connectedClient()
+    const { tools } = await client.listTools()
+    const names = tools.map(t => t.name).sort()
+    expect(names).toEqual(
+      [
+        'get-club-health',
+        'get-district-snapshot',
+        'get-latest-date',
+        'get-time-series',
+        'list-dates',
+        'list-districts',
+        'query-rankings',
+        'resolve-club',
+      ].sort()
+    )
+    // each advertises an input schema (JSON Schema object) and is read-only
+    for (const t of tools) {
+      expect(t.inputSchema).toBeDefined()
+      expect(t.annotations?.readOnlyHint).toBe(true)
+    }
+    await client.close()
+  })
+
+  it('invokes a tool end-to-end and returns the CDN-grounded envelope', async () => {
+    const client = await connectedClient()
+    const result = await client.callTool({
+      name: 'get-latest-date',
+      arguments: {},
+    })
+    const content = result.content as { type: string; text: string }[]
+    expect(content[0]!.type).toBe('text')
+    const env = JSON.parse(content[0]!.text) as {
+      available: boolean
+      sourceUrl: string
+      data: { latestSnapshotDate: string }
+    }
+    expect(env.available).toBe(true)
+    expect(env.sourceUrl).toBe(`${BASE}/v1/latest.json`)
+    expect(env.data.latestSnapshotDate).toBe('2026-05-31')
+    await client.close()
+  })
+
+  it('flags an invalid tool argument shape via the registered input schema', async () => {
+    const client = await connectedClient()
+    // resolve-club requires a non-empty clubId; an empty object is rejected by
+    // the SDK against the registered zod raw-shape before the handler runs,
+    // surfaced as an error result (proves the input schema is actually wired).
+    const result = await client.callTool({
+      name: 'resolve-club',
+      arguments: {},
+    })
+    expect(result.isError).toBe(true)
+    const content = result.content as { type: string; text: string }[]
+    expect(content[0]!.text).toMatch(/expected string|invalid|required/i)
+    await client.close()
+  })
+})

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -1,15 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
-import { CdnClient } from '../cdn/CdnClient.js'
+import type { CdnClient } from '../cdn/CdnClient.js'
 import { TOOLS, type ToolDef } from '../tools/tools.js'
 import { parseToolText } from '../tools/envelope.js'
-
-const here = dirname(fileURLToPath(import.meta.url))
-const fixtureDir = join(here, '..', '__fixtures__')
-
-const BASE = 'https://cdn.taverns.red'
+import { BASE, makeClient, makeFixtureFetch } from './_fixture-fetch.js'
 
 const ROUTES: Record<string, string> = {
   '/v1/latest.json': 'latest.json',
@@ -23,20 +16,8 @@ const ROUTES: Record<string, string> = {
   '/time-series/district_61/2025-2026.json': 'time-series.json',
 }
 
-function fixtureFetch(): typeof fetch {
-  return (async (input: string | URL | Request) => {
-    const url = typeof input === 'string' ? input : input.toString()
-    const file = ROUTES[url.replace(BASE, '')]
-    if (!file) return new Response('not found', { status: 404 })
-    return new Response(readFileSync(join(fixtureDir, file), 'utf8'), {
-      status: 200,
-      headers: { 'content-type': 'application/json' },
-    })
-  }) as typeof fetch
-}
-
-function client(fetchFn: typeof fetch = fixtureFetch()): CdnClient {
-  return new CdnClient({ baseUrl: BASE, fetchFn })
+function client(fetchFn: typeof fetch = makeFixtureFetch(ROUTES)): CdnClient {
+  return makeClient(fetchFn)
 }
 
 function tool(name: string): ToolDef {

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { CdnClient } from '../cdn/CdnClient.js'
+import { TOOLS, type ToolDef } from '../tools/tools.js'
+import { parseToolText } from '../tools/envelope.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixtureDir = join(here, '..', '__fixtures__')
+
+const BASE = 'https://cdn.taverns.red'
+
+const ROUTES: Record<string, string> = {
+  '/v1/latest.json': 'latest.json',
+  '/v1/dates.json': 'dates.json',
+  '/config/district-snapshot-index.json': 'district-snapshot-index.json',
+  '/config/club-index.json': 'club-index.json',
+  '/v1/rankings.json': 'v1-rankings.json',
+  '/snapshots/2026-05-31/all-districts-rankings.json':
+    'dated-all-districts-rankings.json',
+  '/snapshots/2026-05-31/district_61.json': 'district-snapshot.json',
+  '/time-series/district_61/2025-2026.json': 'time-series.json',
+}
+
+function fixtureFetch(): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const file = ROUTES[url.replace(BASE, '')]
+    if (!file) return new Response('not found', { status: 404 })
+    return new Response(readFileSync(join(fixtureDir, file), 'utf8'), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as typeof fetch
+}
+
+function client(fetchFn: typeof fetch = fixtureFetch()): CdnClient {
+  return new CdnClient({ baseUrl: BASE, fetchFn })
+}
+
+function tool(name: string): ToolDef {
+  const found = TOOLS.find(t => t.name === name)
+  if (!found) throw new Error(`tool not registered: ${name}`)
+  return found
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function call(name: string, args: any, c: CdnClient = client()) {
+  return parseToolText(await tool(name).handler(c, args)) as Record<
+    string,
+    unknown
+  >
+}
+
+describe('tool set — registration', () => {
+  it('registers exactly the 8 ADR-008 Sprint-2 tools, each with metadata', () => {
+    const names = TOOLS.map(t => t.name).sort()
+    expect(names).toEqual(
+      [
+        'get-club-health',
+        'get-district-snapshot',
+        'get-latest-date',
+        'get-time-series',
+        'list-dates',
+        'list-districts',
+        'query-rankings',
+        'resolve-club',
+      ].sort()
+    )
+    for (const t of TOOLS) {
+      expect(t.title.length).toBeGreaterThan(0)
+      expect(t.description.length).toBeGreaterThan(0)
+      expect(typeof t.inputSchema).toBe('object')
+    }
+  })
+})
+
+describe('discovery tools', () => {
+  it('get-latest-date returns the latest date + source URL', async () => {
+    const env = await call('get-latest-date', {})
+    expect(env.available).toBe(true)
+    expect(env.sourceUrl).toBe(`${BASE}/v1/latest.json`)
+    expect(
+      (env.data as { latestSnapshotDate: string }).latestSnapshotDate
+    ).toBe('2026-05-31')
+  })
+
+  it('list-dates returns the date list', async () => {
+    const env = await call('list-dates', {})
+    expect(env.available).toBe(true)
+    expect(Array.isArray((env.data as { dates: string[] }).dates)).toBe(true)
+  })
+
+  it('list-districts projects district ids + available dates', async () => {
+    const env = await call('list-districts', {})
+    expect(env.available).toBe(true)
+    const data = env.data as {
+      districtIds: string[]
+      availableDatesByDistrict: Record<string, string[]>
+    }
+    expect(data.districtIds.length).toBeGreaterThan(0)
+    expect(
+      data.availableDatesByDistrict[data.districtIds[0]!]!.length
+    ).toBeGreaterThan(0)
+  })
+
+  it('resolve-club resolves a known club and is not-available for an unknown one', async () => {
+    const c = client()
+    const known = (await c.getClubIndex()) as {
+      available: true
+      data: { clubs: Record<string, unknown> }
+    }
+    const clubId = Object.keys(known.data.clubs)[0]!
+
+    const ok = await call('resolve-club', { clubId })
+    expect(ok.available).toBe(true)
+    expect((ok.data as { clubId: string }).clubId).toBe(clubId)
+
+    const missing = await call('resolve-club', { clubId: '00000000' })
+    expect(missing.available).toBe(false)
+    expect(missing.reason).toMatch(/not available/i)
+  })
+})
+
+describe('snapshot + rankings tools', () => {
+  it('get-district-snapshot reads the dated snapshot when a date is given', async () => {
+    const env = await call('get-district-snapshot', {
+      districtId: '61',
+      date: '2026-05-31',
+    })
+    expect(env.available).toBe(true)
+    expect(env.sourceUrl).toBe(`${BASE}/snapshots/2026-05-31/district_61.json`)
+    expect(env.date).toBe('2026-05-31')
+  })
+
+  it('get-district-snapshot resolves the latest date when date is omitted', async () => {
+    const env = await call('get-district-snapshot', { districtId: '61' })
+    expect(env.available).toBe(true)
+    // resolved to latest (2026-05-31) under the hood
+    expect(env.sourceUrl).toBe(`${BASE}/snapshots/2026-05-31/district_61.json`)
+  })
+
+  it('query-rankings returns current rankings when no date is given', async () => {
+    const env = await call('query-rankings', {})
+    expect(env.available).toBe(true)
+    expect(env.sourceUrl).toBe(`${BASE}/v1/rankings.json`)
+  })
+
+  it('query-rankings returns the dated rankings when a date is given', async () => {
+    const env = await call('query-rankings', { date: '2026-05-31' })
+    expect(env.available).toBe(true)
+    expect(env.sourceUrl).toBe(
+      `${BASE}/snapshots/2026-05-31/all-districts-rankings.json`
+    )
+  })
+})
+
+describe('get-club-health — raw fields, no derivation', () => {
+  it('returns raw health-signal fields per club and never a derived status', async () => {
+    const env = await call('get-club-health', {
+      districtId: '61',
+      date: '2026-05-31',
+    })
+    expect(env.available).toBe(true)
+    const data = env.data as {
+      note: string
+      clubs: Record<string, unknown>[]
+    }
+    expect(data.clubs.length).toBe(2)
+    const club = data.clubs[0]!
+    expect(club).toHaveProperty('membershipCount')
+    expect(club).toHaveProperty('membershipBase')
+    expect(club).toHaveProperty('newMembers')
+    expect(club).toHaveProperty('dcpGoals')
+    // never derives the categorical classification
+    expect(club).not.toHaveProperty('healthStatus')
+    expect(JSON.stringify(data)).not.toMatch(
+      /thriving|vulnerable|intervention/i
+    )
+    expect(data.note).toMatch(/not derived|not a pre-computed/i)
+  })
+
+  it('filters clubs to a single division when divisionId is given', async () => {
+    const env = await call('get-club-health', {
+      districtId: '61',
+      date: '2026-05-31',
+      divisionId: 'B',
+    })
+    const data = env.data as { clubs: { divisionId: string }[] }
+    expect(data.clubs.length).toBe(1)
+    expect(data.clubs[0]!.divisionId).toBe('B')
+  })
+})
+
+describe('get-time-series', () => {
+  it('returns the program-year series with data points + summary', async () => {
+    const env = await call('get-time-series', {
+      districtId: '61',
+      programYear: '2025-2026',
+    })
+    expect(env.available).toBe(true)
+    expect(env.sourceUrl).toBe(`${BASE}/time-series/district_61/2025-2026.json`)
+    const data = env.data as { dataPoints: unknown[]; summary: unknown }
+    expect(data.dataPoints.length).toBe(2)
+    expect(data.summary).toBeDefined()
+  })
+
+  it('is not-available for an unknown program year', async () => {
+    const env = await call('get-time-series', {
+      districtId: '61',
+      programYear: '1999-2000',
+    })
+    expect(env.available).toBe(false)
+    expect(env.reason).toMatch(/not available/i)
+  })
+})
+
+describe('not-available propagation through date resolution', () => {
+  it('surfaces the latest-date failure when latest.json is unreachable', async () => {
+    const c = client(
+      (async () => new Response('x', { status: 500 })) as typeof fetch
+    )
+    const env = await call('get-district-snapshot', { districtId: '61' }, c)
+    expect(env.available).toBe(false)
+    expect(env.sourceUrl).toBe(`${BASE}/v1/latest.json`)
+  })
+})

--- a/packages/mcp-server/src/bin.ts
+++ b/packages/mcp-server/src/bin.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+/**
+ * Executable entry point for the local Toast Stats MCP server (ADR-008).
+ *
+ * Serves the read-only tools over stdio. All diagnostics go to stderr (R4) —
+ * stdout carries only the MCP JSON-RPC stream the transport owns.
+ */
+import { startStdioServer } from './server.js'
+
+startStdioServer().catch((err: unknown) => {
+  console.error('[toast-stats-mcp] failed to start:', err)
+  process.exit(1)
+})

--- a/packages/mcp-server/src/cdn/CdnClient.ts
+++ b/packages/mcp-server/src/cdn/CdnClient.ts
@@ -8,8 +8,7 @@
  * performs NO computation, imports NO analytics-core, and never throws on a
  * missing/invalid response — it returns a typed not-available result instead.
  */
-import type { ZodType } from 'zod'
-import type { z } from 'zod'
+import type { ZodType, z } from 'zod'
 import {
   AllDistrictsRankingsDataSchema,
   type AllDistrictsRankingsData,
@@ -35,13 +34,13 @@ import {
   PROGRAM_YEAR_RE,
   DISTRICT_ID_RE,
 } from '../schemas/common.js'
+import { type CdnReadResult, notAvailable } from './result.js'
 
 /** A dated per-district snapshot (`snapshots/{date}/district_{id}.json`). */
 export type DistrictSnapshot = z.infer<typeof PerDistrictDataSchema>
 
 /** A program-year time-series file (`time-series/district_{id}/{py}.json`). */
 export type TimeSeriesProgramYear = z.infer<typeof ProgramYearIndexFileSchema>
-import { type CdnReadResult, notAvailable } from './result.js'
 
 /** Default public CDN origin (ADR-008). */
 export const DEFAULT_CDN_BASE_URL = 'https://cdn.taverns.red'

--- a/packages/mcp-server/src/cdn/CdnClient.ts
+++ b/packages/mcp-server/src/cdn/CdnClient.ts
@@ -9,9 +9,12 @@
  * missing/invalid response — it returns a typed not-available result instead.
  */
 import type { ZodType } from 'zod'
+import type { z } from 'zod'
 import {
   AllDistrictsRankingsDataSchema,
   type AllDistrictsRankingsData,
+  PerDistrictDataSchema,
+  ProgramYearIndexFileSchema,
 } from '@toastmasters/shared-contracts'
 import {
   LatestManifestSchema,
@@ -27,7 +30,17 @@ import {
   CdnRankingsSchema,
   type CdnRankings,
 } from '../schemas/cdn-rankings.schema.js'
-import { ISO_DATE_RE } from '../schemas/common.js'
+import {
+  ISO_DATE_RE,
+  PROGRAM_YEAR_RE,
+  DISTRICT_ID_RE,
+} from '../schemas/common.js'
+
+/** A dated per-district snapshot (`snapshots/{date}/district_{id}.json`). */
+export type DistrictSnapshot = z.infer<typeof PerDistrictDataSchema>
+
+/** A program-year time-series file (`time-series/district_{id}/{py}.json`). */
+export type TimeSeriesProgramYear = z.infer<typeof ProgramYearIndexFileSchema>
 import { type CdnReadResult, notAvailable } from './result.js'
 
 /** Default public CDN origin (ADR-008). */
@@ -150,6 +163,62 @@ export class CdnClient {
       `snapshots/${date}/all-districts-rankings.json`,
       AllDistrictsRankingsDataSchema,
       d => d.metadata.snapshotId
+    )
+  }
+
+  /**
+   * `snapshots/{date}/district_{id}.json` — the full dated per-district
+   * snapshot (roster, division/area aggregates, totals, raw performance rows),
+   * validated against the shared `PerDistrictData` write-contract. The snapshot
+   * `date` is surfaced from the inner `data.snapshotDate`, not the request arg.
+   */
+  getDistrictSnapshot(
+    districtId: string,
+    date: string
+  ): Promise<CdnReadResult<DistrictSnapshot>> {
+    if (!DISTRICT_ID_RE.test(districtId) || !ISO_DATE_RE.test(date)) {
+      return Promise.resolve(
+        notAvailable(
+          `${this.baseUrl}/snapshots/${encodeURIComponent(date)}/district_${encodeURIComponent(districtId)}.json`,
+          `not available — "${districtId}"/"${date}" is not a valid district id / YYYY-MM-DD date`
+        )
+      )
+    }
+    return this.read(
+      `snapshots/${date}/district_${districtId}.json`,
+      PerDistrictDataSchema,
+      d => d.data.snapshotDate
+    )
+  }
+
+  /**
+   * `time-series/district_{id}/{programYear}.json` — pre-computed membership /
+   * payments / DCP / distinguished / club-health-count series for a program
+   * year, validated against the shared `ProgramYearIndexFile` contract. The
+   * surfaced `date` is the most recent data point in the series.
+   */
+  getTimeSeries(
+    districtId: string,
+    programYear: string
+  ): Promise<CdnReadResult<TimeSeriesProgramYear>> {
+    if (
+      !DISTRICT_ID_RE.test(districtId) ||
+      !PROGRAM_YEAR_RE.test(programYear)
+    ) {
+      return Promise.resolve(
+        notAvailable(
+          `${this.baseUrl}/time-series/district_${encodeURIComponent(districtId)}/${encodeURIComponent(programYear)}.json`,
+          `not available — "${districtId}"/"${programYear}" is not a valid district id / YYYY-YYYY program year`
+        )
+      )
+    }
+    return this.read(
+      `time-series/district_${districtId}/${programYear}.json`,
+      ProgramYearIndexFileSchema,
+      d =>
+        d.dataPoints.length > 0
+          ? d.dataPoints[d.dataPoints.length - 1]!.date
+          : null
     )
   }
 

--- a/packages/mcp-server/src/cdn/CdnClient.ts
+++ b/packages/mcp-server/src/cdn/CdnClient.ts
@@ -171,23 +171,31 @@ export class CdnClient {
    * validated against the shared `PerDistrictData` write-contract. The snapshot
    * `date` is surfaced from the inner `data.snapshotDate`, not the request arg.
    */
-  getDistrictSnapshot(
+  async getDistrictSnapshot(
     districtId: string,
     date: string
   ): Promise<CdnReadResult<DistrictSnapshot>> {
     if (!DISTRICT_ID_RE.test(districtId) || !ISO_DATE_RE.test(date)) {
-      return Promise.resolve(
-        notAvailable(
-          `${this.baseUrl}/snapshots/${encodeURIComponent(date)}/district_${encodeURIComponent(districtId)}.json`,
-          `not available — "${districtId}"/"${date}" is not a valid district id / YYYY-MM-DD date`
-        )
+      return notAvailable(
+        `${this.baseUrl}/snapshots/${encodeURIComponent(date)}/district_${encodeURIComponent(districtId)}.json`,
+        `not available — "${districtId}"/"${date}" is not a valid district id / YYYY-MM-DD date`
       )
     }
-    return this.read(
+    const res = await this.read(
       `snapshots/${date}/district_${districtId}.json`,
       PerDistrictDataSchema,
       d => d.data.snapshotDate
     )
+    // A failed-collection snapshot is well-formed but carries partial/empty
+    // data — surface it as not-available rather than presenting it as real.
+    if (res.available && res.data.status === 'failed') {
+      const detail = res.data.errorMessage ? `: ${res.data.errorMessage}` : ''
+      return notAvailable(
+        res.sourceUrl,
+        `not available — snapshot for district ${districtId} on ${date} reports a failed collection${detail}`
+      )
+    }
+    return res
   }
 
   /**

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -8,6 +8,8 @@ export {
   DEFAULT_CDN_BASE_URL,
   type CdnClientOptions,
   type ResolvedClub,
+  type DistrictSnapshot,
+  type TimeSeriesProgramYear,
 } from './cdn/CdnClient.js'
 
 export { type CdnReadResult, notAvailable } from './cdn/result.js'

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,7 +1,7 @@
 // @toastmasters/mcp-server — public barrel.
 //
-// ADR-008 Sprint 1 (#1043): the typed, read-only CDN read client. No MCP tools
-// yet — those are layered on top of this client in a later sprint.
+// ADR-008 Sprint 1 (#1043): the typed, read-only CDN read client.
+// ADR-008 Sprint 2 (#1044): the read-only MCP tools + stdio server over it.
 
 export {
   CdnClient,
@@ -31,3 +31,18 @@ export {
   CdnRankingsSchema,
   type CdnRankings,
 } from './schemas/cdn-rankings.schema.js'
+
+// MCP tools + server (Sprint 2)
+export { TOOLS, type ToolDef } from './tools/tools.js'
+export {
+  toToolResult,
+  parseToolText,
+  type ToolTextResult,
+} from './tools/envelope.js'
+export {
+  createServer,
+  registerTools,
+  startStdioServer,
+  SERVER_NAME,
+  SERVER_VERSION,
+} from './server.js'

--- a/packages/mcp-server/src/schemas/common.ts
+++ b/packages/mcp-server/src/schemas/common.ts
@@ -1,3 +1,12 @@
 /** Matches a YYYY-MM-DD snapshot date — the single source for the date contract
  * shared by the read-schemas and the CdnClient pre-flight date guard. */
 export const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/** Matches a YYYY-YYYY program-year identifier (e.g. "2025-2026"). */
+export const PROGRAM_YEAR_RE = /^\d{4}-\d{4}$/
+
+/**
+ * Matches a Toastmasters district identifier: one or more alphanumerics
+ * (e.g. "61", "F", "U"). The CdnClient uses this as a pre-flight guard so a
+ * raw id can never inject a path segment (`../`, slashes) into a CDN URL. */
+export const DISTRICT_ID_RE = /^[A-Za-z0-9]+$/

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,0 +1,56 @@
+/**
+ * MCP server bootstrap (ADR-008 Sprint 2).
+ *
+ * Builds an `McpServer` over the official SDK, registers the read-only
+ * {@link TOOLS} backed by a {@link CdnClient}, and (for the installed binary)
+ * serves them over stdio. The server is thin: it owns no state beyond the
+ * client and performs no computation.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { CdnClient } from './cdn/CdnClient.js'
+import { TOOLS } from './tools/tools.js'
+
+export const SERVER_NAME = 'toast-stats'
+export const SERVER_VERSION = '0.1.0'
+
+/** Register every read-only tool on `server`, backed by `client`. */
+export function registerTools(server: McpServer, client: CdnClient): void {
+  for (const t of TOOLS) {
+    server.registerTool(
+      t.name,
+      {
+        title: t.title,
+        description: t.description,
+        inputSchema: t.inputSchema,
+        // Every tool is a pure CDN read — advertise it so clients can trust it.
+        annotations: { readOnlyHint: true },
+      },
+      // The handler's text envelope IS a valid CallToolResult at runtime; the
+      // assertion bridges our minimal ToolTextResult to the SDK's wider type.
+      async args =>
+        (await t.handler(
+          client,
+          args as Record<string, unknown>
+        )) as CallToolResult
+    )
+  }
+}
+
+/** Build a fully-wired MCP server. Inject a `client` in tests. */
+export function createServer(client: CdnClient = new CdnClient()): McpServer {
+  const server = new McpServer({
+    name: SERVER_NAME,
+    version: SERVER_VERSION,
+  })
+  registerTools(server, client)
+  return server
+}
+
+/** Start the server over stdio (the local/self-installed transport). */
+export async function startStdioServer(): Promise<void> {
+  const server = createServer()
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+}

--- a/packages/mcp-server/src/tools/envelope.ts
+++ b/packages/mcp-server/src/tools/envelope.ts
@@ -1,0 +1,47 @@
+/**
+ * The consistent text envelope every MCP tool returns (ADR-008 Sprint 2).
+ *
+ * A tool wraps a {@link CdnReadResult} into an MCP `content` block whose text is
+ * a stable JSON object:
+ *  - success → `{ available: true, sourceUrl, date, data }`
+ *  - not-available → `{ available: false, sourceUrl, reason }`
+ *
+ * Every payload carries the exact CDN `sourceUrl` (human-verifiable against the
+ * live site) and the snapshot `date`. A not-available is a *valid* answer (the
+ * ADR's "not-available, never guess"), so it is NOT flagged as an MCP error.
+ */
+import type { CdnReadResult } from '../cdn/result.js'
+
+/** An MCP tool result carrying a single text block. */
+export interface ToolTextResult {
+  content: { type: 'text'; text: string }[]
+}
+
+/**
+ * Wrap a CDN read result in the standard tool envelope. An optional `project`
+ * reshapes the success payload (field selection / filtering only — never
+ * derivation), keeping responses focused without importing any computation.
+ */
+export function toToolResult<T>(
+  result: CdnReadResult<T>,
+  project?: (data: T) => unknown
+): ToolTextResult {
+  const body = result.available
+    ? {
+        available: true as const,
+        sourceUrl: result.sourceUrl,
+        date: result.date,
+        data: project ? project(result.data) : result.data,
+      }
+    : {
+        available: false as const,
+        sourceUrl: result.sourceUrl,
+        reason: result.reason,
+      }
+  return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }] }
+}
+
+/** Parse a tool result's single text block back into its envelope object. */
+export function parseToolText(result: ToolTextResult): unknown {
+  return JSON.parse(result.content[0]!.text)
+}

--- a/packages/mcp-server/src/tools/tools.ts
+++ b/packages/mcp-server/src/tools/tools.ts
@@ -1,0 +1,260 @@
+/**
+ * The MCP read-only tool set over the {@link CdnClient} (ADR-008 Sprint 2).
+ *
+ * Each tool validates its args, calls the thin CDN reader, and returns the
+ * standard {@link toToolResult} envelope (data + sourceUrl + date, or a
+ * structured not-available). Handlers do retrieval + field projection/filtering
+ * ONLY — they never derive a tier, threshold, or recognition state, and the
+ * package imports no `analytics-core` (enforced by a dependency test).
+ */
+import { z, type ZodRawShape } from 'zod'
+import type { CdnClient } from '../cdn/CdnClient.js'
+import { toToolResult, type ToolTextResult } from './envelope.js'
+
+/**
+ * A registrable MCP tool, stored with its handler args type-erased to a plain
+ * record. The server validates args against `inputSchema` before invoking the
+ * handler, so the erased shape is safe; {@link defineTool} preserves full
+ * arg-type inference at the authoring site.
+ */
+export interface ToolDef {
+  name: string
+  title: string
+  description: string
+  inputSchema: ZodRawShape
+  handler: (
+    client: CdnClient,
+    args: Record<string, unknown>
+  ) => Promise<ToolTextResult>
+}
+
+/**
+ * Author a tool with handler args inferred from its Zod raw-shape input, then
+ * erase to {@link ToolDef} for heterogeneous storage in {@link TOOLS}. The cast
+ * bridges handler contravariance — sound because args are runtime-validated
+ * against `inputSchema` by the MCP server before the handler runs.
+ */
+function defineTool<Shape extends ZodRawShape>(def: {
+  name: string
+  title: string
+  description: string
+  inputSchema: Shape
+  handler: (
+    client: CdnClient,
+    args: z.infer<z.ZodObject<Shape>>
+  ) => Promise<ToolTextResult>
+}): ToolDef {
+  return def as unknown as ToolDef
+}
+
+/**
+ * Resolve the date to read: the caller's `date` if given, else the current
+ * `latest.json` date. Returns the not-available envelope verbatim if the
+ * latest-date discovery read itself fails (never guesses a date).
+ */
+async function resolveDate(
+  client: CdnClient,
+  date: string | undefined
+): Promise<{ date: string } | { error: ToolTextResult }> {
+  if (date) return { date }
+  const latest = await client.getLatestDate()
+  if (!latest.available) return { error: toToolResult(latest) }
+  return { date: latest.data.latestSnapshotDate }
+}
+
+/** The raw health-signal fields surfaced per club (no derived status). */
+interface ClubHealthFields {
+  clubId: string
+  clubName: string
+  divisionId: string
+  divisionName: string
+  areaId: string
+  areaName: string
+  membershipCount: number
+  membershipBase: number
+  newMembers: number
+  octoberRenewals: number
+  aprilRenewals: number
+  paymentsCount: number
+  dcpGoals: number
+  status: string
+  clubStatus: string | null
+  charterDate: string | null
+}
+
+/** The health-relevant RAW fields a snapshot already carries, per club. No
+ * derived thriving/vulnerable/intervention status (that needs analytics-core,
+ * which this package must not import — see plan + ADR-008 discrepancy note). */
+function projectClubHealthFields(club: {
+  clubId: string
+  clubName: string
+  divisionId: string
+  divisionName: string
+  areaId: string
+  areaName: string
+  membershipCount: number
+  membershipBase: number
+  newMembers: number
+  octoberRenewals: number
+  aprilRenewals: number
+  paymentsCount: number
+  dcpGoals: number
+  status: string
+  clubStatus?: string
+  charterDate?: string
+}): ClubHealthFields {
+  return {
+    clubId: club.clubId,
+    clubName: club.clubName,
+    divisionId: club.divisionId,
+    divisionName: club.divisionName,
+    areaId: club.areaId,
+    areaName: club.areaName,
+    membershipCount: club.membershipCount,
+    membershipBase: club.membershipBase,
+    newMembers: club.newMembers,
+    octoberRenewals: club.octoberRenewals,
+    aprilRenewals: club.aprilRenewals,
+    paymentsCount: club.paymentsCount,
+    dcpGoals: club.dcpGoals,
+    status: club.status,
+    clubStatus: club.clubStatus ?? null,
+    charterDate: club.charterDate ?? null,
+  }
+}
+
+export const TOOLS: ToolDef[] = [
+  defineTool({
+    name: 'get-latest-date',
+    title: 'Get latest snapshot date',
+    description:
+      'Return the most recent snapshot date the CDN has published (from v1/latest.json).',
+    inputSchema: {},
+    handler: async client => toToolResult(await client.getLatestDate()),
+  }),
+
+  defineTool({
+    name: 'list-dates',
+    title: 'List available snapshot dates',
+    description:
+      'Return every snapshot date available on the CDN (from v1/dates.json).',
+    inputSchema: {},
+    handler: async client => toToolResult(await client.listDates()),
+  }),
+
+  defineTool({
+    name: 'list-districts',
+    title: 'List districts',
+    description:
+      'Return the district ids that have published snapshots, with the dates available for each (from config/district-snapshot-index.json).',
+    inputSchema: {},
+    handler: async client =>
+      toToolResult(await client.getDistrictSnapshotIndex(), d => ({
+        districtIds: Object.keys(d.districts),
+        availableDatesByDistrict: d.districts,
+      })),
+  }),
+
+  defineTool({
+    name: 'resolve-club',
+    title: 'Resolve a club to its district',
+    description:
+      'Look up which district a club id belongs to (from config/club-index.json). Returns not-available for an unknown club — never guesses.',
+    inputSchema: {
+      clubId: z.string().min(1).describe('Club id, e.g. "28680300"'),
+    },
+    handler: async (client, { clubId }) =>
+      toToolResult(await client.resolveClubDistrict(clubId)),
+  }),
+
+  defineTool({
+    name: 'get-district-snapshot',
+    title: 'Get a district snapshot',
+    description:
+      'Return the full per-district snapshot (club roster, division/area aggregates, district totals) for a date. Omit date for the latest snapshot.',
+    inputSchema: {
+      districtId: z.string().min(1).describe('District id, e.g. "61" or "F"'),
+      date: z
+        .string()
+        .optional()
+        .describe('Snapshot date YYYY-MM-DD; omit for latest'),
+    },
+    handler: async (client, { districtId, date }) => {
+      const resolved = await resolveDate(client, date)
+      if ('error' in resolved) return resolved.error
+      return toToolResult(
+        await client.getDistrictSnapshot(districtId, resolved.date)
+      )
+    },
+  }),
+
+  defineTool({
+    name: 'query-rankings',
+    title: 'Query all-districts rankings',
+    description:
+      'Return the all-districts rankings (ranks, paid clubs, payments, distinguished tiers). Omit date for the current rankings, or pass a date for that dated snapshot.',
+    inputSchema: {
+      date: z
+        .string()
+        .optional()
+        .describe('Snapshot date YYYY-MM-DD; omit for current rankings'),
+    },
+    handler: async (client, { date }) =>
+      date
+        ? toToolResult(await client.getDistrictRankingsForDate(date))
+        : toToolResult(await client.getRankings()),
+  }),
+
+  defineTool({
+    name: 'get-club-health',
+    title: 'Get club health-signal fields',
+    description:
+      'Return the raw health-signal fields per club (membership, base, new members, renewals, DCP goals, status) from a district snapshot, optionally filtered to one division. These are the pre-computed inputs; the categorical thriving/vulnerable/intervention status is NOT a snapshot field and is not derived here.',
+    inputSchema: {
+      districtId: z.string().min(1).describe('District id, e.g. "61"'),
+      date: z
+        .string()
+        .optional()
+        .describe('Snapshot date YYYY-MM-DD; omit for latest'),
+      divisionId: z
+        .string()
+        .optional()
+        .describe('Optional division id to filter clubs by, e.g. "B"'),
+    },
+    handler: async (client, { districtId, date, divisionId }) => {
+      const resolved = await resolveDate(client, date)
+      if ('error' in resolved) return resolved.error
+      const snapshot = await client.getDistrictSnapshot(
+        districtId,
+        resolved.date
+      )
+      return toToolResult(snapshot, d => {
+        const clubs = divisionId
+          ? d.data.clubs.filter(c => c.divisionId === divisionId)
+          : d.data.clubs
+        return {
+          districtId: d.data.districtId,
+          snapshotDate: d.data.snapshotDate,
+          divisionId: divisionId ?? null,
+          note: 'Raw health-signal fields only; categorical health status is not a pre-computed snapshot field and is not derived.',
+          clubs: clubs.map(projectClubHealthFields),
+        }
+      })
+    },
+  }),
+
+  defineTool({
+    name: 'get-time-series',
+    title: 'Get a district time-series',
+    description:
+      'Return the pre-computed program-year time series for a district (membership / payments / DCP goals / distinguished totals / club-health counts over time, plus a summary).',
+    inputSchema: {
+      districtId: z.string().min(1).describe('District id, e.g. "61"'),
+      programYear: z
+        .string()
+        .describe('Program year YYYY-YYYY, e.g. "2025-2026"'),
+    },
+    handler: async (client, { districtId, programYear }) =>
+      toToolResult(await client.getTimeSeries(districtId, programYear)),
+  }),
+]

--- a/packages/mcp-server/src/tools/tools.ts
+++ b/packages/mcp-server/src/tools/tools.ts
@@ -55,11 +55,11 @@ function defineTool<Shape extends ZodRawShape>(def: {
 async function resolveDate(
   client: CdnClient,
   date: string | undefined
-): Promise<{ date: string } | { error: ToolTextResult }> {
-  if (date) return { date }
+): Promise<{ ok: true; date: string } | { ok: false; error: ToolTextResult }> {
+  if (date) return { ok: true, date }
   const latest = await client.getLatestDate()
-  if (!latest.available) return { error: toToolResult(latest) }
-  return { date: latest.data.latestSnapshotDate }
+  if (!latest.available) return { ok: false, error: toToolResult(latest) }
+  return { ok: true, date: latest.data.latestSnapshotDate }
 }
 
 /** The raw health-signal fields surfaced per club (no derived status). */
@@ -181,7 +181,7 @@ export const TOOLS: ToolDef[] = [
     },
     handler: async (client, { districtId, date }) => {
       const resolved = await resolveDate(client, date)
-      if ('error' in resolved) return resolved.error
+      if (!resolved.ok) return resolved.error
       return toToolResult(
         await client.getDistrictSnapshot(districtId, resolved.date)
       )
@@ -223,7 +223,7 @@ export const TOOLS: ToolDef[] = [
     },
     handler: async (client, { districtId, date, divisionId }) => {
       const resolved = await resolveDate(client, date)
-      if ('error' in resolved) return resolved.error
+      if (!resolved.ok) return resolved.error
       const snapshot = await client.getDistrictSnapshot(
         districtId,
         resolved.date

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
       'src/**/*.spec.ts',
       'src/**/__tests__/**/*.ts',
     ],
+    // `__tests__/**/*.ts` would otherwise collect shared support files; skip the
+    // underscore-prefixed helpers (e.g. _fixture-fetch.ts) while keeping defaults.
+    exclude: ['**/node_modules/**', '**/dist/**', 'src/**/__tests__/**/_*.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/tasks/lessons/150-an-adr-claim-that-a-derived-field-is-in-the-snapshot-can-be-false-verify-the-live-payload.md
+++ b/tasks/lessons/150-an-adr-claim-that-a-derived-field-is-in-the-snapshot-can-be-false-verify-the-live-payload.md
@@ -1,0 +1,67 @@
+---
+id: '150'
+category: lesson
+tags: [data-pipeline, analytics, verification, scope, mcp, process]
+auto_load: true
+date: 2026-06-01
+issues: [1044, 1042]
+---
+
+# Lesson 150 — An ADR/spec claim that a derived field "lives in the snapshot" can be false; verify the live payload before building a tool that promises it
+
+**Date:** 2026-06-01
+**Issue:** #1044 (epic #1042 Sprint 2 — read-only MCP tools over the CDN client)
+**PR:** (this sprint)
+
+## What happened
+
+ADR-008's data-surface table lists **Club health status** as
+`(per club, in snapshot)` with values `thriving / vulnerable /
+intervention-required`, and the sprint sub-issue asked for a `get-club-health`
+tool returning "club-health-status fields from the snapshot." But the binding
+hard rule of the same ADR is **no computation, no `analytics-core` import,
+never derive a tier/threshold/recognition state**.
+
+Curling the live `snapshots/{date}/district_{id}.json` settled it: the club
+records carry only the **raw inputs** — `membershipCount`, `membershipBase`,
+`newMembers`, `dcpGoals`, `status`, `clubStatus` — and **no** `healthStatus`
+field. The categorical enum is computed by `analytics-core` for the website; it
+is **not** a served snapshot field. So the ADR table's "in snapshot" claim was
+aspirational, describing the _conceptual_ corpus, not the _bytes on the CDN_.
+
+The two requirements only reconcile one way: `get-club-health` surfaces the raw
+health-signal fields (plus an explicit `note` that the categorical status is not
+a snapshot field), and does **not** derive the enum. The "no computation"
+constraint is the tiebreaker, not the table.
+
+## The transferable principle
+
+**A spec/ADR sentence that a _derived_ value is "already in" a data file is a
+claim about the live payload — check it against the actual bytes before building
+anything that promises it. When a hard constraint (here: no computation) and a
+descriptive table conflict, the constraint wins, and the right move is to
+surface the raw inputs the file genuinely carries, never to quietly recompute
+the derived value to satisfy the table.** A `safeParse` against the read-schema
+won't catch this — Zod object schemas strip unknowns and pass when the _required_
+fields are present, so a missing _optional/derived_ field validates silently.
+
+## How to apply
+
+- Before wiring a "return field X" tool/feature, `curl --compressed` the real
+  CDN/file and confirm X is actually present — don't trust the schema's
+  _optional_ fields or a doc table. (Kin to R7 "inventory existing fields" and
+  [[115-a-fields-name-and-comment-can-lie-about-whether-its-populated]].)
+- If X is derived and a constraint forbids deriving it, ship the raw inputs +
+  a `note`, and record the doc discrepancy for an ADR follow-up rather than
+  silently importing the compute path.
+- Remember CDN snapshots are gzip-served: a bare `curl` shows binary; use
+  `--compressed` (or the client's fetch) to read the JSON.
+
+## Related
+
+- [[115-a-fields-name-and-comment-can-lie-about-whether-its-populated]] — a
+  field can be typed/named yet unpopulated in _your_ surface; same "verify the
+  payload" reflex.
+- `packages/mcp-server/src/tools/tools.ts` (`get-club-health`, the `note`),
+  `packages/mcp-server/src/cdn/CdnClient.ts` (`getDistrictSnapshot`),
+  `docs/architecture-decisions/008-ai-enable-toast-stats.md` (the table claim).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -128,4 +128,5 @@
 - **147** [frontend, react, scope, refactor, verification] — A reused "parity" surface must render from its own data source, not sit behind a sibling source's emptiness check (#1015, #1008)
 - **148** [router, react, frontend, verification, error-handling] — A render-thrown `Response` is NOT wrapped into an ErrorResponse; `isRouteErrorResponse` misses it (#1017, #1008)
 - **149** [verification, playwright, frontend, responsive, charts, scope] — A responsively-duplicated component needs a `:visible` selector in live verification (or the assertion hits the hidden twin) (#1023, #1022)
+- **150** [data-pipeline, analytics, verification, scope, mcp, process] — An ADR/spec claim that a derived field "lives in the snapshot" can be false; verify the live payload before building a tool that promises it (#1044, #1042)
 - **150** [monorepo, tdd, build, ci, automation] — TDD-scaffolding a new workspace package has two silent gate traps: the typecheck "no inputs" abort and the explicitly-enumerated CI job (#1043, #1042)

--- a/tasks/plans/sprint-1044-mcp-tools.md
+++ b/tasks/plans/sprint-1044-mcp-tools.md
@@ -1,0 +1,66 @@
+# Sprint 2 (#1044) — MCP read-only tools over the CDN client
+
+Epic #1042 (ADR-008). Branch `sprint/1044-mcp-tools` from `origin/main`.
+
+## Goal
+
+Wrap the Sprint-1 `CdnClient` as MCP tools using the official MCP SDK
+(`@modelcontextprotocol/sdk` v1.29, stdio transport). Read-only, no computation,
+no `analytics-core`. Every tool returns the pre-computed fields + exact CDN
+`sourceUrl` + snapshot `date`, or a structured "not available".
+
+## Verified facts (evidence, not guesses)
+
+- SDK API (from installed `.d.ts`): `new McpServer({name,version})`;
+  `server.registerTool(name, {title?,description?,inputSchema?,annotations?}, cb)`
+  where `inputSchema` is a **Zod raw shape** (`{f: z.string()}`), not `z.object`.
+  Handler returns `{ content: [{type:'text', text}] }`.
+  `StdioServerTransport` from `…/server/stdio.js`; `await server.connect(t)`.
+- CDN paths (frontend + ADR-008 §queryable surface):
+  - `snapshots/{date}/district_{id}.json` → validates `PerDistrictDataSchema`
+    (wrapper `{districtId,districtName,collectedAt,status,data:DistrictStatisticsFile}`).
+    Confirmed live: `data.clubs[]` carry raw fields only.
+  - `time-series/district_{id}/{programYear}.json` → `ProgramYearIndexFileSchema`.
+- **ADR-table discrepancy (documented):** ADR-008 line 92 says club health status
+  is "per club, in snapshot (thriving/vulnerable/intervention-required)". The LIVE
+  snapshot clubs carry NO `healthStatus` field — only the raw inputs
+  (membershipCount, membershipBase, newMembers, dcpGoals, status, clubStatus).
+  The classification is computed by `analytics-core`, which this package is
+  FORBIDDEN to import. Per the binding hard rule ("no computation, never derive a
+  tier/threshold/state"), `get-club-health` surfaces the **raw health-signal
+  fields** per club; it does NOT derive the enum. The client reasons over them
+  (the ADR's own "retrieval-and-explain" model). Flagged for ADR follow-up.
+
+## Work
+
+1. **CdnClient extension** (`src/cdn/CdnClient.ts`): add
+   - `getDistrictSnapshot(districtId, date)` → `PerDistrictDataSchema`, date guard
+     (ISO_DATE_RE), districtId guard (no path traversal — `encodeURIComponent` +
+     a charset check), date = `data.snapshotDate`.
+   - `getTimeSeries(districtId, programYear)` → `ProgramYearIndexFileSchema`,
+     programYear `YYYY-YYYY` guard, date = last dataPoint date or null.
+2. **Envelope** (`src/tools/envelope.ts`): `toToolResult(result, project?)` maps a
+   `CdnReadResult<T>` → `{content:[{type:'text', text: JSON}]}` with a consistent
+   `{available, sourceUrl, date, data|reason}` shape.
+3. **Tools** (`src/tools/tools.ts`): 8 tool defs `{name,title,description,
+inputSchema(rawShape), handler(client,args)}`:
+   - `get-latest-date`, `list-dates`, `list-districts`, `resolve-club`,
+     `get-district-snapshot`, `query-rankings`, `get-club-health`, `get-time-series`.
+     Handlers do retrieval + field projection/filtering only (no derivation).
+4. **Server** (`src/server.ts`): `createServer(client?)` builds McpServer + registers
+   all tools; `startStdioServer()` connects stdio. `bin` entry for npx.
+5. **Barrel** (`index.ts`): export `createServer`, `registerTools`, `TOOLS`.
+
+## TDD
+
+- Red: per-tool tests with a stubbed `CdnClient` (inject `fetchFn`) asserting
+  returned fields + sourceUrl + the not-available path; CdnClient new-method tests
+  (mocked fetch); a server-registration test (all 8 tools registered).
+- Green: implement.
+- Refactor: shared envelope; `/simplify` + `review` pass.
+
+## DoD
+
+All tools unit-tested; server starts over stdio; no `analytics-core` (existing
+guard test stays green); CI green; preview job is path-filtered to frontend so no
+live preview — code-proof per bootstrap step 5.


### PR DESCRIPTION
## Sprint 2 of epic #1042 (ADR-008) — read-only MCP tools over the CDN client

Closes #1044 — wraps the Sprint-1 `CdnClient` as MCP tools using the official
`@modelcontextprotocol/sdk` v1.29 over stdio. Thin, local, **read-only, no
computation, no `analytics-core`** (enforced by the existing dependency test).

### What landed
- **CdnClient extension** (`cdn/CdnClient.ts`): `getDistrictSnapshot(districtId, date)`
  (`PerDistrictData` schema) and `getTimeSeries(districtId, programYear)`
  (`ProgramYearIndexFile` schema). Pre-flight guards (`DISTRICT_ID_RE` / `ISO_DATE_RE`
  / `PROGRAM_YEAR_RE`) reject malformed/path-traversal input **before** any fetch.
  A failed-collection snapshot (`status: "failed"`) resolves to not-available.
- **8 MCP tools** (`tools/tools.ts`): `get-latest-date`, `list-dates`,
  `list-districts`, `resolve-club`, `get-district-snapshot`, `query-rankings`,
  `get-club-health`, `get-time-series`. Each returns a consistent envelope
  (`{ available, sourceUrl, date, data | reason }`) — every response carries the
  exact CDN URL and snapshot date; missing date/field → structured not-available,
  never a guess. Handlers do retrieval + field projection/filtering only.
- **stdio server** (`server.ts` + `bin.ts`): `createServer()` / `startStdioServer()`,
  `npx`-runnable via `bin: toast-stats-mcp`. Read-only annotations on every tool.

### `get-club-health` — ADR discrepancy (flagged for follow-up)
ADR-008's data-surface table lists club health status (thriving/vulnerable/
intervention) as "per club, in snapshot." The **live** snapshot clubs carry only
the raw inputs (membership, base, new members, DCP goals, status) — the
categorical enum is computed by `analytics-core` and is **not** a served field.
Per the binding hard rule (no computation), `get-club-health` surfaces the raw
health-signal fields + an explicit `note`; it does **not** derive the enum. The
client reasons over them (the ADR's own "retrieval-and-explain" model). See
[Lesson 150](tasks/lessons/150-an-adr-claim-that-a-derived-field-is-in-the-snapshot-can-be-false-verify-the-live-payload.md).
The ADR table should be corrected in a doc follow-up.

### Verification
- TDD throughout (Red→Green per logical change). **42 package tests pass**
  (CdnClient reads, every tool, end-to-end MCP client over in-memory transport,
  no-analytics-core guard). Typecheck + lint clean.
- **Built stdio binary smoke-tested as a real process**: `initialize` →
  `serverInfo {name: "toast-stats", version: "0.1.0"}`, `tools/list` → all 8 tools.
- `/simplify` (shared test fetch helper; tagged `resolveDate` union) and a
  fresh-context `/review` (APPROVE-WITH-NITS; the one medium finding —
  failed-status snapshot — is fixed) applied.

### No live preview
`pr-preview.yml` is path-filtered to `frontend/**` + `packages/{shared-contracts,analytics-core}`;
this PR touches only `packages/mcp-server`, so there is no preview surface. Per
the runner's step-5 fallback, verification is the full test suite + the built-binary
stdio smoke + code-proof above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
