### PR TITLE
Sprint 1 (#1062) — Daily Reports ingest spike: contract, keep/EXCLUDE map, privacy (#1063)

### DIFF
--- a/docs/investigations/1063-daily-reports-ingest-spike.md
+++ b/docs/investigations/1063-daily-reports-ingest-spike.md
@@ -1,0 +1,206 @@
+# Spike #1063 — TM District "Daily Reports" ingest: feasibility, contract, keep/EXCLUDE map + privacy
+
+**Epic:** #1062 — Evaluate ingesting the 12 District Daily Reports
+**Sprint:** 1 (spike, doc-only — no pipeline writes)
+**Date:** 2026-06-01 · **District sampled:** D61, PY 2025-2026
+**Status:** Recommendation ready for operator decision
+
+---
+
+## 1. TL;DR / recommendation
+
+Ingestion is **feasible and low-risk**: the data API is anonymous, daily-fresh, and
+parses with the same HTML-table shape the collector already handles. The full per-report
+keep/EXCLUDE column map is **validated against live D61 fixtures** (see
+`packages/collector-cli/src/__tests__/dailyReportsColumnMap.test.ts`, 30 assertions,
+including a privacy backstop that goes red if any personal column is mis-classified as KEEP).
+
+**Wire these (high value, clean privacy posture):**
+
+| Priority | Report                                                         | New signal we don't have today                                                            |
+| -------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 1        | **July / January Officer List Status**                         | Per-club officer-list submission — a **DCP prerequisite** we cannot verify per club today |
+| 2        | **Education Achievements** → per-club award **counts by type** | De-identified award activity per club/area (names stripped)                               |
+| 3        | **Club Success Plan Submission**                               | CSP **submission date** (we only carry a bool)                                            |
+| 4        | **April / October Dues Renewal Status**                        | Per-club renewal status — **moves during closing**                                        |
+| 5        | **New Clubs / Prospective Clubs**                              | The actual **lists** (we derive only counts); Prospective drops `Club Contact`            |
+
+**Skip / defer:**
+
+- **Triple Crown Awards** — the report has **no club column** and its only non-personal
+  columns are per-member `Count`/`Award`; with `Member` excluded it collapses to a single
+  **district-level count**. Low value, awkward shape. Defer (or ingest as one district scalar).
+- **Club Coaches**, **New Club Sponsors and Mentors** — once names are stripped these are
+  **presence/count only** (how many coaches/sponsors per club). Marginal value; defer to a
+  later sprint if a "club has a coach" badge is ever wanted.
+- **Educational Achievement Archive** — empty this PY (returns an empty body); ignore until
+  a PY actually populates it.
+
+**Two items need an operator decision before Sprint 2 builds anything — see §6.**
+
+---
+
+## 2. Verified API contract
+
+Anonymous `GET`, no auth, no cookie. Returns rendered **HTML** (not JSON):
+
+```
+GET https://www.toastmasters.org/api/sitecore/DistrictReports/GetDistrictReport
+      ?tableID=<report-GUID>&district=<D>&year=<PY>&sortBy=
+```
+
+- **Response shape:** a desktop `<table>` carrying the data, **followed by a
+  `<div class="mobile-table">` that duplicates every row** (~5× the bytes). The parser must
+  key off the `<table>` and ignore the mobile copy. (The committed fixtures keep the desktop
+  table only — this is why the raw Education Achievements response is 2.5 MB but the fixture
+  is 32 KB.)
+- **Freshness:** each response carries `Reports are uploaded daily - Updated: <date> MT`.
+  Sampled 2026-06-01 → `Updated: June 01, 2026`. Daily cadence confirmed for a single day;
+  **cross-closing movement is NOT yet proven** (see §5).
+- **`year` param:** in this sample, `year=2025-2026`, `year=2026`, and `year=2025` all
+  returned byte-identical current-PY data. Treat `year` as **"current PY" only** until proven
+  otherwise; do not assume arbitrary historical PYs are retrievable.
+- **`sortBy`:** empty is accepted (default order). DataTables sorting/Export is **client-side
+  only** — the HTML response IS the complete dataset; there is no separate authed download.
+- **Empty reports** return a body with **no `<table>`** (Educational Achievement Archive
+  returned 0 bytes). The parser must tolerate this without throwing.
+
+### The 12 report-type GUIDs (full, verified from the D61 page)
+
+| Report                           | tableID GUID                           | D61 rows (2025-26) |
+| -------------------------------- | -------------------------------------- | ------------------ |
+| April Dues Renewal Status        | `0235cdd5-ffee-4101-ab43-a952a2736fc0` | 160                |
+| October Dues Renewal Status      | `0d56c054-0cd2-46ba-b3b1-3bf17221bd6c` | 160                |
+| January Club Officer List Status | `43abeb51-40a6-4514-868a-d697d6481753` | 7                  |
+| July Club Officer List Status    | `68d834ff-90c1-40ae-a79e-c9270bd9919c` | 160                |
+| Club Success Plan Submission     | `99b20422-f82f-456b-8376-18d5ce1b70c5` | 160                |
+| Education Achievements           | `c757d313-f815-4b22-93dc-b839d04cec7b` | 1,125              |
+| Triple Crown Awards              | `b546ef04-e602-4ffc-95c5-5a786aba36b7` | 94                 |
+| Educational Achievement Archive  | `a30b93f3-081e-42c8-9a36-137acb24be69` | 0 (empty)          |
+| New Clubs                        | `ac6df5db-13de-425a-b8b9-f9c6093b538a` | 5                  |
+| Prospective Clubs                | `50630d17-1492-40c9-8244-930b1d94167b` | 8                  |
+| New Club Sponsors and Mentors    | `4da53bd8-f6d9-4fa5-81d8-34ed5966dddd` | 21                 |
+| Club Coaches                     | `41955922-25ab-4a5a-8025-ebb7634f68bf` | 16                 |
+
+To re-capture a fixture:
+
+```bash
+curl -s -A "Mozilla/5.0" \
+  "https://www.toastmasters.org/api/sitecore/DistrictReports/GetDistrictReport?tableID=<GUID>&district=61&year=2025-2026&sortBy="
+```
+
+---
+
+## 3. Per-report keep/EXCLUDE column map (validated)
+
+Header order below is **exactly** as the live report emits it. `Name` is overloaded — in most
+reports it is the **club** name (KEEP); in three people-listing reports the personal column is
+named differently (`Member`, `Club Contact`, or a second `Name`) and is EXCLUDED. The map is
+encoded as data in the validation test and proven exhaustive (every live header is classified
+exactly once) and disjoint.
+
+| Report                            | KEEP                                                                | EXCLUDE (personal)                              |
+| --------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------- |
+| April / October Dues Renewal      | Club, Division, Area, Renewal Status, **Name=club**, Location       | —                                               |
+| Officer List Status (Jan/Jul)     | Club, Division, Area, List Status, Election, **Name=club**          | —                                               |
+| Club Success Plan                 | Club Number, Division, Area, Submission Date, **Club Name**         | —                                               |
+| **Education Achievements**        | Club, Division, Area, Award, Date, **Name=club**, Location          | **Member** (e.g. "Ricardo J. Bocanegra, DTM")   |
+| **Triple Crown Awards**           | Count, Award                                                        | **Member** (e.g. "00987204 - Name unavailable") |
+| New Clubs                         | Division, Area, Club, Charter Date, Status, **Name=club**, Location | —                                               |
+| **Prospective Clubs**             | Division, Area, Club, Status, **Name=club**, Location, Prospect     | **Club Contact** (e.g. "Linda Brisebois")       |
+| **New Club Sponsors and Mentors** | Club, Club Name, Charter Date, Code, Status                         | **Name** (e.g. "Louise Audy, PM5")              |
+| **Club Coaches**                  | Club, Club Name, Code, Begin Date, Status                           | **Name** (e.g. "Rodica Jelea, VC1")             |
+
+### Edge cases the parser must handle
+
+- **Education Achievements — `Member` vs `Name`.** Both columns exist in the same row; `Member`
+  is the person (EXCLUDE), `Name` is the club (KEEP). A blanket "drop Name" rule would wrongly
+  drop the club and keep nothing useful. Classify per column, per report.
+- **Triple Crown — `Member` is `"<memberId> - <name|Name unavailable>"`.** Even the rows that
+  opted into "Name unavailable" still carry a **member ID number**, which is itself
+  identifying. The whole `Member` column is excluded — you cannot keep "just the ID". And
+  because the report has **no club/area/division column**, nothing per-club survives.
+- **Multi-line / entity cells.** Award cells contain `&nbsp;` and embedded newlines
+  (`EH5&nbsp;Engaging Humor Level 5,\nPM1…`); Prospective's `Prospect` cell concatenates
+  multiple dated milestones. Normalise whitespace on parse.
+- **Empty body** (Archive) → no `<table>` → return empty, do not throw.
+
+---
+
+## 4. Privacy assessment
+
+**Hard rule (epic #1062): no individual personal name — or personal identifier — is ever
+persisted.** The EXCLUDE map is applied at **parse time**, before any GCS/CDN write. What
+remains is club/area/division-level, the same posture as today's published stats.
+
+- **Education Achievements** de-identifies cleanly to **per-club / per-area award counts by
+  award type** — a strong recognition signal with zero personal data. This is the recommended
+  shape, **not** a member-level ledger.
+- **Triple Crown** cannot be de-identified to anything per-club (no club column); only a
+  district scalar count survives. Excluding `Member` is mandatory regardless.
+- **Coaches / Sponsors-Mentors / Prospective** keep only club aggregates + status; the
+  personal column (`Name` / `Club Contact`) is dropped.
+
+The validation test enforces this two ways: an **exhaustiveness** check (the map can't silently
+omit a header the report emits) and an independent **personal-value denylist** (no known
+personal string may appear in any KEEP projection — this fails loudly if a future edit
+re-classifies a personal column as KEEP, even though the header set would still "look" valid).
+
+---
+
+## 5. Closing-period augmentation — the strategic driver (evaluate, don't build yet)
+
+The epic's real prize: these reports update **daily even during month-end closing**, when the
+main `club-/division-/district-performance` dashboards freeze and date-remap (the #309 closing
+logic). Overlaying daily-fresh report fields onto the frozen base would show district leaders
+**current** reality for the things that actually move during closing.
+
+**Premise not yet proven — this is the #1 risk to carry into Sprint 2.** A single-day capture
+shows today's data is fresh, but cannot prove the reports _keep moving_ across a real closing
+window. **Before building any overlay**, capture daily snapshots of (at minimum) Dues Renewal,
+Officer List, CSP, New/Prospective Clubs across a month-end (e.g. June 28 → July 3) and diff
+them. If they move while the base snapshot is frozen, the thesis holds.
+
+**Overlay-eligible fields** (report-authoritative; everything else stays with the main
+dashboard, esp. membership/payment _counts_):
+
+- Dues renewal **status** (per club)
+- Officer-list **status** + election type (per club)
+- CSP **submission date**
+- New-club **charter date / status**; prospective-club **status / milestones**
+
+**Design constraints for the overlay (Sprint 2+):**
+
+- **Explicit provenance.** A blended snapshot is _base (frozen) + overlay (daily reports)_.
+  Every augmented field must carry its source + as-of date — never silently merge two cadences
+  into one number (the multi-source hazard behind #800 and the D61 150→151 stale-prod incident).
+- **Clean hand-off on un-freeze.** When closing ends and the base updates, the overlay must
+  yield to the authoritative base without a value jumping backward.
+- **Field-by-field eligibility only.** Counts the reports don't authoritatively cover are never
+  overlaid.
+
+---
+
+## 6. Open questions for operator decision (gating Sprint 2)
+
+1. **Republication licensing.** Anonymously _fetchable_ ≠ licensed to _republish_. The kept
+   fields are club-aggregate (same posture as today's stats), and all personal columns are
+   excluded specifically to preserve that posture — but this is TI's data. **Confirm
+   republishing club-aggregate report fields is acceptable** before wiring ingest.
+2. **Scope confirmation.** Proposed Sprint 2 = Officer List + Education Achievements (counts) +
+   CSP + Dues Renewal + New/Prospective lists; defer Triple Crown, Coaches, Sponsors-Mentors.
+   Confirm or re-prioritise.
+
+---
+
+## 7. Evidence / artifacts shipped this sprint
+
+- `packages/collector-cli/src/__tests__/fixtures/daily-reports/` — 12 recorded D61 fixtures
+  (desktop table only; trimmed for repo size, full shape + all edge cases preserved).
+- `packages/collector-cli/src/__tests__/dailyReportsColumnMap.test.ts` — the validated map +
+  30 assertions (exhaustiveness, disjointness, projection drops personal columns, personal-value
+  denylist backstop, empty-body tolerance). Falsifiability confirmed: mis-classifying a personal
+  column as KEEP turns the suite red.
+- This doc.
+
+No pipeline code changed; no personal data persisted.

--- a/packages/collector-cli/src/__tests__/dailyReportsColumnMap.test.ts
+++ b/packages/collector-cli/src/__tests__/dailyReportsColumnMap.test.ts
@@ -1,0 +1,281 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Spike #1063 (epic #1062) — Daily Reports ingest feasibility.
+ *
+ * This is the validated keep/EXCLUDE column map for the 12 District "Daily
+ * Reports", verified against live D61 fixtures captured 2026-06-01 (see
+ * `docs/investigations/1063-daily-reports-ingest-spike.md`).
+ *
+ * HARD PRIVACY RULE (epic #1062): ingest club/area/division-level data only;
+ * EXCLUDE every individual personal name (and any personal identifier such as
+ * a member number) at parse time, before anything is persisted.
+ *
+ * The map below is data, not pipeline wiring — nothing imports it yet. Sprint 2
+ * promotes it into the real parser. This test proves, on recorded fixtures,
+ * that the map is exhaustive (covers every header the live report emits) and
+ * that projecting to KEEP columns drops every personal cell value.
+ */
+
+const FIXTURE_DIR = fileURLToPath(
+  new URL('./fixtures/daily-reports/', import.meta.url)
+)
+
+interface ReportSpec {
+  /** Human label. */
+  report: string
+  /** Report-type GUID (the `tableID` query param). */
+  tableId: string
+  /** Recorded fixture filename. */
+  fixture: string
+  /** Columns safe to persist (club/area/division-level). */
+  keep: string[]
+  /** Personal columns that must be dropped at parse time. */
+  exclude: string[]
+  /** Known personal cell values that must NOT survive projection. */
+  personalSamples?: string[]
+  /** Some PYs return an empty body (no table) — parser must tolerate it. */
+  allowEmpty?: boolean
+}
+
+const DAILY_REPORTS: ReportSpec[] = [
+  {
+    report: 'April Dues Renewal Status',
+    tableId: '0235cdd5-ffee-4101-ab43-a952a2736fc0',
+    fixture: 'april-dues-renewal.html',
+    keep: ['Club', 'Division', 'Area', 'Renewal Status', 'Name', 'Location'],
+    exclude: [],
+  },
+  {
+    report: 'October Dues Renewal Status',
+    tableId: '0d56c054-0cd2-46ba-b3b1-3bf17221bd6c',
+    fixture: 'october-dues-renewal.html',
+    keep: ['Club', 'Division', 'Area', 'Renewal Status', 'Name', 'Location'],
+    exclude: [],
+  },
+  {
+    report: 'January Club Officer List Status',
+    tableId: '43abeb51-40a6-4514-868a-d697d6481753',
+    fixture: 'officer-list-january.html',
+    keep: ['Club', 'Division', 'Area', 'List Status', 'Election', 'Name'],
+    exclude: [],
+  },
+  {
+    report: 'July Club Officer List Status',
+    tableId: '68d834ff-90c1-40ae-a79e-c9270bd9919c',
+    fixture: 'officer-list-july.html',
+    keep: ['Club', 'Division', 'Area', 'List Status', 'Election', 'Name'],
+    exclude: [],
+  },
+  {
+    report: 'Club Success Plan Submission',
+    tableId: '99b20422-f82f-456b-8376-18d5ce1b70c5',
+    fixture: 'club-success-plan.html',
+    keep: ['Club Number', 'Division', 'Area', 'Submission Date', 'Club Name'],
+    exclude: [],
+  },
+  {
+    // The overloaded-"Name" case: Name = CLUB (keep), Member = PERSON (exclude).
+    report: 'Education Achievements',
+    tableId: 'c757d313-f815-4b22-93dc-b839d04cec7b',
+    fixture: 'education-achievements.html',
+    keep: ['Club', 'Division', 'Area', 'Award', 'Date', 'Name', 'Location'],
+    exclude: ['Member'],
+    personalSamples: ['Ricardo J. Bocanegra, DTM'],
+  },
+  {
+    // Member is "<memberId> - <name|Name unavailable>": the ID itself is
+    // identifying, so the whole column is excluded. No club column exists →
+    // only a district-level count is derivable.
+    report: 'Triple Crown Awards',
+    tableId: 'b546ef04-e602-4ffc-95c5-5a786aba36b7',
+    fixture: 'triple-crown.html',
+    keep: ['Count', 'Award'],
+    exclude: ['Member'],
+    personalSamples: ['00987204 - Name unavailable'],
+  },
+  {
+    report: 'Educational Achievement Archive (empty this PY)',
+    tableId: 'a30b93f3-081e-42c8-9a36-137acb24be69',
+    fixture: 'education-archive-empty.html',
+    keep: [],
+    exclude: [],
+    allowEmpty: true,
+  },
+  {
+    report: 'New Clubs',
+    tableId: 'ac6df5db-13de-425a-b8b9-f9c6093b538a',
+    fixture: 'new-clubs.html',
+    keep: [
+      'Division',
+      'Area',
+      'Club',
+      'Charter Date',
+      'Status',
+      'Name',
+      'Location',
+    ],
+    exclude: [],
+  },
+  {
+    report: 'Prospective Clubs',
+    tableId: '50630d17-1492-40c9-8244-930b1d94167b',
+    fixture: 'prospective-clubs.html',
+    keep: [
+      'Division',
+      'Area',
+      'Club',
+      'Status',
+      'Name',
+      'Location',
+      'Prospect',
+    ],
+    exclude: ['Club Contact'],
+    personalSamples: ['Linda Brisebois'],
+  },
+  {
+    report: 'New Club Sponsors and Mentors',
+    tableId: '4da53bd8-f6d9-4fa5-81d8-34ed5966dddd',
+    fixture: 'sponsors-mentors.html',
+    keep: ['Club', 'Club Name', 'Charter Date', 'Code', 'Status'],
+    exclude: ['Name'],
+    personalSamples: ['Louise Audy, PM5'],
+  },
+  {
+    report: 'Club Coaches',
+    tableId: '41955922-25ab-4a5a-8025-ebb7634f68bf',
+    fixture: 'coaches.html',
+    keep: ['Club', 'Club Name', 'Code', 'Begin Date', 'Status'],
+    exclude: ['Name'],
+    personalSamples: ['Rodica Jelea, VC1'],
+  },
+]
+
+/** Strip tags + collapse whitespace from an HTML cell's inner content. */
+function cellText(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+interface ParsedTable {
+  headers: string[]
+  rows: string[][]
+}
+
+/**
+ * Parse the desktop `<table>` of a Daily Report response. The response also
+ * carries a `<div class="mobile-table">` duplicate of the same data — the
+ * parser keys off the `<table>` only (the fixtures drop the mobile copy).
+ */
+function parseDesktopTable(htmlRaw: string): ParsedTable {
+  const tableMatch = htmlRaw.match(/<table[^>]*>([\s\S]*?)<\/table>/i)
+  if (!tableMatch) return { headers: [], rows: [] }
+  const trs = tableMatch[1].match(/<tr[^>]*>[\s\S]*?<\/tr>/gi) ?? []
+  const cellsOf = (tr: string): string[] =>
+    (tr.match(/<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/gi) ?? []).map(c =>
+      cellText(c.replace(/^<t[dh][^>]*>/i, '').replace(/<\/t[dh]>$/i, ''))
+    )
+  if (trs.length === 0) return { headers: [], rows: [] }
+  return {
+    headers: cellsOf(trs[0]),
+    rows: trs.slice(1).map(cellsOf),
+  }
+}
+
+/** Project rows to only the KEEP columns, in the fixture's header order. */
+function projectKeep(
+  table: ParsedTable,
+  keep: string[]
+): { headers: string[]; rows: string[][] } {
+  const keepIdx = table.headers
+    .map((h, i) => ({ h, i }))
+    .filter(({ h }) => keep.includes(h))
+    .map(({ i }) => i)
+  return {
+    headers: keepIdx.map(i => table.headers[i]),
+    rows: table.rows.map(r => keepIdx.map(i => r[i] ?? '')),
+  }
+}
+
+describe('Daily Reports keep/EXCLUDE column map (spike #1063)', () => {
+  it('covers all 12 report types', () => {
+    expect(DAILY_REPORTS).toHaveLength(12)
+  })
+
+  it.each(DAILY_REPORTS)(
+    'keep ∪ exclude exactly equals the live header set — $report',
+    spec => {
+      const html = readFileSync(FIXTURE_DIR + spec.fixture, 'utf8')
+      const { headers } = parseDesktopTable(html)
+
+      if (spec.allowEmpty && headers.length === 0) {
+        // Empty body is a real shape — parser must tolerate it, not crash.
+        expect(spec.keep).toEqual([])
+        expect(spec.exclude).toEqual([])
+        return
+      }
+
+      // Exhaustive + disjoint (R20 spirit): every live header is classified
+      // exactly once, and the map invents no header the report doesn't emit.
+      const classified = [...spec.keep, ...spec.exclude].sort()
+      expect(classified).toEqual([...headers].sort())
+      // keep ∩ exclude = ∅
+      expect(spec.keep.filter(k => spec.exclude.includes(k))).toEqual([])
+    }
+  )
+
+  it.each(DAILY_REPORTS.filter(s => s.exclude.length > 0))(
+    'projection drops every EXCLUDE column and personal value — $report',
+    spec => {
+      const html = readFileSync(FIXTURE_DIR + spec.fixture, 'utf8')
+      const table = parseDesktopTable(html)
+      const projected = projectKeep(table, spec.keep)
+
+      // No excluded column header survives.
+      for (const col of spec.exclude) {
+        expect(projected.headers).not.toContain(col)
+      }
+      // No personal cell value survives anywhere in the projected output...
+      const flat = projected.rows.flat().join('')
+      for (const sample of spec.personalSamples ?? []) {
+        expect(flat).not.toContain(sample)
+        // ...even though it WAS present in the raw fixture (proves the drop
+        // is real, not a fixture that never had the value — falsifiability).
+        expect(html).toContain(sample)
+      }
+    }
+  )
+
+  // Independent of how the map classifies columns: no known personal value may
+  // ever survive a KEEP projection. This is the privacy backstop — if a future
+  // edit mis-classifies a personal column as KEEP, the exhaustiveness test still
+  // passes (the header set is unchanged) but THIS test goes red.
+  const PERSONAL_DENYLIST = DAILY_REPORTS.flatMap(s => s.personalSamples ?? [])
+
+  it.each(DAILY_REPORTS.filter(s => !s.allowEmpty))(
+    'no personal value from any report survives KEEP projection — $report',
+    spec => {
+      const html = readFileSync(FIXTURE_DIR + spec.fixture, 'utf8')
+      const projected = projectKeep(parseDesktopTable(html), spec.keep)
+      const flat = projected.rows.flat().join('')
+      for (const personal of PERSONAL_DENYLIST) {
+        expect(flat).not.toContain(personal)
+      }
+    }
+  )
+
+  it('tolerates the empty-body archive report without throwing', () => {
+    const html = readFileSync(
+      FIXTURE_DIR + 'education-archive-empty.html',
+      'utf8'
+    )
+    const table = parseDesktopTable(html)
+    expect(table.headers).toEqual([])
+    expect(table.rows).toEqual([])
+  })
+})

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/april-dues-renewal.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/april-dues-renewal.html
@@ -1,0 +1,84 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:renewals@toastmasters.org&quot;&gt;renewals@toastmasters.org&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Club&quot;,&quot;Value&quot;:&quot;17.3%&quot;},{&quot;Key&quot;:&quot;Division&quot;,&quot;Value&quot;:&quot;19.3%&quot;},{&quot;Key&quot;:&quot;Area&quot;,&quot;Value&quot;:&quot;12.9%&quot;},{&quot;Key&quot;:&quot;Renewal_Status&quot;,&quot;Value&quot;:&quot;17.6%&quot;},{&quot;Key&quot;:&quot;Name&quot;,&quot;Value&quot;:&quot;22%&quot;},{&quot;Key&quot;:&quot;Location&quot;,&quot;Value&quot;:&quot;18%&quot;}]" />
+        <div id="april_dues_renewal_status_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 8 of 160 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="april_dues_renewal_status" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Club" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club</th>
+                            <th role="columnheader" id="Division" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Division</th>
+                            <th role="columnheader" id="Area" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Area</th>
+                            <th role="columnheader" id="Renewal_Status" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Renewal Status</th>
+                            <th role="columnheader" id="Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Name</th>
+                            <th role="columnheader" id="Location" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Location</th>
+                    </tr>
+<tr>
+                                    <td style="width:17.3%">1009147</td>
+                                    <td style="width:19.3%">D</td>
+                                    <td style="width:12.9%">33</td>
+                                    <td style="width:17.6%">Verified complete - 01/30/2026</td>
+                                    <td style="width:22%">Los Amigos Online</td>
+                                    <td style="width:18%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:17.3%">1036983</td>
+                                    <td style="width:19.3%">F</td>
+                                    <td style="width:12.9%">53</td>
+                                    <td style="width:17.6%">Verified complete - 03/16/2026</td>
+                                    <td style="width:22%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:18%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:17.3%">1099641</td>
+                                    <td style="width:19.3%">I</td>
+                                    <td style="width:12.9%">93</td>
+                                    <td style="width:17.6%">Verified complete - 01/30/2026</td>
+                                    <td style="width:22%">Toastmasters Vallee Du Richelieu</td>
+                                    <td style="width:18%">Mont-St-Hilaire</td>
+                            </tr>
+<tr>
+                                    <td style="width:17.3%">1100158</td>
+                                    <td style="width:19.3%">A</td>
+                                    <td style="width:12.9%">4</td>
+                                    <td style="width:17.6%">Verified complete - 01/30/2026</td>
+                                    <td style="width:22%">IBM Ottawa Toastmasters</td>
+                                    <td style="width:18%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:17.3%">1106180</td>
+                                    <td style="width:19.3%">C</td>
+                                    <td style="width:12.9%">21</td>
+                                    <td style="width:17.6%">Verified complete - 01/30/2026</td>
+                                    <td style="width:22%">A Matter of Taste</td>
+                                    <td style="width:18%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:17.3%">1261</td>
+                                    <td style="width:19.3%">H</td>
+                                    <td style="width:12.9%">73</td>
+                                    <td style="width:17.6%">Verified complete - 01/30/2026</td>
+                                    <td style="width:22%">Club Toastmasters Lemoyne de Candiac</td>
+                                    <td style="width:18%">Candiac</td>
+                            </tr>
+<tr>
+                                    <td style="width:17.3%">1269833</td>
+                                    <td style="width:19.3%">I</td>
+                                    <td style="width:12.9%">91</td>
+                                    <td style="width:17.6%">Ineligible - Minimum requirement not yet met</td>
+                                    <td style="width:22%">FSA-Universite Laval</td>
+                                    <td style="width:18%">Québec</td>
+                            </tr>
+<tr>
+                                    <td style="width:17.3%">1296822</td>
+                                    <td style="width:19.3%">F</td>
+                                    <td style="width:12.9%">54</td>
+                                    <td style="width:17.6%">Low - Minimum requirement not yet met</td>
+                                    <td style="width:22%">Les Explosifs De Laval</td>
+                                    <td style="width:18%">Ste-Rose Laval</td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/club-success-plan.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/club-success-plan.html
@@ -1,0 +1,75 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:&quot;&gt;&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Club_Number&quot;,&quot;Value&quot;:&quot;20%&quot;},{&quot;Key&quot;:&quot;Division&quot;,&quot;Value&quot;:&quot;15%&quot;},{&quot;Key&quot;:&quot;Area&quot;,&quot;Value&quot;:&quot;15%&quot;},{&quot;Key&quot;:&quot;Submission_Date&quot;,&quot;Value&quot;:&quot;20%&quot;},{&quot;Key&quot;:&quot;Club_Name&quot;,&quot;Value&quot;:&quot;30%&quot;}]" />
+        <div id="club_success_plan_submission_report_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 8 of 160 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="club_success_plan_submission_report" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Club_Number" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club Number</th>
+                            <th role="columnheader" id="Division" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Division</th>
+                            <th role="columnheader" id="Area" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Area</th>
+                            <th role="columnheader" id="Submission_Date" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Submission Date</th>
+                            <th role="columnheader" id="Club_Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club Name</th>
+                    </tr>
+<tr>
+                                    <td style="width:20%">1009147</td>
+                                    <td style="width:15%">D</td>
+                                    <td style="width:15%">33</td>
+                                    <td style="width:20%">September 17, 2025</td>
+                                    <td style="width:30%">Los Amigos Online</td>
+                            </tr>
+<tr>
+                                    <td style="width:20%">1036983</td>
+                                    <td style="width:15%">F</td>
+                                    <td style="width:15%">53</td>
+                                    <td style="width:20%">September 28, 2025</td>
+                                    <td style="width:30%">Maîtres parleurs de Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:20%">1099641</td>
+                                    <td style="width:15%">I</td>
+                                    <td style="width:15%">93</td>
+                                    <td style="width:20%">August 29, 2025</td>
+                                    <td style="width:30%">Toastmasters Vallee Du Richelieu</td>
+                            </tr>
+<tr>
+                                    <td style="width:20%">1100158</td>
+                                    <td style="width:15%">A</td>
+                                    <td style="width:15%">4</td>
+                                    <td style="width:20%">September 23, 2025</td>
+                                    <td style="width:30%">IBM Ottawa Toastmasters</td>
+                            </tr>
+<tr>
+                                    <td style="width:20%">1106180</td>
+                                    <td style="width:15%">C</td>
+                                    <td style="width:15%">21</td>
+                                    <td style="width:20%">August 2, 2025</td>
+                                    <td style="width:30%">A Matter of Taste</td>
+                            </tr>
+<tr>
+                                    <td style="width:20%">1261</td>
+                                    <td style="width:15%">H</td>
+                                    <td style="width:15%">73</td>
+                                    <td style="width:20%">September 13, 2025</td>
+                                    <td style="width:30%">Club Toastmasters Lemoyne de Candiac</td>
+                            </tr>
+<tr>
+                                    <td style="width:20%">1269833</td>
+                                    <td style="width:15%">I</td>
+                                    <td style="width:15%">91</td>
+                                    <td style="width:20%">September 28, 2025</td>
+                                    <td style="width:30%">FSA-Universite Laval</td>
+                            </tr>
+<tr>
+                                    <td style="width:20%">1296822</td>
+                                    <td style="width:15%">F</td>
+                                    <td style="width:15%">54</td>
+                                    <td style="width:20%">August 19, 2025</td>
+                                    <td style="width:30%">Les Explosifs De Laval</td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/coaches.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/coaches.html
@@ -1,0 +1,148 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:newclubs@toastmasters.org&quot;&gt;newclubs@toastmasters.org&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Club&quot;,&quot;Value&quot;:&quot;15%&quot;},{&quot;Key&quot;:&quot;Club_Name&quot;,&quot;Value&quot;:&quot;17.9%&quot;},{&quot;Key&quot;:&quot;Code&quot;,&quot;Value&quot;:&quot;15%&quot;},{&quot;Key&quot;:&quot;Name&quot;,&quot;Value&quot;:&quot;20%&quot;},{&quot;Key&quot;:&quot;Begin_Date&quot;,&quot;Value&quot;:&quot;23%&quot;},{&quot;Key&quot;:&quot;Status&quot;,&quot;Value&quot;:&quot;15%&quot;}]" />
+        <div id="club_coaches_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 16 of 16 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="club_coaches" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Club" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club</th>
+                            <th role="columnheader" id="Club_Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club Name</th>
+                            <th role="columnheader" id="Code" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Code</th>
+                            <th role="columnheader" id="Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Name</th>
+                            <th role="columnheader" id="Begin_Date" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Begin Date</th>
+                            <th role="columnheader" id="Status" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Status</th>
+                    </tr>
+<tr>
+                                    <td style="width:15%">1296822</td>
+                                    <td style="width:17.9%">Les Explosifs De Laval</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Rodica Jelea, VC1</td>
+                                    <td style="width:23%">08/22/2024</td>
+                                    <td style="width:15%">AWARDED</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">1296822</td>
+                                    <td style="width:17.9%">Les Explosifs De Laval</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Raymond Leclair, DTM</td>
+                                    <td style="width:23%">09/20/2024</td>
+                                    <td style="width:15%">AWARDED</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">3475582</td>
+                                    <td style="width:17.9%">Tunney's Toastmasters</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Minnie Y. Chen, PI5</td>
+                                    <td style="width:23%">09/27/2024</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">4673</td>
+                                    <td style="width:17.9%">Bombardier Canadair Toastmasters Club</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Alain Lamoureux, DL5</td>
+                                    <td style="width:23%">12/09/2025</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">4673</td>
+                                    <td style="width:17.9%">Bombardier Canadair Toastmasters Club</td>
+                                    <td style="width:15%">COACHU</td>
+                                    <td style="width:20%">07914910 - Name unavailable</td>
+                                    <td style="width:23%">09/05/2024</td>
+                                    <td style="width:15%">AWARDED</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">4675249</td>
+                                    <td style="width:17.9%">Carleton Place Toastmasters</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Lucy Wong, PM3</td>
+                                    <td style="width:23%">12/21/2024</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">5046</td>
+                                    <td style="width:17.9%">Avance Synergie </td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Lise Blondin, DTM</td>
+                                    <td style="width:23%">01/20/2026</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">5833</td>
+                                    <td style="width:17.9%">Pembroke & Area Club</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">01389244 - Name unavailable</td>
+                                    <td style="width:23%">08/22/2024</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">6502</td>
+                                    <td style="width:17.9%">TM Francophone de Chicoutimi Club</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Céline Dorion, EC5</td>
+                                    <td style="width:23%">12/16/2025</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">6502</td>
+                                    <td style="width:17.9%">TM Francophone de Chicoutimi Club</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Isabelle Fournier, DTM</td>
+                                    <td style="width:23%">12/16/2025</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">6552</td>
+                                    <td style="width:17.9%">Expression Club</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Caroline Cyr, PM5</td>
+                                    <td style="width:23%">05/17/2025</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">684093</td>
+                                    <td style="width:17.9%">Club avancé international</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Roselvie Makosso, PM5</td>
+                                    <td style="width:23%">09/23/2025</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">7027</td>
+                                    <td style="width:17.9%">Les Orateurs Pratt & Whitney - Canada</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Céline Dorion, EC5</td>
+                                    <td style="width:23%">12/22/2024</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">901116</td>
+                                    <td style="width:17.9%">La Seigneurie De Boucherville</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">67620679 - Name unavailable</td>
+                                    <td style="width:23%">12/31/2025</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">9361</td>
+                                    <td style="width:17.9%">Club Toastmasters Montréal</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Thomas Feray, DTM</td>
+                                    <td style="width:23%">05/17/2025</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:15%">9560</td>
+                                    <td style="width:17.9%">CFB Kingston Toastmasters</td>
+                                    <td style="width:15%">COACH</td>
+                                    <td style="width:20%">Stephen M. Fritz-Millett, DTM</td>
+                                    <td style="width:23%">08/21/2024</td>
+                                    <td style="width:15%">PENDING</td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/education-achievements.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/education-achievements.html
@@ -1,0 +1,422 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:educationprogram@toastmasters.org&quot;&gt;educationprogram@toastmasters.org&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Club&quot;,&quot;Value&quot;:&quot;10%&quot;},{&quot;Key&quot;:&quot;Division&quot;,&quot;Value&quot;:&quot;12%&quot;},{&quot;Key&quot;:&quot;Area&quot;,&quot;Value&quot;:&quot;8.5%&quot;},{&quot;Key&quot;:&quot;Award&quot;,&quot;Value&quot;:&quot;16.4%&quot;},{&quot;Key&quot;:&quot;Date&quot;,&quot;Value&quot;:&quot;12.3%&quot;},{&quot;Key&quot;:&quot;Member&quot;,&quot;Value&quot;:&quot;15%&quot;},{&quot;Key&quot;:&quot;Name&quot;,&quot;Value&quot;:&quot;15%&quot;},{&quot;Key&quot;:&quot;Location&quot;,&quot;Value&quot;:&quot;12%&quot;}]" />
+        <div id="educational_achievements_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 40 of 1125 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="educational_achievements" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Club" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club</th>
+                            <th role="columnheader" id="Division" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Division</th>
+                            <th role="columnheader" id="Area" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Area</th>
+                            <th role="columnheader" id="Award" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Award</th>
+                            <th role="columnheader" id="Date" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Date</th>
+                            <th role="columnheader" id="Member" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Member</th>
+                            <th role="columnheader" id="Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Name</th>
+                            <th role="columnheader" id="Location" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Location</th>
+                    </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">DL2<span class="tooltiptext">Dynamic Leadership Level 2</span></div></td>
+                                    <td style="width:12.3%">09/16/2025</td>
+                                    <td style="width:15%">Ricardo J. Bocanegra, DTM</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">DL3<span class="tooltiptext">Dynamic Leadership Level 3</span></div></td>
+                                    <td style="width:12.3%">09/23/2025</td>
+                                    <td style="width:15%">Ricardo J. Bocanegra, DTM</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">DL4<span class="tooltiptext">Dynamic Leadership Level 4</span></div></td>
+                                    <td style="width:12.3%">07/11/2025</td>
+                                    <td style="width:15%">Ricardo J. Bocanegra, DTM</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">EC4<span class="tooltiptext">Effective Coaching Level 4 </span></div></td>
+                                    <td style="width:12.3%">10/21/2025</td>
+                                    <td style="width:15%">06629398 - Name unavailable</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">EH4<span class="tooltiptext">Engaging Humor Level 4</span></div></td>
+                                    <td style="width:12.3%">09/08/2025</td>
+                                    <td style="width:15%">Ricardo J. Bocanegra, DTM</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">LD1<span class="tooltiptext">Leadership Development Level 1 </span></div></td>
+                                    <td style="width:12.3%">09/29/2025</td>
+                                    <td style="width:15%">Kamala Aksamija, PM1</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">MS1<span class="tooltiptext">Motivational Strategies Level 1 </span></div></td>
+                                    <td style="width:12.3%">10/06/2025</td>
+                                    <td style="width:15%">Silvia Olivares-Guevara, DTM</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">MS2<span class="tooltiptext">Motivational Strategies Level 2</span></div></td>
+                                    <td style="width:12.3%">07/11/2025</td>
+                                    <td style="width:15%">Beth Stoeckly, DTM</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">MS5<span class="tooltiptext">Motivational Strategies Level 5</span></div></td>
+                                    <td style="width:12.3%">07/11/2025</td>
+                                    <td style="width:15%">Ricardo J. Bocanegra, DTM</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM1<span class="tooltiptext">Presentation Mastery Level 1</span></div></td>
+                                    <td style="width:12.3%">08/31/2025</td>
+                                    <td style="width:15%">Ricardo J. Bocanegra, DTM</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM1<span class="tooltiptext">Presentation Mastery Level 1</span></div></td>
+                                    <td style="width:12.3%">09/29/2025</td>
+                                    <td style="width:15%">Kamala Aksamija, PM1</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM1<span class="tooltiptext">Presentation Mastery Level 1 </span></div></td>
+                                    <td style="width:12.3%">09/27/2025</td>
+                                    <td style="width:15%">05698558 - Name unavailable</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM2<span class="tooltiptext">Presentation Mastery Level 2</span></div></td>
+                                    <td style="width:12.3%">09/01/2025</td>
+                                    <td style="width:15%">Ricardo J. Bocanegra, DTM</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM2<span class="tooltiptext">Presentation Mastery Level 2 </span></div></td>
+                                    <td style="width:12.3%">10/06/2025</td>
+                                    <td style="width:15%">05698558 - Name unavailable</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM2<span class="tooltiptext">Presentation Mastery Level 2 </span></div></td>
+                                    <td style="width:12.3%">10/13/2025</td>
+                                    <td style="width:15%">67521977 - Name unavailable</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM3<span class="tooltiptext">Presentation Mastery Level 3</span></div></td>
+                                    <td style="width:12.3%">09/01/2025</td>
+                                    <td style="width:15%">Ricardo J. Bocanegra, DTM</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM3<span class="tooltiptext">Presentation Mastery Level 3 </span></div></td>
+                                    <td style="width:12.3%">08/05/2025</td>
+                                    <td style="width:15%">00303461 - Name unavailable</td>
+                                    <td style="width:15%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">DL4<span class="tooltiptext">Dynamic Leadership Level 4 </span></div></td>
+                                    <td style="width:12.3%">10/10/2025</td>
+                                    <td style="width:15%">Glifoli Tagbata, DL5</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">DL5<span class="tooltiptext">Dynamic Leadership Level 5 </span></div></td>
+                                    <td style="width:12.3%">04/25/2026</td>
+                                    <td style="width:15%">Glifoli Tagbata, DL5</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">EC2<span class="tooltiptext">Effective Coaching Level 2</span></div></td>
+                                    <td style="width:12.3%">12/10/2025</td>
+                                    <td style="width:15%">Roseline Dumouchel, EC2</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">MS2<span class="tooltiptext">Motivational Strategies Level 2 </span></div></td>
+                                    <td style="width:12.3%">04/06/2026</td>
+                                    <td style="width:15%">Raymond Leclair, DTM</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PI1<span class="tooltiptext">Persuasive Influence Level 1 </span></div></td>
+                                    <td style="width:12.3%">02/25/2026</td>
+                                    <td style="width:15%">Jonathan Miller, PI2</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PI2<span class="tooltiptext">Persuasive Influence Level 2 </span></div></td>
+                                    <td style="width:12.3%">05/20/2026</td>
+                                    <td style="width:15%">Jonathan Miller, PI2</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM1<span class="tooltiptext">Presentation Mastery Level 1 </span></div></td>
+                                    <td style="width:12.3%">12/10/2025</td>
+                                    <td style="width:15%">Nicole Fournier, PM1</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM1<span class="tooltiptext">Presentation Mastery Level 1 </span></div></td>
+                                    <td style="width:12.3%">03/17/2026</td>
+                                    <td style="width:15%">Bambehane Cécile Lendi, PM1</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM1<span class="tooltiptext">Presentation Mastery Level 1 </span></div></td>
+                                    <td style="width:12.3%">05/11/2026</td>
+                                    <td style="width:15%">67492616 - Name unavailable</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM2<span class="tooltiptext">Presentation Mastery Level 2 </span></div></td>
+                                    <td style="width:12.3%">10/10/2025</td>
+                                    <td style="width:15%">Luc Lafontaine, PM3</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM3<span class="tooltiptext">Presentation Mastery Level 3 </span></div></td>
+                                    <td style="width:12.3%">03/04/2026</td>
+                                    <td style="width:15%">Luc Lafontaine, PM3</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM4<span class="tooltiptext">Presentation Mastery Level 4 </span></div></td>
+                                    <td style="width:12.3%">10/10/2025</td>
+                                    <td style="width:15%">Raymond Leclair, DTM</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PM5<span class="tooltiptext">Presentation Mastery Level 5 </span></div></td>
+                                    <td style="width:12.3%">10/10/2025</td>
+                                    <td style="width:15%">Raymond Leclair, DTM</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">PWMENTORPGM<span class="tooltiptext">Pathways Mentor Program</span></div></td>
+                                    <td style="width:12.3%">04/26/2026</td>
+                                    <td style="width:15%">Luc Lafontaine, PM3</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">VC2<span class="tooltiptext">Visionary Communication Level 2 </span></div></td>
+                                    <td style="width:12.3%">10/10/2025</td>
+                                    <td style="width:15%">Raymond Leclair, DTM</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">VC3<span class="tooltiptext">Visionary Communication Level 3 </span></div></td>
+                                    <td style="width:12.3%">10/10/2025</td>
+                                    <td style="width:15%">Raymond Leclair, DTM</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">VC4<span class="tooltiptext">Visionary Communication Level 4 </span></div></td>
+                                    <td style="width:12.3%">10/10/2025</td>
+                                    <td style="width:15%">Raymond Leclair, DTM</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">VC5<span class="tooltiptext">Visionary Communication Level 5 </span></div></td>
+                                    <td style="width:12.3%">10/13/2025</td>
+                                    <td style="width:15%">Raymond Leclair, DTM</td>
+                                    <td style="width:15%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1099641</td>
+                                    <td style="width:12%">I</td>
+                                    <td style="width:8.5%">93</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">DL2<span class="tooltiptext">Dynamic Leadership Level 2 </span></div></td>
+                                    <td style="width:12.3%">11/17/2025</td>
+                                    <td style="width:15%">David Chabot, DL3</td>
+                                    <td style="width:15%">Toastmasters Vallee Du Richelieu</td>
+                                    <td style="width:12%">Mont-St-Hilaire</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1099641</td>
+                                    <td style="width:12%">I</td>
+                                    <td style="width:8.5%">93</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">DL3<span class="tooltiptext">Dynamic Leadership Level 3 </span></div></td>
+                                    <td style="width:12.3%">03/27/2026</td>
+                                    <td style="width:15%">David Chabot, DL3</td>
+                                    <td style="width:15%">Toastmasters Vallee Du Richelieu</td>
+                                    <td style="width:12%">Mont-St-Hilaire</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1099641</td>
+                                    <td style="width:12%">I</td>
+                                    <td style="width:8.5%">93</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">MS1<span class="tooltiptext">Motivational Strategies Level 1 </span></div></td>
+                                    <td style="width:12.3%">02/20/2026</td>
+                                    <td style="width:15%">Dominic Charbonneau, MS3</td>
+                                    <td style="width:15%">Toastmasters Vallee Du Richelieu</td>
+                                    <td style="width:12%">Mont-St-Hilaire</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1099641</td>
+                                    <td style="width:12%">I</td>
+                                    <td style="width:8.5%">93</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">MS2<span class="tooltiptext">Motivational Strategies Level 2 </span></div></td>
+                                    <td style="width:12.3%">03/27/2026</td>
+                                    <td style="width:15%">Dominic Charbonneau, MS3</td>
+                                    <td style="width:15%">Toastmasters Vallee Du Richelieu</td>
+                                    <td style="width:12%">Mont-St-Hilaire</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">1099641</td>
+                                    <td style="width:12%">I</td>
+                                    <td style="width:8.5%">93</td>
+                                    <td style="width:16.4%"><div class="awrd-tooltip">MS3<span class="tooltiptext">Motivational Strategies Level 3 </span></div></td>
+                                    <td style="width:12.3%">05/15/2026</td>
+                                    <td style="width:15%">Dominic Charbonneau, MS3</td>
+                                    <td style="width:15%">Toastmasters Vallee Du Richelieu</td>
+                                    <td style="width:12%">Mont-St-Hilaire</td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/new-clubs.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/new-clubs.html
@@ -1,0 +1,66 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:newclubs@toastmasters.org&quot;&gt;newclubs@toastmasters.org&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Division&quot;,&quot;Value&quot;:&quot;16%&quot;},{&quot;Key&quot;:&quot;Area&quot;,&quot;Value&quot;:&quot;13.5%&quot;},{&quot;Key&quot;:&quot;Club&quot;,&quot;Value&quot;:&quot;14.8%&quot;},{&quot;Key&quot;:&quot;Charter_Date&quot;,&quot;Value&quot;:&quot;16%&quot;},{&quot;Key&quot;:&quot;Status&quot;,&quot;Value&quot;:&quot;13%&quot;},{&quot;Key&quot;:&quot;Name&quot;,&quot;Value&quot;:&quot;16%&quot;},{&quot;Key&quot;:&quot;Location&quot;,&quot;Value&quot;:&quot;11%&quot;}]" />
+        <div id="new_clubs_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 5 of 5 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="new_clubs" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Division" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Division</th>
+                            <th role="columnheader" id="Area" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Area</th>
+                            <th role="columnheader" id="Club" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club</th>
+                            <th role="columnheader" id="Charter_Date" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Charter Date</th>
+                            <th role="columnheader" id="Status" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Status</th>
+                            <th role="columnheader" id="Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Name</th>
+                            <th role="columnheader" id="Location" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Location</th>
+                    </tr>
+<tr>
+                                    <td style="width:16%">I</td>
+                                    <td style="width:13.5%">93</td>
+                                    <td style="width:14.8%">28678571</td>
+                                    <td style="width:16%">04/17/2026</td>
+                                    <td style="width:13%">Complete</td>
+                                    <td style="width:16%">Club Toastmasters de Drummondville</td>
+                                    <td style="width:11%">Drummondville</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">G</td>
+                                    <td style="width:13.5%">62</td>
+                                    <td style="width:14.8%">28679190</td>
+                                    <td style="width:16%">04/15/2026</td>
+                                    <td style="width:13%">Complete</td>
+                                    <td style="width:16%">Club Toastmasters Les Entrepreneurs de Montreal</td>
+                                    <td style="width:11%">Montreal</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">I</td>
+                                    <td style="width:13.5%">92</td>
+                                    <td style="width:14.8%">28679222</td>
+                                    <td style="width:16%">01/22/2026</td>
+                                    <td style="width:13%">Complete</td>
+                                    <td style="width:16%">Club Toastmasters IA</td>
+                                    <td style="width:11%">Quebec</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">G</td>
+                                    <td style="width:13.5%">63</td>
+                                    <td style="width:14.8%">28679503</td>
+                                    <td style="width:16%">12/01/2025</td>
+                                    <td style="width:13%">Complete</td>
+                                    <td style="width:16%">TENE Toastmasters</td>
+                                    <td style="width:11%">Montreal</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">G</td>
+                                    <td style="width:13.5%">61</td>
+                                    <td style="width:14.8%">28680300</td>
+                                    <td style="width:16%">05/22/2026</td>
+                                    <td style="width:13%">Complete</td>
+                                    <td style="width:16%">iA Montreal Toastmasters</td>
+                                    <td style="width:11%">Montreal</td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/october-dues-renewal.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/october-dues-renewal.html
@@ -1,0 +1,84 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:renewals@toastmasters.org&quot;&gt;renewals@toastmasters.org&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Club&quot;,&quot;Value&quot;:&quot;16%&quot;},{&quot;Key&quot;:&quot;Division&quot;,&quot;Value&quot;:&quot;17%&quot;},{&quot;Key&quot;:&quot;Area&quot;,&quot;Value&quot;:&quot;14%&quot;},{&quot;Key&quot;:&quot;Renewal_Status&quot;,&quot;Value&quot;:&quot;18%&quot;},{&quot;Key&quot;:&quot;Name&quot;,&quot;Value&quot;:&quot;24.2%&quot;},{&quot;Key&quot;:&quot;Location&quot;,&quot;Value&quot;:&quot;12%&quot;}]" />
+        <div id="october_dues_renewal_status_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 8 of 160 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="october_dues_renewal_status" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Club" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club</th>
+                            <th role="columnheader" id="Division" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Division</th>
+                            <th role="columnheader" id="Area" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Area</th>
+                            <th role="columnheader" id="Renewal_Status" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Renewal Status</th>
+                            <th role="columnheader" id="Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Name</th>
+                            <th role="columnheader" id="Location" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Location</th>
+                    </tr>
+<tr>
+                                    <td style="width:16%">1009147</td>
+                                    <td style="width:17%">D</td>
+                                    <td style="width:14%">33</td>
+                                    <td style="width:18%">Verified complete - 08/09/2025</td>
+                                    <td style="width:24.2%">Los Amigos Online</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">1036983</td>
+                                    <td style="width:17%">F</td>
+                                    <td style="width:14%">53</td>
+                                    <td style="width:18%">Verified complete - 09/10/2025</td>
+                                    <td style="width:24.2%">Maîtres parleurs de Blainville</td>
+                                    <td style="width:12%">Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">1099641</td>
+                                    <td style="width:17%">I</td>
+                                    <td style="width:14%">93</td>
+                                    <td style="width:18%">Verified complete - 09/30/2025</td>
+                                    <td style="width:24.2%">Toastmasters Vallee Du Richelieu</td>
+                                    <td style="width:12%">Mont-St-Hilaire</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">1100158</td>
+                                    <td style="width:17%">A</td>
+                                    <td style="width:14%">4</td>
+                                    <td style="width:18%">Verified complete - 09/29/2025</td>
+                                    <td style="width:24.2%">IBM Ottawa Toastmasters</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">1106180</td>
+                                    <td style="width:17%">C</td>
+                                    <td style="width:14%">21</td>
+                                    <td style="width:18%">Verified complete - 07/31/2025</td>
+                                    <td style="width:24.2%">A Matter of Taste</td>
+                                    <td style="width:12%">Ottawa</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">1261</td>
+                                    <td style="width:17%">H</td>
+                                    <td style="width:14%">73</td>
+                                    <td style="width:18%">Verified complete - 07/31/2025</td>
+                                    <td style="width:24.2%">Club Toastmasters Lemoyne de Candiac</td>
+                                    <td style="width:12%">Candiac</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">1269833</td>
+                                    <td style="width:17%">I</td>
+                                    <td style="width:14%">91</td>
+                                    <td style="width:18%">Verified complete - 02/19/2026</td>
+                                    <td style="width:24.2%">FSA-Universite Laval</td>
+                                    <td style="width:12%">Québec</td>
+                            </tr>
+<tr>
+                                    <td style="width:16%">1296822</td>
+                                    <td style="width:17%">F</td>
+                                    <td style="width:14%">54</td>
+                                    <td style="width:18%">Verified complete - 10/17/2025</td>
+                                    <td style="width:24.2%">Les Explosifs De Laval</td>
+                                    <td style="width:12%">Ste-Rose Laval</td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/officer-list-january.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/officer-list-january.html
@@ -1,0 +1,76 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:clubofficers@toastmasters.org&quot;&gt;clubofficers@toastmasters.org&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Club&quot;,&quot;Value&quot;:&quot;10%&quot;},{&quot;Key&quot;:&quot;Division&quot;,&quot;Value&quot;:&quot;11%&quot;},{&quot;Key&quot;:&quot;Area&quot;,&quot;Value&quot;:&quot;8.5%&quot;},{&quot;Key&quot;:&quot;List_Status&quot;,&quot;Value&quot;:&quot;11.9%&quot;},{&quot;Key&quot;:&quot;Election&quot;,&quot;Value&quot;:&quot;12.5%&quot;},{&quot;Key&quot;:&quot;Name&quot;,&quot;Value&quot;:&quot;12.5%&quot;}]" />
+        <div id="january_club_officer_list_status_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 7 of 7 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="january_club_officer_list_status" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Club" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club</th>
+                            <th role="columnheader" id="Division" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Division</th>
+                            <th role="columnheader" id="Area" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Area</th>
+                            <th role="columnheader" id="List_Status" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">List Status</th>
+                            <th role="columnheader" id="Election" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Election</th>
+                            <th role="columnheader" id="Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Name</th>
+                    </tr>
+<tr>
+                                    <td style="width:10%">28678588</td>
+                                    <td style="width:11%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:11.9%">Received - 01/16/2026</td>
+                                    <td style="width:12.5%">Semiannual</td>
+                                    <td style="width:12.5%">Club Toastmasters Fonds de Solidarite FTQ</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">28679222</td>
+                                    <td style="width:11%">I</td>
+                                    <td style="width:8.5%">92</td>
+                                    <td style="width:11.9%">Received - 01/22/2026</td>
+                                    <td style="width:12.5%">Semiannual</td>
+                                    <td style="width:12.5%">Club Toastmasters IA</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">4311</td>
+                                    <td style="width:11%">G</td>
+                                    <td style="width:8.5%">63</td>
+                                    <td style="width:11.9%">Received - 12/16/2025</td>
+                                    <td style="width:12.5%">Semiannual</td>
+                                    <td style="width:12.5%">McGill Club</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">613576</td>
+                                    <td style="width:11%">G</td>
+                                    <td style="width:8.5%">63</td>
+                                    <td style="width:11.9%">Received - 01/07/2026</td>
+                                    <td style="width:12.5%">Semiannual</td>
+                                    <td style="width:12.5%">Speak with Style Toastmasters Club</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">813731</td>
+                                    <td style="width:11%">H</td>
+                                    <td style="width:8.5%">70</td>
+                                    <td style="width:11.9%">Received - 11/16/2025</td>
+                                    <td style="width:12.5%">Semiannual</td>
+                                    <td style="width:12.5%">Leaders En Action</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">9560</td>
+                                    <td style="width:11%">A</td>
+                                    <td style="width:8.5%">1</td>
+                                    <td style="width:11.9%">Received - 11/26/2025</td>
+                                    <td style="width:12.5%">Semiannual</td>
+                                    <td style="width:12.5%">CFB Kingston Toastmasters</td>
+                            </tr>
+<tr>
+                                    <td style="width:10%">9886</td>
+                                    <td style="width:11%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:11.9%">Received - 11/06/2025</td>
+                                    <td style="width:12.5%">Semiannual</td>
+                                    <td style="width:12.5%">Golden Mile Toastmasters Club</td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/officer-list-july.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/officer-list-july.html
@@ -1,0 +1,100 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:clubofficers@toastmasters.org&quot;&gt;clubofficers@toastmasters.org&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Club&quot;,&quot;Value&quot;:&quot;10.5%&quot;},{&quot;Key&quot;:&quot;Division&quot;,&quot;Value&quot;:&quot;12%&quot;},{&quot;Key&quot;:&quot;Area&quot;,&quot;Value&quot;:&quot;8.5%&quot;},{&quot;Key&quot;:&quot;List_Status&quot;,&quot;Value&quot;:&quot;12%&quot;},{&quot;Key&quot;:&quot;Election&quot;,&quot;Value&quot;:&quot;11.5%&quot;},{&quot;Key&quot;:&quot;Name&quot;,&quot;Value&quot;:&quot;16%&quot;}]" />
+        <div id="july_club_officer_list_status_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 10 of 160 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="july_club_officer_list_status" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Club" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club</th>
+                            <th role="columnheader" id="Division" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Division</th>
+                            <th role="columnheader" id="Area" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Area</th>
+                            <th role="columnheader" id="List_Status" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">List Status</th>
+                            <th role="columnheader" id="Election" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Election</th>
+                            <th role="columnheader" id="Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Name</th>
+                    </tr>
+<tr>
+                                    <td style="width:10.5%">1009147</td>
+                                    <td style="width:12%">D</td>
+                                    <td style="width:8.5%">33</td>
+                                    <td style="width:12%">Received - 05/25/2026</td>
+                                    <td style="width:11.5%">Annual</td>
+                                    <td style="width:16%">Los Amigos Online</td>
+                            </tr>
+<tr>
+                                    <td style="width:10.5%">1036983</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">53</td>
+                                    <td style="width:12%">List Not Here</td>
+                                    <td style="width:11.5%">Annual</td>
+                                    <td style="width:16%">Maîtres parleurs de Blainville</td>
+                            </tr>
+<tr>
+                                    <td style="width:10.5%">1099641</td>
+                                    <td style="width:12%">I</td>
+                                    <td style="width:8.5%">93</td>
+                                    <td style="width:12%">Received - 05/15/2026</td>
+                                    <td style="width:11.5%">Annual</td>
+                                    <td style="width:16%">Toastmasters Vallee Du Richelieu</td>
+                            </tr>
+<tr>
+                                    <td style="width:10.5%">1100158</td>
+                                    <td style="width:12%">A</td>
+                                    <td style="width:8.5%">4</td>
+                                    <td style="width:12%">Received - 05/22/2026</td>
+                                    <td style="width:11.5%">Annual</td>
+                                    <td style="width:16%">IBM Ottawa Toastmasters</td>
+                            </tr>
+<tr>
+                                    <td style="width:10.5%">1106180</td>
+                                    <td style="width:12%">C</td>
+                                    <td style="width:8.5%">21</td>
+                                    <td style="width:12%">Received - 05/08/2026</td>
+                                    <td style="width:11.5%">Annual</td>
+                                    <td style="width:16%">A Matter of Taste</td>
+                            </tr>
+<tr>
+                                    <td style="width:10.5%">1261</td>
+                                    <td style="width:12%">H</td>
+                                    <td style="width:8.5%">73</td>
+                                    <td style="width:12%">Received - 05/06/2026</td>
+                                    <td style="width:11.5%">Annual</td>
+                                    <td style="width:16%">Club Toastmasters Lemoyne de Candiac</td>
+                            </tr>
+<tr>
+                                    <td style="width:10.5%">1269833</td>
+                                    <td style="width:12%">I</td>
+                                    <td style="width:8.5%">91</td>
+                                    <td style="width:12%">List Not Here</td>
+                                    <td style="width:11.5%">Annual</td>
+                                    <td style="width:16%">FSA-Universite Laval</td>
+                            </tr>
+<tr>
+                                    <td style="width:10.5%">1296822</td>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:8.5%">54</td>
+                                    <td style="width:12%">Received - 05/08/2026</td>
+                                    <td style="width:11.5%">Annual</td>
+                                    <td style="width:16%">Les Explosifs De Laval</td>
+                            </tr>
+<tr>
+                                    <td style="width:10.5%">1377570</td>
+                                    <td style="width:12%">I</td>
+                                    <td style="width:8.5%">92</td>
+                                    <td style="width:12%">List Not Here</td>
+                                    <td style="width:11.5%">Annual</td>
+                                    <td style="width:16%">Club Toastmasters YWCA Québec</td>
+                            </tr>
+<tr>
+                                    <td style="width:10.5%">1417584</td>
+                                    <td style="width:12%">I</td>
+                                    <td style="width:8.5%">93</td>
+                                    <td style="width:12%">Received - 05/12/2026</td>
+                                    <td style="width:11.5%">Annual</td>
+                                    <td style="width:16%">Extra-Expressif</td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/prospective-clubs.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/prospective-clubs.html
@@ -1,0 +1,102 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:newclubs@toastmasters.org&quot;&gt;newclubs@toastmasters.org&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Division&quot;,&quot;Value&quot;:&quot;12%&quot;},{&quot;Key&quot;:&quot;Area&quot;,&quot;Value&quot;:&quot;9%&quot;},{&quot;Key&quot;:&quot;Club&quot;,&quot;Value&quot;:&quot;12%&quot;},{&quot;Key&quot;:&quot;Status&quot;,&quot;Value&quot;:&quot;19%&quot;},{&quot;Key&quot;:&quot;Name&quot;,&quot;Value&quot;:&quot;11.3%&quot;},{&quot;Key&quot;:&quot;Location&quot;,&quot;Value&quot;:&quot;11%&quot;},{&quot;Key&quot;:&quot;Prospect&quot;,&quot;Value&quot;:&quot;12%&quot;},{&quot;Key&quot;:&quot;Club_Contact&quot;,&quot;Value&quot;:&quot;21%&quot;}]" />
+        <div id="prospective_clubs_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 8 of 8 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="prospective_clubs" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Division" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Division</th>
+                            <th role="columnheader" id="Area" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Area</th>
+                            <th role="columnheader" id="Club" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club</th>
+                            <th role="columnheader" id="Status" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Status</th>
+                            <th role="columnheader" id="Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Name</th>
+                            <th role="columnheader" id="Location" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Location</th>
+                            <th role="columnheader" id="Prospect" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Prospect</th>
+                            <th role="columnheader" id="Club_Contact" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club Contact</th>
+                    </tr>
+<tr>
+                                    <td style="width:12%">F</td>
+                                    <td style="width:9%">53</td>
+                                    <td style="width:12%">28678700</td>
+                                    <td style="width:19%">Prospective</td>
+                                    <td style="width:11.3%">Parole Chrétienne et Passionné de Dieu</td>
+                                    <td style="width:11%">Hawkesbury</td>
+                                    <td style="width:12%">#1 Application to Organize Complete - 04/15/2025<br>Payment Complete - 04/19/2025</td>
+                                    <td style="width:21%">Linda Brisebois</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">A</td>
+                                    <td style="width:9%">3</td>
+                                    <td style="width:12%">28679454</td>
+                                    <td style="width:19%">Prospective</td>
+                                    <td style="width:11.3%">Perth, CAN Prospective Club</td>
+                                    <td style="width:11%">Perth</td>
+                                    <td style="width:12%">#1 Application to Organize Complete - 12/03/2025<br>Payment Complete - 12/03/2025</td>
+                                    <td style="width:21%">Stephanie Drummond</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">C</td>
+                                    <td style="width:9%">21</td>
+                                    <td style="width:12%">28679513</td>
+                                    <td style="width:19%">Prospective</td>
+                                    <td style="width:11.3%">Wendover, CAN Prospective Club</td>
+                                    <td style="width:11%">Wendover</td>
+                                    <td style="width:12%">#1 Application to Organize Complete - 11/26/2025<br>Payment Complete - 11/26/2025</td>
+                                    <td style="width:21%">Ominini Ambie-Barango</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%"></td>
+                                    <td style="width:9%"></td>
+                                    <td style="width:12%">28679714</td>
+                                    <td style="width:19%">Prospective</td>
+                                    <td style="width:11.3%">Vaudreuil-Dorion CAN Prospective Club</td>
+                                    <td style="width:11%">Vaudreuil-Dorion</td>
+                                    <td style="width:12%">#1 Application to Organize Complete - 04/29/2026<br>Payment Complete - 04/29/2026</td>
+                                    <td style="width:21%">Sylvie Bergeron</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%"></td>
+                                    <td style="width:9%"></td>
+                                    <td style="width:12%">28679937</td>
+                                    <td style="width:19%">Prospective</td>
+                                    <td style="width:11.3%">Montreal, CAN Prospective Club</td>
+                                    <td style="width:11%">Montreal</td>
+                                    <td style="width:12%">#1 Application to Organize Complete - 03/21/2026<br>Payment Incomplete </td>
+                                    <td style="width:21%">Golsa Sadegheslam</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%"></td>
+                                    <td style="width:9%"></td>
+                                    <td style="width:12%">28679953</td>
+                                    <td style="width:19%">Prospective</td>
+                                    <td style="width:11.3%">Montreal Canada Pros Club</td>
+                                    <td style="width:11%">Montreal</td>
+                                    <td style="width:12%">#1 Application to Organize Complete - 03/23/2026<br>Payment Complete - 03/27/2026</td>
+                                    <td style="width:21%">Anne-Françoise Rattis</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%"></td>
+                                    <td style="width:9%"></td>
+                                    <td style="width:12%">28680007</td>
+                                    <td style="width:19%">Prospective</td>
+                                    <td style="width:11.3%">Laval, CAN Prospective Club</td>
+                                    <td style="width:11%">Laval</td>
+                                    <td style="width:12%">#1 Application to Organize Complete - 04/09/2026<br>Payment Complete - 04/09/2026</td>
+                                    <td style="width:21%">Jean-Francois Denault</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%"></td>
+                                    <td style="width:9%"></td>
+                                    <td style="width:12%">28680099</td>
+                                    <td style="width:19%">Prospective</td>
+                                    <td style="width:11.3%">MTL, CAN Prospective Club</td>
+                                    <td style="width:11%">MTL</td>
+                                    <td style="width:12%">#1 Application to Organize Complete - 04/20/2026<br>Payment Incomplete </td>
+                                    <td style="width:21%">Jonas Agbakou</td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/sponsors-mentors.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/sponsors-mentors.html
@@ -1,0 +1,188 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:newclubs@toastmasters.org&quot;&gt;newclubs@toastmasters.org&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Club&quot;,&quot;Value&quot;:&quot;12%&quot;},{&quot;Key&quot;:&quot;Club_Name&quot;,&quot;Value&quot;:&quot;14%&quot;},{&quot;Key&quot;:&quot;Charter_Date&quot;,&quot;Value&quot;:&quot;13%&quot;},{&quot;Key&quot;:&quot;Code&quot;,&quot;Value&quot;:&quot;12%&quot;},{&quot;Key&quot;:&quot;Name&quot;,&quot;Value&quot;:&quot;12%&quot;},{&quot;Key&quot;:&quot;Status&quot;,&quot;Value&quot;:&quot;16%&quot;}]" />
+        <div id="new_club_sponsors_and_mentors_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 21 of 21 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="new_club_sponsors_and_mentors" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Club" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club</th>
+                            <th role="columnheader" id="Club_Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Club Name</th>
+                            <th role="columnheader" id="Charter_Date" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Charter Date</th>
+                            <th role="columnheader" id="Code" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Code</th>
+                            <th role="columnheader" id="Name" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Name</th>
+                            <th role="columnheader" id="Status" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Status</th>
+                    </tr>
+<tr>
+                                    <td style="width:12%">28678571</td>
+                                    <td style="width:14%">Club Toastmasters de Drummondville</td>
+                                    <td style="width:13%">04/17/2026</td>
+                                    <td style="width:12%">MENTOR</td>
+                                    <td style="width:12%">Louise Audy, PM5</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28678571</td>
+                                    <td style="width:14%">Club Toastmasters de Drummondville</td>
+                                    <td style="width:13%">04/17/2026</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">Philippe Legare, IP5</td>
+                                    <td style="width:16%">AWARDED</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28678571</td>
+                                    <td style="width:14%">Club Toastmasters de Drummondville</td>
+                                    <td style="width:13%">04/17/2026</td>
+                                    <td style="width:12%">MENTOR</td>
+                                    <td style="width:12%">Philippe Legare, IP5</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28678571</td>
+                                    <td style="width:14%">Club Toastmasters de Drummondville</td>
+                                    <td style="width:13%">04/17/2026</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">Ghyslaine Morel, DTM</td>
+                                    <td style="width:16%">AWARDED</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28678920</td>
+                                    <td style="width:14%">Family Club</td>
+                                    <td style="width:13%">06/25/2025</td>
+                                    <td style="width:12%">MENTOR</td>
+                                    <td style="width:12%">Marie Sandra H. Bien Aime, IP2</td>
+                                    <td style="width:16%">AWARDED</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28678920</td>
+                                    <td style="width:14%">Family Club</td>
+                                    <td style="width:13%">06/25/2025</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">Talot Bertrand, DTM</td>
+                                    <td style="width:16%">AWARDED</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28678920</td>
+                                    <td style="width:14%">Family Club</td>
+                                    <td style="width:13%">06/25/2025</td>
+                                    <td style="width:12%">MENTORU</td>
+                                    <td style="width:12%">Talot Bertrand, DTM</td>
+                                    <td style="width:16%">AWARDED</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28678920</td>
+                                    <td style="width:14%">Family Club</td>
+                                    <td style="width:13%">06/25/2025</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">Olivier Beaulieu-Mathurin, SR5</td>
+                                    <td style="width:16%">AWARDED</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28679190</td>
+                                    <td style="width:14%">Club Toastmasters Les Entrepreneurs de Montreal</td>
+                                    <td style="width:13%">04/15/2026</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">Davender Gupta, DTM</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28679190</td>
+                                    <td style="width:14%">Club Toastmasters Les Entrepreneurs de Montreal</td>
+                                    <td style="width:13%">04/15/2026</td>
+                                    <td style="width:12%">MENTOR</td>
+                                    <td style="width:12%">Davender Gupta, DTM</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28679222</td>
+                                    <td style="width:14%">Club Toastmasters IA</td>
+                                    <td style="width:13%">01/22/2026</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">Mélissa Thibault, SR2</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28679222</td>
+                                    <td style="width:14%">Club Toastmasters IA</td>
+                                    <td style="width:13%">01/22/2026</td>
+                                    <td style="width:12%">MENTOR</td>
+                                    <td style="width:12%">Marie-Andrée Lessard, DTM</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28679222</td>
+                                    <td style="width:14%">Club Toastmasters IA</td>
+                                    <td style="width:13%">01/22/2026</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">01322322 - Name unavailable</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28679222</td>
+                                    <td style="width:14%">Club Toastmasters IA</td>
+                                    <td style="width:13%">01/22/2026</td>
+                                    <td style="width:12%">MENTOR</td>
+                                    <td style="width:12%">CHRISTINE BERNIER, DL2</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28679503</td>
+                                    <td style="width:14%">TENE Toastmasters</td>
+                                    <td style="width:13%">12/01/2025</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">Nadine Mbikina, DTM</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28679503</td>
+                                    <td style="width:14%">TENE Toastmasters</td>
+                                    <td style="width:13%">12/01/2025</td>
+                                    <td style="width:12%">MENTOR</td>
+                                    <td style="width:12%">Frédéric Corbi, PI5</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28679503</td>
+                                    <td style="width:14%">TENE Toastmasters</td>
+                                    <td style="width:13%">12/01/2025</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">Janson Bemba, PI3</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28680300</td>
+                                    <td style="width:14%">iA Montreal Toastmasters</td>
+                                    <td style="width:13%">05/22/2026</td>
+                                    <td style="width:12%">MENTOR</td>
+                                    <td style="width:12%">Denyse Lecat, VC5</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28680300</td>
+                                    <td style="width:14%">iA Montreal Toastmasters</td>
+                                    <td style="width:13%">05/22/2026</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">Jocelyne Vezina, DTM</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28680300</td>
+                                    <td style="width:14%">iA Montreal Toastmasters</td>
+                                    <td style="width:13%">05/22/2026</td>
+                                    <td style="width:12%">SPONSOR</td>
+                                    <td style="width:12%">Thomas Feray, DTM</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+<tr>
+                                    <td style="width:12%">28680300</td>
+                                    <td style="width:14%">iA Montreal Toastmasters</td>
+                                    <td style="width:13%">05/22/2026</td>
+                                    <td style="width:12%">MENTOR</td>
+                                    <td style="width:12%">Thomas Feray, DTM</td>
+                                    <td style="width:16%">PENDING</td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/packages/collector-cli/src/__tests__/fixtures/daily-reports/triple-crown.html
+++ b/packages/collector-cli/src/__tests__/fixtures/daily-reports/triple-crown.html
@@ -1,0 +1,126 @@
+<input type="hidden" name="reportUpdatedMsg" id="reportUpdatedMsg" value="Reports are uploaded daily - Updated: June 01, 2026 08: 06 AM MT	Education Awards Key
+A number of districts have awarded the Triple Crown to members who achieve three education awards in a single program year, and now it can be put into practice by any district that chooses to recognize its members. Each district will identify the combination of educational awards and any other parameters that count toward the Triple Crown. For questions regarding the information found on this report, please contact &lt;a href=&quot;mailto:educationprogram@toastmasters.org&quot;&gt;educationprogram@toastmasters.org&lt;/a&gt;." />
+<input type="hidden" id="programYears" value='null' />
+<div class="desktop-view">
+    
+
+        <input type="hidden" id="district_report_columns" value="[{&quot;Key&quot;:&quot;Member&quot;,&quot;Value&quot;:&quot;13%&quot;},{&quot;Key&quot;:&quot;Count&quot;,&quot;Value&quot;:&quot;8.89%&quot;},{&quot;Key&quot;:&quot;Award&quot;,&quot;Value&quot;:&quot;17%&quot;}]" />
+        <div id="triple_crown_awards_DataTable" class="tableFixHead">
+            <!-- FIXTURE: live D61 capture 2026-06-01. Desktop <table> only; mobile-table duplicate omitted. Header + 12 of 94 data rows. -->
+<table class="table table-bordered rwd-table dataTable no-footer dtr-inline daily-reports" id="triple_crown_awards" style="width: 1140px;">
+<tr role="row">
+                            <th role="columnheader" id="Member" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Member</th>
+                            <th role="columnheader" id="Count" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Count</th>
+                            <th role="columnheader" id="Award" data-printable="true" class="sorting" tabindex="-1" aria-controls="membership_history">Award</th>
+                    </tr>
+<tr>
+                                    <td style="width:13%">00987204 - Name unavailable</td>
+                                    <td style="width:8.89%">4</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">EH5&nbsp;<span class="tooltiptext">Engaging Humor Level 5</span></div>,
+<div class="awrd-tooltip">PM1&nbsp;<span class="tooltiptext">Presentation Mastery Level 1</span></div>,
+<div class="awrd-tooltip">PM2&nbsp;<span class="tooltiptext">Presentation Mastery Level 2</span></div>,
+<div class="awrd-tooltip">PM5&nbsp;<span class="tooltiptext">Presentation Mastery Level 5</span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">01236561 - Name unavailable</td>
+                                    <td style="width:8.89%">4</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">DL2&nbsp;<span class="tooltiptext">Dynamic Leadership Level 2</span></div>,
+<div class="awrd-tooltip">PI2&nbsp;<span class="tooltiptext">Persuasive Influence Level 2</span></div>,
+<div class="awrd-tooltip">PI3&nbsp;<span class="tooltiptext">Persuasive Influence Level 3</span></div>,
+<div class="awrd-tooltip">PWMENTORPGM&nbsp;<span class="tooltiptext">Pathways Mentor Program</span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">02979735 - Name unavailable</td>
+                                    <td style="width:8.89%">9</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">IP1&nbsp;<span class="tooltiptext">Innovative Planning Level 1</span></div>,
+<div class="awrd-tooltip">IP2&nbsp;<span class="tooltiptext">Innovative Planning Level 2</span></div>,
+<div class="awrd-tooltip">SR3&nbsp;<span class="tooltiptext">Strategic Relationships Level 3</span></div>,
+<div class="awrd-tooltip">SR4&nbsp;<span class="tooltiptext">Strategic Relationships Level 4</span></div>,
+<div class="awrd-tooltip">SR5&nbsp;<span class="tooltiptext">Strategic Relationships Level 5</span></div>,
+<div class="awrd-tooltip">VC1&nbsp;<span class="tooltiptext">Visionary Communication Level 1</span></div>,
+<div class="awrd-tooltip">IP3&nbsp;<span class="tooltiptext">Innovative Planning Level 3</span></div>,
+<div class="awrd-tooltip">IP4&nbsp;<span class="tooltiptext">Innovative Planning Level 4</span></div>,
+<div class="awrd-tooltip">PWMENTORPGM&nbsp;<span class="tooltiptext">Pathways Mentor Program</span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">04587444 - Name unavailable</td>
+                                    <td style="width:8.89%">3</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">EH3&nbsp;<span class="tooltiptext">Engaging Humor Level 3 </span></div>,
+<div class="awrd-tooltip">EH4&nbsp;<span class="tooltiptext">Engaging Humor Level 4 </span></div>,
+<div class="awrd-tooltip">EH5&nbsp;<span class="tooltiptext">Engaging Humor Level 5 </span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">05137208 - Name unavailable</td>
+                                    <td style="width:8.89%">3</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">PWMENTORPGM&nbsp;<span class="tooltiptext">Pathways Mentor Program</span></div>,
+<div class="awrd-tooltip">TC2&nbsp;<span class="tooltiptext">Team Collaboration Level 2</span></div>,
+<div class="awrd-tooltip">TC3&nbsp;<span class="tooltiptext">Team Collaboration Level 3</span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">06085473 - Name unavailable</td>
+                                    <td style="width:8.89%">4</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">LD1&nbsp;<span class="tooltiptext">Leadership Development Level 1</span></div>,
+<div class="awrd-tooltip">LD2&nbsp;<span class="tooltiptext">Leadership Development Level 2</span></div>,
+<div class="awrd-tooltip">LD3&nbsp;<span class="tooltiptext">Leadership Development Level 3</span></div>,
+<div class="awrd-tooltip">LD4&nbsp;<span class="tooltiptext">Leadership Development Level 4</span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">06101620 - Name unavailable</td>
+                                    <td style="width:8.89%">3</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">EH1&nbsp;<span class="tooltiptext">Engaging Humor Level 1</span></div>,
+<div class="awrd-tooltip">EH2&nbsp;<span class="tooltiptext">Engaging Humor Level 2</span></div>,
+<div class="awrd-tooltip">MS4&nbsp;<span class="tooltiptext">Motivational Strategies Level 4</span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">06917167 - Name unavailable</td>
+                                    <td style="width:8.89%">3</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">DL3&nbsp;<span class="tooltiptext">Dynamic Leadership Level 3</span></div>,
+<div class="awrd-tooltip">DL4&nbsp;<span class="tooltiptext">Dynamic Leadership Level 4</span></div>,
+<div class="awrd-tooltip">IP2&nbsp;<span class="tooltiptext">Innovative Planning Level 2</span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">07190224 - Name unavailable</td>
+                                    <td style="width:8.89%">3</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">VC3&nbsp;<span class="tooltiptext">Visionary Communication Level 3</span></div>,
+<div class="awrd-tooltip">VC4&nbsp;<span class="tooltiptext">Visionary Communication Level 4</span></div>,
+<div class="awrd-tooltip">VC5&nbsp;<span class="tooltiptext">Visionary Communication Level 5</span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">07497807 - Name unavailable</td>
+                                    <td style="width:8.89%">3</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">EH3&nbsp;<span class="tooltiptext">Engaging Humor Level 3</span></div>,
+<div class="awrd-tooltip">EH4&nbsp;<span class="tooltiptext">Engaging Humor Level 4</span></div>,
+<div class="awrd-tooltip">EH5&nbsp;<span class="tooltiptext">Engaging Humor Level 5</span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">07914910 - Name unavailable</td>
+                                    <td style="width:8.89%">6</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">DTM&nbsp;<span class="tooltiptext">Distinguished Toastmaster</span></div>,
+<div class="awrd-tooltip">MS4&nbsp;<span class="tooltiptext">Motivational Strategies Level 4</span></div>,
+<div class="awrd-tooltip">MS5&nbsp;<span class="tooltiptext">Motivational Strategies Level 5</span></div>,
+<div class="awrd-tooltip">DL3&nbsp;<span class="tooltiptext">Dynamic Leadership Level 3 </span></div>,
+<div class="awrd-tooltip">DL4&nbsp;<span class="tooltiptext">Dynamic Leadership Level 4 </span></div>,
+<div class="awrd-tooltip">DL5&nbsp;<span class="tooltiptext">Dynamic Leadership Level 5 </span></div></td>
+                            </tr>
+<tr>
+                                    <td style="width:13%">07966095 - Name unavailable</td>
+                                    <td style="width:8.89%">3</td>
+                                    <td style="width:17%">
+<div class="awrd-tooltip">EH2&nbsp;<span class="tooltiptext">Engaging Humor Level 2</span></div>,
+<div class="awrd-tooltip">EH3&nbsp;<span class="tooltiptext">Engaging Humor Level 3</span></div>,
+<div class="awrd-tooltip">EH4&nbsp;<span class="tooltiptext">Engaging Humor Level 4</span></div></td>
+                            </tr>
+</table>
+</div>
+</body></html>

