### PR TITLE
feat: unified search index + matcher — omni-search Sprint 1 (#1056)

### DIFF
--- a/frontend/src/services/__tests__/searchIndex.loader.test.ts
+++ b/frontend/src/services/__tests__/searchIndex.loader.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the CDN service so we can assert the loader fetches lazily — and that
+// merely importing the module triggers no network call (the 1MB club index
+// must not be pulled at import / app boot).
+const fetchCdnRankings = vi.fn()
+const fetchCdnClubIndex = vi.fn()
+vi.mock('../cdn', () => ({
+  fetchCdnRankings: (...args: unknown[]) => fetchCdnRankings(...args),
+  fetchCdnClubIndex: (...args: unknown[]) => fetchCdnClubIndex(...args),
+}))
+
+describe('loadSearchIndex (lazy)', () => {
+  beforeEach(() => {
+    fetchCdnRankings.mockReset()
+    fetchCdnClubIndex.mockReset()
+    fetchCdnRankings.mockResolvedValue({
+      rankings: [
+        { districtId: '61', districtName: 'District 61', region: '07' },
+      ],
+      date: '2026-06-01',
+      generatedAt: '2026-06-01T00:00:00Z',
+    })
+    fetchCdnClubIndex.mockResolvedValue({
+      clubs: {
+        '00001234': { districtId: '61', clubName: 'Toast of the Town' },
+      },
+    })
+  })
+
+  it('does not fetch anything at import time', async () => {
+    await import('../searchIndex')
+    expect(fetchCdnRankings).not.toHaveBeenCalled()
+    expect(fetchCdnClubIndex).not.toHaveBeenCalled()
+  })
+
+  it('fetches rankings + club index only when invoked, and builds an index', async () => {
+    const { loadSearchIndex } = await import('../searchIndex')
+    expect(fetchCdnClubIndex).not.toHaveBeenCalled()
+
+    const index = await loadSearchIndex()
+
+    expect(fetchCdnRankings).toHaveBeenCalledTimes(1)
+    expect(fetchCdnClubIndex).toHaveBeenCalledTimes(1)
+    expect(
+      index.entities.some(e => e.type === 'district' && e.id === '61')
+    ).toBe(true)
+    expect(
+      index.entities.some(e => e.type === 'club' && e.id === '00001234')
+    ).toBe(true)
+  })
+})

--- a/frontend/src/services/__tests__/searchIndex.test.ts
+++ b/frontend/src/services/__tests__/searchIndex.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  buildSearchIndex,
+  searchEntities,
+  type SearchIndex,
+  type SearchResultGroup,
+} from '../searchIndex'
+
+// --- Fixtures (shapes mirror fetchCdnRankings().rankings + fetchCdnClubIndex().clubs) ---
+
+type RankingRow = Parameters<typeof buildSearchIndex>[0][number]
+
+function ranking(
+  districtId: string,
+  districtName: string,
+  region: string
+): RankingRow {
+  // Only the three fields the index reads matter; the rest are padding so the
+  // fixture matches the real CdnRankingsData['rankings'] row shape loosely.
+  return { districtId, districtName, region } as RankingRow
+}
+
+const RANKINGS: RankingRow[] = [
+  ranking('61', 'District 61', '07'),
+  ranking('6', 'District 6', '07'),
+  ranking('57', 'District 57 Carolinas', '08'),
+  ranking('F', 'District F', '01'),
+]
+
+const CLUBS: Record<string, { districtId: string; clubName: string }> = {
+  '00001234': { districtId: '61', clubName: 'Toast of the Town' },
+  '00005678': { districtId: '57', clubName: 'Club 61 Speakers' },
+  '00009999': { districtId: '6', clubName: 'Sunrise Communicators' },
+}
+
+// Flatten grouped results into a single ranked list, preserving group order,
+// so "above" assertions read naturally.
+function flatten(groups: SearchResultGroup[]) {
+  return groups.flatMap(g => g.entities)
+}
+
+describe('buildSearchIndex', () => {
+  let index: SearchIndex
+  beforeEach(() => {
+    index = buildSearchIndex(RANKINGS, CLUBS)
+  })
+
+  it('creates one district entity per ranking row with the canonical route', () => {
+    const d61 = index.entities.find(e => e.type === 'district' && e.id === '61')
+    expect(d61).toBeDefined()
+    expect(d61!.label).toBe('District 61')
+    expect(d61!.route).toBe('/district/61')
+  })
+
+  it('derives one region entity per distinct numeric region, deduped', () => {
+    const regions = index.entities.filter(e => e.type === 'region')
+    // 07 and 08 and 01 → three regions (07 appears twice in rankings)
+    expect(regions.map(r => r.id).sort()).toEqual(['01', '07', '08'])
+    const r07 = regions.find(r => r.id === '07')!
+    expect(r07.label).toBe('Region 7')
+    expect(r07.route).toBe('/region/07')
+  })
+
+  it('creates a club entity resolving to /district/{districtId}/club/{clubId} with district context', () => {
+    const club = index.entities.find(
+      e => e.type === 'club' && e.id === '00001234'
+    )
+    expect(club).toBeDefined()
+    expect(club!.label).toBe('Toast of the Town')
+    expect(club!.context).toBe('District 61')
+    expect(club!.route).toBe('/district/61/club/00001234')
+  })
+})
+
+describe('searchEntities', () => {
+  let index: SearchIndex
+  beforeEach(() => {
+    index = buildSearchIndex(RANKINGS, CLUBS)
+  })
+
+  it('returns no results for an empty or whitespace query', () => {
+    expect(searchEntities('', index)).toEqual([])
+    expect(searchEntities('   ', index)).toEqual([])
+  })
+
+  it('ranks an exact-id district above a club that merely contains the query', () => {
+    const flat = flatten(searchEntities('61', index))
+    const ids = flat.map(e => `${e.type}:${e.id}`)
+    expect(ids).toContain('district:61')
+    expect(ids).toContain('club:00005678') // "Club 61 Speakers"
+    expect(ids.indexOf('district:61')).toBeLessThan(
+      ids.indexOf('club:00005678')
+    )
+  })
+
+  it('matches a region by its number (padded or unpadded) and ranks it above clubs', () => {
+    const flat = flatten(searchEntities('7', index))
+    const ids = flat.map(e => `${e.type}:${e.id}`)
+    expect(ids).toContain('region:07')
+    // Region must outrank any club that only substring-matches "7".
+    const regionIdx = ids.indexOf('region:07')
+    const firstClubIdx = ids.findIndex(id => id.startsWith('club:'))
+    if (firstClubIdx !== -1) {
+      expect(regionIdx).toBeLessThan(firstClubIdx)
+    }
+    // Padded form also matches.
+    const paddedIds = flatten(searchEntities('07', index)).map(
+      e => `${e.type}:${e.id}`
+    )
+    expect(paddedIds).toContain('region:07')
+  })
+
+  it('is case-insensitive and matches club names by substring', () => {
+    const flat = flatten(searchEntities('toast', index))
+    expect(flat.some(e => e.id === '00001234')).toBe(true)
+    const upper = flatten(searchEntities('TOAST', index))
+    expect(upper.some(e => e.id === '00001234')).toBe(true)
+  })
+
+  it('ranks exact > prefix > substring at the same type weight', () => {
+    // Among clubs: "Club 61 Speakers" prefix-matches "club", exact none.
+    const flat = flatten(searchEntities('sun', index))
+    // "Sunrise Communicators" prefix-matches "sun".
+    expect(flat[0]?.id).toBe('00009999')
+  })
+
+  it('groups results by type in district → region → club order', () => {
+    const groups = searchEntities('6', index)
+    const types = groups.map(g => g.type)
+    // Every present group respects the canonical order.
+    const order = ['district', 'region', 'club']
+    const indices = types.map(t => order.indexOf(t))
+    expect(indices).toEqual([...indices].sort((a, b) => a - b))
+  })
+
+  it('caps the total number of results', () => {
+    const many: Record<string, { districtId: string; clubName: string }> = {}
+    for (let i = 0; i < 50; i++) {
+      many[`club${i}`] = { districtId: '61', clubName: `Sixty One Club ${i}` }
+    }
+    const bigIndex = buildSearchIndex(RANKINGS, many)
+    const total = flatten(searchEntities('six', bigIndex, { cap: 8 })).length
+    expect(total).toBeLessThanOrEqual(8)
+  })
+})

