### PR TITLE
feat(mcp-server): Sprint 3 — install path, README + offline stdio boot smoke (#1045)

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -169,13 +169,14 @@ All Toastmasters-specific rules are documented in [toastmasters-rules-reference.
 
 ## Architecture Decisions
 
-| Decision                            | Rationale                                                                | Date     |
-| ----------------------------------- | ------------------------------------------------------------------------ | -------- |
-| CDN-only frontend (no API server)   | Data is pre-computed and immutable; CDN scales infinitely                | Jan 2026 |
-| One snapshot per month (pruned)     | Daily snapshots were wasteful; monthly is sufficient for trends          | Feb 2026 |
-| Time-series separate from analytics | Analytics JSON has 1-2 trend points; time-series has monthly granularity | Mar 2026 |
-| Borda-count for global rankings     | Fair multi-metric ranking without over-weighting any single metric       | Jan 2026 |
-| Toastmasters brand colors           | Professional appearance aligned with TI brand guidelines                 | Jan 2026 |
+| Decision                                  | Rationale                                                                                                                                                                                       | Date     |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| CDN-only frontend (no API server)         | Data is pre-computed and immutable; CDN scales infinitely                                                                                                                                       | Jan 2026 |
+| One snapshot per month (pruned)           | Daily snapshots were wasteful; monthly is sufficient for trends                                                                                                                                 | Feb 2026 |
+| Time-series separate from analytics       | Analytics JSON has 1-2 trend points; time-series has monthly granularity                                                                                                                        | Mar 2026 |
+| Borda-count for global rankings           | Fair multi-metric ranking without over-weighting any single metric                                                                                                                              | Jan 2026 |
+| Toastmasters brand colors                 | Professional appearance aligned with TI brand guidelines                                                                                                                                        | Jan 2026 |
+| Thin local read-only MCP server (ADR-008) | AI-enable Toast Stats: a self-installed stdio MCP server exposes the public snapshot CDN as read-only tools (no computation, no analytics-core, cite-the-source). `packages/mcp-server` (#1042) | May 2026 |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8713,6 +8713,9 @@
         "@toastmasters/shared-contracts": "^1.0.0",
         "zod": "^4.4.3"
       },
+      "bin": {
+        "toast-stats-mcp": "dist/bin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.9.1",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -93,11 +93,11 @@ Every tool returns a single text content block whose JSON is the standard envelo
 ```jsonc
 {
   "available": true,
+  "sourceUrl": "https://cdn.taverns.red/v1/latest.json", // verify against the live site
+  "date": "2026-05-31", // the snapshot date the data is from (or null)
   "data": {
     /* the validated CDN fields */
   },
-  "sourceUrl": "https://cdn.taverns.red/v1/latest.json", // verify against the live site
-  "date": "2026-05-31", // the snapshot date the data is from (or null)
 }
 ```
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,120 @@
+# @toastmasters/mcp-server
+
+A **thin, local, read-only [MCP](https://modelcontextprotocol.io) server** over the
+public Toast Stats snapshot CDN ([ADR-008](../../docs/architecture-decisions/008-ai-enable-toast-stats.md)).
+It lets any MCP-capable client (Claude Desktop, Claude Code, …) answer open-ended
+questions about Toastmasters district performance, grounded in the **pre-computed**
+pipeline output published at `https://cdn.taverns.red`.
+
+It is deliberately **thin**:
+
+- **Read-only, no computation.** Tools fetch CDN JSON, validate it with the
+  `shared-contracts` read-schemas, and return fields. They never derive a tier,
+  threshold, or recognition state, and the package imports **no `analytics-core`**.
+- **Not-available, never guess.** If a question needs something a snapshot doesn't
+  already contain, the tool returns a structured _not available_ — it never fabricates.
+- **Local only.** stdio transport, runs on your machine. No hosting, no always-on
+  service, no auth (the data is public).
+- **Cite the source.** Every response carries the exact CDN URL it read and the
+  snapshot `date`, so any answer is human-verifiable against the live site.
+
+## Install
+
+This is a workspace package in the [Toast Stats monorepo](../../), distributed
+**locally / self-installed** (not published to a public registry). Build it once,
+then point your MCP client at the built binary.
+
+```bash
+# from the monorepo root
+npm install
+npm run build:shared-contracts   # mcp-server depends on the built contracts
+npm run build:mcp-server         # emits packages/mcp-server/dist/bin.js
+```
+
+This produces the executable `dist/bin.js` (bin name: `toast-stats-mcp`).
+
+## Configure your MCP client
+
+Add a `mcpServers` entry pointing at the built bin. Use an **absolute** path.
+
+**Claude Desktop** (`claude_desktop_config.json`) / **Claude Code** (`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "toast-stats": {
+      "command": "node",
+      "args": ["/absolute/path/to/toast-stats/packages/mcp-server/dist/bin.js"]
+    }
+  }
+}
+```
+
+Restart the client; the `toast-stats` tools below become available.
+
+### Pointing at a different CDN (optional)
+
+The server reads `https://cdn.taverns.red` by default. Set `CDN_BASE_URL` to read a
+staging origin or a local fixture server instead:
+
+```json
+{
+  "mcpServers": {
+    "toast-stats": {
+      "command": "node",
+      "args": ["/absolute/path/to/.../dist/bin.js"],
+      "env": { "CDN_BASE_URL": "https://staging.example" }
+    }
+  }
+}
+```
+
+## Tools
+
+All eight tools are **read-only** (advertised via `readOnlyHint`). Each returns a
+JSON envelope (see [Response shape](#response-shape)). `date` arguments are
+`YYYY-MM-DD`; omit `date` on the dated reads to use the latest snapshot.
+
+| Tool                    | Purpose                                                                                                                                                                                                                 |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get-latest-date`       | Most recent published snapshot date (`v1/latest.json`).                                                                                                                                                                 |
+| `list-dates`            | Every available snapshot date (`v1/dates.json`).                                                                                                                                                                        |
+| `list-districts`        | District ids with snapshots + the dates each has.                                                                                                                                                                       |
+| `resolve-club`          | Which district a club id belongs to. Unknown club → not available (never guessed).                                                                                                                                      |
+| `get-district-snapshot` | Full per-district snapshot (roster, division/area aggregates, totals) for a date.                                                                                                                                       |
+| `query-rankings`        | All-districts rankings (ranks, paid clubs, payments, distinguished tiers).                                                                                                                                              |
+| `get-club-health`       | Raw per-club health-signal fields (membership, base, renewals, DCP goals, status), optionally filtered to one division. The categorical thriving/vulnerable status is **not** a snapshot field and is not derived here. |
+| `get-time-series`       | Pre-computed program-year time series for a district (membership / payments / DCP / distinguished / club-health counts).                                                                                                |
+
+## Response shape
+
+Every tool returns a single text content block whose JSON is the standard envelope:
+
+```jsonc
+{
+  "available": true,
+  "data": {
+    /* the validated CDN fields */
+  },
+  "sourceUrl": "https://cdn.taverns.red/v1/latest.json", // verify against the live site
+  "date": "2026-05-31", // the snapshot date the data is from (or null)
+}
+```
+
+A not-available result keeps the same shape with `available: false` and a `reason`,
+and still cites the `sourceUrl` it tried — the server never guesses a value it
+couldn't read.
+
+## Verify the install (offline smoke)
+
+`npm run smoke` builds the package and boots the **real** `dist/bin.js` over stdio
+against a localhost server serving committed CDN fixtures — no network, no live
+Claude client. It asserts the bin lists its tools and answers a tool call:
+
+```bash
+npm run smoke --workspace=@toastmasters/mcp-server
+```
+
+This is the same offline check CI runs (it's part of the package test suite). It
+proves the install/boot path end to end; live end-to-end verification against the
+real CDN from a Claude client is a separate operator-run step.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint . --ext .ts",
     "test": "vitest --run",
     "test:watch": "vitest",
+    "smoke": "npm run build && vitest run src/__tests__/stdio-boot.smoke.test.ts",
     "typecheck": "tsc --noEmit --skipLibCheck"
   },
   "dependencies": {

--- a/packages/mcp-server/src/__tests__/_fixture-routes.ts
+++ b/packages/mcp-server/src/__tests__/_fixture-routes.ts
@@ -1,0 +1,17 @@
+/**
+ * The canonical CDN-path → committed-fixture-filename map shared across the
+ * mcp-server test suites. Both the in-process fixture `fetch` stub
+ * ({@link makeFixtureFetch}) and the offline stdio smoke's localhost HTTP server
+ * route off this single source so the two transports can't drift.
+ */
+export const FIXTURE_ROUTES: Record<string, string> = {
+  '/v1/latest.json': 'latest.json',
+  '/v1/dates.json': 'dates.json',
+  '/config/district-snapshot-index.json': 'district-snapshot-index.json',
+  '/config/club-index.json': 'club-index.json',
+  '/v1/rankings.json': 'v1-rankings.json',
+  '/snapshots/2026-05-31/all-districts-rankings.json':
+    'dated-all-districts-rankings.json',
+  '/snapshots/2026-05-31/district_61.json': 'district-snapshot.json',
+  '/time-series/district_61/2025-2026.json': 'time-series.json',
+}

--- a/packages/mcp-server/src/__tests__/resolve-base-url.test.ts
+++ b/packages/mcp-server/src/__tests__/resolve-base-url.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { resolveCdnBaseUrl } from '../server.js'
+import { DEFAULT_CDN_BASE_URL } from '../cdn/CdnClient.js'
+
+describe('resolveCdnBaseUrl', () => {
+  it('returns the default public CDN origin when CDN_BASE_URL is unset', () => {
+    expect(resolveCdnBaseUrl({})).toBe(DEFAULT_CDN_BASE_URL)
+  })
+
+  it('returns the CDN_BASE_URL override when set (self-hosting / offline smoke)', () => {
+    expect(resolveCdnBaseUrl({ CDN_BASE_URL: 'http://127.0.0.1:8123' })).toBe(
+      'http://127.0.0.1:8123'
+    )
+  })
+
+  it('trims surrounding whitespace from the override', () => {
+    expect(
+      resolveCdnBaseUrl({ CDN_BASE_URL: '  https://staging.example  ' })
+    ).toBe('https://staging.example')
+  })
+
+  it('falls back to the default for a blank/whitespace-only override', () => {
+    expect(resolveCdnBaseUrl({ CDN_BASE_URL: '   ' })).toBe(
+      DEFAULT_CDN_BASE_URL
+    )
+    expect(resolveCdnBaseUrl({ CDN_BASE_URL: '' })).toBe(DEFAULT_CDN_BASE_URL)
+  })
+
+  it('defaults to process.env when called with no argument', () => {
+    // Smoke: the zero-arg form reads the ambient environment without throwing.
+    expect(typeof resolveCdnBaseUrl()).toBe('string')
+  })
+})

--- a/packages/mcp-server/src/__tests__/stdio-boot.smoke.test.ts
+++ b/packages/mcp-server/src/__tests__/stdio-boot.smoke.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Offline stdio boot smoke (#1045, ADR-008 Sprint 3).
+ *
+ * Proves the *installed binary* boots and serves over **real stdio** — not the
+ * in-memory transport pair the server unit test uses. It spawns the built
+ * `dist/bin.js` exactly as an MCP client (Claude Desktop / Claude Code) would,
+ * connects a real {@link Client} over {@link StdioClientTransport}, and drives
+ * it against a **localhost** HTTP server serving the committed CDN fixtures via
+ * the `CDN_BASE_URL` override. No live CDN, no internet, no live Claude client.
+ *
+ * Requires the package to be built first (`npm run build:mcp-server`); CI builds
+ * it before this test runs, and `npm run smoke` builds then runs just this file.
+ * The `beforeAll` guard fails loudly with that instruction if `dist/` is stale.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const packageRoot = join(here, '..', '..')
+const binPath = join(packageRoot, 'dist', 'bin.js')
+const fixtureDir = join(here, '..', '__fixtures__')
+
+/** CDN path (after the origin) → committed fixture filename. */
+const ROUTES: Record<string, string> = {
+  '/v1/latest.json': 'latest.json',
+  '/v1/dates.json': 'dates.json',
+  '/config/district-snapshot-index.json': 'district-snapshot-index.json',
+  '/config/club-index.json': 'club-index.json',
+  '/v1/rankings.json': 'v1-rankings.json',
+  '/snapshots/2026-05-31/all-districts-rankings.json':
+    'dated-all-districts-rankings.json',
+  '/snapshots/2026-05-31/district_61.json': 'district-snapshot.json',
+  '/time-series/district_61/2025-2026.json': 'time-series.json',
+}
+
+interface ToolEnvelope {
+  available: boolean
+  sourceUrl: string
+  date: string | null
+  data: unknown
+}
+
+function startFixtureCdn(): Promise<{ server: Server; baseUrl: string }> {
+  const server = createServer((req, res) => {
+    const file = req.url ? ROUTES[req.url] : undefined
+    if (!file) {
+      res.writeHead(404).end('not found')
+      return
+    }
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(readFileSync(join(fixtureDir, file), 'utf8'))
+  })
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` })
+    })
+  })
+}
+
+describe('installed bin boots over real stdio (offline, fixture-backed)', () => {
+  let cdn: { server: Server; baseUrl: string }
+  let client: Client
+
+  beforeAll(async () => {
+    if (!existsSync(binPath)) {
+      throw new Error(
+        `dist/bin.js not found at ${binPath} — build first: ` +
+          '`npm run build:mcp-server` (or `npm run smoke`). CI builds before this test.'
+      )
+    }
+    cdn = await startFixtureCdn()
+
+    const transport = new StdioClientTransport({
+      command: process.execPath, // the current node binary
+      args: [binPath],
+      // Point the real server at the localhost fixture CDN; keep PATH so any
+      // child resolution still works. Nothing else from the parent env leaks in.
+      env: { CDN_BASE_URL: cdn.baseUrl, PATH: process.env.PATH ?? '' },
+    })
+    client = new Client({ name: 'smoke-client', version: '0.0.0' })
+    await client.connect(transport)
+  }, 30000)
+
+  afterAll(async () => {
+    await client?.close()
+    await new Promise<void>(resolve => cdn?.server.close(() => resolve()))
+  })
+
+  it('lists all 8 read-only tools to a real stdio client', async () => {
+    const { tools } = await client.listTools()
+    expect(tools.map(t => t.name).sort()).toEqual(
+      [
+        'get-club-health',
+        'get-district-snapshot',
+        'get-latest-date',
+        'get-time-series',
+        'list-dates',
+        'list-districts',
+        'query-rankings',
+        'resolve-club',
+      ].sort()
+    )
+  })
+
+  it('answers a discovery tool call from the fixture CDN, citing the source URL', async () => {
+    const result = await client.callTool({
+      name: 'get-latest-date',
+      arguments: {},
+    })
+    const content = result.content as { type: string; text: string }[]
+    expect(content[0]!.type).toBe('text')
+    const env = JSON.parse(content[0]!.text) as ToolEnvelope
+    expect(env.available).toBe(true)
+    expect(env.sourceUrl).toBe(`${cdn.baseUrl}/v1/latest.json`)
+    expect(
+      (env.data as { latestSnapshotDate: string }).latestSnapshotDate
+    ).toBe('2026-05-31')
+  })
+
+  it('answers a dated district-snapshot read end-to-end over the boot path', async () => {
+    const result = await client.callTool({
+      name: 'get-district-snapshot',
+      arguments: { districtId: '61', date: '2026-05-31' },
+    })
+    const content = result.content as { type: string; text: string }[]
+    const env = JSON.parse(content[0]!.text) as ToolEnvelope
+    expect(env.available).toBe(true)
+    expect(env.sourceUrl).toBe(
+      `${cdn.baseUrl}/snapshots/2026-05-31/district_61.json`
+    )
+    expect(env.date).toBe('2026-05-31')
+  })
+})