--- a/tasks/lessons/150-an-exhaustiveness-guard-on-a-classification-map-misses-a-misclassification-that-keeps-the-set-valid.md
+++ b/tasks/lessons/150-an-exhaustiveness-guard-on-a-classification-map-misses-a-misclassification-that-keeps-the-set-valid.md
@@ -1,0 +1,72 @@
+---
+id: '150'
+category: lesson
+tags: [tests, vitest, privacy, data-pipeline, collector-cli, verification]
+auto_load: true
+date: 2026-06-01
+issues: [1063, 1062]
+---
+
+# Lesson 150 — An exhaustiveness guard on a keep/EXCLUDE map misses a mis-classification that keeps the header set valid; pair it with a value-level denylist
+
+**Date:** 2026-06-01
+**Issue:** #1063 (epic #1062 Sprint 1 — Daily Reports ingest spike)
+**PR:** (this sprint)
+
+## What happened
+
+The spike validated a per-report keep/EXCLUDE **column map** for 12 TM Daily
+Reports whose hard rule is "no personal column is ever persisted". The first
+test was an **exhaustiveness/disjointness** check: `keep ∪ exclude` must equal
+the live header set, each header classified exactly once (R20 spirit).
+
+The falsifiability check exposed a hole. Moving the personal `Member` column from
+`exclude` into `keep` for Education Achievements did **not** turn the suite red —
+it went from 19 passing to **18 passing**. The exhaustiveness test still passed
+(the header set was unchanged; `Member` was simply now on the other side of the
+partition), and the projection test that asserted the drop was filtered to
+`exclude.length > 0`, so it silently **stopped covering** that report. A
+mis-classification that leaks a personal name produced a quieter, still-green
+suite — the exact privacy regression the test existed to catch sailed through.
+
+## The transferable principle
+
+**An exhaustiveness guard on a classification map proves every item is labelled,
+not that it's labelled _correctly_. Moving an item between buckets keeps the set
+exhaustive and disjoint, so the structural check stays green.** To catch a
+mis-assignment whose only consequence is in the _output_, you need an assertion
+sourced from the consequence, not the structure: a value-level backstop that is
+**independent of the map**.
+
+Here that's a `PERSONAL_DENYLIST` of known personal sample values, asserted
+absent from **every** report's KEEP projection regardless of how the map labels
+columns. Re-classifying `Member` as KEEP now lets "Ricardo J. Bocanegra, DTM"
+survive the projection → the denylist test fails loudly. Same shape as
+verifying the _rendered_ thing, not the proxy the structure exposes (cf. L134,
+L149).
+
+A second trap fed the false green: a parametrized test filtered by the very
+field under test (`.filter(s => s.exclude.length > 0)`) **shrinks its own
+coverage** when that field is edited wrong. A guard must not be gated on the
+attribute it's guarding.
+
+## How to apply
+
+- Validating a keep/drop, allow/deny, or safe/unsafe **map**? Add two layers:
+  (1) structural — exhaustive + disjoint vs the real input; (2) **consequential**
+  — a fixed denylist/allowlist of values asserted against the map's _output_,
+  independent of the map. Layer 2 is the one that catches a wrong label.
+- Never filter a guard test by the field it guards. If "only reports with
+  excludes" run the drop-check, mis-labelling a column to have no excludes
+  removes it from the check. Run the value-level guard over **all** items.
+- Re-run the falsifiability check after adding the backstop: a wrong label must
+  produce a **failing** test, not merely fewer passing ones. "19 → 18 passing"
+  is a smell that a guard is opting out instead of failing.
+
+## Related
+
+- [[090-splitting-one-test-suite-into-named-projects-needs-a-partition-guard]]
+  — exhaustiveness from the tool's own resolution; this is the sibling caveat
+  that exhaustiveness ≠ correctness of assignment.
+- `packages/collector-cli/src/__tests__/dailyReportsColumnMap.test.ts`,
+  `docs/investigations/1063-daily-reports-ingest-spike.md`.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -129,6 +129,7 @@
 - **148** [router, react, frontend, verification, error-handling] — A render-thrown `Response` is NOT wrapped into an ErrorResponse; `isRouteErrorResponse` misses it (#1017, #1008)
 - **149** [verification, playwright, frontend, responsive, charts, scope] — A responsively-duplicated component needs a `:visible` selector in live verification (or the assertion hits the hidden twin) (#1023, #1022)
 - **150** [data-pipeline, analytics, verification, scope, mcp, process] — An ADR/spec claim that a derived field "lives in the snapshot" can be false; verify the live payload before building a tool that promises it (#1044, #1042)
+- **150** [tests, vitest, privacy, data-pipeline, collector-cli, verification] — An exhaustiveness guard on a keep/EXCLUDE map misses a mis-classification that keeps the header set valid; pair it with a value-level denylist (#1063, #1062)
 - **150** [mcp, verification, tdd, monorepo, ci, automation] — An installable stdio server needs an env-injectable base URL to be offline-smoke-tested via the real bin (#1045, #1042)
 - **150** [monorepo, tdd, build, ci, automation] — TDD-scaffolding a new workspace package has two silent gate traps: the typecheck "no inputs" abort and the explicitly-enumerated CI job (#1043, #1042)
 - **151** [monorepo, automation, sprint-runner, build, ci] — A long-lived worktree has stale `node_modules` after a new workspace package merges; `npm install`, never `--no-verify` (#1056, #1055)


### PR DESCRIPTION
## Sprint 1 of epic #1062 — Daily Reports ingest spike (doc-only)

Feasibility spike + recommendation for ingesting the 12 TM District "Daily Reports". **No pipeline writes; no personal data persisted.**

### What shipped
- **Spike doc** — `docs/investigations/1063-daily-reports-ingest-spike.md`: verified anonymous API contract, all 12 report-type GUIDs, validated per-report keep/EXCLUDE column map, privacy assessment, wire/skip recommendation, and the closing-period overlay premise flagged as the #1 unproven risk for Sprint 2.
- **12 recorded D61 fixtures** (`packages/collector-cli/src/__tests__/fixtures/daily-reports/`) — desktop `<table>` only (the response also carries a ~5× mobile-table duplicate), trimmed for repo size with full shape + every edge case preserved.
- **Map-validation test** (`dailyReportsColumnMap.test.ts`, 30 assertions): exhaustive + disjoint vs live headers, KEEP projection drops every personal column, an independent **personal-value denylist** backstop, and empty-body tolerance.

### Key findings
- API is anonymous, daily-fresh, same HTML-table parse shape the collector already handles.
- `Name` is overloaded — club name (KEEP) in most reports, but `Member` / `Club Contact` / a second `Name` are personal (EXCLUDE) in Education Achievements, Triple Crown, Prospective, Coaches, Sponsors-Mentors.
- **Triple Crown** has no club column and even its "Name unavailable" rows carry an identifying member ID → only a district-level count survives; recommend defer.
- Two operator decisions surfaced (republication licensing + Sprint 2 scope) — see doc §6.

### Verification
- `npm run test:collector-cli` → 783 passed.
- Falsifiability confirmed: mis-classifying a personal column as KEEP turns the suite red (drove L150).
- Path-filtered PR Preview does not trigger (no `frontend/**` or analytics/shared-contracts changes) — verification is the full test suite + code-proof on recorded fixtures, per the doc-only sprint protocol.

Refs #1063, #1062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
