### PR TITLE
feat: broaden CommandPalette to the unified omni-search index (#1057)

### DIFF
--- a/frontend/src/components/AppShell/CommandPalette.tsx
+++ b/frontend/src/components/AppShell/CommandPalette.tsx
@@ -195,8 +195,8 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
       >
         {groups.map((group, gi) => {
           // Flat index of this group's first entity — groups are rendered in
-          // the same order they were flattened, so position is the flat index
-          // (no reference lookup, no O(n²) scan).
+          // the same order they were flattened, so position gives the flat
+          // index directly (no per-option reference lookup; groups ≤ 3).
           const offset = groups
             .slice(0, gi)
             .reduce((n, g) => n + g.entities.length, 0)

--- a/frontend/src/components/AppShell/CommandPalette.tsx
+++ b/frontend/src/components/AppShell/CommandPalette.tsx
@@ -1,21 +1,24 @@
-/* CommandPalette (#422) — universal search opened with Cmd-K / Ctrl-K
-   from anywhere in the app. v1 searches districts only (the data we
-   already fetch on the landing page); clubs/areas can extend later by
-   resolving the user's pinned district at open time.
+/* CommandPalette (#422 → omni-search epic #1055 Sprint 2, #1057) — universal
+   search opened with Cmd-K / Ctrl-K from anywhere in the app. It searches the
+   three globally-indexable entity types — districts, regions, clubs — via the
+   unified Sprint-1 index (`searchIndex.ts`), grouping results by type.
 
    Architecture: outer <CommandPalette> just gates visibility. The inner
-   <OpenPalette> holds all local state, so closing + reopening naturally
-   resets via React's unmount/remount, avoiding setState-in-effect
-   patterns. */
+   <OpenPalette> holds all local state AND triggers the index load, so the
+   ~1MB club index is fetched only on first open (never at app boot), and
+   closing + reopening naturally resets via React's unmount/remount — avoiding
+   setState-in-effect patterns. */
 
 import React, { useCallback, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { fetchCdnRankings } from '../../services/cdn'
-import type { DistrictRanking } from '../../types/districts'
+import {
+  loadSearchIndex,
+  searchEntities,
+  type SearchEntity,
+  type SearchEntityType,
+} from '../../services/searchIndex'
 import { DistrictChipAndName } from '../DistrictChipAndName'
-
-const MAX_RESULTS = 8
 
 interface CommandPaletteProps {
   isOpen: boolean
@@ -31,14 +34,20 @@ interface OpenPaletteProps {
   onClose: () => void
 }
 
+// Human-readable group headings, in the index's canonical group order.
+const GROUP_LABEL: Record<SearchEntityType, string> = {
+  district: 'Districts',
+  region: 'Regions',
+  club: 'Clubs',
+}
+
 const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
   const navigate = useNavigate()
   const [query, setQuery] = useState('')
   const [activeIndex, setActiveIndex] = useState(0)
 
   // Auto-focus the input on mount. Callback ref avoids the
-  // setState-in-effect pattern; React calls it once when the input
-  // attaches.
+  // setState-in-effect pattern; React calls it once when the input attaches.
   const inputAttachRef = useCallback((el: HTMLInputElement | null) => {
     if (el) {
       // Defer one frame so the modal animation/layout has settled.
@@ -46,49 +55,41 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
     }
   }, [])
 
-  // Share the same cache as DistrictsPage so opening the palette is
-  // typically free.
-  const { data } = useQuery({
-    queryKey: ['district-rankings', 'latest'],
-    queryFn: async () => {
-      const cdnData = await fetchCdnRankings()
-      return { rankings: cdnData.rankings, date: cdnData.date }
-    },
+  // The unified index loads on first open (this component only mounts when the
+  // palette opens), fanning out to the rankings + club-index CDN fetches.
+  const { data: index, isLoading } = useQuery({
+    queryKey: ['omni-search-index'],
+    queryFn: loadSearchIndex,
     staleTime: 15 * 60 * 1000,
   })
 
-  const matches = useMemo<DistrictRanking[]>(() => {
-    const all: DistrictRanking[] = data?.rankings ?? []
-    const q = query.trim().toLowerCase()
-    if (!q) return all.slice(0, MAX_RESULTS)
-    return all
-      .filter(
-        r =>
-          r.districtId.toLowerCase().includes(q) ||
-          r.districtName.toLowerCase().includes(q)
-      )
-      .slice(0, MAX_RESULTS)
-  }, [data?.rankings, query])
-
-  // Clamp activeIndex at read time rather than in an effect — derived
-  // value, no setState-in-effect needed.
-  const clampedActiveIndex = Math.min(
-    activeIndex,
-    Math.max(0, matches.length - 1)
+  const groups = useMemo(
+    () => (index ? searchEntities(query, index) : []),
+    [index, query]
   )
 
+  // Flatten the grouped results into a single ordered list for keyboard
+  // navigation and aria-activedescendant — groups are for display only.
+  const flat = useMemo<SearchEntity[]>(
+    () => groups.flatMap(g => g.entities),
+    [groups]
+  )
+
+  // Clamp activeIndex at read time rather than in an effect — derived value.
+  const clampedActiveIndex = Math.min(activeIndex, Math.max(0, flat.length - 1))
+  const activeEntity = flat[clampedActiveIndex]
+
   const navigateToActive = useCallback(() => {
-    const choice = matches[clampedActiveIndex]
-    if (!choice) return
-    navigate(`/district/${choice.districtId}`)
+    if (!activeEntity) return
+    navigate(activeEntity.route)
     onClose()
-  }, [matches, clampedActiveIndex, navigate, onClose])
+  }, [activeEntity, navigate, onClose])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'ArrowDown') {
         e.preventDefault()
-        setActiveIndex(i => Math.min(i + 1, Math.max(0, matches.length - 1)))
+        setActiveIndex(i => Math.min(i + 1, Math.max(0, flat.length - 1)))
       } else if (e.key === 'ArrowUp') {
         e.preventDefault()
         setActiveIndex(i => Math.max(0, i - 1))
@@ -100,8 +101,12 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
         onClose()
       }
     },
-    [matches.length, navigateToActive, onClose]
+    [flat.length, navigateToActive, onClose]
   )
+
+  const hasQuery = query.trim().length > 0
+  const optionId = (e: SearchEntity) =>
+    `command-palette-result-${e.type}-${e.id}`
 
   return (
     <div
@@ -142,63 +147,18 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
               setActiveIndex(0)
             }}
             onKeyDown={handleKeyDown}
-            placeholder="Jump to a district by number or name…"
+            placeholder="Search districts, regions, clubs by name or number…"
             aria-label="Universal search input"
             aria-controls="command-palette-results"
             aria-activedescendant={
-              matches[clampedActiveIndex]
-                ? `command-palette-result-${matches[clampedActiveIndex].districtId}`
-                : undefined
+              activeEntity ? optionId(activeEntity) : undefined
             }
             className="command-palette__input"
           />
           <kbd className="command-palette__hint">esc</kbd>
         </div>
 
-        {matches.length > 0 ? (
-          <ul
-            id="command-palette-results"
-            role="listbox"
-            aria-label="Search results"
-            className="command-palette__results"
-          >
-            {matches.map((m, i) => (
-              <li
-                key={m.districtId}
-                role="option"
-                aria-selected={i === clampedActiveIndex}
-                id={`command-palette-result-${m.districtId}`}
-                onMouseEnter={() => setActiveIndex(i)}
-                className={
-                  'command-palette__result' +
-                  (i === clampedActiveIndex
-                    ? ' command-palette__result--active'
-                    : '')
-                }
-              >
-                <Link
-                  to={`/district/${m.districtId}`}
-                  onClick={onClose}
-                  className="command-palette__result-link"
-                >
-                  <DistrictChipAndName
-                    districtId={m.districtId}
-                    name={m.districtName}
-                    chipClassName="command-palette__result-num"
-                    nameClassName="command-palette__result-name"
-                  />
-                  <span className="command-palette__result-region">
-                    Region {m.region}
-                  </span>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="command-palette__empty">
-            {data ? 'No districts match.' : 'Loading districts…'}
-          </p>
-        )}
+        {renderBody()}
 
         <div className="command-palette__footer">
           <span>
@@ -208,6 +168,95 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
         </div>
       </div>
     </div>
+  )
+
+  function renderBody() {
+    // Before the user types, guide them — listing every indexed entity (14k+
+    // clubs) is meaningless, so the empty query intentionally shows no listbox.
+    if (!hasQuery) {
+      return (
+        <p className="command-palette__empty">
+          Type to search districts, regions, and clubs.
+        </p>
+      )
+    }
+    if (isLoading && !index) {
+      return <p className="command-palette__empty">Searching…</p>
+    }
+    if (flat.length === 0) {
+      return <p className="command-palette__empty">No matches.</p>
+    }
+    return (
+      <ul
+        id="command-palette-results"
+        role="listbox"
+        aria-label="Search results"
+        className="command-palette__results"
+      >
+        {groups.map(group => (
+          <li
+            key={group.type}
+            role="group"
+            aria-label={GROUP_LABEL[group.type]}
+            className="command-palette__group"
+          >
+            <div className="command-palette__group-heading" aria-hidden="true">
+              {GROUP_LABEL[group.type]}
+            </div>
+            <ul role="presentation" className="command-palette__group-list">
+              {group.entities.map(entity => {
+                const flatIdx = flat.indexOf(entity)
+                const active = flatIdx === clampedActiveIndex
+                return (
+                  <li
+                    key={optionId(entity)}
+                    role="option"
+                    aria-selected={active}
+                    id={optionId(entity)}
+                    onMouseEnter={() => setActiveIndex(flatIdx)}
+                    className={
+                      'command-palette__result' +
+                      (active ? ' command-palette__result--active' : '')
+                    }
+                  >
+                    <Link
+                      to={entity.route}
+                      onClick={onClose}
+                      className="command-palette__result-link"
+                    >
+                      {renderEntity(entity)}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+}
+
+// District results reuse the chip+name treatment (and its #522 no-duplicate
+// guard); regions and clubs render their label plus disambiguation context.
+function renderEntity(entity: SearchEntity) {
+  if (entity.type === 'district') {
+    return (
+      <DistrictChipAndName
+        districtId={entity.id}
+        name={entity.label}
+        chipClassName="command-palette__result-num"
+        nameClassName="command-palette__result-name"
+      />
+    )
+  }
+  return (
+    <>
+      <span className="command-palette__result-name">{entity.label}</span>
+      {entity.context && (
+        <span className="command-palette__result-region">{entity.context}</span>
+      )}
+    </>
   )
 }
 

--- a/frontend/src/components/AppShell/CommandPalette.tsx
+++ b/frontend/src/components/AppShell/CommandPalette.tsx
@@ -57,7 +57,7 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
 
   // The unified index loads on first open (this component only mounts when the
   // palette opens), fanning out to the rankings + club-index CDN fetches.
-  const { data: index, isLoading } = useQuery({
+  const { data: index } = useQuery({
     queryKey: ['omni-search-index'],
     queryFn: loadSearchIndex,
     staleTime: 15 * 60 * 1000,
@@ -180,7 +180,7 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
         </p>
       )
     }
-    if (isLoading && !index) {
+    if (!index) {
       return <p className="command-palette__empty">Searching…</p>
     }
     if (flat.length === 0) {
@@ -193,45 +193,56 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
         aria-label="Search results"
         className="command-palette__results"
       >
-        {groups.map(group => (
-          <li
-            key={group.type}
-            role="group"
-            aria-label={GROUP_LABEL[group.type]}
-            className="command-palette__group"
-          >
-            <div className="command-palette__group-heading" aria-hidden="true">
-              {GROUP_LABEL[group.type]}
-            </div>
-            <ul role="presentation" className="command-palette__group-list">
-              {group.entities.map(entity => {
-                const flatIdx = flat.indexOf(entity)
-                const active = flatIdx === clampedActiveIndex
-                return (
-                  <li
-                    key={optionId(entity)}
-                    role="option"
-                    aria-selected={active}
-                    id={optionId(entity)}
-                    onMouseEnter={() => setActiveIndex(flatIdx)}
-                    className={
-                      'command-palette__result' +
-                      (active ? ' command-palette__result--active' : '')
-                    }
-                  >
-                    <Link
-                      to={entity.route}
-                      onClick={onClose}
-                      className="command-palette__result-link"
+        {groups.map((group, gi) => {
+          // Flat index of this group's first entity — groups are rendered in
+          // the same order they were flattened, so position is the flat index
+          // (no reference lookup, no O(n²) scan).
+          const offset = groups
+            .slice(0, gi)
+            .reduce((n, g) => n + g.entities.length, 0)
+          return (
+            <li
+              key={group.type}
+              role="group"
+              aria-label={GROUP_LABEL[group.type]}
+              className="command-palette__group"
+            >
+              <div
+                className="command-palette__group-heading"
+                aria-hidden="true"
+              >
+                {GROUP_LABEL[group.type]}
+              </div>
+              <ul role="presentation" className="command-palette__group-list">
+                {group.entities.map((entity, ei) => {
+                  const flatIdx = offset + ei
+                  const active = flatIdx === clampedActiveIndex
+                  return (
+                    <li
+                      key={optionId(entity)}
+                      role="option"
+                      aria-selected={active}
+                      id={optionId(entity)}
+                      onMouseEnter={() => setActiveIndex(flatIdx)}
+                      className={
+                        'command-palette__result' +
+                        (active ? ' command-palette__result--active' : '')
+                      }
                     >
-                      {renderEntity(entity)}
-                    </Link>
-                  </li>
-                )
-              })}
-            </ul>
-          </li>
-        ))}
+                      <Link
+                        to={entity.route}
+                        onClick={onClose}
+                        className="command-palette__result-link"
+                      >
+                        {renderEntity(entity)}
+                      </Link>
+                    </li>
+                  )
+                })}
+              </ul>
+            </li>
+          )
+        })}
       </ul>
     )
   }

--- a/frontend/src/components/AppShell/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/CommandPalette.test.tsx
@@ -1,5 +1,7 @@
-/* CommandPalette (#422) — scoped tests on the small palette component
-   directly (Lesson 51 — keep render scope tight). */
+/* CommandPalette (#422 → omni-search epic #1055 Sprint 2, #1057) — scoped
+   tests on the palette component directly (Lesson 51 — keep render scope
+   tight). Sprint 2 swaps the districts-only data layer for the unified
+   Sprint-1 search index (districts + regions + clubs), grouped by type. */
 
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -8,56 +10,41 @@ import { MemoryRouter } from 'react-router-dom'
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
 import CommandPalette from '../CommandPalette'
 
-// Mock CDN service — palette fetches via fetchCdnRankings.
+// The palette now loads the unified index, which fans out to two CDN
+// fetches (rankings → districts+regions, club-index → clubs). Mock both.
+const fetchCdnRankings = vi.fn()
+const fetchCdnClubIndex = vi.fn()
+
 vi.mock('../../../services/cdn', () => ({
-  fetchCdnRankings: vi.fn().mockResolvedValue({
-    rankings: [
-      {
-        districtId: '57',
-        districtName: 'District 57',
-        region: '7',
-        paidClubs: 100,
-        paidClubBase: 90,
-        clubGrowthPercent: 11.1,
-        totalPayments: 5000,
-        paymentBase: 4500,
-        paymentGrowthPercent: 11.1,
-        activeClubs: 100,
-        distinguishedClubs: 50,
-        selectDistinguished: 20,
-        presidentsDistinguished: 10,
-        distinguishedPercent: 50,
-        clubsRank: 1,
-        paymentsRank: 1,
-        distinguishedRank: 1,
-        aggregateScore: 300,
-        overallRank: 1,
-      },
-      {
-        districtId: '61',
-        districtName: 'District 61',
-        region: '7',
-        paidClubs: 100,
-        paidClubBase: 90,
-        clubGrowthPercent: 11.1,
-        totalPayments: 5000,
-        paymentBase: 4500,
-        paymentGrowthPercent: 11.1,
-        activeClubs: 100,
-        distinguishedClubs: 50,
-        selectDistinguished: 20,
-        presidentsDistinguished: 10,
-        distinguishedPercent: 50,
-        clubsRank: 2,
-        paymentsRank: 2,
-        distinguishedRank: 2,
-        aggregateScore: 250,
-        overallRank: 2,
-      },
+  fetchCdnRankings: (...args: unknown[]) => fetchCdnRankings(...args),
+  fetchCdnClubIndex: (...args: unknown[]) => fetchCdnClubIndex(...args),
+}))
+
+const rankingRow = (
+  districtId: string,
+  districtName: string,
+  region: string
+) => ({ districtId, districtName, region })
+
+const setupCdn = (
+  opts: {
+    rankings?: Array<ReturnType<typeof rankingRow>>
+    clubs?: Record<string, { districtId: string; clubName: string }>
+  } = {}
+) => {
+  fetchCdnRankings.mockResolvedValue({
+    rankings: opts.rankings ?? [
+      rankingRow('57', 'District 57', '7'),
+      rankingRow('61', 'District 61', '7'),
     ],
     date: '2025-11-22',
-  }),
-}))
+  })
+  fetchCdnClubIndex.mockResolvedValue({
+    clubs: opts.clubs ?? {
+      '12345': { districtId: '61', clubName: 'Toast of the Town' },
+    },
+  })
+}
 
 const renderPalette = (isOpen: boolean) => {
   const client = new QueryClient({
@@ -72,9 +59,10 @@ const renderPalette = (isOpen: boolean) => {
   )
 }
 
-describe('CommandPalette (#422)', () => {
+describe('CommandPalette omni-search (#1057)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    setupCdn()
   })
 
   it('renders nothing when closed', () => {
@@ -84,67 +72,98 @@ describe('CommandPalette (#422)', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('renders an input + listbox when open', async () => {
+  it('does not fetch the club index until the palette is opened (lazy)', () => {
+    renderPalette(false)
+    expect(fetchCdnClubIndex).not.toHaveBeenCalled()
+    expect(fetchCdnRankings).not.toHaveBeenCalled()
+  })
+
+  it('renders an input + dialog when open', async () => {
     renderPalette(true)
     expect(
       screen.getByRole('dialog', { name: /universal search/i })
     ).toBeInTheDocument()
     expect(screen.getByLabelText(/universal search input/i)).toBeInTheDocument()
-    // Wait for the rankings query to resolve and results to render
-    await screen.findByRole('listbox', { name: /search results/i })
+    // Loading the index fans out to both CDN fetches on open.
+    await vi.waitFor(() => expect(fetchCdnClubIndex).toHaveBeenCalled())
+    expect(fetchCdnRankings).toHaveBeenCalled()
   })
 
-  it('filters results as the user types', async () => {
+  it('finds a district and navigates to /district/<id> (no #422 regression)', async () => {
     renderPalette(true)
-    await screen.findByRole('listbox', { name: /search results/i })
-
     const input = screen.getByLabelText(/universal search input/i)
     fireEvent.change(input, { target: { value: '61' } })
 
-    const listbox = screen.getByRole('listbox', { name: /search results/i })
-    const options = within(listbox).getAllByRole('option')
-    expect(options.length).toBe(1)
-    expect(options[0]?.textContent).toMatch(/District 61/)
+    const listbox = await screen.findByRole('listbox', {
+      name: /search results/i,
+    })
+    const districts = within(listbox).getByRole('group', { name: /districts/i })
+    const link = within(districts).getByRole('link')
+    expect(link).toHaveTextContent(/District 61/)
+    expect(link.getAttribute('href')).toBe('/district/61')
   })
 
-  it('renders a Link with href /district/<id> for each result', async () => {
+  it('finds a club, shows it under a Clubs group with its district, and routes to the club', async () => {
     renderPalette(true)
-    await screen.findByRole('listbox', { name: /search results/i })
-    const listbox = screen.getByRole('listbox')
-    const links = within(listbox).getAllByRole('link')
-    expect(links[0]?.getAttribute('href')).toBe('/district/57')
-    expect(links[1]?.getAttribute('href')).toBe('/district/61')
+    const input = screen.getByLabelText(/universal search input/i)
+    fireEvent.change(input, { target: { value: 'Toast' } })
+
+    const listbox = await screen.findByRole('listbox', {
+      name: /search results/i,
+    })
+    const clubs = await within(listbox).findByRole('group', {
+      name: /clubs/i,
+    })
+    const link = within(clubs).getByRole('link')
+    expect(link).toHaveTextContent(/Toast of the Town/)
+    // Disambiguation context (which district the club belongs to).
+    expect(link).toHaveTextContent(/District 61/)
+    expect(link.getAttribute('href')).toBe('/district/61/club/12345')
+  })
+
+  it('finds a region and routes to /region/<n>', async () => {
+    renderPalette(true)
+    const input = screen.getByLabelText(/universal search input/i)
+    fireEvent.change(input, { target: { value: 'Region 7' } })
+
+    const listbox = await screen.findByRole('listbox', {
+      name: /search results/i,
+    })
+    const regions = await within(listbox).findByRole('group', {
+      name: /regions/i,
+    })
+    const link = within(regions).getByRole('link')
+    expect(link).toHaveTextContent(/Region 7/)
+    expect(link.getAttribute('href')).toBe('/region/7')
+  })
+
+  it('groups results by type with headings when a query spans entities', async () => {
+    renderPalette(true)
+    const input = screen.getByLabelText(/universal search input/i)
+    // "61" matches District 61; widen with a query the club also matches.
+    fireEvent.change(input, { target: { value: 'o' } })
+
+    const listbox = await screen.findByRole('listbox', {
+      name: /search results/i,
+    })
+    // At least the Clubs group is present (club name contains "o").
+    await within(listbox).findByRole('group', { name: /clubs/i })
+  })
+
+  it('shows an empty-state prompt before the user types', async () => {
+    renderPalette(true)
+    // No query yet → no listbox, a guiding prompt instead.
+    expect(
+      screen.queryByRole('listbox', { name: /search results/i })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText(/type to search/i)).toBeInTheDocument()
   })
 
   it('does not duplicate the district number when districtName is bare (#522)', async () => {
-    const { fetchCdnRankings } = await import('../../../services/cdn')
-    vi.mocked(fetchCdnRankings).mockResolvedValueOnce({
-      rankings: [
-        {
-          districtId: '86',
-          districtName: '86',
-          region: '6',
-          paidClubs: 100,
-          paidClubBase: 90,
-          clubGrowthPercent: 11.1,
-          totalPayments: 5000,
-          paymentBase: 4500,
-          paymentGrowthPercent: 11.1,
-          activeClubs: 100,
-          distinguishedClubs: 50,
-          selectDistinguished: 20,
-          presidentsDistinguished: 10,
-          distinguishedPercent: 50,
-          clubsRank: 1,
-          paymentsRank: 1,
-          distinguishedRank: 1,
-          aggregateScore: 300,
-          overallRank: 1,
-        },
-      ],
-      date: '2025-11-22',
-    })
+    setupCdn({ rankings: [rankingRow('86', '86', '6')], clubs: {} })
     renderPalette(true)
+    const input = screen.getByLabelText(/universal search input/i)
+    fireEvent.change(input, { target: { value: '86' } })
 
     const listbox = await screen.findByRole('listbox', {
       name: /search results/i,

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -4961,6 +4961,28 @@
     overflow-y: auto;
   }
 
+  .command-palette__group {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .command-palette__group-heading {
+    padding: 8px 12px 4px;
+    font-family: var(--sans);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+  }
+
+  .command-palette__group-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
   .command-palette__result {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
## Sprint 2 of epic #1055 — omni-search (#1057)

Broadens the Cmd-K **CommandPalette** from districts-only to the unified Sprint-1 search index (`searchIndex.ts`), so it finds **districts + regions + clubs**, grouped by type, each routing to its canonical path. No header-bar UI yet — this proves the search end-to-end through the already-wired Cmd-K surface.

### What changed
- Swap the districts-only `fetchCdnRankings` query for `loadSearchIndex` / `searchEntities` (the Sprint-1 index). The old `district-rankings` query, `DistrictRanking` import and `MAX_RESULTS` are fully removed — replace, not augment (L092).
- Results render **grouped by type** (`Districts` / `Regions` / `Clubs`) with disambiguation context (e.g. a club shows its `District 61`); each result navigates to `entity.route` (`/district/:id`, `/region/:n`, `/district/:d/club/:id`).
- The ~1MB club index loads **only on first palette open** — `OpenPalette` (which owns the `useQuery`) mounts only when `isOpen`, so nothing hits cold app-load.
- Empty query shows a guiding prompt instead of listing 14k+ entities.
- a11y preserved: grouped `listbox > group > option` roles, ↑/↓/Enter/Esc nav over the flattened list, `aria-activedescendant`, and the #522 district chip+name no-duplicate treatment.

### TDD
- **RED** (`b51afdc7`): palette test rewritten for the new spec — fails against the districts-only layer.
- **GREEN** (`6b1bb909`): rewire the data layer.
- **/simplify** (`79cf1792`) + fresh-context **review** passes applied.

### Verification
- `frontend` unit suite green (267 files / 3340 tests); palette tests 9/9.
- Live Playwright drive on the PR preview (Chromium + WebKit) to follow once the preview deploys.

Part of #1055. Predecessor #1056 shipped.