--- a/frontend/src/services/__tests__/searchIndex.test.ts
+++ b/frontend/src/services/__tests__/searchIndex.test.ts
@@ -100,9 +100,10 @@ describe('searchEntities', () => {
     // Region must outrank any club that only substring-matches "7".
     const regionIdx = ids.indexOf('region:07')
     const firstClubIdx = ids.findIndex(id => id.startsWith('club:'))
-    if (firstClubIdx !== -1) {
-      expect(regionIdx).toBeLessThan(firstClubIdx)
-    }
+    // clubId "00005678" substring-matches "7", so a club is present — the
+    // ordering assertion is not vacuous.
+    expect(firstClubIdx).not.toBe(-1)
+    expect(regionIdx).toBeLessThan(firstClubIdx)
     // Padded form also matches.
     const paddedIds = flatten(searchEntities('07', index)).map(
       e => `${e.type}:${e.id}`
@@ -133,7 +134,7 @@ describe('searchEntities', () => {
     expect(indices).toEqual([...indices].sort((a, b) => a - b))
   })
 
-  it('caps the total number of results', () => {
+  it('caps the total result count', () => {
     const many: Record<string, { districtId: string; clubName: string }> = {}
     for (let i = 0; i < 50; i++) {
       many[`club${i}`] = { districtId: '61', clubName: `Sixty One Club ${i}` }
@@ -141,5 +142,20 @@ describe('searchEntities', () => {
     const bigIndex = buildSearchIndex(RANKINGS, many)
     const total = flatten(searchEntities('six', bigIndex, { cap: 8 })).length
     expect(total).toBeLessThanOrEqual(8)
+  })
+
+  it('keeps a weighted district above the cap when a club flood would crowd it out', () => {
+    // 50 clubs all substring-matching "61" — without the type weighting,
+    // a global sort→cap could evict District 61 entirely.
+    const flood: Record<string, { districtId: string; clubName: string }> = {}
+    for (let i = 0; i < 50; i++) {
+      flood[`club${i}`] = { districtId: '61', clubName: `Club 61 #${i}` }
+    }
+    const bigIndex = buildSearchIndex(RANKINGS, flood)
+    const groups = searchEntities('61', bigIndex, { cap: 8 })
+    const flat = flatten(groups)
+    expect(flat.length).toBeLessThanOrEqual(8)
+    // The exact-id district must survive the cap and lead the results.
+    expect(flat[0]).toMatchObject({ type: 'district', id: '61' })
   })
 })

--- a/frontend/src/services/searchIndex.ts
+++ b/frontend/src/services/searchIndex.ts
@@ -1,0 +1,199 @@
+/* Unified omni-search data layer (epic #1055 Sprint 1, #1056).
+
+   A pure, React-free module: a typed in-memory index over the three
+   globally-indexable entity types (districts, regions, clubs) plus a ranked
+   substring/prefix matcher. The UI (header bar, modal palette) is built on top
+   of this in later sprints — keep this file presentation-free.
+
+   Laziness: the 1MB club index is only fetched when `loadSearchIndex()` is
+   invoked, never at import / app boot. `buildSearchIndex` is pure (data in,
+   index out) so it is trivially unit-testable without the network. */
+
+import { fetchCdnRankings, fetchCdnClubIndex } from './cdn'
+
+export type SearchEntityType = 'district' | 'region' | 'club'
+
+export interface SearchEntity {
+  type: SearchEntityType
+  /** Stable id: districtId | region string ("07") | clubId */
+  id: string
+  /** Primary display label, e.g. "District 61", "Region 7", "Toast of the Town" */
+  label: string
+  /** Disambiguation context shown beside the label, e.g. a club's "District 61" */
+  context?: string
+  /** Canonical route to navigate to */
+  route: string
+  /** Lowercased terms the query is matched against (id, name, aliases) */
+  terms: string[]
+}
+
+export interface SearchIndex {
+  entities: SearchEntity[]
+}
+
+export interface SearchResultGroup {
+  type: SearchEntityType
+  entities: SearchEntity[]
+}
+
+export interface SearchOptions {
+  /** Maximum total results across all groups. */
+  cap?: number
+}
+
+/** The three fields the index reads from a CDN rankings row. */
+type RankingRow = {
+  districtId: string
+  districtName: string
+  region: string
+}
+
+type ClubIndexEntry = { districtId: string; clubName: string }
+
+const DEFAULT_CAP = 8
+
+// Group display order: navigate-to-a-place entities (districts, regions) lead;
+// clubs follow. The matcher also weights types so this order survives the cap.
+const GROUP_ORDER: SearchEntityType[] = ['district', 'region', 'club']
+
+// Higher = ranked first among equal-strength matches, and weighted to survive
+// the result cap (so a club merely containing "61" can't bury District 61).
+const TYPE_RANK: Record<SearchEntityType, number> = {
+  district: 2,
+  region: 1,
+  club: 0,
+}
+
+/**
+ * Build the unified search index from already-loaded data. Pure — no network,
+ * no React. Districts + regions come from the rankings file; clubs from the
+ * global club index.
+ */
+export function buildSearchIndex(
+  rankings: ReadonlyArray<RankingRow>,
+  clubs: Readonly<Record<string, ClubIndexEntry>>
+): SearchIndex {
+  const entities: SearchEntity[] = []
+
+  // Districts — one per ranking row.
+  for (const r of rankings) {
+    entities.push({
+      type: 'district',
+      id: r.districtId,
+      label: r.districtName,
+      route: `/district/${r.districtId}`,
+      terms: dedupeTerms([r.districtId, r.districtName]),
+    })
+  }
+
+  // Regions — one per distinct numeric region (rankings repeat it per district).
+  const seenRegions = new Set<string>()
+  for (const r of rankings) {
+    if (!/^\d+$/.test(r.region) || seenRegions.has(r.region)) continue
+    seenRegions.add(r.region)
+    const n = Number(r.region)
+    entities.push({
+      type: 'region',
+      id: r.region,
+      label: `Region ${n}`,
+      route: `/region/${r.region}`,
+      // Match both padded ("07") and unpadded ("7") forms.
+      terms: dedupeTerms([r.region, String(n), `region ${n}`]),
+    })
+  }
+
+  // Clubs — resolve each to its district's club route.
+  for (const [clubId, club] of Object.entries(clubs)) {
+    entities.push({
+      type: 'club',
+      id: clubId,
+      label: club.clubName,
+      context: `District ${club.districtId}`,
+      route: `/district/${club.districtId}/club/${clubId}`,
+      terms: dedupeTerms([clubId, club.clubName]),
+    })
+  }
+
+  return { entities }
+}
+
+function dedupeTerms(raw: string[]): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const t of raw) {
+    const lower = t.toLowerCase()
+    if (!seen.has(lower)) {
+      seen.add(lower)
+      out.push(lower)
+    }
+  }
+  return out
+}
+
+// Match strength of a single entity against the query: 3 exact, 2 prefix,
+// 1 substring, 0 no match (best over all of the entity's terms).
+function matchLevel(terms: string[], q: string): number {
+  let best = 0
+  for (const term of terms) {
+    if (term === q) return 3
+    if (term.startsWith(q)) best = Math.max(best, 2)
+    else if (term.includes(q)) best = Math.max(best, 1)
+  }
+  return best
+}
+
+/**
+ * Rank entities matching `query`, grouped by type. Case-insensitive
+ * substring/prefix match; ranked exact > prefix > substring, with
+ * districts/regions weighted above clubs and shorter labels preferred. The
+ * total result count is capped (default 8) before grouping. An empty or
+ * whitespace-only query returns no results.
+ */
+export function searchEntities(
+  query: string,
+  index: SearchIndex,
+  options: SearchOptions = {}
+): SearchResultGroup[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return []
+
+  const cap = options.cap ?? DEFAULT_CAP
+
+  const scored = index.entities
+    .map(entity => ({ entity, level: matchLevel(entity.terms, q) }))
+    .filter(s => s.level > 0)
+    .sort((a, b) => {
+      // 1) stronger match first
+      if (a.level !== b.level) return b.level - a.level
+      // 2) districts/regions above clubs
+      const at = TYPE_RANK[a.entity.type]
+      const bt = TYPE_RANK[b.entity.type]
+      if (at !== bt) return bt - at
+      // 3) shorter label first
+      if (a.entity.label.length !== b.entity.label.length) {
+        return a.entity.label.length - b.entity.label.length
+      }
+      // 4) stable alphabetical
+      return a.entity.label.localeCompare(b.entity.label)
+    })
+    .slice(0, cap)
+    .map(s => s.entity)
+
+  // Group the survivors by type in canonical order; drop empty groups.
+  return GROUP_ORDER.map(type => ({
+    type,
+    entities: scored.filter(e => e.type === type),
+  })).filter(g => g.entities.length > 0)
+}
+
+/**
+ * Load and build the unified index from the CDN. The club index (~1MB) is only
+ * fetched here — never at import — so it does not regress cold app-load.
+ */
+export async function loadSearchIndex(): Promise<SearchIndex> {
+  const [rankings, clubIndex] = await Promise.all([
+    fetchCdnRankings(),
+    fetchCdnClubIndex(),
+  ])
+  return buildSearchIndex(rankings.rankings, clubIndex.clubs)
+}

--- a/frontend/src/services/searchIndex.ts
+++ b/frontend/src/services/searchIndex.ts
@@ -118,16 +118,7 @@ export function buildSearchIndex(
 }
 
 function dedupeTerms(raw: string[]): string[] {
-  const out: string[] = []
-  const seen = new Set<string>()
-  for (const t of raw) {
-    const lower = t.toLowerCase()
-    if (!seen.has(lower)) {
-      seen.add(lower)
-      out.push(lower)
-    }
-  }
-  return out
+  return Array.from(new Set(raw.map(t => t.toLowerCase())))
 }
 
 // Match strength of a single entity against the query: 3 exact, 2 prefix,

--- a/tasks/lessons/151-a-long-lived-worktree-has-stale-node-modules-after-a-new-workspace-package-merges.md
+++ b/tasks/lessons/151-a-long-lived-worktree-has-stale-node-modules-after-a-new-workspace-package-merges.md
@@ -1,0 +1,58 @@
+---
+id: '151'
+category: lesson
+tags: [monorepo, automation, sprint-runner, build, ci]
+auto_load: true
+date: 2026-06-01
+issues: [1056, 1055]
+---
+
+# Lesson 151 — A long-lived worktree has stale `node_modules` after a new workspace package merges; `npm install`, never `--no-verify`
+
+**Date:** 2026-06-01
+**Issue:** #1056 (epic #1055 Sprint 1 — unified search index + matcher)
+**PR:** (this sprint)
+
+## What happened
+
+The first commit of a frontend-only sprint failed the pre-commit hook with
+`Cannot find module '@modelcontextprotocol/sdk/...'` in `packages/mcp-server` —
+a package this sprint never touched. The hook runs `npm run typecheck
+--workspaces`, which typechecks **every** workspace, while the blocking CI
+`test`/typecheck job only runs `typecheck:frontend` (`.github/workflows/ci.yml`).
+
+Root cause: `mcp-server` (ADR-008) had merged to `origin/main` _after_ this
+long-lived sprint-runner worktree last ran `npm install`. Its declared dep
+`@modelcontextprotocol/sdk` was in `package-lock.json` but absent from
+`node_modules` — the worktree's install was stale, not the lockfile. `npm
+install` populated it (lockfile unchanged), the hook passed, baseline restored.
+
+## The transferable principle
+
+**A long-lived worktree's `node_modules` drifts from `package-lock.json` the
+moment a new workspace package merges to main. The local `--workspaces`
+pre-commit gate surfaces it; frontend-scoped CI does not — so it's invisible
+until you commit.** The signal is a typecheck/module-resolution failure in a
+package your diff never touched. The fix is `npm install` (restore the
+baseline), **never** `--no-verify` (R1) — bypassing only defers the failure and
+hides whether your own change is clean.
+
+## How to apply
+
+- Commit hook fails on a package outside your diff with "Cannot find module" /
+  missing types? Check `ls node_modules/<thatdep>` before suspecting your code.
+  Empty → run `npm install`, then retry the commit.
+- A worktree branched from a fresh `origin/main` (R19) carries main's
+  `package.json`/lockfile but **not** a fresh `node_modules` — branching is not
+  installing. Treat `npm install` as part of the baseline-establishment step
+  when the runner hands you a worktree.
+- If `npm install` changes `package-lock.json`, that's a real dependency drift —
+  surface it; if it doesn't, it was purely a stale local install.
+
+## Related
+
+- [[092-workspace-package-dist-is-gitignored-and-not-auto-rebuilt]] — sibling
+  trap: built `dist/` is stale even when `node_modules` is fresh (R16).
+- [[087-spawned-sessions-need-their-own-worktree-not-shared-checkout]] /
+  [[150-tdd-scaffolding-a-new-workspace-package-has-two-gate-traps]] — worktree
+  provisioning and the gate asymmetry between local hooks and CI.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -131,3 +131,4 @@
 - **150** [data-pipeline, analytics, verification, scope, mcp, process] — An ADR/spec claim that a derived field "lives in the snapshot" can be false; verify the live payload before building a tool that promises it (#1044, #1042)
 - **150** [mcp, verification, tdd, monorepo, ci, automation] — An installable stdio server needs an env-injectable base URL to be offline-smoke-tested via the real bin (#1045, #1042)
 - **150** [monorepo, tdd, build, ci, automation] — TDD-scaffolding a new workspace package has two silent gate traps: the typecheck "no inputs" abort and the explicitly-enumerated CI job (#1043, #1042)
+- **151** [monorepo, automation, sprint-runner, build, ci] — A long-lived worktree has stale `node_modules` after a new workspace package merges; `npm install`, never `--no-verify` (#1056, #1055)


### PR DESCRIPTION
## Sprint 1 of epic #1055 — unified omni-search **data layer** (TDD, no UI)

Closes #1056 once verified. Builds the pure, React-free foundation the omni-search bar sits on in later sprints. **No UI, no rendered surface** — types + index builder + ranked matcher only.

### What landed
- `frontend/src/services/searchIndex.ts`
  - `SearchEntity` union (`district | region | club`) — each carries `label`, optional disambiguation `context`, `type`, the canonical `route`, and lowercased match `terms`.
  - `buildSearchIndex(rankings, clubs)` — **pure**. Districts + regions from the rankings shape; regions deduped to distinct numeric values (`Region 7`, route `/region/07`); clubs resolve to `/district/{districtId}/club/{clubId}` with `District N` context.
  - `searchEntities(query, index, { cap })` — case-insensitive, ranked **exact > prefix > substring**, districts/regions type-weighted above clubs (so a club merely containing "61" can't bury District 61), capped (default 8) **before** grouping, grouped by type in `district → region → club` order. Empty/whitespace query → no results.
  - `loadSearchIndex()` — fetches rankings + club index **lazily** (only when invoked), so the ~1MB club index never loads at import / app boot.

### TDD
- **Red:** `searchIndex.test.ts` (13 cases) + `searchIndex.loader.test.ts` (lazy-fetch / no-import-time-fetch) committed failing first.
- **Green:** minimal pure implementation.
- **Refactor:** `/simplify` collapsed `dedupeTerms`; fresh-context `/review` hardened the cap-survival + region-ordering assertions (added the "weighted district survives a club flood" test).

### Verification (code-proof — no live surface)
This PR touches only `frontend/src/services/**` (+ a lesson). The module isn't imported by any rendered component yet, so there's nothing to drive on the PR preview — verification is the test suite:
- 13 dedicated unit tests pass (matching, ranking, routes, lazy fetch, cap survival).
- Full frontend suite green: **267 files / 3336 tests**; pre-push unit gate **193 files / 2624 tests** green.

### Notes
- Routes verified against `App.tsx`: `/district/:districtId`, `/region/:n` (raw region string), `/district/:districtId/club/:clubId`.
- Filters are untouched — `DistrictsPage ?q=` and `FiltersPanel` are out of scope (epic).
- Product-spec deferred to the UI sprint (no user-facing feature ships here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
