### PR TITLE
feat(search): header omni-search bar — desktop combobox + mobile icon→modal (#1058)

### DIFF
--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -2,17 +2,19 @@
 
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AppShell from '../../components/AppShell/AppShell'
 import { DarkModeProvider } from '../../contexts/DarkModeContext'
 import { useIsMobile } from '../../hooks/useIsMobile'
 
-// Mock the CDN service the CommandPalette (#422) lazy-fetches when the
-// shell mounts — keeps these tests isolated from the network layer.
+// Mock the CDN service the omni-search (#422 → #1058) lazy-fetches when the
+// palette opens — keeps these tests isolated from the network layer. Both
+// fetches are stubbed so opening the modal doesn't hit the network.
 vi.mock('../../services/cdn', () => ({
   fetchCdnRankings: vi.fn().mockResolvedValue({ rankings: [], date: '' }),
+  fetchCdnClubIndex: vi.fn().mockResolvedValue({ clubs: {} }),
 }))
 
 // #889: the footer is dropped at <768px (its meta moves to the nav "About"
@@ -146,6 +148,35 @@ describe('AppShell (#354)', () => {
       const nav = screen.getByRole('navigation', { name: /primary/i })
       const historyLink = within(nav).getByRole('link', { name: 'History' })
       expect(historyLink).toHaveAttribute('aria-current', 'page')
+    })
+  })
+
+  describe('header search (#1058)', () => {
+    it('opens the modal palette when the mobile search icon is tapped', () => {
+      vi.mocked(useIsMobile).mockReturnValue(true)
+      renderShell()
+      // No palette before interaction.
+      expect(
+        screen.queryByRole('dialog', { name: /universal search/i })
+      ).not.toBeInTheDocument()
+      fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+      expect(
+        screen.getByRole('dialog', { name: /universal search/i })
+      ).toBeInTheDocument()
+    })
+
+    it('renders the desktop inline combobox (no modal-opening icon)', () => {
+      vi.mocked(useIsMobile).mockReturnValue(false)
+      renderShell()
+      const header = screen.getByRole('banner')
+      expect(
+        within(header).getByRole('combobox', {
+          name: /search districts, regions/i,
+        })
+      ).toBeInTheDocument()
+      expect(
+        within(header).queryByRole('button', { name: /^search$/i })
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/AppShell/AppShell.tsx
+++ b/frontend/src/components/AppShell/AppShell.tsx
@@ -24,6 +24,7 @@ const AppShell: React.FC = () => {
 
   const [paletteOpen, setPaletteOpen] = useState(false)
   const closePalette = useCallback(() => setPaletteOpen(false), [])
+  const openPalette = useCallback(() => setPaletteOpen(true), [])
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -41,7 +42,7 @@ const AppShell: React.FC = () => {
       <a href="#main-content" className="tm-skip-link">
         Skip to main content
       </a>
-      <AppShellTopBar />
+      <AppShellTopBar onOpenSearch={openPalette} />
       <main id="main-content" className="app-shell__main">
         <Outlet />
       </main>

--- a/frontend/src/components/AppShell/AppShellTopBar.tsx
+++ b/frontend/src/components/AppShell/AppShellTopBar.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { NavLink, Link, useLocation } from 'react-router-dom'
 import ThemeToggle from '../ThemeToggle'
 import AppMeta from './AppMeta'
+import HeaderSearch from './HeaderSearch'
 import { useIsMobile } from '../../hooks/useIsMobile'
 
 const NAV_ITEMS = [
@@ -13,7 +14,12 @@ const NAV_ITEMS = [
 
 const PRIMARY_NAV_ID = 'app-shell-primary-nav'
 
-const AppShellTopBar: React.FC = () => {
+interface AppShellTopBarProps {
+  /** Open the modal palette — the mobile search icon's target, shared with Cmd-K. */
+  onOpenSearch: () => void
+}
+
+const AppShellTopBar: React.FC<AppShellTopBarProps> = ({ onOpenSearch }) => {
   // Mobile (<768px) disclosure: the primary nav collapses behind a
   // hamburger toggle so the 56px bar stops overflowing the viewport at
   // 375px (#735). On desktop the nav is always inline and `navOpen` is
@@ -138,6 +144,9 @@ const AppShellTopBar: React.FC = () => {
       </nav>
 
       <div className="app-shell-tools">
+        {/* Omni-search (#1058): inline combobox on desktop, icon→modal on
+            mobile. Cmd-K opens the same modal everywhere (AppShell). */}
+        <HeaderSearch onOpenSearch={onOpenSearch} />
         {/* Bell stub removed per #411 — a non-functional icon erodes
             trust. Re-add when there's real notification content. */}
         <Link

--- a/frontend/src/components/AppShell/CommandPalette.tsx
+++ b/frontend/src/components/AppShell/CommandPalette.tsx
@@ -68,6 +68,9 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
     }
   }, [])
 
+  // The listbox only mounts once a query yields results; gate the ARIA refs
+  // on that so they never point at an absent id while loading/empty.
+  const listboxOpen = hasQuery && !!index && flat.length > 0
   const optionId = (e: SearchEntity) => `${OPTION_PREFIX}-${e.type}-${e.id}`
 
   return (
@@ -108,9 +111,9 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
             onKeyDown={handleKeyDown}
             placeholder="Search districts, regions, clubs by name or number…"
             aria-label="Universal search input"
-            aria-controls={LISTBOX_ID}
+            aria-controls={listboxOpen ? LISTBOX_ID : undefined}
             aria-activedescendant={
-              activeEntity ? optionId(activeEntity) : undefined
+              listboxOpen && activeEntity ? optionId(activeEntity) : undefined
             }
             className="command-palette__input"
           />

--- a/frontend/src/components/AppShell/CommandPalette.tsx
+++ b/frontend/src/components/AppShell/CommandPalette.tsx
@@ -1,29 +1,30 @@
-/* CommandPalette (#422 → omni-search epic #1055 Sprint 2, #1057) — universal
-   search opened with Cmd-K / Ctrl-K from anywhere in the app. It searches the
-   three globally-indexable entity types — districts, regions, clubs — via the
-   unified Sprint-1 index (`searchIndex.ts`), grouping results by type.
+/* CommandPalette (#422 → omni-search epic #1055 Sprint 2 #1057, Sprint 3 #1058)
+   — the universal-search MODAL, opened with Cmd-K / Ctrl-K from anywhere and by
+   the mobile header search icon. It searches the three globally-indexable entity
+   types — districts, regions, clubs — via the unified index (`searchIndex.ts`),
+   grouping results by type.
 
-   Architecture: outer <CommandPalette> just gates visibility. The inner
-   <OpenPalette> holds all local state AND triggers the index load, so the
-   ~1MB club index is fetched only on first open (never at app boot), and
-   closing + reopening naturally resets via React's unmount/remount — avoiding
-   setState-in-effect patterns. */
+   Sprint 3: the search behavior (lazy index load, keyboard nav, ARIA, result
+   rendering) is shared with the desktop header combobox via `useOmniSearch` +
+   `OmniSearchResults`. This component is now just the modal shell around them.
 
-import React, { useCallback, useMemo, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
-import {
-  loadSearchIndex,
-  searchEntities,
-  type SearchEntity,
-  type SearchEntityType,
-} from '../../services/searchIndex'
-import { DistrictChipAndName } from '../DistrictChipAndName'
+   Architecture: outer <CommandPalette> gates visibility; the inner <OpenPalette>
+   only mounts when open, so the ~1MB club index is fetched on first open (never
+   at app boot) and closing + reopening resets state via unmount/remount. */
+
+import React, { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useOmniSearch } from '../../hooks/useOmniSearch'
+import OmniSearchResults from './OmniSearchResults'
+import { type SearchEntity } from '../../services/searchIndex'
 
 interface CommandPaletteProps {
   isOpen: boolean
   onClose: () => void
 }
+
+const LISTBOX_ID = 'command-palette-results'
+const OPTION_PREFIX = 'command-palette-result'
 
 const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose }) => {
   if (!isOpen) return null
@@ -34,17 +35,29 @@ interface OpenPaletteProps {
   onClose: () => void
 }
 
-// Human-readable group headings, in the index's canonical group order.
-const GROUP_LABEL: Record<SearchEntityType, string> = {
-  district: 'Districts',
-  region: 'Regions',
-  club: 'Clubs',
-}
-
 const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
   const navigate = useNavigate()
-  const [query, setQuery] = useState('')
-  const [activeIndex, setActiveIndex] = useState(0)
+
+  const selectEntity = useCallback(
+    (entity: SearchEntity) => {
+      navigate(entity.route)
+      onClose()
+    },
+    [navigate, onClose]
+  )
+
+  const {
+    query,
+    setQuery,
+    index,
+    groups,
+    flat,
+    activeIndex,
+    setActiveIndex,
+    activeEntity,
+    hasQuery,
+    handleKeyDown,
+  } = useOmniSearch({ onSelect: selectEntity, onDismiss: onClose })
 
   // Auto-focus the input on mount. Callback ref avoids the
   // setState-in-effect pattern; React calls it once when the input attaches.
@@ -55,58 +68,7 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
     }
   }, [])
 
-  // The unified index loads on first open (this component only mounts when the
-  // palette opens), fanning out to the rankings + club-index CDN fetches.
-  const { data: index } = useQuery({
-    queryKey: ['omni-search-index'],
-    queryFn: loadSearchIndex,
-    staleTime: 15 * 60 * 1000,
-  })
-
-  const groups = useMemo(
-    () => (index ? searchEntities(query, index) : []),
-    [index, query]
-  )
-
-  // Flatten the grouped results into a single ordered list for keyboard
-  // navigation and aria-activedescendant — groups are for display only.
-  const flat = useMemo<SearchEntity[]>(
-    () => groups.flatMap(g => g.entities),
-    [groups]
-  )
-
-  // Clamp activeIndex at read time rather than in an effect — derived value.
-  const clampedActiveIndex = Math.min(activeIndex, Math.max(0, flat.length - 1))
-  const activeEntity = flat[clampedActiveIndex]
-
-  const navigateToActive = useCallback(() => {
-    if (!activeEntity) return
-    navigate(activeEntity.route)
-    onClose()
-  }, [activeEntity, navigate, onClose])
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault()
-        setActiveIndex(i => Math.min(i + 1, Math.max(0, flat.length - 1)))
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault()
-        setActiveIndex(i => Math.max(0, i - 1))
-      } else if (e.key === 'Enter') {
-        e.preventDefault()
-        navigateToActive()
-      } else if (e.key === 'Escape') {
-        e.preventDefault()
-        onClose()
-      }
-    },
-    [flat.length, navigateToActive, onClose]
-  )
-
-  const hasQuery = query.trim().length > 0
-  const optionId = (e: SearchEntity) =>
-    `command-palette-result-${e.type}-${e.id}`
+  const optionId = (e: SearchEntity) => `${OPTION_PREFIX}-${e.type}-${e.id}`
 
   return (
     <div
@@ -142,14 +104,11 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
             ref={inputAttachRef}
             type="text"
             value={query}
-            onChange={e => {
-              setQuery(e.target.value)
-              setActiveIndex(0)
-            }}
+            onChange={e => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Search districts, regions, clubs by name or number…"
             aria-label="Universal search input"
-            aria-controls="command-palette-results"
+            aria-controls={LISTBOX_ID}
             aria-activedescendant={
               activeEntity ? optionId(activeEntity) : undefined
             }
@@ -158,7 +117,26 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
           <kbd className="command-palette__hint">esc</kbd>
         </div>
 
-        {renderBody()}
+        {!hasQuery ? (
+          // Before the user types, guide them — listing every indexed entity
+          // (14k+ clubs) is meaningless, so the empty query shows no listbox.
+          <p className="command-palette__empty">
+            Type to search districts, regions, and clubs.
+          </p>
+        ) : !index ? (
+          <p className="command-palette__empty">Searching…</p>
+        ) : flat.length === 0 ? (
+          <p className="command-palette__empty">No matches.</p>
+        ) : (
+          <OmniSearchResults
+            groups={groups}
+            activeIndex={activeIndex}
+            onActivate={setActiveIndex}
+            onSelect={onClose}
+            listboxId={LISTBOX_ID}
+            idPrefix={OPTION_PREFIX}
+          />
+        )}
 
         <div className="command-palette__footer">
           <span>
@@ -168,106 +146,6 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
         </div>
       </div>
     </div>
-  )
-
-  function renderBody() {
-    // Before the user types, guide them — listing every indexed entity (14k+
-    // clubs) is meaningless, so the empty query intentionally shows no listbox.
-    if (!hasQuery) {
-      return (
-        <p className="command-palette__empty">
-          Type to search districts, regions, and clubs.
-        </p>
-      )
-    }
-    if (!index) {
-      return <p className="command-palette__empty">Searching…</p>
-    }
-    if (flat.length === 0) {
-      return <p className="command-palette__empty">No matches.</p>
-    }
-    return (
-      <ul
-        id="command-palette-results"
-        role="listbox"
-        aria-label="Search results"
-        className="command-palette__results"
-      >
-        {groups.map((group, gi) => {
-          // Flat index of this group's first entity — groups are rendered in
-          // the same order they were flattened, so position gives the flat
-          // index directly (no per-option reference lookup; groups ≤ 3).
-          const offset = groups
-            .slice(0, gi)
-            .reduce((n, g) => n + g.entities.length, 0)
-          return (
-            <li
-              key={group.type}
-              role="group"
-              aria-label={GROUP_LABEL[group.type]}
-              className="command-palette__group"
-            >
-              <div
-                className="command-palette__group-heading"
-                aria-hidden="true"
-              >
-                {GROUP_LABEL[group.type]}
-              </div>
-              <ul role="presentation" className="command-palette__group-list">
-                {group.entities.map((entity, ei) => {
-                  const flatIdx = offset + ei
-                  const active = flatIdx === clampedActiveIndex
-                  return (
-                    <li
-                      key={optionId(entity)}
-                      role="option"
-                      aria-selected={active}
-                      id={optionId(entity)}
-                      onMouseEnter={() => setActiveIndex(flatIdx)}
-                      className={
-                        'command-palette__result' +
-                        (active ? ' command-palette__result--active' : '')
-                      }
-                    >
-                      <Link
-                        to={entity.route}
-                        onClick={onClose}
-                        className="command-palette__result-link"
-                      >
-                        {renderEntity(entity)}
-                      </Link>
-                    </li>
-                  )
-                })}
-              </ul>
-            </li>
-          )
-        })}
-      </ul>
-    )
-  }
-}
-
-// District results reuse the chip+name treatment (and its #522 no-duplicate
-// guard); regions and clubs render their label plus disambiguation context.
-function renderEntity(entity: SearchEntity) {
-  if (entity.type === 'district') {
-    return (
-      <DistrictChipAndName
-        districtId={entity.id}
-        name={entity.label}
-        chipClassName="command-palette__result-num"
-        nameClassName="command-palette__result-name"
-      />
-    )
-  }
-  return (
-    <>
-      <span className="command-palette__result-name">{entity.label}</span>
-      {entity.context && (
-        <span className="command-palette__result-region">{entity.context}</span>
-      )}
-    </>
   )
 }
 

--- a/frontend/src/components/AppShell/HeaderSearch.tsx
+++ b/frontend/src/components/AppShell/HeaderSearch.tsx
@@ -120,6 +120,10 @@ const DesktopOmniCombobox: React.FC = () => {
   }, [focused, dismiss])
 
   const showDropdown = focused && hasQuery
+  // The listbox only mounts once results exist; gate aria-expanded /
+  // -controls / -activedescendant on that so they never reference an absent
+  // id (the strictly-correct WAI-ARIA 1.2 combobox form).
+  const listboxOpen = showDropdown && !!index && flat.length > 0
   const optionId = (e: SearchEntity) => `${OPTION_PREFIX}-${e.type}-${e.id}`
 
   return (
@@ -137,10 +141,10 @@ const DesktopOmniCombobox: React.FC = () => {
           placeholder="Search…"
           aria-label="Search districts, regions, clubs by name or number"
           aria-autocomplete="list"
-          aria-expanded={showDropdown}
-          aria-controls={LISTBOX_ID}
+          aria-expanded={listboxOpen}
+          aria-controls={listboxOpen ? LISTBOX_ID : undefined}
           aria-activedescendant={
-            showDropdown && activeEntity ? optionId(activeEntity) : undefined
+            listboxOpen && activeEntity ? optionId(activeEntity) : undefined
           }
           className="header-search__input"
         />

--- a/frontend/src/components/AppShell/HeaderSearch.tsx
+++ b/frontend/src/components/AppShell/HeaderSearch.tsx
@@ -1,0 +1,170 @@
+/* HeaderSearch (epic #1055 Sprint 3, #1058) — the header entry point to the
+   unified omni-search. ONE behavior (useOmniSearch + OmniSearchResults), two
+   presentations chosen by viewport so only the active one mounts (no hidden
+   responsive twin — Lesson 149):
+
+   - desktop (≥768px): an inline combobox with a typeahead dropdown. The ~1MB
+     club index is fetched lazily on first focus, never at cold app load.
+   - mobile  (<768px): a compact search-icon button that opens the full-screen
+     modal palette (owned by AppShell). Keeps the cramped header clean.
+
+   Cmd-K / Ctrl-K opens the modal on all viewports — that lives in AppShell. */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useIsMobile } from '../../hooks/useIsMobile'
+import { useOmniSearch } from '../../hooks/useOmniSearch'
+import OmniSearchResults from './OmniSearchResults'
+import { type SearchEntity } from '../../services/searchIndex'
+
+interface HeaderSearchProps {
+  /** Open the modal palette (mobile icon + the shared Cmd-K surface). */
+  onOpenSearch: () => void
+}
+
+const LISTBOX_ID = 'header-search-results'
+const OPTION_PREFIX = 'header-search-option'
+
+const SearchGlyph: React.FC = () => (
+  <svg
+    width="18"
+    height="18"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    className="header-search__icon"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+    />
+  </svg>
+)
+
+const HeaderSearch: React.FC<HeaderSearchProps> = ({ onOpenSearch }) => {
+  const isMobile = useIsMobile(768)
+  if (isMobile) {
+    return (
+      <button
+        type="button"
+        className="app-shell-icon-btn header-search__trigger"
+        aria-label="Search"
+        title="Search districts, regions, clubs"
+        onClick={onOpenSearch}
+      >
+        <SearchGlyph />
+      </button>
+    )
+  }
+  return <DesktopOmniCombobox />
+}
+
+const DesktopOmniCombobox: React.FC = () => {
+  const navigate = useNavigate()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  // `focused` both gates the lazy index fetch and gates dropdown visibility,
+  // so the 1MB club index is fetched only once the user engages the field.
+  const [focused, setFocused] = useState(false)
+
+  // Collapse the dropdown and drop DOM focus so React state and the input
+  // agree (a still-focused input with focused=false would swallow typing).
+  const dismiss = useCallback(() => {
+    setFocused(false)
+    inputRef.current?.blur()
+  }, [])
+
+  const selectEntity = useCallback(
+    (entity: SearchEntity) => {
+      navigate(entity.route)
+      dismiss()
+    },
+    [navigate, dismiss]
+  )
+
+  const {
+    query,
+    setQuery,
+    index,
+    groups,
+    flat,
+    activeIndex,
+    setActiveIndex,
+    activeEntity,
+    hasQuery,
+    handleKeyDown,
+  } = useOmniSearch({
+    onSelect: selectEntity,
+    onDismiss: dismiss,
+    enabled: focused,
+  })
+
+  // Clear the query whenever the field collapses (select / Esc / outside-click)
+  // so reopening starts fresh — the palette-style reset, minus a remount.
+  useEffect(() => {
+    if (!focused) setQuery('')
+  }, [focused, setQuery])
+
+  // Outside-click closes the dropdown (focus stays inert until re-engaged).
+  // Bound only while open so idle pages carry no global listener.
+  useEffect(() => {
+    if (!focused) return
+    const onPointerDown = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) dismiss()
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    return () => document.removeEventListener('mousedown', onPointerDown)
+  }, [focused, dismiss])
+
+  const showDropdown = focused && hasQuery
+  const optionId = (e: SearchEntity) => `${OPTION_PREFIX}-${e.type}-${e.id}`
+
+  return (
+    <div className="header-search" ref={containerRef}>
+      <div className="header-search__field">
+        <SearchGlyph />
+        <input
+          ref={inputRef}
+          type="text"
+          role="combobox"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search…"
+          aria-label="Search districts, regions, clubs by name or number"
+          aria-autocomplete="list"
+          aria-expanded={showDropdown}
+          aria-controls={LISTBOX_ID}
+          aria-activedescendant={
+            showDropdown && activeEntity ? optionId(activeEntity) : undefined
+          }
+          className="header-search__input"
+        />
+      </div>
+      {showDropdown && (
+        <div className="header-search__dropdown">
+          {!index ? (
+            <p className="command-palette__empty">Searching…</p>
+          ) : flat.length === 0 ? (
+            <p className="command-palette__empty">No matches.</p>
+          ) : (
+            <OmniSearchResults
+              groups={groups}
+              activeIndex={activeIndex}
+              onActivate={setActiveIndex}
+              onSelect={dismiss}
+              listboxId={LISTBOX_ID}
+              idPrefix={OPTION_PREFIX}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default HeaderSearch

--- a/frontend/src/components/AppShell/OmniSearchResults.tsx
+++ b/frontend/src/components/AppShell/OmniSearchResults.tsx
@@ -27,7 +27,8 @@ interface OmniSearchResultsProps {
   /** Already-clamped flat index of the highlighted row. */
   activeIndex: number
   onActivate: (flatIndex: number) => void
-  /** Fired when a result link is clicked (e.g. close the surface). */
+  /** Notification (no payload) that a result was chosen — callers close the
+      surface here; navigation is handled by the result's own <Link>. */
   onSelect: () => void
   listboxId: string
   /** Prefix for each option's element id (must be unique per mount). */

--- a/frontend/src/components/AppShell/OmniSearchResults.tsx
+++ b/frontend/src/components/AppShell/OmniSearchResults.tsx
@@ -1,0 +1,127 @@
+/* OmniSearchResults (epic #1055 Sprint 3, #1058) — the grouped ARIA listbox
+   shared by the modal palette and the desktop header combobox. Presentational:
+   it renders the result groups it is handed and reports hover/click; all state
+   (query, active row, index load) lives in the caller via useOmniSearch.
+
+   Each mount gets a distinct `listboxId`/`optionId` prefix so two instances can
+   coexist in the DOM with valid, non-colliding ARIA ids. */
+
+import React from 'react'
+import { Link } from 'react-router-dom'
+import {
+  type SearchEntity,
+  type SearchEntityType,
+  type SearchResultGroup,
+} from '../../services/searchIndex'
+import { DistrictChipAndName } from '../DistrictChipAndName'
+
+// Human-readable group headings, in the index's canonical group order.
+const GROUP_LABEL: Record<SearchEntityType, string> = {
+  district: 'Districts',
+  region: 'Regions',
+  club: 'Clubs',
+}
+
+interface OmniSearchResultsProps {
+  groups: SearchResultGroup[]
+  /** Already-clamped flat index of the highlighted row. */
+  activeIndex: number
+  onActivate: (flatIndex: number) => void
+  /** Fired when a result link is clicked (e.g. close the surface). */
+  onSelect: () => void
+  listboxId: string
+  /** Prefix for each option's element id (must be unique per mount). */
+  idPrefix: string
+}
+
+const OmniSearchResults: React.FC<OmniSearchResultsProps> = ({
+  groups,
+  activeIndex,
+  onActivate,
+  onSelect,
+  listboxId,
+  idPrefix,
+}) => {
+  const optionId = (e: SearchEntity) => `${idPrefix}-${e.type}-${e.id}`
+  return (
+    <ul
+      id={listboxId}
+      role="listbox"
+      aria-label="Search results"
+      className="command-palette__results"
+    >
+      {groups.map((group, gi) => {
+        // Flat index of this group's first entity — groups render in the same
+        // order they were flattened, so position gives the flat index directly.
+        const offset = groups
+          .slice(0, gi)
+          .reduce((n, g) => n + g.entities.length, 0)
+        return (
+          <li
+            key={group.type}
+            role="group"
+            aria-label={GROUP_LABEL[group.type]}
+            className="command-palette__group"
+          >
+            <div className="command-palette__group-heading" aria-hidden="true">
+              {GROUP_LABEL[group.type]}
+            </div>
+            <ul role="presentation" className="command-palette__group-list">
+              {group.entities.map((entity, ei) => {
+                const flatIdx = offset + ei
+                const active = flatIdx === activeIndex
+                return (
+                  <li
+                    key={optionId(entity)}
+                    role="option"
+                    aria-selected={active}
+                    id={optionId(entity)}
+                    onMouseEnter={() => onActivate(flatIdx)}
+                    className={
+                      'command-palette__result' +
+                      (active ? ' command-palette__result--active' : '')
+                    }
+                  >
+                    <Link
+                      to={entity.route}
+                      onClick={onSelect}
+                      className="command-palette__result-link"
+                    >
+                      {renderEntity(entity)}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+// District results reuse the chip+name treatment (and its #522 no-duplicate
+// guard); regions and clubs render their label plus disambiguation context.
+function renderEntity(entity: SearchEntity) {
+  if (entity.type === 'district') {
+    return (
+      <DistrictChipAndName
+        districtId={entity.id}
+        name={entity.label}
+        chipClassName="command-palette__result-num"
+        nameClassName="command-palette__result-name"
+      />
+    )
+  }
+  return (
+    <>
+      <span className="command-palette__result-name">{entity.label}</span>
+      {entity.context && (
+        <span className="command-palette__result-region">{entity.context}</span>
+      )}
+    </>
+  )
+}
+
+export { GROUP_LABEL }
+export default OmniSearchResults

--- a/frontend/src/components/AppShell/__tests__/AppShellTopBar.about.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/AppShellTopBar.about.test.tsx
@@ -13,6 +13,7 @@
 import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
 import { cleanup, render, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { DarkModeProvider } from '../../../contexts/DarkModeContext'
 
 vi.mock('../../../hooks/useIsMobile', () => ({
@@ -25,13 +26,21 @@ import AppShellTopBar from '../AppShellTopBar'
 afterEach(() => cleanup())
 beforeEach(() => vi.mocked(useIsMobile).mockReturnValue(false))
 
+// The bar now hosts HeaderSearch (#1058), whose desktop combobox calls
+// useQuery (disabled until focused) — so a QueryClient must be present.
 const renderBar = () =>
   render(
-    <DarkModeProvider>
-      <MemoryRouter>
-        <AppShellTopBar />
-      </MemoryRouter>
-    </DarkModeProvider>
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <DarkModeProvider>
+        <MemoryRouter>
+          <AppShellTopBar onOpenSearch={() => {}} />
+        </MemoryRouter>
+      </DarkModeProvider>
+    </QueryClientProvider>
   )
 
 describe('AppShellTopBar "About ▾" disclosure (#889)', () => {

--- a/frontend/src/components/AppShell/__tests__/AppShellTopBar.mobile-nav.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/AppShellTopBar.mobile-nav.test.tsx
@@ -18,18 +18,27 @@ import {
   fireEvent,
 } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { DarkModeProvider } from '../../../contexts/DarkModeContext'
 import AppShellTopBar from '../AppShellTopBar'
 
 afterEach(() => cleanup())
 
+// The bar now hosts HeaderSearch (#1058), whose desktop combobox calls
+// useQuery (disabled until focused) — so a QueryClient must be present.
 const renderBar = () =>
   render(
-    <DarkModeProvider>
-      <MemoryRouter>
-        <AppShellTopBar />
-      </MemoryRouter>
-    </DarkModeProvider>
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <DarkModeProvider>
+        <MemoryRouter>
+          <AppShellTopBar onOpenSearch={() => {}} />
+        </MemoryRouter>
+      </DarkModeProvider>
+    </QueryClientProvider>
   )
 
 const getToggle = () => screen.getByRole('button', { name: /menu/i })

--- a/frontend/src/components/AppShell/__tests__/HeaderSearch.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/HeaderSearch.test.tsx
@@ -1,0 +1,136 @@
+/* HeaderSearch (omni-search epic #1055 Sprint 3, #1058) — the header entry
+   point to the unified search. Two presentations of ONE behavior:
+   - desktop (≥768px): an inline combobox with a typeahead dropdown
+   - mobile  (<768px): a search-icon button that opens the modal palette
+   Cmd-K continues to open the modal everywhere (owned by AppShell, not here). */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import HeaderSearch from '../HeaderSearch'
+import { useIsMobile } from '../../../hooks/useIsMobile'
+
+const fetchCdnRankings = vi.fn()
+const fetchCdnClubIndex = vi.fn()
+
+vi.mock('../../../services/cdn', () => ({
+  fetchCdnRankings: (...args: unknown[]) => fetchCdnRankings(...args),
+  fetchCdnClubIndex: (...args: unknown[]) => fetchCdnClubIndex(...args),
+}))
+
+vi.mock('../../../hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(() => false),
+}))
+
+const setupCdn = () => {
+  fetchCdnRankings.mockResolvedValue({
+    rankings: [
+      { districtId: '57', districtName: 'District 57', region: '7' },
+      { districtId: '61', districtName: 'District 61', region: '7' },
+    ],
+    date: '2025-11-22',
+  })
+  fetchCdnClubIndex.mockResolvedValue({
+    clubs: { '12345': { districtId: '61', clubName: 'Toast of the Town' } },
+  })
+}
+
+const renderHeaderSearch = (onOpenSearch = () => {}) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <HeaderSearch onOpenSearch={onOpenSearch} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('HeaderSearch (#1058)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupCdn()
+    vi.mocked(useIsMobile).mockReturnValue(false)
+  })
+
+  describe('desktop (≥768px)', () => {
+    beforeEach(() => vi.mocked(useIsMobile).mockReturnValue(false))
+
+    it('renders an inline combobox, not a modal-opening icon', () => {
+      renderHeaderSearch()
+      expect(
+        screen.getByRole('combobox', { name: /search districts, regions/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /^search$/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('is lazy — does not fetch the index until the input is focused', () => {
+      renderHeaderSearch()
+      expect(fetchCdnRankings).not.toHaveBeenCalled()
+      expect(fetchCdnClubIndex).not.toHaveBeenCalled()
+    })
+
+    it('fetches the index once focused and shows grouped results when typing', async () => {
+      renderHeaderSearch()
+      const input = screen.getByRole('combobox', {
+        name: /search districts, regions/i,
+      })
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: '61' } })
+
+      const listbox = await screen.findByRole('listbox', {
+        name: /search results/i,
+      })
+      const districts = within(listbox).getByRole('group', {
+        name: /districts/i,
+      })
+      const link = within(districts).getByRole('link')
+      expect(link).toHaveTextContent(/District 61/)
+      expect(link.getAttribute('href')).toBe('/district/61')
+      await vi.waitFor(() => expect(fetchCdnClubIndex).toHaveBeenCalled())
+    })
+
+    it('marks the combobox expanded only while results are shown', async () => {
+      renderHeaderSearch()
+      const input = screen.getByRole('combobox', {
+        name: /search districts, regions/i,
+      })
+      expect(input).toHaveAttribute('aria-expanded', 'false')
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: '61' } })
+      await screen.findByRole('listbox', { name: /search results/i })
+      expect(input).toHaveAttribute('aria-expanded', 'true')
+    })
+  })
+
+  describe('mobile (<768px)', () => {
+    beforeEach(() => vi.mocked(useIsMobile).mockReturnValue(true))
+
+    it('renders a search-icon button, not an inline combobox', () => {
+      renderHeaderSearch()
+      expect(
+        screen.getByRole('button', { name: /^search$/i })
+      ).toBeInTheDocument()
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    })
+
+    it('opens the modal palette when the icon is clicked', () => {
+      const onOpenSearch = vi.fn()
+      renderHeaderSearch(onOpenSearch)
+      fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+      expect(onOpenSearch).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not fetch the index (no inline search on mobile)', () => {
+      renderHeaderSearch()
+      expect(fetchCdnRankings).not.toHaveBeenCalled()
+      expect(fetchCdnClubIndex).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/hooks/__tests__/useOmniSearch.test.tsx
+++ b/frontend/src/hooks/__tests__/useOmniSearch.test.tsx
@@ -1,0 +1,148 @@
+/* useOmniSearch (epic #1055 Sprint 3, #1058) — the shared search behavior
+   behind the modal palette and the desktop header combobox. These tests lock
+   the logic-dense, surface-independent contract: lazy index gating, keyboard
+   navigation (arrow clamping, Enter→onSelect, Escape→onDismiss), and the
+   query-reset-clears-active-row rule. Both consumers rely on this. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React, { ReactNode } from 'react'
+import { useOmniSearch } from '../useOmniSearch'
+import { fetchCdnRankings, fetchCdnClubIndex } from '../../services/cdn'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnRankings: vi.fn(),
+  fetchCdnClubIndex: vi.fn(),
+}))
+
+const mockedRankings = vi.mocked(fetchCdnRankings)
+const mockedClubIndex = vi.mocked(fetchCdnClubIndex)
+
+const wrapper = ({ children }: { children: ReactNode }) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+// A minimal KeyboardEvent stand-in — handleKeyDown only reads `key` and calls
+// preventDefault().
+const keyEvent = (key: string) =>
+  ({
+    key,
+    preventDefault: vi.fn(),
+  }) as unknown as React.KeyboardEvent<HTMLInputElement>
+
+const setupCdn = () => {
+  mockedRankings.mockResolvedValue({
+    rankings: [
+      { districtId: '57', districtName: 'District 57', region: '7' },
+      { districtId: '61', districtName: 'District 61', region: '7' },
+    ],
+    date: '2025-11-22',
+  } as Awaited<ReturnType<typeof fetchCdnRankings>>)
+  mockedClubIndex.mockResolvedValue({
+    clubs: { '12345': { districtId: '61', clubName: 'Toast of the Town' } },
+  } as Awaited<ReturnType<typeof fetchCdnClubIndex>>)
+}
+
+describe('useOmniSearch (#1058)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupCdn()
+  })
+
+  it('does not fetch the index while disabled (lazy gate)', () => {
+    renderHook(() => useOmniSearch({ onSelect: vi.fn(), enabled: false }), {
+      wrapper,
+    })
+    expect(mockedRankings).not.toHaveBeenCalled()
+    expect(mockedClubIndex).not.toHaveBeenCalled()
+  })
+
+  it('fetches the index once enabled and matches a query into grouped results', async () => {
+    const { result } = renderHook(() => useOmniSearch({ onSelect: vi.fn() }), {
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.index).toBeDefined())
+    act(() => result.current.setQuery('61'))
+    expect(result.current.flat.length).toBeGreaterThan(0)
+    expect(result.current.flat[0].route).toBe('/district/61')
+    expect(result.current.hasQuery).toBe(true)
+  })
+
+  it('ArrowDown advances the active row and clamps at the last result', async () => {
+    const { result } = renderHook(() => useOmniSearch({ onSelect: vi.fn() }), {
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.index).toBeDefined())
+    act(() => result.current.setQuery('7')) // matches both districts + region
+    const last = result.current.flat.length - 1
+    expect(result.current.activeIndex).toBe(0)
+    for (let i = 0; i < last + 3; i++) {
+      act(() => result.current.handleKeyDown(keyEvent('ArrowDown')))
+    }
+    expect(result.current.activeIndex).toBe(last) // clamped, never overruns
+  })
+
+  it('ArrowUp clamps at the first result', async () => {
+    const { result } = renderHook(() => useOmniSearch({ onSelect: vi.fn() }), {
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.index).toBeDefined())
+    act(() => result.current.setQuery('7'))
+    act(() => result.current.handleKeyDown(keyEvent('ArrowDown')))
+    act(() => result.current.handleKeyDown(keyEvent('ArrowUp')))
+    act(() => result.current.handleKeyDown(keyEvent('ArrowUp')))
+    expect(result.current.activeIndex).toBe(0)
+  })
+
+  it('Enter selects the active entity', async () => {
+    const onSelect = vi.fn()
+    const { result } = renderHook(() => useOmniSearch({ onSelect }), {
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.index).toBeDefined())
+    act(() => result.current.setQuery('61'))
+    const active = result.current.activeEntity
+    act(() => result.current.handleKeyDown(keyEvent('Enter')))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith(active)
+  })
+
+  it('Enter with no results is a no-op (does not call onSelect)', async () => {
+    const onSelect = vi.fn()
+    const { result } = renderHook(() => useOmniSearch({ onSelect }), {
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.index).toBeDefined())
+    // Empty query → no results, no active entity.
+    expect(result.current.activeEntity).toBeUndefined()
+    act(() => result.current.handleKeyDown(keyEvent('Enter')))
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('Escape calls onDismiss', async () => {
+    const onDismiss = vi.fn()
+    const { result } = renderHook(
+      () => useOmniSearch({ onSelect: vi.fn(), onDismiss }),
+      { wrapper }
+    )
+    await waitFor(() => expect(result.current.index).toBeDefined())
+    act(() => result.current.handleKeyDown(keyEvent('Escape')))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('changing the query resets the active row to the first result', async () => {
+    const { result } = renderHook(() => useOmniSearch({ onSelect: vi.fn() }), {
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.index).toBeDefined())
+    act(() => result.current.setQuery('7'))
+    act(() => result.current.handleKeyDown(keyEvent('ArrowDown')))
+    expect(result.current.activeIndex).toBe(1)
+    act(() => result.current.setQuery('61')) // new query
+    expect(result.current.activeIndex).toBe(0)
+  })
+})

--- a/frontend/src/hooks/useOmniSearch.ts
+++ b/frontend/src/hooks/useOmniSearch.ts
@@ -1,0 +1,111 @@
+/* useOmniSearch (epic #1055 Sprint 3, #1058) — the shared behavior behind both
+   omni-search presentations: the Cmd-K modal palette and the desktop header
+   combobox. Extracting it keeps the keyboard-nav + ARIA + lazy-load logic in
+   ONE place rather than diverging across two surfaces (Lesson 092 / R6).
+
+   Lazy load: the ~1MB club index fetch is gated by `enabled`. The modal only
+   mounts when open, so it passes `enabled: true`; the always-mounted header
+   combobox flips `enabled` on first focus so cold app-load stays untouched. */
+
+import { useCallback, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  loadSearchIndex,
+  searchEntities,
+  type SearchEntity,
+  type SearchIndex,
+  type SearchResultGroup,
+} from '../services/searchIndex'
+
+export interface UseOmniSearchOptions {
+  /** Navigate to (and otherwise act on) the chosen entity. */
+  onSelect: (entity: SearchEntity) => void
+  /** Esc handler — modal closes, combobox collapses. Optional. */
+  onDismiss?: () => void
+  /** Gate the (lazy) index fetch. Defaults to true. */
+  enabled?: boolean
+}
+
+export interface UseOmniSearch {
+  query: string
+  setQuery: (q: string) => void
+  index: SearchIndex | undefined
+  groups: SearchResultGroup[]
+  flat: SearchEntity[]
+  /** Already clamped into [0, flat.length-1]. */
+  activeIndex: number
+  setActiveIndex: (i: number) => void
+  activeEntity: SearchEntity | undefined
+  hasQuery: boolean
+  handleKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void
+}
+
+const INDEX_STALE_MS = 15 * 60 * 1000
+
+export function useOmniSearch(options: UseOmniSearchOptions): UseOmniSearch {
+  const { onSelect, onDismiss, enabled = true } = options
+  const [query, setQueryRaw] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const { data: index } = useQuery({
+    queryKey: ['omni-search-index'],
+    queryFn: loadSearchIndex,
+    staleTime: INDEX_STALE_MS,
+    enabled,
+  })
+
+  const groups = useMemo(
+    () => (index ? searchEntities(query, index) : []),
+    [index, query]
+  )
+
+  // Flatten grouped results into one ordered list for keyboard nav /
+  // aria-activedescendant — groups are display-only.
+  const flat = useMemo<SearchEntity[]>(
+    () => groups.flatMap(g => g.entities),
+    [groups]
+  )
+
+  // Clamp at read time rather than in an effect — it is a derived value.
+  const clampedActiveIndex = Math.min(activeIndex, Math.max(0, flat.length - 1))
+  const activeEntity = flat[clampedActiveIndex]
+
+  // Reset the active row whenever the query changes so the first result is
+  // pre-highlighted; callers only ever set the query through this wrapper.
+  const setQuery = useCallback((q: string) => {
+    setQueryRaw(q)
+    setActiveIndex(0)
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setActiveIndex(i => Math.min(i + 1, Math.max(0, flat.length - 1)))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setActiveIndex(i => Math.max(0, i - 1))
+      } else if (e.key === 'Enter') {
+        e.preventDefault()
+        if (activeEntity) onSelect(activeEntity)
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        onDismiss?.()
+      }
+    },
+    [flat.length, activeEntity, onSelect, onDismiss]
+  )
+
+  return {
+    query,
+    setQuery,
+    index,
+    groups,
+    flat,
+    activeIndex: clampedActiveIndex,
+    setActiveIndex,
+    activeEntity,
+    hasQuery: query.trim().length > 0,
+    handleKeyDown,
+  }
+}

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -324,6 +324,81 @@
     outline-offset: 2px;
   }
 
+  /* HeaderSearch (#1058) — desktop inline combobox + mobile icon trigger.
+     The desktop dropdown reuses the .command-palette__* result styles. All
+     colours are theme tokens so dark mode follows the existing remaps (R10);
+     the dropdown is absolutely positioned so the header never shifts (no CLS). */
+  .header-search {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .header-search__field {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 36px;
+    padding: 0 12px;
+    min-width: 180px;
+    max-width: 260px;
+    background-color: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-md);
+  }
+
+  .header-search__field:focus-within {
+    border-color: var(--link);
+    outline: 2px solid var(--link);
+    outline-offset: 1px;
+  }
+
+  .header-search__icon {
+    flex-shrink: 0;
+    color: var(--ink-3);
+  }
+
+  .header-search__input {
+    flex: 1;
+    min-width: 0;
+    border: 0;
+    background: transparent;
+    font-family: var(--sans);
+    font-size: 14px;
+    color: var(--ink);
+    outline: none;
+  }
+
+  .header-search__input::placeholder {
+    color: var(--ink-4);
+  }
+
+  /* The mobile search trigger needs a ≥44px touch target (#1058 AC). It is
+     only rendered <768px (the combobox replaces it on desktop), so widening
+     past the 32px icon-btn baseline is always the mobile case. */
+  .header-search__trigger {
+    width: 44px;
+    height: 44px;
+  }
+
+  .header-search__dropdown {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    width: min(420px, 92vw);
+    max-height: 60vh;
+    overflow: hidden;
+    background-color: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--rds-radius-lg);
+    box-shadow: var(--rds-shadow-lg);
+    z-index: 90;
+  }
+
+  .header-search__dropdown .command-palette__results {
+    max-height: 60vh;
+  }
+
   .app-shell-avatar {
     width: 32px;
     height: 32px;
@@ -4998,6 +5073,9 @@
     grid-template-columns: auto 1fr auto;
     align-items: center;
     gap: 12px;
+    /* ≥44px touch target (#1058 AC) — these rows are the mobile modal's
+       primary tap surface; harmless on the desktop dropdown/mouse. */
+    min-height: 44px;
     padding: 10px 12px;
     text-decoration: none;
     color: var(--ink);

--- a/tasks/lessons/152-a-live-result-locator-must-key-on-the-stable-route-not-the-cdn-derived-label.md
+++ b/tasks/lessons/152-a-live-result-locator-must-key-on-the-stable-route-not-the-cdn-derived-label.md
@@ -1,0 +1,67 @@
+---
+id: '152'
+category: lesson
+tags: [verification, playwright, frontend, cdn, scope]
+auto_load: true
+date: 2026-06-01
+issues: [1058, 1055]
+---
+
+# Lesson 152 — A live-verification locator must key on the stable route, not a CDN-derived label
+
+**Date:** 2026-06-01
+**Issue:** #1058 (epic #1055 Sprint 3 — omni-search header bar)
+**PR:** [#1061](https://github.com/taverns-red/toast-stats/pull/1061)
+
+## What happened
+
+The header omni-search Playwright smoke located a district result by its
+accessible name — `getByRole('link', { name: /District 61/i })`. It passed in
+the unit tests (whose fixtures set `districtName: 'District 61'`) and on the
+region/Cmd-K cases, but **failed on the preview** for districts in both
+engines: 4 of 8 checks red on a feature that actually worked.
+
+Root cause was the data, not the UI. The staging CDN's `v1/rankings.json` ships
+`districtName` as the **bare number** (`"61"`, `"93"`, …), not `"District 61"`.
+The district result correctly renders that through `DistrictChipAndName`, whose
+#522 no-duplicate guard collapses a bare-number name into just the `D61` chip —
+so the rendered link's accessible name is `"D61"`, and `/District 61/i` never
+matches. Regions passed because their label is built **in code**
+(`` `Region ${n}` ``), independent of the CDN string.
+
+Switching the locator to the route — `locator('a[href="/district/61"]')` —
+made all 8 green. The route is derived from `districtId`, which is stable and
+identical in fixtures and prod; the label is CDN-authored and varies.
+
+## The transferable principle
+
+**When you live-verify a result/link against deployed CDN data, key the locator
+on the stable identifier the app derives (the route / `href` / `data-id`), not
+on display text that the CDN authors.** Unit fixtures are the author's idea of
+the data; the live payload is the real thing, and a human-readable label is
+exactly the field most likely to differ (bare vs prefixed, abbreviated,
+localized, re-skinned). A label-based assertion that passes in jsdom can still
+be testing a string the backend never emits.
+
+## How to apply
+
+- Prefer `a[href="…"]` / `getByTestId` / `data-*` over `getByRole('link', {
+name })` whenever the visible text comes from fetched data. Reserve
+  name-based locators for labels the component builds itself (here: regions).
+- When a label-based live assertion fails on a feature you can see working,
+  suspect the CDN string before the component — `curl` the actual
+  `rankings.json` / index and read the field, don't assume the fixture shape.
+- The chip-vs-name divergence is a known local trap: `DistrictChipAndName`
+  hides the name when it equals the id (#522), so "the district's name" is not
+  reliably on screen as text at all.
+
+## Related
+
+- [[149-a-responsively-duplicated-component-needs-a-visible-selector-in-live-verification]]
+  — sibling lesson: the live-drive locator must target what the user actually
+  sees; here the failure mode is the label's _content_, there it's the hidden
+  twin.
+- [[115-a-fields-name-and-comment-can-lie-about-whether-its-populated]] — same
+  theme one layer down: don't trust the fixture/comment about a field's live value.
+- `frontend/src/components/DistrictChipAndName.tsx` (#522 guard),
+  `frontend/src/services/searchIndex.ts` (region label built in code).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -132,3 +132,4 @@
 - **150** [mcp, verification, tdd, monorepo, ci, automation] — An installable stdio server needs an env-injectable base URL to be offline-smoke-tested via the real bin (#1045, #1042)
 - **150** [monorepo, tdd, build, ci, automation] — TDD-scaffolding a new workspace package has two silent gate traps: the typecheck "no inputs" abort and the explicitly-enumerated CI job (#1043, #1042)
 - **151** [monorepo, automation, sprint-runner, build, ci] — A long-lived worktree has stale `node_modules` after a new workspace package merges; `npm install`, never `--no-verify` (#1056, #1055)
+- **152** [verification, playwright, frontend, cdn, scope] — A live-verification locator must key on the stable route, not a CDN-derived label (#1058, #1055)


### PR DESCRIPTION
Sprint 3 of epic #1055 (omni-search header bar). Embeds the unified search in the header and confirms the consolidation.

## What ships
- **Desktop (≥768px):** an inline `role="combobox"` in the header tools cluster with a typeahead dropdown over the Sprint-1 unified index (districts / regions / clubs), grouped by type and disambiguated.
- **Mobile (<768px):** a 44px search-icon button that opens the existing full-screen modal palette.
- **Cmd-K / Ctrl-K** opens the same modal on all viewports (unchanged).

## Architecture
Two presentations of one search → extracted the shared behavior rather than duplicating (Lesson 092 / R6):
- `hooks/useOmniSearch.ts` — lazy index query (gated by `enabled`), query/active-row state, keyboard nav, grouped/flat results.
- `components/AppShell/OmniSearchResults.tsx` — the grouped ARIA listbox, parameterized by `listboxId`/`idPrefix` so the two instances carry non-colliding option ids.
- `CommandPalette` refactored to consume both (behavior-identical; existing tests stay green).
- `HeaderSearch` picks ONE presentation via `useIsMobile(768)` — no hidden responsive twin (Lesson 149).

## Lazy load
The ~1MB club index is fetched only on first focus of the desktop combobox (`enabled: focused`) — never at cold app load. Mobile mounts no combobox at all.

## Consolidation
Sprint 2 already subsumed the districts-only #422 palette into the unified index, so there is **no separate navigate-by-name search left to delete**. The `DistrictsPage ?q=` box is a **table filter** (in-place narrow) — explicitly out of scope, untouched, and still covered by its existing tests. `FiltersPanel` untouched.

## a11y
WAI-ARIA 1.2 combobox wiring (`aria-expanded` / `-controls` / `-activedescendant` / `aria-autocomplete`), gated on the listbox actually mounting so they never reference an absent id; keyboard nav (↑↓/Enter/Esc); Esc / outside-click collapse + clear with focus drop; focus-visible ring; 44px touch targets. Theme tokens only — dark mode follows existing remaps (R10).

## Tests
- `useOmniSearch.test.tsx` — lazy gate, query→grouped match, ArrowDown/Up clamping, Enter→onSelect (+ no-op when no active entity), Escape→onDismiss, query-change resets active row.
- `HeaderSearch.test.tsx` — desktop combobox vs mobile icon presentation, lazy fetch, grouped results→route, `aria-expanded`.
- `AppShell.test.tsx` — mobile icon opens the modal; desktop renders the inline combobox.
- Full suite green: unit 2647 + integration 712.

## Quality gates
- `/simplify` (4 agents): clean; two reuse suggestions deferred as out-of-scope follow-ups (shared `SearchIcon`, `useOutsideClick` hook).
- Fresh-context `/review`: APPROVE-WITH-NITS, no blockers; both Mediums addressed (keyboard-nav test coverage + conditional ARIA refs).

Refs #1058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)