--- a/packages/mcp-server/src/__tests__/stdio-boot.smoke.test.ts
+++ b/packages/mcp-server/src/__tests__/stdio-boot.smoke.test.ts
@@ -20,24 +20,12 @@ import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { FIXTURE_ROUTES } from './_fixture-routes.js'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const packageRoot = join(here, '..', '..')
 const binPath = join(packageRoot, 'dist', 'bin.js')
 const fixtureDir = join(here, '..', '__fixtures__')
-
-/** CDN path (after the origin) → committed fixture filename. */
-const ROUTES: Record<string, string> = {
-  '/v1/latest.json': 'latest.json',
-  '/v1/dates.json': 'dates.json',
-  '/config/district-snapshot-index.json': 'district-snapshot-index.json',
-  '/config/club-index.json': 'club-index.json',
-  '/v1/rankings.json': 'v1-rankings.json',
-  '/snapshots/2026-05-31/all-districts-rankings.json':
-    'dated-all-districts-rankings.json',
-  '/snapshots/2026-05-31/district_61.json': 'district-snapshot.json',
-  '/time-series/district_61/2025-2026.json': 'time-series.json',
-}
 
 interface ToolEnvelope {
   available: boolean
@@ -48,7 +36,7 @@ interface ToolEnvelope {
 
 function startFixtureCdn(): Promise<{ server: Server; baseUrl: string }> {
   const server = createServer((req, res) => {
-    const file = req.url ? ROUTES[req.url] : undefined
+    const file = req.url ? FIXTURE_ROUTES[req.url] : undefined
     if (!file) {
       res.writeHead(404).end('not found')
       return

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -3,20 +3,11 @@ import type { CdnClient } from '../cdn/CdnClient.js'
 import { TOOLS, type ToolDef } from '../tools/tools.js'
 import { parseToolText } from '../tools/envelope.js'
 import { BASE, makeClient, makeFixtureFetch } from './_fixture-fetch.js'
+import { FIXTURE_ROUTES } from './_fixture-routes.js'
 
-const ROUTES: Record<string, string> = {
-  '/v1/latest.json': 'latest.json',
-  '/v1/dates.json': 'dates.json',
-  '/config/district-snapshot-index.json': 'district-snapshot-index.json',
-  '/config/club-index.json': 'club-index.json',
-  '/v1/rankings.json': 'v1-rankings.json',
-  '/snapshots/2026-05-31/all-districts-rankings.json':
-    'dated-all-districts-rankings.json',
-  '/snapshots/2026-05-31/district_61.json': 'district-snapshot.json',
-  '/time-series/district_61/2025-2026.json': 'time-series.json',
-}
-
-function client(fetchFn: typeof fetch = makeFixtureFetch(ROUTES)): CdnClient {
+function client(
+  fetchFn: typeof fetch = makeFixtureFetch(FIXTURE_ROUTES)
+): CdnClient {
   return makeClient(fetchFn)
 }
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -9,11 +9,25 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import { CdnClient } from './cdn/CdnClient.js'
+import { CdnClient, DEFAULT_CDN_BASE_URL } from './cdn/CdnClient.js'
 import { TOOLS } from './tools/tools.js'
 
 export const SERVER_NAME = 'toast-stats'
 export const SERVER_VERSION = '0.1.0'
+
+/**
+ * Resolve the CDN origin the installed server reads from. Honors a `CDN_BASE_URL`
+ * environment override (self-hosting, a staging CDN, or the offline smoke check
+ * pointing at a localhost fixture server); falls back to the public
+ * {@link DEFAULT_CDN_BASE_URL} when unset or blank. A whitespace-only value is
+ * treated as unset so a stray export can't silently break the default.
+ */
+export function resolveCdnBaseUrl(
+  env: { CDN_BASE_URL?: string } = process.env
+): string {
+  const override = env.CDN_BASE_URL?.trim()
+  return override ? override : DEFAULT_CDN_BASE_URL
+}
 
 /** Register every read-only tool on `server`, backed by `client`. */
 export function registerTools(server: McpServer, client: CdnClient): void {
@@ -50,7 +64,7 @@ export function createServer(client: CdnClient = new CdnClient()): McpServer {
 
 /** Start the server over stdio (the local/self-installed transport). */
 export async function startStdioServer(): Promise<void> {
-  const server = createServer()
+  const server = createServer(new CdnClient({ baseUrl: resolveCdnBaseUrl() }))
   const transport = new StdioServerTransport()
   await server.connect(transport)
 }

--- a/tasks/lessons/150-an-installable-stdio-server-needs-an-env-injectable-base-url-to-be-offline-smoke-tested-via-the-real-bin.md
+++ b/tasks/lessons/150-an-installable-stdio-server-needs-an-env-injectable-base-url-to-be-offline-smoke-tested-via-the-real-bin.md
@@ -1,0 +1,67 @@
+---
+id: '150'
+category: lesson
+tags: [mcp, verification, tdd, monorepo, ci, automation]
+auto_load: true
+date: 2026-06-01
+issues: [1045, 1042]
+---
+
+# Lesson 150 — An installable stdio server needs an env-injectable base URL to be offline-smoke-tested via the real bin
+
+**Date:** 2026-06-01
+**Issue:** #1045 (epic #1042 Sprint 3 — make the thin local MCP server installable + documented)
+**PR:** (this sprint)
+
+## What happened
+
+Sprint 2 already had an end-to-end server test (`server.test.ts`) that wires a real
+MCP `Client` to the server over the SDK's **in-memory** transport pair. That proves
+tool registration and the request/response envelope — but it does **not** prove the
+thing a Sprint-3 "install path" DoD actually cares about: that the published
+**binary** (`dist/bin.js`) boots, speaks **real stdio**, and reads the CDN, exactly
+as a Claude Desktop / Claude Code `mcpServers` entry would launch it.
+
+To smoke that boot path _offline_ (the DoD forbids a live CDN or live client), the
+test must spawn the real built bin and point it at **localhost fixtures** — which is
+impossible if the only CDN origin the bin knows is the hard-coded production default.
+The unlock was a one-line seam: `resolveCdnBaseUrl(env)` reads a `CDN_BASE_URL`
+override (falling back to the public default), wired into `startStdioServer`'s
+`CdnClient`. The smoke then starts a `node:http` server on `127.0.0.1:0` serving the
+committed fixtures, spawns `process.execPath dist/bin.js` with
+`env: { CDN_BASE_URL, PATH }` over `StdioClientTransport`, and asserts `listTools` +
+real fixture-backed tool calls with the cited source URL. No internet, no live client.
+
+## The transferable principle
+
+**An in-memory-transport test of a stdio server is necessary but not sufficient for
+an _install/boot_ proof. To smoke the real bin offline you need a configuration seam
+the spawned process can be pointed through — an env-injectable base URL (or fixture
+dir) — so the genuine artifact can be driven against localhost fixtures over real
+stdio.** Put the env read at the **server entry/boot seam**, not buried in the client
+class: the client keeps taking an injected `baseUrl` (testable, env-agnostic), and the
+entry point is the single place that translates environment → config. That same
+override is also the legitimate self-hosting / staging-CDN feature, so it isn't
+test-only scaffolding.
+
+## How to apply
+
+- Building an installable stdio/CLI server? Add the base-URL/fixture override **before**
+  you write the offline smoke — the smoke depends on it.
+- The smoke spawns the **built** artifact, so it has an implicit build dependency:
+  guard `existsSync(dist/bin.js)` with an actionable "build first" message, ensure CI
+  builds the package _before_ its test step (R16), and give it a `npm run smoke` that
+  builds then runs. Coverage of a spawned subprocess isn't instrumented — that's fine;
+  the in-memory test covers the units, the smoke covers the boot.
+- Pass `process.execPath` (absolute) as the spawn command so node resolves without a
+  PATH lookup; still forward `PATH` so the child's own module resolution works.
+
+## Related
+
+- [[143-a-probe-whose-production-feed-was-deferred-reports-unknown-forever]] — same
+  spirit: a verification sprint is where you drive the real feed/boot end-to-end, not
+  a stand-in.
+- [[092-workspace-package-dist-is-gitignored-and-not-auto-rebuilt]] (R16) — the build
+  dependency the spawned-bin smoke inherits.
+- `packages/mcp-server/src/server.ts` (`resolveCdnBaseUrl`),
+  `packages/mcp-server/src/__tests__/stdio-boot.smoke.test.ts`.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -129,4 +129,5 @@
 - **148** [router, react, frontend, verification, error-handling] — A render-thrown `Response` is NOT wrapped into an ErrorResponse; `isRouteErrorResponse` misses it (#1017, #1008)
 - **149** [verification, playwright, frontend, responsive, charts, scope] — A responsively-duplicated component needs a `:visible` selector in live verification (or the assertion hits the hidden twin) (#1023, #1022)
 - **150** [data-pipeline, analytics, verification, scope, mcp, process] — An ADR/spec claim that a derived field "lives in the snapshot" can be false; verify the live payload before building a tool that promises it (#1044, #1042)
+- **150** [mcp, verification, tdd, monorepo, ci, automation] — An installable stdio server needs an env-injectable base URL to be offline-smoke-tested via the real bin (#1045, #1042)
 - **150** [monorepo, tdd, build, ci, automation] — TDD-scaffolding a new workspace package has two silent gate traps: the typecheck "no inputs" abort and the explicitly-enumerated CI job (#1043, #1042)


### PR DESCRIPTION
## Sprint 3 of epic #1042 — install path + package docs (autonomous)

Closes none directly (sprint sub-issue #1045 is closed by the runner after verification). Makes the thin local read-only MCP server (`packages/mcp-server`, ADR-008) **installable and documented**, buildable + CI-verifiable end-to-end **without a live Claude client**.

### What shipped
- **`CDN_BASE_URL` env override** (`server.ts` `resolveCdnBaseUrl`, wired into `startStdioServer`) — lets the installed bin be pointed at a staging CDN or a localhost fixture server. The legit self-hosting seam **and** the unlock for an offline boot smoke. Default stays the public CDN.
- **Offline stdio boot smoke** (`src/__tests__/stdio-boot.smoke.test.ts`) — spawns the **real built `dist/bin.js`** over real stdio (`StdioClientTransport`), pointed at a `127.0.0.1` HTTP server serving the committed `__fixtures__`. Asserts it lists all 8 tools and answers two real fixture-backed tool calls, each citing its source URL. **No network, no live CDN, no live client.** Runs in CI via the existing `test:mcp-server --coverage` step (which already runs after `build:mcp-server`); also `npm run smoke` (builds then runs).
- **README** — install (local/self-installed build), the `mcpServers` client config snippet, the 8-tool list, the response envelope, and the cite-the-source contract.
- `/simplify` pass extracted the shared `FIXTURE_ROUTES` so the in-process fetch stub and the smoke's HTTP server route off one source.

### Verification
- Full `mcp-server` suite: **50/50 pass**, coverage 96/83/97/97 (thresholds 85/70/90/85 — none lowered). Full workspace `npm run test`: green.
- **No PR preview** deploys: `pr-preview.yml`'s path filter is `frontend/**` + `packages/{shared-contracts,analytics-core}/**` + firebase config, which **excludes** `packages/mcp-server/**`. There is no live web surface to drive — the offline stdio smoke (boots the real installed bin) is the boot/install proof, per the sprint's code-proof allowance.
- **AC delta (intentional):** the AC says "npx-runnable bin." The package is `private: true` (not published), so the README documents the realistic local install — a `command: node` + absolute-path `mcpServers` entry — rather than `npx @toastmasters/mcp-server` against a registry that doesn't have it. The `bin` (`toast-stats-mcp`) exists and is npx-runnable once/if published.

### Out of scope
Live end-to-end verification against the real CDN from a Claude client is split to **#1049** (operator-run), intentionally not wired into this epic's sprint checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
