### PR TITLE
Sprint 1 (#1072) — alert on held promotion + staging-ahead detector (#1073)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -83,6 +83,7 @@ env:
 permissions:
   contents: read
   id-token: write # Required for Workload Identity Federation
+  issues: write # File/refresh/close the promotion-held alert issue (#1073)
 
 jobs:
   pipeline:
@@ -1378,6 +1379,73 @@ jobs:
           echo "- Value gate: **${{ steps.valuediff.outputs.value_promote }}**" >> "$GITHUB_STEP_SUMMARY"
           echo "Production data is **unchanged**. Review the diffs above." >> "$GITHUB_STEP_SUMMARY"
           echo "For a reviewed re-derive, re-run with **allow_value_changes = true**." >> "$GITHUB_STEP_SUMMARY"
+
+      # ════════════════════════════════════════════════════════
+      # PROMOTION-HELD ALERT (#1073, epic #1072)
+      # A blocked promotion leaves prod serving stale content while the run
+      # still reports success. Turn that silent state into a loud, self-
+      # clearing `promotion-held` issue. Decision logic is unit-tested in
+      # scripts/lib/promotionAlert.ts; these steps are thin glue.
+      # ════════════════════════════════════════════════════════
+      - name: Evaluate promotion alert (#1073)
+        id: promoalert
+        if: steps.mode.outputs.mode != 'prune'
+        env:
+          COUNT_PROMOTE: ${{ steps.diff.outputs.promote }}
+          VALUE_PROMOTE: ${{ steps.valuediff.outputs.value_promote }}
+          VALUE_DIFF_FILE: /tmp/value-diff.json
+        run: npx tsx scripts/promotion-alert.ts
+
+      - name: Ensure promotion-held label exists
+        if: steps.promoalert.outputs.blocked == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create promotion-held \
+            --color B60205 \
+            --description "Staging→prod promotion is held; prod is serving stale content" \
+            2>/dev/null || echo "Label already exists"
+
+      - name: File or refresh promotion-held issue
+        if: steps.promoalert.outputs.blocked == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Deduplicate: one open alert at a time. Refresh (comment on) the
+          # existing issue rather than spamming a new one each blocked run.
+          EXISTING=$(gh issue list --label promotion-held --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${EXISTING}" ]; then
+            echo "Existing open alert #${EXISTING} — adding a refresh comment."
+            gh issue comment "${EXISTING}" \
+              --body-file "${{ steps.promoalert.outputs.body_file }}"
+          else
+            echo "No open alert — creating one."
+            gh issue create \
+              --title "${{ steps.promoalert.outputs.title }}" \
+              --label promotion-held \
+              --body-file "${{ steps.promoalert.outputs.body_file }}"
+          fi
+
+      - name: Auto-close promotion-held issue on a promoting run
+        if: steps.promoalert.outputs.promoted == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # A later run promoted — the held state cleared. Close every open
+          # promotion-held issue with a note (there should be at most one).
+          OPEN=$(gh issue list --label promotion-held --state open \
+            --json number --jq '.[].number')
+          if [ -z "${OPEN}" ]; then
+            echo "No open promotion-held issue to close."
+          else
+            for n in ${OPEN}; do
+              echo "Closing promotion-held issue #${n} — promotion succeeded."
+              gh issue close "${n}" \
+                --comment "✅ A subsequent pipeline run promoted staging → production; the held state has cleared. Auto-closing (#1073)." \
+                --reason completed
+            done
+          fi
 
       # ── Summary ──
       - name: Pipeline summary

--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -1433,7 +1433,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # A later run promoted — the held state cleared. Close every open
-          # promotion-held issue with a note (there should be at most one).
+          # promotion-held issue with a note. The `concurrency: data-pipeline`
+          # group (top of file) serializes pipeline runs, so a promoting run
+          # can't race a concurrent blocking run — once we promote, any prior
+          # held state is genuinely resolved regardless of which mode filed it.
           OPEN=$(gh issue list --label promotion-held --state open \
             --json number --jq '.[].number')
           if [ -z "${OPEN}" ]; then

--- a/scripts/lib/__tests__/promotionAlert.test.ts
+++ b/scripts/lib/__tests__/promotionAlert.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for scripts/lib/promotionAlert.ts (#1073)
+ *
+ * When the staging→prod promotion gate blocks (count gate or the #1034 value
+ * gate), the corrected staging data silently fails to reach prod with no
+ * alert (epic #1072). These pure functions decide, from the two gate outputs
+ * and the value-diff report, whether to file/refresh a `promotion-held` issue
+ * or auto-close it on a promoting run — and distinguish the
+ * operator-review-needed value gate from a possible-regression count gate.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  classifyGate,
+  evaluatePromotion,
+  buildPromotionHeldTitle,
+  buildPromotionHeldBody,
+  type ValueDiffOutput,
+} from '../promotionAlert'
+
+// A value-diff where 2 overlap dates changed (staging ahead of prod in
+// CONTENT even though dates/districts counts match) — the D61 150-vs-151 case.
+const CHANGED_DIFF: ValueDiffOutput = {
+  promote: false,
+  reasons: ['value changes on overlap dates require allow_value_changes'],
+  report: {
+    added: [],
+    removed: [],
+    changed: [
+      { date: '2026-05-30', changedDistricts: ['61', '50'] },
+      { date: '2026-05-31', changedDistricts: ['61', '25', '129'] },
+    ],
+    unchanged: ['2026-05-29'],
+    overlapCount: 3,
+  },
+}
+
+const CLEAN_DIFF: ValueDiffOutput = {
+  promote: true,
+  reasons: [],
+  report: {
+    added: [],
+    removed: [],
+    changed: [],
+    unchanged: ['2026-05-31'],
+    overlapCount: 1,
+  },
+}
+
+const OPTS = { now: new Date('2026-06-01T14:00:00Z') }
+
+// ── classifyGate ───────────────────────────────────────────────────────────
+
+describe('classifyGate', () => {
+  it('returns "none" when both gates allow promotion', () => {
+    expect(classifyGate(true, true)).toBe('none')
+  })
+  it('returns "value" when only the value gate refused', () => {
+    expect(classifyGate(true, false)).toBe('value')
+  })
+  it('returns "count" when only the count gate refused', () => {
+    expect(classifyGate(false, true)).toBe('count')
+  })
+  it('returns "both" when both gates refused', () => {
+    expect(classifyGate(false, false)).toBe('both')
+  })
+})
+
+// ── evaluatePromotion ────────────────────────────────────────────────────────
+
+describe('evaluatePromotion', () => {
+  it('is promoted (not blocked) when both gates pass', () => {
+    const r = evaluatePromotion({
+      countPromote: true,
+      valuePromote: true,
+      valueDiff: CLEAN_DIFF,
+    })
+    expect(r.promoted).toBe(true)
+    expect(r.blocked).toBe(false)
+    expect(r.gate).toBe('none')
+  })
+
+  it('is blocked by the value gate and reports staging-ahead with affected districts', () => {
+    const r = evaluatePromotion({
+      countPromote: true,
+      valuePromote: false,
+      valueDiff: CHANGED_DIFF,
+    })
+    expect(r.blocked).toBe(true)
+    expect(r.promoted).toBe(false)
+    expect(r.gate).toBe('value')
+    expect(r.stagingAhead).toBe(true)
+    expect(r.changedDateCount).toBe(2)
+    // unique, sorted union of changed districts across dates
+    expect(r.affectedDistricts).toEqual(['129', '25', '50', '61'])
+  })
+
+  it('is blocked by the count gate (possible regression)', () => {
+    const r = evaluatePromotion({
+      countPromote: false,
+      valuePromote: true,
+      valueDiff: CLEAN_DIFF,
+    })
+    expect(r.blocked).toBe(true)
+    expect(r.gate).toBe('count')
+  })
+
+  it('treats a missing/unparseable value-diff as blocked when a gate refused', () => {
+    const r = evaluatePromotion({
+      countPromote: true,
+      valuePromote: false,
+      valueDiff: null,
+    })
+    expect(r.blocked).toBe(true)
+    expect(r.gate).toBe('value')
+    // no diff to read → staging-ahead can't be confirmed, but still blocked
+    expect(r.stagingAhead).toBe(false)
+    expect(r.changedDateCount).toBe(0)
+  })
+
+  it('detects staging-ahead even when the value gate would allow (changed>0 with override)', () => {
+    // allow_value_changes=true → valuePromote true, but content still differs.
+    const r = evaluatePromotion({
+      countPromote: true,
+      valuePromote: true,
+      valueDiff: CHANGED_DIFF,
+    })
+    expect(r.stagingAhead).toBe(true)
+    expect(r.changedDateCount).toBe(2)
+    // promoting run → not blocked; the auto-close path keys on `promoted`
+    expect(r.promoted).toBe(true)
+  })
+})
+
+// ── buildPromotionHeldTitle / Body ───────────────────────────────────────────
+
+describe('buildPromotionHeldTitle', () => {
+  it('names the value gate in the title', () => {
+    const r = evaluatePromotion({
+      countPromote: true,
+      valuePromote: false,
+      valueDiff: CHANGED_DIFF,
+    })
+    expect(buildPromotionHeldTitle(r)).toMatch(/promotion held/i)
+    expect(buildPromotionHeldTitle(r)).toMatch(/value/i)
+  })
+
+  it('names the count gate in the title', () => {
+    const r = evaluatePromotion({
+      countPromote: false,
+      valuePromote: true,
+      valueDiff: CLEAN_DIFF,
+    })
+    expect(buildPromotionHeldTitle(r)).toMatch(/count/i)
+  })
+})
+
+describe('buildPromotionHeldBody', () => {
+  it('value-gate body explains operator review and the allow_value_changes clear path', () => {
+    const r = evaluatePromotion({
+      countPromote: true,
+      valuePromote: false,
+      valueDiff: CHANGED_DIFF,
+    })
+    const body = buildPromotionHeldBody(r, OPTS)
+    expect(body).toMatch(/allow_value_changes\s*=\s*true/)
+    expect(body).toMatch(/review/i)
+    // surfaces affected districts and the changed-date count
+    expect(body).toContain('61')
+    expect(body).toMatch(/2 .*date/i)
+    // staging-ahead is called out
+    expect(body).toMatch(/staging.*ahead/i)
+  })
+
+  it('count-gate body frames a possible regression and does NOT lead with allow_value_changes', () => {
+    const r = evaluatePromotion({
+      countPromote: false,
+      valuePromote: true,
+      valueDiff: CLEAN_DIFF,
+    })
+    const body = buildPromotionHeldBody(r, OPTS)
+    expect(body).toMatch(/regression|subtractive|fewer/i)
+    expect(body).toMatch(/investigate/i)
+  })
+
+  it('both-gates body mentions both gates', () => {
+    const r = evaluatePromotion({
+      countPromote: false,
+      valuePromote: false,
+      valueDiff: CHANGED_DIFF,
+    })
+    const body = buildPromotionHeldBody(r, OPTS)
+    expect(body).toMatch(/count gate/i)
+    expect(body).toMatch(/value gate/i)
+  })
+})

--- a/scripts/lib/__tests__/promotionAlert.test.ts
+++ b/scripts/lib/__tests__/promotionAlert.test.ts
@@ -91,8 +91,8 @@ describe('evaluatePromotion', () => {
     expect(r.gate).toBe('value')
     expect(r.stagingAhead).toBe(true)
     expect(r.changedDateCount).toBe(2)
-    // unique, sorted union of changed districts across dates
-    expect(r.affectedDistricts).toEqual(['129', '25', '50', '61'])
+    // unique, numeric-aware sorted union of changed districts across dates
+    expect(r.affectedDistricts).toEqual(['25', '50', '61', '129'])
   })
 
   it('is blocked by the count gate (possible regression)', () => {

--- a/scripts/lib/promotionAlert.ts
+++ b/scripts/lib/promotionAlert.ts
@@ -1,0 +1,229 @@
+/**
+ * Promotion-Held Alert Evaluation — Pure Functions (#1073, epic #1072)
+ *
+ * The daily Data Pipeline writes staging first, then promotes staging → prod
+ * only when BOTH gates allow it (`data-pipeline.yml`):
+ *   - the COUNT gate (`steps.diff`)        — additive-only: blocks a subtractive
+ *     change (staging has fewer ranked districts/dates than prod);
+ *   - the VALUE gate (`steps.valuediff`, #1034) — blocks a re-derive that keeps
+ *     the same dates/districts but changes VALUES, until an operator reviews
+ *     them (`allow_value_changes=true`).
+ *
+ * When a gate refuses, the corrected staging data silently fails to reach prod
+ * and the run still reports `success` — prod keeps serving stale content with
+ * no alert (epic #1072; observed live 2026-06-01 when D61 showed 150 active
+ * clubs on prod for 5 days while staging correctly held 151).
+ *
+ * These pure functions turn the two gate outputs + the value-diff report into
+ * a decision: file/refresh a `promotion-held` issue (distinguishing the
+ * operator-review-needed value gate from a possible-regression count gate), or
+ * auto-close it on a promoting run. They also surface the staging-ahead signal
+ * — overlap dates whose CONTENT differs — which the date-based freshness
+ * monitor (#753) can't see because a held promotion leaves `latest.json`
+ * current. No network/GCS I/O lives here so the decision is unit-testable; the
+ * workflow supplies the fetched gate outputs and value-diff JSON.
+ */
+
+/** One overlap date whose per-district values differ between staging & prod. */
+export interface ValueDiffChangedDate {
+  date: string
+  changedDistricts: string[]
+}
+
+/** The `report` block of `collector-cli value-diff` JSON output. */
+export interface ValueDiffReportBody {
+  /** dates present in staging but not prod (additive) */
+  added: string[]
+  /** dates present in prod but not staging (subtractive) */
+  removed: string[]
+  /** overlap dates whose values differ */
+  changed: ValueDiffChangedDate[]
+  /** overlap dates whose values are identical */
+  unchanged: string[]
+  /** number of dates present in both sets */
+  overlapCount: number
+}
+
+/** Full `collector-cli value-diff` stdout JSON. */
+export interface ValueDiffOutput {
+  promote: boolean
+  reasons: string[]
+  report: ValueDiffReportBody
+}
+
+/** Which gate(s) refused promotion. */
+export type BlockingGate = 'count' | 'value' | 'both' | 'none'
+
+export interface PromotionAlertInput {
+  /** `steps.diff.outputs.promote` — the additive-only count gate. */
+  countPromote: boolean
+  /** `steps.valuediff.outputs.value_promote` — the #1034 value gate. */
+  valuePromote: boolean
+  /**
+   * Parsed value-diff JSON, or null when the file was missing/unparseable
+   * (the value-diff step fails closed). Null does not change the block
+   * decision — that is driven by the gate outputs — it only means the
+   * staging-ahead content signal can't be confirmed.
+   */
+  valueDiff: ValueDiffOutput | null
+}
+
+export interface PromotionAlertResult {
+  /** A gate refused — file/refresh the `promotion-held` issue. */
+  blocked: boolean
+  /** Both gates allowed — auto-close any open `promotion-held` issue. */
+  promoted: boolean
+  /** Which gate(s) refused. */
+  gate: BlockingGate
+  /**
+   * Staging holds content prod doesn't (overlap changed-count > 0), detected
+   * independent of `latest.json` date — the content-stale signal the
+   * freshness monitor misses.
+   */
+  stagingAhead: boolean
+  /** Number of overlap dates whose values differ. */
+  changedDateCount: number
+  /** Unique, sorted union of district ids that changed across overlap dates. */
+  affectedDistricts: string[]
+  countPromote: boolean
+  valuePromote: boolean
+  /** value-gate reasons, surfaced verbatim in the alert. */
+  reasons: string[]
+}
+
+/** Classify which gate(s) refused promotion from the two boolean outputs. */
+export function classifyGate(
+  countPromote: boolean,
+  valuePromote: boolean
+): BlockingGate {
+  if (countPromote && valuePromote) return 'none'
+  if (!countPromote && !valuePromote) return 'both'
+  return countPromote ? 'value' : 'count'
+}
+
+/** Decide the promotion-alert state from the gate outputs + value-diff. */
+export function evaluatePromotion(
+  input: PromotionAlertInput
+): PromotionAlertResult {
+  const { countPromote, valuePromote, valueDiff } = input
+  const gate = classifyGate(countPromote, valuePromote)
+  const promoted = gate === 'none'
+
+  const changed = valueDiff?.report.changed ?? []
+  const changedDateCount = changed.length
+  const affectedDistricts = [
+    ...new Set(changed.flatMap(c => c.changedDistricts)),
+  ].sort()
+
+  return {
+    blocked: !promoted,
+    promoted,
+    gate,
+    stagingAhead: changedDateCount > 0,
+    changedDateCount,
+    affectedDistricts,
+    countPromote,
+    valuePromote,
+    reasons: valueDiff?.reasons ?? [],
+  }
+}
+
+export interface PromotionAlertBodyOptions {
+  /** Evaluation time, surfaced for context. */
+  now: Date
+}
+
+const GATE_LABEL: Record<Exclude<BlockingGate, 'none'>, string> = {
+  value: 'value gate',
+  count: 'count gate',
+  both: 'count gate + value gate',
+}
+
+/** Title for the `promotion-held` alert issue. */
+export function buildPromotionHeldTitle(result: PromotionAlertResult): string {
+  if (result.gate === 'none') return 'promotion not held'
+  const label =
+    result.gate === 'both' ? 'count + value gates' : GATE_LABEL[result.gate]
+  return `🚫 Promotion held — prod stale (${label})`
+}
+
+/**
+ * Markdown body for the `promotion-held` alert. Distinguishes the
+ * operator-review-needed value gate (clear with `allow_value_changes=true`)
+ * from a possible-regression count gate (investigate the subtractive change
+ * before clearing). When both refused, the regression is the more serious
+ * signal and leads.
+ */
+export function buildPromotionHeldBody(
+  result: PromotionAlertResult,
+  opts: PromotionAlertBodyOptions
+): string {
+  const lines: string[] = [
+    '## 🚫 Staging → production promotion is held',
+    '',
+    `A daily Data Pipeline run completed but **did not promote** staging to production — the corrected staging data is **not on prod**. Checked at ${opts.now.toISOString()}.`,
+    '',
+    '| Gate | Result |',
+    '|------|--------|',
+    `| Count gate (additive) | ${result.countPromote ? '✅ pass' : '❌ **blocked**'} |`,
+    `| Value gate (#1034) | ${result.valuePromote ? '✅ pass' : '❌ **blocked**'} |`,
+    '',
+  ]
+
+  // Count-gate framing leads when present — a subtractive change is the more
+  // serious "possible real regression" signal.
+  if (result.gate === 'count' || result.gate === 'both') {
+    lines.push(
+      '### 🛑 Count gate blocked — possible regression',
+      '',
+      'Staging has **fewer** ranked districts or dates than production (a subtractive change). This may be a real data regression, not a routine re-derive.',
+      '',
+      '**Do not** clear this with `allow_value_changes` — that flag only overrides the value gate. **Investigate** the missing districts/dates first (check the collector logs and the staging vs prod diff in the run summary).',
+      ''
+    )
+  }
+
+  if (result.gate === 'value' || result.gate === 'both') {
+    lines.push(
+      '### 🔶 Value gate blocked — operator review needed',
+      '',
+      `A re-derive changed **values** on ${result.changedDateCount} overlap date(s) that staging and production share, while the date/district counts stayed the same. The value gate holds promotion until a human reviews the change.`,
+      ''
+    )
+    if (result.affectedDistricts.length > 0) {
+      lines.push(
+        `**Affected districts:** ${result.affectedDistricts.join(', ')}`,
+        ''
+      )
+    }
+    if (result.reasons.length > 0) {
+      lines.push('**Value-gate reasons:**', '')
+      for (const r of result.reasons) lines.push(`- ${r}`)
+      lines.push('')
+    }
+    lines.push(
+      '**Clear path:** after reviewing the value-diff in the run summary, re-run the pipeline with the override:',
+      '',
+      '```bash',
+      'gh workflow run data-pipeline.yml -f mode=daily -f allow_value_changes=true',
+      '```',
+      ''
+    )
+  }
+
+  if (result.stagingAhead) {
+    lines.push(
+      '### ⏫ Staging is ahead of production',
+      '',
+      `Staging holds content production doesn't — **${result.changedDateCount} overlap date(s) differ** even though \`v1/latest.json\` may show the same date. This is the content-stale case the date-based freshness monitor (#753) can't see.`,
+      ''
+    )
+  }
+
+  lines.push(
+    '---',
+    '_This issue auto-closes when a later run successfully promotes. Filed by `.github/workflows/data-pipeline.yml` (#1073)._'
+  )
+
+  return lines.join('\n')
+}

--- a/scripts/lib/promotionAlert.ts
+++ b/scripts/lib/promotionAlert.ts
@@ -111,9 +111,11 @@ export function evaluatePromotion(
 
   const changed = valueDiff?.report.changed ?? []
   const changedDateCount = changed.length
+  // Numeric-aware sort: district ids are mostly numeric ("25" < "61" < "129")
+  // but a few are alpha ("F", "U"); localeCompare with numeric handles both.
   const affectedDistricts = [
     ...new Set(changed.flatMap(c => c.changedDistricts)),
-  ].sort()
+  ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
 
   return {
     blocked: !promoted,

--- a/scripts/promotion-alert.ts
+++ b/scripts/promotion-alert.ts
@@ -1,0 +1,112 @@
+/**
+ * Promotion-Held Alert — Runner (#1073, epic #1072)
+ *
+ * Thin glue around the pure functions in ./lib/promotionAlert.js:
+ *   1. read the two gate outputs (count gate + #1034 value gate) and the
+ *      value-diff JSON the pipeline already produced,
+ *   2. decide whether promotion was blocked (file/refresh a `promotion-held`
+ *      issue) or promoted (auto-close it),
+ *   3. emit the decision + alert title/body for the data-pipeline workflow.
+ *
+ * No decision logic lives here — that is unit-tested in
+ * scripts/lib/__tests__/promotionAlert.test.ts. All logging goes to stderr
+ * (R4); stdout/$GITHUB_OUTPUT carry only the structured decision.
+ *
+ * Env:
+ *   COUNT_PROMOTE   — `steps.diff.outputs.promote`        ("true"/"false")
+ *   VALUE_PROMOTE   — `steps.valuediff.outputs.value_promote` ("true"/"false")
+ *   VALUE_DIFF_FILE — path to the value-diff JSON (default /tmp/value-diff.json)
+ *
+ * Always exits 0; the workflow decides whether to open/refresh or close the
+ * issue based on the `blocked`/`promoted` outputs. A missing/garbage
+ * value-diff does NOT flip the block decision (that is the gate outputs' job)
+ * — it only means the staging-ahead content signal can't be confirmed.
+ */
+
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs'
+import {
+  evaluatePromotion,
+  buildPromotionHeldTitle,
+  buildPromotionHeldBody,
+  type ValueDiffOutput,
+} from './lib/promotionAlert.js'
+
+const DEFAULT_VALUE_DIFF_FILE = '/tmp/value-diff.json'
+const BODY_FILE = '/tmp/promotion-held-body.md'
+
+function log(msg: string): void {
+  process.stderr.write(`${msg}\n`)
+}
+
+function emitOutput(key: string, value: string): void {
+  const out = process.env.GITHUB_OUTPUT
+  if (out) appendFileSync(out, `${key}=${value}\n`)
+}
+
+/** Parse the value-diff JSON, returning null on any read/parse failure. */
+function readValueDiff(path: string): ValueDiffOutput | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'report' in parsed &&
+      Array.isArray((parsed as ValueDiffOutput).report?.changed)
+    ) {
+      return parsed as ValueDiffOutput
+    }
+    log(`Value-diff at ${path} missing a usable .report.changed — ignoring.`)
+    return null
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log(`Could not read value-diff at ${path}: ${message}`)
+    return null
+  }
+}
+
+function main(): void {
+  const countPromote = process.env.COUNT_PROMOTE === 'true'
+  const valuePromote = process.env.VALUE_PROMOTE === 'true'
+  const valueDiffFile = process.env.VALUE_DIFF_FILE || DEFAULT_VALUE_DIFF_FILE
+  const now = new Date()
+
+  log(
+    `Gate outputs — count_promote=${countPromote} value_promote=${valuePromote}`
+  )
+  const valueDiff = readValueDiff(valueDiffFile)
+  const result = evaluatePromotion({ countPromote, valuePromote, valueDiff })
+
+  log(
+    `Decision — blocked=${result.blocked} gate=${result.gate} ` +
+      `stagingAhead=${result.stagingAhead} changedDates=${result.changedDateCount}`
+  )
+
+  emitOutput('blocked', String(result.blocked))
+  emitOutput('promoted', String(result.promoted))
+  emitOutput('gate', result.gate)
+  emitOutput('staging_ahead', String(result.stagingAhead))
+
+  if (result.blocked) {
+    writeFileSync(BODY_FILE, buildPromotionHeldBody(result, { now }))
+    emitOutput('title', buildPromotionHeldTitle(result))
+    emitOutput('body_file', BODY_FILE)
+    log('Promotion is HELD — alert body written.')
+  } else {
+    log('Promotion succeeded — any open promotion-held issue should close.')
+  }
+}
+
+try {
+  main()
+} catch (err) {
+  const message =
+    err instanceof Error ? (err.stack ?? err.message) : String(err)
+  log(`Unexpected error: ${message}`)
+  // Don't fabricate a block on a crash — the gate outputs already decided
+  // whether prod changed. Default to the non-blocking branch and let the
+  // independent freshness monitor (#753) catch a genuinely stuck prod.
+  emitOutput('blocked', 'false')
+  emitOutput('promoted', 'false')
+}
+
+process.exit(0)

--- a/scripts/promotion-alert.ts
+++ b/scripts/promotion-alert.ts
@@ -102,10 +102,33 @@ try {
   const message =
     err instanceof Error ? (err.stack ?? err.message) : String(err)
   log(`Unexpected error: ${message}`)
-  // Don't fabricate a block on a crash — the gate outputs already decided
-  // whether prod changed. Default to the non-blocking branch and let the
-  // independent freshness monitor (#753) catch a genuinely stuck prod.
-  emitOutput('blocked', 'false')
+  // A monitor that can't read its own signal must ALERT, not pass silently
+  // (Lesson 107). If the runner crashes we can't confirm the promotion
+  // succeeded, so treat it as held and file an issue with a fallback body —
+  // mirroring how the freshness runner surfaces its own crash as stale.
+  try {
+    writeFileSync(
+      BODY_FILE,
+      [
+        '## 🚫 Promotion-held alert runner crashed',
+        '',
+        'The `scripts/promotion-alert.ts` runner threw before it could decide whether staging → production promotion succeeded. **Treat production as potentially stale** and check the run logs / step summary for the gate outcome.',
+        '',
+        '```',
+        message,
+        '```',
+        '',
+        '---',
+        '_Filed by `.github/workflows/data-pipeline.yml` (#1073)._',
+      ].join('\n')
+    )
+    emitOutput('body_file', BODY_FILE)
+    emitOutput('title', '🚫 Promotion-held alert runner crashed (#1073)')
+  } catch {
+    // If even the fallback body can't be written, still flag blocked so the
+    // workflow's create step surfaces *something* rather than going quiet.
+  }
+  emitOutput('blocked', 'true')
   emitOutput('promoted', 'false')
 }
 

--- a/scripts/promotion-alert.ts
+++ b/scripts/promotion-alert.ts
@@ -81,18 +81,23 @@ function main(): void {
       `stagingAhead=${result.stagingAhead} changedDates=${result.changedDateCount}`
   )
 
+  // Do the throw-prone work (body build + file write) BEFORE emitting any
+  // output, so a failure here lands in the catch with no half-written outputs
+  // to override — the crash handler then emits a clean blocked=true alert.
+  if (result.blocked) {
+    writeFileSync(BODY_FILE, buildPromotionHeldBody(result, { now }))
+    log('Promotion is HELD — alert body written.')
+  } else {
+    log('Promotion succeeded — any open promotion-held issue should close.')
+  }
+
   emitOutput('blocked', String(result.blocked))
   emitOutput('promoted', String(result.promoted))
   emitOutput('gate', result.gate)
   emitOutput('staging_ahead', String(result.stagingAhead))
-
   if (result.blocked) {
-    writeFileSync(BODY_FILE, buildPromotionHeldBody(result, { now }))
     emitOutput('title', buildPromotionHeldTitle(result))
     emitOutput('body_file', BODY_FILE)
-    log('Promotion is HELD — alert body written.')
-  } else {
-    log('Promotion succeeded — any open promotion-held issue should close.')
   }
 }
 

--- a/tasks/lessons/155-a-recency-freshness-monitor-is-blind-to-a-held-promotion-content-stale-state.md
+++ b/tasks/lessons/155-a-recency-freshness-monitor-is-blind-to-a-held-promotion-content-stale-state.md
@@ -1,0 +1,76 @@
+---
+id: '155'
+category: principle
+tags: [ci, automation, data-pipeline, monitoring, gcs]
+auto_load: true
+date: 2026-06-02
+issues: [1073, 1072]
+---
+
+# Lesson 155 — A recency-based freshness monitor is blind to a held-promotion "content-stale" state; freshness has two orthogonal axes
+
+**Date:** 2026-06-02
+**Issue:** #1073 (epic #1072 — stale-prod observability)
+**PR:** _(record on merge)_
+
+## What happened
+
+The pipeline writes staging first, then promotes staging → prod only when both
+gates allow it: the additive-only **count gate** and the #1034 **value gate**.
+When a gate refuses (e.g. a reviewed re-derive changed values), promotion is
+**held** — but the daily run still reports `success`, and prod keeps serving the
+last-promoted content. Observed live 2026-06-01: D61 showed **150** active clubs
+on prod for 5 days while staging correctly held **151**, because the value gate
+blocked promotion each day.
+
+The existing freshness monitor (#753, [[107-monitor-the-output-freshness-not-the-best-effort-scheduler]])
+could not see this. It checks the **age** of prod's `v1/latest.json`
+`generatedAt` — a dead-man's-switch for "did the run happen at all." But a held
+promotion leaves `latest.json` perfectly **current** (the run _did_ happen; it
+just didn't promote). The date is fresh; only the _content_ is stale. The two
+failure modes — _run never happened_ vs _run happened but its output never
+reached prod_ — do not overlap, so a recency monitor is structurally blind to
+the second.
+
+## The transferable principle
+
+**"Freshness" of a published artifact is two orthogonal axes, not one:
+_recency_ (was a new version produced recently?) and _propagation_ (did the
+newest produced version actually reach the surface users read?). A
+timestamp/age check only covers recency. A gated, validate-first, or
+promote-on-approval pipeline can produce a fresh artifact that is deliberately
+withheld from prod — current date, stale content — and a recency monitor reports
+green through the entire outage.** Whenever a "produce" step is decoupled from a
+"publish/promote" step by a gate, add a second signal that compares
+**produced-vs-published content** (here: the value-diff overlap changed-count >
+0 between staging and prod), independent of any date. The held state must be
+**loud** (an alert) and **self-clearing** (auto-resolve when a later run
+promotes), because a deliberately-correct gate (the value gate stays
+fail-closed) means the silence — not the block — is the bug.
+
+## How to apply
+
+- For any gated produce→promote pipeline, ask two questions, not one: "did it
+  run recently?" **and** "did the freshest output reach the surface users
+  read?" Monitor both; neither subsumes the other (same shape as #753's
+  "reduce the miss rate" vs "detect the miss" pair).
+- The content signal often already exists upstream — here the promote gate
+  _already_ computed a staging-vs-prod value-diff; the sprint just surfaced
+  `changed.length > 0` as an alert instead of letting it die in a step summary.
+  Grep for an existing diff/compare before building a new comparator (R7).
+- A self-clearing alert keyed on the _positive_ event (a promoting run closes
+  the issue) beats a TTL or a human remembering to close it — and is safe to
+  "close all open" only when runs are **serialized** (`concurrency` group), so
+  a promoting run can't race a concurrent blocking one.
+- Distinguish an operator-review-needed hold (value gate → clear with
+  `allow_value_changes=true`) from a possible real regression (count gate →
+  investigate the subtractive change first); same alert, different remediation.
+
+## Related
+
+- [[107-monitor-the-output-freshness-not-the-best-effort-scheduler]] — the
+  recency axis this lesson is the propagation-axis complement of; a held
+  promotion is exactly the gap that monitor can't see.
+- `scripts/lib/promotionAlert.ts` (the pure decision),
+  `scripts/promotion-alert.ts` (runner),
+  `.github/workflows/data-pipeline.yml` (promotion-held alert steps).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -137,3 +137,4 @@
 - **153** [data-pipeline, analytics, collector-cli, privacy, tdd] — De-identifying a member ledger by aggregation must drop per-row fields, even non-personal ones in the validated KEEP map (#1064, #1062)
 - **154** [frontend, architecture, data-pipeline, scope, verification] — A "never demote" overlay invariant is structural when it can only ever emit the top state — not a rank comparison (#1069, #1062)
 - **154** [data-pipeline, analytics, collector-cli, privacy, tdd] — A pre-filtered report's MEMBERSHIP SET can itself be the datum; derive from presence, not a column (#1065, #1062)
+- **155** [ci, automation, data-pipeline, monitoring, gcs] — A recency-based freshness monitor is blind to a held-promotion "content-stale" state; freshness has two orthogonal axes (#1073, #1072)

--- a/tasks/plan-1073.md
+++ b/tasks/plan-1073.md
@@ -1,0 +1,39 @@
+# Sprint 1073 plan — alert on held promotion + staging-ahead detector
+
+Epic #1072. Sprint #1073. Alerting only — no gate-logic change (#1034 stays fail-closed).
+
+## Architecture (Lesson 107: pure logic + thin workflow glue)
+
+- **New pure module** `scripts/lib/promotionAlert.ts`
+  - `classifyGate(countPromote, valuePromote)` → `'count' | 'value' | 'both' | 'none'`
+  - `evaluatePromotion({ countPromote, valuePromote, valueDiff })` → `PromotionAlertResult`
+    - `blocked`, `promoted`, `gate`, `stagingAhead` (= changedDateCount > 0),
+      `changedDateCount`, `affectedDistricts`, `reasons`
+  - `buildPromotionHeldTitle(result)`
+  - `buildPromotionHeldBody(result, opts)` — distinguishes:
+    - value gate → operator-review-needed; clear path `allow_value_changes=true`
+    - count gate → possible real subtractive regression; investigate before clearing
+    - both → lead with regression
+- **New entry** `scripts/promotion-alert.ts` — thin glue: reads `COUNT_PROMOTE`,
+  `VALUE_PROMOTE`, `VALUE_DIFF_FILE`; emits `blocked/promoted/staging_ahead/title/body_file`
+  to `$GITHUB_OUTPUT`; writes body file. Always exit 0. Logs → stderr (R4).
+- **Workflow glue** in `data-pipeline.yml` after the gates:
+  - Evaluate promotion alert step (tsx) — has count/value outputs + `/tmp/value-diff.json`
+  - On blocked → ensure `promotion-held` label + file/refresh issue (dedupe like freshness monitor)
+  - On promoted → auto-close any open `promotion-held` issue (comment + close)
+
+## Value-diff JSON shape (from SnapshotValueDiff.ts)
+
+`{ promote, reasons[], report: { added[], removed[], changed:[{date, changedDistricts[]}], unchanged[], overlapCount } }`
+
+## TDD
+
+- Red: unit-test promotionAlert pure fns (blocked→issue content per gate; promote→auto-close path;
+  stagingAhead when overlap changed-count > 0 with current date). Fail before impl.
+- Green: implement module + entry.
+- Refactor/glue: wire workflow, reuse freshness dedupe pattern.
+
+## Staging-ahead
+
+The value-diff already computes overlap `changed` per date. `stagingAhead = changedDateCount > 0`
+catches content-stale even when `latest.json` date matches (the D61 150-vs-151 case).


### PR DESCRIPTION
## Sprint 1 of epic #1072 — stale-prod observability

A blocked staging→prod promotion (count gate or the #1034 value gate refusing) left prod serving stale content while the daily run still reported `success` — no alert. Observed live 2026-06-01: D61 showed **150** active clubs on prod for 5 days while staging correctly held **151**. This makes a held promotion **loud and self-clearing**. **Alerting only — the value gate (#1034) stays fail-closed; no gate-logic change.**

### What changed
- **`scripts/lib/promotionAlert.ts`** (pure, unit-tested) — `classifyGate` / `evaluatePromotion` / `buildPromotionHeldTitle` / `buildPromotionHeldBody`. Distinguishes the **value gate** (operator-review-needed → clear with `allow_value_changes=true`) from the **count gate** (possible real subtractive regression → investigate first). Surfaces the **staging-ahead** signal (value-diff overlap changed-count > 0).
- **`scripts/promotion-alert.ts`** — thin runner (mirrors `check-pipeline-freshness.ts`): reads the two gate outputs + the value-diff JSON the pipeline already produces, emits `$GITHUB_OUTPUT`, writes the issue body file. R4-clean (logs→stderr). A runner crash **alerts** (blocked=true) rather than passing silently (Lesson 107).
- **`.github/workflows/data-pipeline.yml`** — adds `issues: write` and 4 steps after the gates: evaluate → ensure `promotion-held` label → file/refresh the issue (dedup, one open at a time) → **auto-close** on a later promoting run (safe because `concurrency: data-pipeline` serializes runs).

### Acceptance criteria (epic #1072)
- [x] Blocked promotion → visible, actionable `promotion-held` issue stating the gate, the diff, and the clear path.
- [x] Auto-resolves when a subsequent run promotes.
- [x] Staging-ahead detected (overlap changed-count > 0) even when `latest.json` date is current.
- [x] Value-gate vs count-gate distinguished in wording.
- [x] Value gate unchanged (alerting only).

### Why the date-based freshness monitor (#753) missed this
A held promotion leaves `v1/latest.json` **current** (the run happened) — only the *content* is stale. Recency and propagation are orthogonal axes. See **Lesson 155**.

### Testing
- TDD: 14 unit tests for the decision module (Red→Green). Full scripts suite: 213 pass. Pre-push full unit suite: 2673 pass.
- Runner smoke-tested end-to-end (Lesson 143): value-gate-blocked, count-gate-blocked, promoted, and missing-value-diff cases all emit correct outputs.

### Verification note
`pr-preview.yml` is path-filtered to `frontend/**` / `packages/{shared-contracts,analytics-core}/**` / firebase config. This PR touches only `scripts/**` + a workflow, so **no PR preview deploys** — there is no live frontend surface to drive. Verification is the full test suite + the end-to-end runner smoke above (code-proof, per the runner instructions).

Part of epic #1072. Sub-issue #1073.

🤖 Generated with [Claude Code](https://claude.com/claude-code)