### PR TITLE
Sprint 2 (#1083) — Closing-Pinned Auto-Allow in the value gate (#1086)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -1345,20 +1345,25 @@ jobs:
             AUTO_ALLOWED=$(jq -r '.autoAllowed // empty' /tmp/value-diff.json)
             if [ -n "${AUTO_ALLOWED}" ]; then
               DERIVED_ONLY=$(jq -r '.derivedOnlyDistricts // 0' /tmp/value-diff.json)
+              DELTA_COUNT=$(jq -r '.closingDeltas | length' /tmp/value-diff.json)
               echo "" >> "$GITHUB_STEP_SUMMARY"
               echo "### 🔓 Closing-Pinned Auto-Allow (\`${AUTO_ALLOWED}\`)" >> "$GITHUB_STEP_SUMMARY"
               {
                 echo "Routine month-end reconciliation auto-promoted (#1083)."
                 echo "${DERIVED_ONLY} derived-only district(s) ignored."
-                echo ""
-                echo "| Date | District | Field | Prod | Staging | Δ |"
-                echo "| --- | --- | --- | ---: | ---: | ---: |"
               } >> "$GITHUB_STEP_SUMMARY"
-              jq -r '.closingDeltas[]?
-                  | "| \(.date) | D\(.districtId) | \(.field) | \(.prod) "
-                    + "| \(.staging) "
-                    + "| \(if .delta >= 0 then "+" else "" end)\(.delta) |"' \
-                /tmp/value-diff.json >> "$GITHUB_STEP_SUMMARY" || true
+              if [ "${DELTA_COUNT}" -gt 0 ] 2>/dev/null; then
+                {
+                  echo ""
+                  echo "| Date | District | Field | Prod | Staging | Δ |"
+                  echo "| --- | --- | --- | ---: | ---: | ---: |"
+                } >> "$GITHUB_STEP_SUMMARY"
+                jq -r '.closingDeltas[]?
+                    | "| \(.date) | D\(.districtId) | \(.field) | \(.prod) "
+                      + "| \(.staging) "
+                      + "| \(if .delta >= 0 then "+" else "" end)\(.delta) |"' \
+                  /tmp/value-diff.json >> "$GITHUB_STEP_SUMMARY" || true
+              fi
             fi
           else
             echo "::warning::value-diff produced no parseable output — failing closed (no promote)"

--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -1339,6 +1339,27 @@ jobs:
             jq -r '.reasons[]? | "  - " + .' /tmp/value-diff.json >> "$GITHUB_STEP_SUMMARY" || true
             jq -r '.report.changed[]? | "  - changed " + .date + " (" + (.changedDistricts | length | tostring) + " districts)"' \
               /tmp/value-diff.json >> "$GITHUB_STEP_SUMMARY" || true
+
+            # Closing-Pinned Auto-Allow provenance (#1086, epic #1083) —
+            # display only; the gate step keeps consuming .promote above.
+            AUTO_ALLOWED=$(jq -r '.autoAllowed // empty' /tmp/value-diff.json)
+            if [ -n "${AUTO_ALLOWED}" ]; then
+              DERIVED_ONLY=$(jq -r '.derivedOnlyDistricts // 0' /tmp/value-diff.json)
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "### 🔓 Closing-Pinned Auto-Allow (\`${AUTO_ALLOWED}\`)" >> "$GITHUB_STEP_SUMMARY"
+              {
+                echo "Routine month-end reconciliation auto-promoted (#1083)."
+                echo "${DERIVED_ONLY} derived-only district(s) ignored."
+                echo ""
+                echo "| Date | District | Field | Prod | Staging | Δ |"
+                echo "| --- | --- | --- | ---: | ---: | ---: |"
+              } >> "$GITHUB_STEP_SUMMARY"
+              jq -r '.closingDeltas[]?
+                  | "| \(.date) | D\(.districtId) | \(.field) | \(.prod) "
+                    + "| \(.staging) "
+                    + "| \(if .delta >= 0 then "+" else "" end)\(.delta) |"' \
+                /tmp/value-diff.json >> "$GITHUB_STEP_SUMMARY" || true
+            fi
           else
             echo "::warning::value-diff produced no parseable output — failing closed (no promote)"
             echo "- ⚠️ value-diff failed to produce output — **failing closed**" >> "$GITHUB_STEP_SUMMARY"

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -1510,12 +1510,28 @@ export function createCLI(): Command {
       'Operator override: promote re-derived value changes after reviewing the diff',
       false
     )
+    .option(
+      '--closing-decrease-floor <n>',
+      'Closing auto-allow: tolerate counter decreases up to n (#1086; default 0 = strict)',
+      (value: string) => {
+        const parsed = Number(value)
+        if (!Number.isFinite(parsed) || parsed < 0) {
+          console.error(
+            `Error: --closing-decrease-floor must be a non-negative number, got "${value}"`
+          )
+          process.exit(ExitCode.COMPLETE_FAILURE)
+        }
+        return parsed
+      },
+      0
+    )
     .option('-v, --verbose', 'Enable detailed logging output', false)
     .action(
       async (options: {
         stagingDir: string
         prodDir: string
         allowValueChanges: boolean
+        closingDecreaseFloor: number
         verbose: boolean
       }) => {
         const { runValueDiff } =
@@ -1527,6 +1543,7 @@ export function createCLI(): Command {
             stagingDir: options.stagingDir,
             prodDir: options.prodDir,
             allowValueChanges: options.allowValueChanges,
+            closingDecreaseFloor: options.closingDecreaseFloor,
           })
         } catch (err) {
           // Fail-closed: if we cannot read/compare the snapshots, do NOT promote.

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -507,19 +507,70 @@ export function diffSnapshots(
 }
 
 /**
+ * CPAA across ALL changed overlap dates: every changed date must individually
+ * pass {@link evaluateClosingAutoAllow}; any failure (or a missing digest)
+ * blocks the whole set — fail-closed.
+ */
+function evaluateClosingAutoAllowAcross(
+  changed: ChangedDate[],
+  digests: PromoteDigests,
+  opts: ClosingAutoAllowOptions
+): ClosingAutoAllowResult & { deltasByDate: PromoteDecision['closingDeltas'] } {
+  const stagingMap = byDate(digests.staging)
+  const prodMap = byDate(digests.prod)
+  const reasons: string[] = []
+  const deltasByDate: NonNullable<PromoteDecision['closingDeltas']> = []
+  const derivedOnly: string[] = []
+
+  for (const { date } of changed) {
+    const staging = stagingMap.get(date)
+    const prod = prodMap.get(date)
+    if (!staging || !prod) {
+      reasons.push(`${date}: digest unavailable — cannot evaluate auto-allow`)
+      continue
+    }
+    const result = evaluateClosingAutoAllow(staging, prod, opts)
+    if (!result.allowed) {
+      reasons.push(...result.reasons)
+    } else {
+      deltasByDate.push(...result.deltas.map(d => ({ date, ...d })))
+      derivedOnly.push(...result.derivedOnlyDistricts)
+    }
+  }
+
+  return {
+    allowed: reasons.length === 0,
+    reasons,
+    deltas: [],
+    derivedOnlyDistricts: derivedOnly,
+    deltasByDate,
+  }
+}
+
+/**
  * Promote gate (validate-first). A SUBTRACTIVE change (date removed from prod)
  * always blocks. A value re-derive (changed overlap dates) requires explicit
  * operator review — it blocks unless `allowValueChanges` is set, signalling the
  * operator has reviewed the value diff. A purely additive change promotes.
+ *
+ * Closing-Pinned Auto-Allow (#1086, epic #1083): when the only objection is
+ * "changed overlap dates" and EVERY changed date is closing-pinned with
+ * monotone, capped counter moves (decision doc §4–§5), the change is routine
+ * month-end reconciliation and promotes autonomously with provenance.
+ * Subtractive changes still block absolutely; without `digests` the legacy
+ * review path applies (fail-closed).
  */
 export function evaluatePromote(
   report: ValueDiffReport,
   opts: PromoteOptions = {},
-  _digests?: PromoteDigests
+  digests?: PromoteDigests
 ): PromoteDecision {
   const reasons: string[] = []
   let promote = true
   let requiresReview = false
+  let autoAllowed: PromoteDecision['autoAllowed']
+  let closingDeltas: PromoteDecision['closingDeltas']
+  let derivedOnlyDistricts: number | undefined
 
   if (report.removed.length > 0) {
     promote = false
@@ -534,10 +585,31 @@ export function evaluatePromote(
       `changed: ${report.changed.length} overlap date(s) have re-derived values differing from production`
     )
     if (!opts.allowValueChanges) {
-      promote = false
-      reasons.push(
-        'value changes require operator review — re-run with --allow-value-changes to promote after reviewing the diff'
-      )
+      // CPAA applies only when the verdict would otherwise be "blocked
+      // because changed is non-empty" — never to a subtractive change.
+      const cpaa =
+        digests && report.removed.length === 0
+          ? evaluateClosingAutoAllowAcross(report.changed, digests, {
+              closingDecreaseFloor: opts.closingDecreaseFloor,
+            })
+          : undefined
+      if (cpaa?.allowed) {
+        requiresReview = false
+        autoAllowed = 'closing-monotonic'
+        closingDeltas = cpaa.deltasByDate
+        derivedOnlyDistricts = cpaa.derivedOnlyDistricts.length
+        reasons.push(
+          `closing-pinned auto-allow: ${cpaa.deltasByDate?.length ?? 0} monotone ` +
+            `counter move(s) across ${report.changed.length} closing-pinned date(s), ` +
+            `${derivedOnlyDistricts} derived-only district(s) ignored (#1086)`
+        )
+      } else {
+        promote = false
+        reasons.push(
+          'value changes require operator review — re-run with --allow-value-changes to promote after reviewing the diff'
+        )
+        if (cpaa) reasons.push(...cpaa.reasons)
+      }
     }
   }
 
@@ -547,5 +619,14 @@ export function evaluatePromote(
     )
   }
 
-  return { promote, requiresReview, reasons }
+  return {
+    promote,
+    requiresReview,
+    reasons,
+    ...(autoAllowed !== undefined && {
+      autoAllowed,
+      closingDeltas,
+      derivedOnlyDistricts,
+    }),
+  }
 }

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -18,6 +18,26 @@ import type {
   DistrictRanking,
 } from '@toastmasters/shared-contracts'
 
+/**
+ * Causal role of a DistrictRanking field for the Closing-Pinned Auto-Allow
+ * policy (epic #1083, decision doc §4). Counters are monotone + capped;
+ * bases/identity must be equal; plan booleans are one-way (false→true);
+ * derived fields are zero-sum re-derivations and excluded from the check.
+ */
+export type FieldClass =
+  | 'counter'
+  | 'base'
+  | 'identity'
+  | 'planBoolean'
+  | 'derived'
+
+/**
+ * Field-classification registry — placeholder, populated at GREEN (#1086).
+ * Exhaustiveness vs DistrictRankingSchema.shape is enforced by unit test;
+ * an unclassified CHANGED field blocks at runtime (fail-closed).
+ */
+export const FIELD_CLASSIFICATION: Record<string, FieldClass> = {}
+
 export interface DateDigest {
   date: string
   totalDistricts: number

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -32,11 +32,49 @@ export type FieldClass =
   | 'derived'
 
 /**
- * Field-classification registry — placeholder, populated at GREEN (#1086).
- * Exhaustiveness vs DistrictRankingSchema.shape is enforced by unit test;
- * an unclassified CHANGED field blocks at runtime (fail-closed).
+ * Field-classification registry (decision doc §4 table). Exhaustiveness vs
+ * DistrictRankingSchema.shape is enforced by unit test; an unclassified
+ * CHANGED field blocks at runtime (fail-closed, R20/L150 spirit).
  */
-export const FIELD_CLASSIFICATION: Record<string, FieldClass> = {}
+export const FIELD_CLASSIFICATION: Record<string, FieldClass> = {
+  // Identity — must be equal
+  districtId: 'identity',
+  districtName: 'identity',
+  region: 'identity',
+  // Counters — non-decreasing, magnitude-capped during closing
+  paidClubs: 'counter',
+  activeClubs: 'counter',
+  totalPayments: 'counter',
+  newPayments: 'counter',
+  aprilPayments: 'counter',
+  octoberPayments: 'counter',
+  latePayments: 'counter',
+  charterPayments: 'counter',
+  distinguishedClubs: 'counter',
+  selectDistinguished: 'counter',
+  presidentsDistinguished: 'counter',
+  smedleyDistinguished: 'counter',
+  clubsWith20PlusMembers: 'counter',
+  newCharteredClubs: 'counter',
+  // Bases — fixed at program-year start; any move is an anomaly
+  paidClubBase: 'base',
+  paymentBase: 'base',
+  // Plan booleans — one-way false→true
+  dspSubmitted: 'planBoolean',
+  trainingMet: 'planBoolean',
+  marketAnalysisSubmitted: 'planBoolean',
+  communicationPlanSubmitted: 'planBoolean',
+  regionAdvisorVisitMet: 'planBoolean',
+  // Derived — re-derived, zero-sum across districts; excluded from the check
+  clubGrowthPercent: 'derived',
+  paymentGrowthPercent: 'derived',
+  distinguishedPercent: 'derived',
+  clubsRank: 'derived',
+  paymentsRank: 'derived',
+  distinguishedRank: 'derived',
+  overallRank: 'derived',
+  aggregateScore: 'derived',
+}
 
 export interface DateDigest {
   date: string

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -76,6 +76,17 @@ export const FIELD_CLASSIFICATION: Record<string, FieldClass> = {
   aggregateScore: 'derived',
 }
 
+/**
+ * Closing-pinned detection (decision doc §5) — placeholder, implemented at
+ * GREEN (#1086).
+ */
+export function isClosingPinned(
+  _date: string,
+  _sourceCsvDate: string | undefined
+): boolean {
+  throw new Error('not implemented')
+}
+
 export interface DateDigest {
   date: string
   totalDistricts: number

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -515,12 +515,17 @@ function evaluateClosingAutoAllowAcross(
   changed: ChangedDate[],
   digests: PromoteDigests,
   opts: ClosingAutoAllowOptions
-): ClosingAutoAllowResult & { deltasByDate: PromoteDecision['closingDeltas'] } {
+): {
+  allowed: boolean
+  reasons: string[]
+  deltas: NonNullable<PromoteDecision['closingDeltas']>
+  derivedOnlyDistricts: number
+} {
   const stagingMap = byDate(digests.staging)
   const prodMap = byDate(digests.prod)
   const reasons: string[] = []
-  const deltasByDate: NonNullable<PromoteDecision['closingDeltas']> = []
-  const derivedOnly: string[] = []
+  const deltas: NonNullable<PromoteDecision['closingDeltas']> = []
+  let derivedOnlyDistricts = 0
 
   for (const { date } of changed) {
     const staging = stagingMap.get(date)
@@ -533,17 +538,16 @@ function evaluateClosingAutoAllowAcross(
     if (!result.allowed) {
       reasons.push(...result.reasons)
     } else {
-      deltasByDate.push(...result.deltas.map(d => ({ date, ...d })))
-      derivedOnly.push(...result.derivedOnlyDistricts)
+      deltas.push(...result.deltas.map(d => ({ date, ...d })))
+      derivedOnlyDistricts += result.derivedOnlyDistricts.length
     }
   }
 
   return {
     allowed: reasons.length === 0,
     reasons,
-    deltas: [],
-    derivedOnlyDistricts: derivedOnly,
-    deltasByDate,
+    deltas,
+    derivedOnlyDistricts,
   }
 }
 
@@ -596,10 +600,10 @@ export function evaluatePromote(
       if (cpaa?.allowed) {
         requiresReview = false
         autoAllowed = 'closing-monotonic'
-        closingDeltas = cpaa.deltasByDate
-        derivedOnlyDistricts = cpaa.derivedOnlyDistricts.length
+        closingDeltas = cpaa.deltas
+        derivedOnlyDistricts = cpaa.derivedOnlyDistricts
         reasons.push(
-          `closing-pinned auto-allow: ${cpaa.deltasByDate?.length ?? 0} monotone ` +
+          `closing-pinned auto-allow: ${cpaa.deltas.length} monotone ` +
             `counter move(s) across ${report.changed.length} closing-pinned date(s), ` +
             `${derivedOnlyDistricts} derived-only district(s) ignored (#1086)`
         )

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -76,15 +76,52 @@ export const FIELD_CLASSIFICATION: Record<string, FieldClass> = {
   aggregateScore: 'derived',
 }
 
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/
+
+/** Parse YYYY-MM-DD into [year, month, day], or null if malformed. */
+function parseIsoDate(value: string): [number, number, number] | null {
+  const m = ISO_DATE.exec(value)
+  if (!m) return null
+  return [Number(m[1]), Number(m[2]), Number(m[3])]
+}
+
 /**
- * Closing-pinned detection (decision doc §5) — placeholder, implemented at
- * GREEN (#1086).
+ * Closing-pinned detection (decision doc §5). A snapshot date `D` carries the
+ * #309 closing-remap signature iff, in staging's own rankings metadata:
+ *   1. `D` is the last day of its calendar month (every remap pins to
+ *      month-end),
+ *   2. `sourceCsvDate > D` (the As-of advanced past the pinned date — TI
+ *      publishes prior-month data with a current-month As-of only during
+ *      closing), and
+ *   3. the gap is ≤ 31 days (belt-and-braces bound; longest closing on record
+ *      is 25 days).
+ *
+ * All comparisons are on the ISO strings / UTC day arithmetic — deliberately
+ * NOT reusing ClosingPeriodDetector, whose `new Date(string)` parsing has a
+ * TZ edge (decision doc §5). Malformed input fails closed (not pinned).
  */
 export function isClosingPinned(
-  _date: string,
-  _sourceCsvDate: string | undefined
+  date: string,
+  sourceCsvDate: string | undefined
 ): boolean {
-  throw new Error('not implemented')
+  if (!sourceCsvDate) return false
+  const pinned = parseIsoDate(date)
+  const asOf = parseIsoDate(sourceCsvDate)
+  if (!pinned || !asOf) return false
+
+  const [year, month, day] = pinned
+  // Day 0 of the NEXT month is the last day of this month (UTC arithmetic —
+  // no string parsing, no local TZ).
+  const lastDayOfMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
+  if (day !== lastDayOfMonth) return false
+
+  // ISO strings compare lexicographically in date order (incl. across years).
+  if (!(sourceCsvDate > date)) return false
+
+  const gapDays =
+    (Date.UTC(asOf[0], asOf[1] - 1, asOf[2]) - Date.UTC(year, month - 1, day)) /
+    86_400_000
+  return gapDays <= 31
 }
 
 export interface DateDigest {

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -361,11 +361,25 @@ export interface PromoteDecision {
   promote: boolean
   requiresReview: boolean
   reasons: string[]
+  /** present when CPAA auto-allowed every changed overlap date (#1086) */
+  autoAllowed?: 'closing-monotonic'
+  /** provenance: per-date monotone counter movements (run-summary table) */
+  closingDeltas?: Array<ClosingDelta & { date: string }>
+  /** districts (across changed dates) whose only moves were derived fields */
+  derivedOnlyDistricts?: number
 }
 
 export interface PromoteOptions {
   /** operator override: promote a reviewed value re-derive despite changed dates */
   allowValueChanges?: boolean
+  /** CPAA counter decrease tolerance — see {@link ClosingAutoAllowOptions} */
+  closingDecreaseFloor?: number
+}
+
+/** Digest sets for CPAA evaluation of changed overlap dates (#1086). */
+export interface PromoteDigests {
+  staging: DateDigest[]
+  prod: DateDigest[]
 }
 
 /**
@@ -500,7 +514,8 @@ export function diffSnapshots(
  */
 export function evaluatePromote(
   report: ValueDiffReport,
-  opts: PromoteOptions = {}
+  opts: PromoteOptions = {},
+  _digests?: PromoteDigests
 ): PromoteDecision {
   const reasons: string[] = []
   let promote = true

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -169,15 +169,174 @@ export interface ClosingAutoAllowOptions {
 }
 
 /**
- * Closing-Pinned Auto-Allow evaluation for ONE changed overlap date —
- * placeholder, implemented at GREEN (#1086).
+ * Closing-Pinned Auto-Allow evaluation for ONE changed overlap date (decision
+ * doc §4–§5, epic #1083). Auto-allow iff the date carries the closing-remap
+ * signature in STAGING's own metadata, the district set is identical, and
+ * every changed field obeys its class rule:
+ *
+ *   counter      −floor ≤ Δ ≤ max(50, 10% × prod)   (floor defaults to 0)
+ *   base         must be equal
+ *   identity     must be equal
+ *   planBoolean  false→true allowed; true→false blocks
+ *   derived      excluded (zero-sum re-derivations)
+ *
+ * Optionality transitions (field present on one side only) and unclassified
+ * CHANGED fields block — fail-closed. Digests lacking the parsed rows (e.g.
+ * hand-built) also fail closed.
  */
 export function evaluateClosingAutoAllow(
-  _stagingDate: DateDigest,
-  _prodDate: DateDigest,
-  _opts: ClosingAutoAllowOptions = {}
+  stagingDate: DateDigest,
+  prodDate: DateDigest,
+  opts: ClosingAutoAllowOptions = {}
 ): ClosingAutoAllowResult {
-  throw new Error('not implemented')
+  const date = stagingDate.date
+  const reasons: string[] = []
+  const deltas: ClosingDelta[] = []
+  const derivedOnly: string[] = []
+  const decreaseFloor = opts.closingDecreaseFloor ?? 0
+
+  const blocked = (): ClosingAutoAllowResult => ({
+    allowed: false,
+    reasons,
+    deltas: [],
+    derivedOnlyDistricts: [],
+  })
+
+  // Fail-closed: without the parsed rows + signature we cannot evaluate.
+  const stagingDistricts = stagingDate.districts
+  const prodDistricts = prodDate.districts
+  if (!stagingDistricts || !prodDistricts) {
+    reasons.push(
+      `${date}: parsed district rows unavailable — cannot evaluate closing auto-allow`
+    )
+    return blocked()
+  }
+  if (!isClosingPinned(date, stagingDate.sourceCsvDate)) {
+    reasons.push(
+      `${date}: not closing-pinned (month-end + advanced As-of signature absent; ` +
+        `sourceCsvDate=${stagingDate.sourceCsvDate ?? 'missing'}) — ` +
+        `a changed non-closing date is a re-derive review`
+    )
+    return blocked()
+  }
+
+  // District set must be identical on the changed date (#1034 D61 protection).
+  const stagingIds = Object.keys(stagingDistricts)
+  const prodIds = Object.keys(prodDistricts)
+  const onlyStaging = stagingIds.filter(id => !(id in prodDistricts))
+  const onlyProd = prodIds.filter(id => !(id in stagingDistricts))
+  if (onlyStaging.length > 0 || onlyProd.length > 0) {
+    if (onlyStaging.length > 0) {
+      reasons.push(
+        `${date}: district(s) only in staging: ${onlyStaging.sort().join(', ')}`
+      )
+    }
+    if (onlyProd.length > 0) {
+      reasons.push(
+        `${date}: district(s) only in production: ${onlyProd.sort().join(', ')}`
+      )
+    }
+    return blocked()
+  }
+
+  for (const id of stagingIds.sort()) {
+    const stagingRow = stagingDistricts[id] as unknown as Record<
+      string,
+      unknown
+    >
+    const prodRow = prodDistricts[id] as unknown as Record<string, unknown>
+    const fields = new Set([
+      ...Object.keys(stagingRow),
+      ...Object.keys(prodRow),
+    ])
+    let nonDerivedChanges = 0
+    let derivedChanges = 0
+
+    for (const field of [...fields].sort()) {
+      const stagingValue = stagingRow[field]
+      const prodValue = prodRow[field]
+      if (Object.is(stagingValue, prodValue)) continue
+
+      const cls = FIELD_CLASSIFICATION[field]
+      if (cls === 'derived') {
+        derivedChanges++
+        continue
+      }
+      nonDerivedChanges++
+
+      // Unclassified CHANGED field — fail-closed (registry exhaustiveness is
+      // also unit-tested against the schema; this guards unvalidated input).
+      if (cls === undefined) {
+        reasons.push(
+          `${date} D${id} ${field}: unclassified field changed — fail-closed`
+        )
+        continue
+      }
+
+      // Optionality transition: present on one side only (any non-derived
+      // class). During closing TI does not add columns — a field appearing
+      // or vanishing means the pipeline code changed (re-derive review).
+      if (stagingValue === undefined || prodValue === undefined) {
+        reasons.push(
+          `${date} D${id} ${field}: optionality transition ` +
+            `(${String(prodValue)}→${String(stagingValue)}) blocks`
+        )
+        continue
+      }
+
+      switch (cls) {
+        case 'counter': {
+          const prod = prodValue as number
+          const staging = stagingValue as number
+          const delta = staging - prod
+          const cap = Math.max(50, 0.1 * prod)
+          if (delta < -decreaseFloor) {
+            reasons.push(
+              `${date} D${id} ${field}: counter decrease ${prod}→${staging} ` +
+                `(Δ ${delta}) blocks (floor ${decreaseFloor})`
+            )
+          } else if (delta > cap) {
+            reasons.push(
+              `${date} D${id} ${field}: counter move ${prod}→${staging} ` +
+                `(Δ +${delta}) exceeds cap ${cap} = max(50, 10% × ${prod})`
+            )
+          } else {
+            deltas.push({ districtId: id, field, prod, staging, delta })
+          }
+          break
+        }
+        case 'base':
+          reasons.push(
+            `${date} D${id} ${field}: base drift ${String(prodValue)}→` +
+              `${String(stagingValue)} blocks (fixed at program-year start)`
+          )
+          break
+        case 'identity':
+          reasons.push(
+            `${date} D${id} ${field}: identity drift ${String(prodValue)}→` +
+              `${String(stagingValue)} blocks`
+          )
+          break
+        case 'planBoolean':
+          if (prodValue === false && stagingValue === true) break // one-way OK
+          reasons.push(
+            `${date} D${id} ${field}: plan boolean ${String(prodValue)}→` +
+              `${String(stagingValue)} blocks (only false→true allowed)`
+          )
+          break
+      }
+    }
+
+    if (nonDerivedChanges === 0 && derivedChanges > 0) derivedOnly.push(id)
+  }
+
+  if (reasons.length > 0) return blocked()
+  return {
+    allowed: true,
+    reasons: [],
+    deltas,
+    derivedOnlyDistricts: derivedOnly,
+  }
 }
 
 export interface ChangedDate {
@@ -249,8 +408,10 @@ export function digestDate(
   data: AllDistrictsRankingsData
 ): DateDigest {
   const districtDigests: Record<string, string> = {}
+  const districts: Record<string, DistrictRanking> = {}
   for (const district of data.rankings) {
     districtDigests[district.districtId] = digestDistrict(district)
+    districts[district.districtId] = district
   }
   // Order-independent: sort by districtId before combining.
   const combined = stableStringify(
@@ -263,6 +424,10 @@ export function digestDate(
     totalDistricts: data.rankings.length,
     districtDigests,
     combined,
+    // CPAA pass-through (#1086): already-parsed rows + the remap signature
+    // input — no new I/O, evaluated only for changed overlap dates.
+    districts,
+    sourceCsvDate: data.metadata.sourceCsvDate,
   }
 }
 

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -131,6 +131,53 @@ export interface DateDigest {
   districtDigests: Record<string, string>
   /** order-independent digest of the whole date */
   combined: string
+  /**
+   * districtId → parsed ranking row, for closing auto-allow evaluation of
+   * changed dates (#1086). Carried from the data the loader already parses —
+   * no new I/O. Absent on hand-built digests ⇒ CPAA fails closed.
+   */
+  districts?: Record<string, DistrictRanking>
+  /** metadata.sourceCsvDate — the closing-remap signature input (#1086) */
+  sourceCsvDate?: string
+}
+
+/** One monotone counter movement, kept for provenance in the run summary. */
+export interface ClosingDelta {
+  districtId: string
+  field: string
+  prod: number
+  staging: number
+  delta: number
+}
+
+export interface ClosingAutoAllowResult {
+  allowed: boolean
+  /** violations when !allowed — each names the date/district/field */
+  reasons: string[]
+  /** monotone counter movements (provenance for the run summary) */
+  deltas: ClosingDelta[]
+  /** districts whose only differences were derived fields (ignored) */
+  derivedOnlyDistricts: string[]
+}
+
+export interface ClosingAutoAllowOptions {
+  /**
+   * Counters may decrease by at most this much during closing (decision doc
+   * §4). Default 0 (strict — the epic's "never auto-promote a decrease").
+   */
+  closingDecreaseFloor?: number
+}
+
+/**
+ * Closing-Pinned Auto-Allow evaluation for ONE changed overlap date —
+ * placeholder, implemented at GREEN (#1086).
+ */
+export function evaluateClosingAutoAllow(
+  _stagingDate: DateDigest,
+  _prodDate: DateDigest,
+  _opts: ClosingAutoAllowOptions = {}
+): ClosingAutoAllowResult {
+  throw new Error('not implemented')
 }
 
 export interface ChangedDate {

--- a/packages/collector-cli/src/services/SnapshotValueDiffLoader.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiffLoader.ts
@@ -24,6 +24,8 @@ export interface RunValueDiffOptions {
   stagingDir: string
   prodDir: string
   allowValueChanges?: boolean
+  /** CPAA counter decrease tolerance (#1086) — default 0 (strict) */
+  closingDecreaseFloor?: number
 }
 
 export interface RunValueDiffResult {

--- a/packages/collector-cli/src/services/SnapshotValueDiffLoader.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiffLoader.ts
@@ -66,8 +66,14 @@ export function runValueDiff(opts: RunValueDiffOptions): RunValueDiffResult {
   const staging = loadDateDigests(opts.stagingDir)
   const prod = loadDateDigests(opts.prodDir)
   const report = diffSnapshots(staging, prod)
-  const decision = evaluatePromote(report, {
-    allowValueChanges: opts.allowValueChanges,
-  })
+  const decision = evaluatePromote(
+    report,
+    {
+      allowValueChanges: opts.allowValueChanges,
+      closingDecreaseFloor: opts.closingDecreaseFloor,
+    },
+    // CPAA (#1086): digests carry the already-parsed rows + sourceCsvDate.
+    { staging, prod }
+  )
   return { report, decision, exitCode: decision.promote ? 0 : 1 }
 }

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
@@ -13,10 +13,21 @@
  * even though the registry stays exhaustive.
  */
 import { describe, it, expect } from 'vitest'
-import { DistrictRankingSchema } from '@toastmasters/shared-contracts'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
+  DistrictRankingSchema,
+  validateAllDistrictsRankings,
+  type AllDistrictsRankingsData,
+  type DistrictRanking,
+} from '@toastmasters/shared-contracts'
+import {
+  digestDate,
+  evaluateClosingAutoAllow,
   FIELD_CLASSIFICATION,
   isClosingPinned,
+  type DateDigest,
   type FieldClass,
 } from '../SnapshotValueDiff.js'
 
@@ -121,5 +132,322 @@ describe('isClosingPinned (#1086, decision doc §5)', () => {
   it('rejects malformed date strings (fail-closed)', () => {
     expect(isClosingPinned('not-a-date', '2026-06-02')).toBe(false)
     expect(isClosingPinned('2026-05-31', 'garbage')).toBe(false)
+  })
+})
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * evaluateClosingAutoAllow — synthetic-edge + real-fixture coverage.
+ * Fixture: the captured 2026-05-31 staging/prod pair (see fixtures README) —
+ * the L150 consequential layer: a mis-classified field flips these verdicts.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+const FIXTURE_DIR = fileURLToPath(
+  new URL('./fixtures/closing-2026-05-31/', import.meta.url)
+)
+
+function loadFixture(name: string): AllDistrictsRankingsData {
+  const parsed = validateAllDistrictsRankings(
+    JSON.parse(readFileSync(join(FIXTURE_DIR, name), 'utf8'))
+  )
+  if (!parsed.success || !parsed.data) {
+    throw new Error(`fixture ${name} failed schema validation: ${parsed.error}`)
+  }
+  return parsed.data
+}
+
+/** The 5 genuine-reversal districts captured in the fixture (doc §3b). */
+const REVERSAL_DISTRICTS = ['114', '88', '128', '44', '50']
+
+function syntheticDistrict(
+  overrides: Partial<DistrictRanking> = {}
+): DistrictRanking {
+  return {
+    districtId: '61',
+    districtName: 'District 61',
+    region: 'Region 7',
+    paidClubs: 100,
+    paidClubBase: 98,
+    clubGrowthPercent: 2.04,
+    totalPayments: 5000,
+    paymentBase: 4800,
+    paymentGrowthPercent: 4.17,
+    activeClubs: 95,
+    distinguishedClubs: 30,
+    selectDistinguished: 10,
+    presidentsDistinguished: 5,
+    distinguishedPercent: 30,
+    clubsRank: 3,
+    paymentsRank: 4,
+    distinguishedRank: 2,
+    aggregateScore: 88.5,
+    overallRank: 3,
+    ...overrides,
+  }
+}
+
+function syntheticRankings(
+  districts: DistrictRanking[],
+  sourceCsvDate: string
+): AllDistrictsRankingsData {
+  return {
+    metadata: {
+      snapshotId: '2026-05-31',
+      calculatedAt: '2026-06-03T00:00:00.000Z',
+      schemaVersion: '1.0.0',
+      calculationVersion: '1.0.0',
+      rankingVersion: '1.0.0',
+      sourceCsvDate,
+      csvFetchedAt: '2026-06-03T00:00:00.000Z',
+      totalDistricts: districts.length,
+      fromCache: false,
+    },
+    rankings: districts,
+  }
+}
+
+/** Digest pair for one synthetic district: prod baseline vs staging override. */
+function syntheticPair(
+  stagingOverrides: Partial<DistrictRanking>,
+  prodOverrides: Partial<DistrictRanking> = {},
+  {
+    date = '2026-05-31',
+    stagingSourceCsvDate = '2026-06-02',
+    prodSourceCsvDate = '2026-05-31',
+  } = {}
+): [DateDigest, DateDigest] {
+  return [
+    digestDate(
+      date,
+      syntheticRankings(
+        [syntheticDistrict(stagingOverrides)],
+        stagingSourceCsvDate
+      )
+    ),
+    digestDate(
+      date,
+      syntheticRankings([syntheticDistrict(prodOverrides)], prodSourceCsvDate)
+    ),
+  ]
+}
+
+describe('digestDate CPAA pass-through (#1086)', () => {
+  it('carries the parsed district rows and sourceCsvDate', () => {
+    const data = syntheticRankings([syntheticDistrict()], '2026-06-02')
+    const digest = digestDate('2026-05-31', data)
+    expect(digest.sourceCsvDate).toBe('2026-06-02')
+    expect(digest.districts?.['61']?.paidClubs).toBe(100)
+  })
+})
+
+describe('evaluateClosingAutoAllow — fixture (2026-05-31 pair)', () => {
+  const stagingData = loadFixture('staging-all-districts-rankings.json')
+  const prodData = loadFixture('prod-all-districts-rankings.json')
+  const stagingDigest = digestDate('2026-05-31', stagingData)
+  const prodDigest = digestDate('2026-05-31', prodData)
+
+  it('blocks the as-is pair, naming each of the 5 reversal districts', () => {
+    const res = evaluateClosingAutoAllow(stagingDigest, prodDigest)
+    expect(res.allowed).toBe(false)
+    for (const id of REVERSAL_DISTRICTS) {
+      expect(
+        res.reasons.some(r => r.includes(`D${id} `)),
+        `expected a reason naming D${id}`
+      ).toBe(true)
+    }
+  })
+
+  it('auto-allows once the 5 reversal districts match prod (19 monotone movers, 78 derived-only)', () => {
+    const prodRowById = new Map(prodData.rankings.map(r => [r.districtId, r]))
+    const patched: AllDistrictsRankingsData = {
+      ...stagingData,
+      rankings: stagingData.rankings.map(r =>
+        REVERSAL_DISTRICTS.includes(r.districtId)
+          ? (prodRowById.get(r.districtId) ?? r)
+          : r
+      ),
+    }
+    const res = evaluateClosingAutoAllow(
+      digestDate('2026-05-31', patched),
+      prodDigest
+    )
+    expect(res.allowed).toBe(true)
+    expect(res.reasons).toEqual([])
+    const moverIds = new Set(res.deltas.map(d => d.districtId))
+    expect(moverIds.size).toBe(19)
+    expect(res.derivedOnlyDistricts).toHaveLength(78)
+    // Provenance is monotone and capped by construction.
+    for (const d of res.deltas) {
+      expect(d.delta).toBeGreaterThan(0)
+      expect(d.delta).toBeLessThanOrEqual(Math.max(50, 0.1 * d.prod))
+    }
+  })
+})
+
+describe('evaluateClosingAutoAllow — edges (decision doc §8.3)', () => {
+  it('allows a monotone within-cap counter move on a pinned date', () => {
+    const [s, p] = syntheticPair({ totalPayments: 5050 })
+    const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(true)
+    expect(res.deltas).toEqual([
+      {
+        districtId: '61',
+        field: 'totalPayments',
+        prod: 5000,
+        staging: 5050,
+        delta: 50,
+      },
+    ])
+  })
+
+  it('allows a small-base spike within the absolute floor of 50', () => {
+    // charterPayments 160→186 (+26): 10% cap would be 16, floor 50 covers it.
+    const [s, p] = syntheticPair(
+      { charterPayments: 186 },
+      { charterPayments: 160 }
+    )
+    expect(evaluateClosingAutoAllow(s, p).allowed).toBe(true)
+  })
+
+  it('blocks when the signature is absent (sourceCsvDate == date)', () => {
+    const [s, p] = syntheticPair(
+      { totalPayments: 5050 },
+      {},
+      { stagingSourceCsvDate: '2026-05-31' }
+    )
+    const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(false)
+    expect(res.reasons.join(' ')).toMatch(/closing-pinned/i)
+  })
+
+  it('blocks a changed non-month-end date even with an advanced As-of', () => {
+    const [s, p] = syntheticPair(
+      { totalPayments: 5050 },
+      {},
+      {
+        date: '2026-05-30',
+      }
+    )
+    expect(evaluateClosingAutoAllow(s, p).allowed).toBe(false)
+  })
+
+  it('detects the December cross-year signature', () => {
+    const [s, p] = syntheticPair(
+      { totalPayments: 5050 },
+      {},
+      {
+        date: '2025-12-31',
+        stagingSourceCsvDate: '2026-01-10',
+        prodSourceCsvDate: '2025-12-31',
+      }
+    )
+    expect(evaluateClosingAutoAllow(s, p).allowed).toBe(true)
+  })
+
+  it('blocks a counter exceeding the max(50, 10%) cap', () => {
+    // Δ +600 on prod 5000: cap is max(50, 500) = 500.
+    const [s, p] = syntheticPair({ totalPayments: 5600 })
+    const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(false)
+    expect(res.reasons.join(' ')).toMatch(/cap/i)
+  })
+
+  it('blocks a counter decrease at the default floor of 0', () => {
+    const [s, p] = syntheticPair({ totalPayments: 4999 })
+    const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(false)
+    expect(res.reasons.join(' ')).toMatch(/decrease/i)
+  })
+
+  it('honours a configured decrease floor without weakening the default', () => {
+    const [s, p] = syntheticPair({ totalPayments: 4997 }) // Δ -3
+    expect(
+      evaluateClosingAutoAllow(s, p, { closingDecreaseFloor: 5 }).allowed
+    ).toBe(true)
+    expect(
+      evaluateClosingAutoAllow(s, p, { closingDecreaseFloor: 2 }).allowed
+    ).toBe(false)
+  })
+
+  it('blocks base drift (paymentBase moved)', () => {
+    const [s, p] = syntheticPair({ paymentBase: 4801 })
+    const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(false)
+    expect(res.reasons.join(' ')).toMatch(/base/i)
+  })
+
+  it('blocks identity drift (districtName changed)', () => {
+    const [s, p] = syntheticPair({ districtName: 'District 61 Renamed' })
+    expect(evaluateClosingAutoAllow(s, p).allowed).toBe(false)
+  })
+
+  it('allows a plan boolean false→true but blocks true→false', () => {
+    const [allowS, allowP] = syntheticPair(
+      { dspSubmitted: true },
+      { dspSubmitted: false }
+    )
+    expect(evaluateClosingAutoAllow(allowS, allowP).allowed).toBe(true)
+
+    const [blockS, blockP] = syntheticPair(
+      { trainingMet: false },
+      { trainingMet: true }
+    )
+    const res = evaluateClosingAutoAllow(blockS, blockP)
+    expect(res.allowed).toBe(false)
+    expect(res.reasons.join(' ')).toMatch(/trainingMet/)
+  })
+
+  it('blocks an optionality transition (field appears on one side only)', () => {
+    const [s, p] = syntheticPair({ smedleyDistinguished: 2 }, {})
+    const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(false)
+    expect(res.reasons.join(' ')).toMatch(/smedleyDistinguished/)
+  })
+
+  it('blocks an unclassified changed field (fail-closed)', () => {
+    const withUnknown = (v: number) =>
+      ({
+        ...syntheticDistrict(),
+        mysteryField: v,
+      }) as unknown as DistrictRanking
+    const s = digestDate(
+      '2026-05-31',
+      syntheticRankings([withUnknown(2)], '2026-06-02')
+    )
+    const p = digestDate(
+      '2026-05-31',
+      syntheticRankings([withUnknown(1)], '2026-05-31')
+    )
+    const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(false)
+    expect(res.reasons.join(' ')).toMatch(/mysteryField/)
+  })
+
+  it('blocks when the district set differs on the changed date', () => {
+    const extra = syntheticDistrict({ districtId: '99' })
+    const s = digestDate(
+      '2026-05-31',
+      syntheticRankings([syntheticDistrict(), extra], '2026-06-02')
+    )
+    const p = digestDate(
+      '2026-05-31',
+      syntheticRankings(
+        [syntheticDistrict({ totalPayments: 4900 })],
+        '2026-05-31'
+      )
+    )
+    const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(false)
+    expect(res.reasons.join(' ')).toMatch(/99/)
+  })
+
+  it('fails closed when digests lack the parsed rows (hand-built digests)', () => {
+    const [s, p] = syntheticPair({ totalPayments: 5050 })
+    const stripped: DateDigest = {
+      date: s.date,
+      totalDistricts: s.totalDistricts,
+      districtDigests: s.districtDigests,
+      combined: s.combined,
+    }
+    expect(evaluateClosingAutoAllow(stripped, p).allowed).toBe(false)
   })
 })

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
@@ -14,7 +14,11 @@
  */
 import { describe, it, expect } from 'vitest'
 import { DistrictRankingSchema } from '@toastmasters/shared-contracts'
-import { FIELD_CLASSIFICATION, type FieldClass } from '../SnapshotValueDiff.js'
+import {
+  FIELD_CLASSIFICATION,
+  isClosingPinned,
+  type FieldClass,
+} from '../SnapshotValueDiff.js'
 
 describe('FIELD_CLASSIFICATION registry (#1086)', () => {
   it('classifies every DistrictRankingSchema field exactly once (exhaustive)', () => {
@@ -75,5 +79,47 @@ describe('FIELD_CLASSIFICATION registry (#1086)', () => {
         'aggregateScore',
       ].sort()
     )
+  })
+})
+
+describe('isClosingPinned (#1086, decision doc §5)', () => {
+  it('detects the live 2026-05-31 signature (month-end, As-of advanced, gap ≤ 31d)', () => {
+    expect(isClosingPinned('2026-05-31', '2026-06-02')).toBe(true)
+  })
+
+  it('detects the December cross-year signature via ISO-string comparison', () => {
+    expect(isClosingPinned('2025-12-31', '2026-01-15')).toBe(true)
+  })
+
+  it('rejects a non-month-end date even when the As-of advanced', () => {
+    expect(isClosingPinned('2026-05-30', '2026-06-02')).toBe(false)
+  })
+
+  it('rejects when sourceCsvDate equals the snapshot date (signature absent)', () => {
+    expect(isClosingPinned('2026-05-31', '2026-05-31')).toBe(false)
+  })
+
+  it('rejects when sourceCsvDate precedes the snapshot date', () => {
+    expect(isClosingPinned('2026-05-31', '2026-05-29')).toBe(false)
+  })
+
+  it('rejects a gap beyond 31 days; accepts the 31-day boundary', () => {
+    expect(isClosingPinned('2026-05-31', '2026-07-02')).toBe(false) // 32 days
+    expect(isClosingPinned('2026-05-31', '2026-07-01')).toBe(true) // 31 days
+  })
+
+  it('rejects a missing sourceCsvDate (fail-closed)', () => {
+    expect(isClosingPinned('2026-05-31', undefined)).toBe(false)
+  })
+
+  it('handles February month-end including leap years', () => {
+    expect(isClosingPinned('2026-02-28', '2026-03-05')).toBe(true)
+    expect(isClosingPinned('2024-02-28', '2024-03-05')).toBe(false) // leap year: not month-end
+    expect(isClosingPinned('2024-02-29', '2024-03-05')).toBe(true)
+  })
+
+  it('rejects malformed date strings (fail-closed)', () => {
+    expect(isClosingPinned('not-a-date', '2026-06-02')).toBe(false)
+    expect(isClosingPinned('2026-05-31', 'garbage')).toBe(false)
   })
 })

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Closing-Pinned Auto-Allow (CPAA) — epic #1083 Sprint 2 (#1086).
+ *
+ * Policy spec: docs/investigations/closing-period-promote-policy-2026-06-03.md
+ * §4 (field classes + rules), §5 (closing-pinned detection), §8 (test scope).
+ *
+ * Layer 1 (structural): the field-classification registry must be exhaustive
+ * against DistrictRankingSchema.shape — an unclassified schema field fails
+ * here (fail-closed, R20/L150 spirit).
+ * Layer 2 (consequential, L150): the closing-2026-05-31 fixture tests assert
+ * the OUTPUT of the classification — a mis-classified field (e.g. a counter
+ * labelled derived) flips the fixture verdicts, so a wrong label fails loudly
+ * even though the registry stays exhaustive.
+ */
+import { describe, it, expect } from 'vitest'
+import { DistrictRankingSchema } from '@toastmasters/shared-contracts'
+import { FIELD_CLASSIFICATION, type FieldClass } from '../SnapshotValueDiff.js'
+
+describe('FIELD_CLASSIFICATION registry (#1086)', () => {
+  it('classifies every DistrictRankingSchema field exactly once (exhaustive)', () => {
+    const schemaFields = Object.keys(DistrictRankingSchema.shape).sort()
+    const classifiedFields = Object.keys(FIELD_CLASSIFICATION).sort()
+    expect(classifiedFields).toEqual(schemaFields)
+  })
+
+  it('matches the decision-doc §4 class table exactly', () => {
+    const byClass = (cls: FieldClass) =>
+      Object.entries(FIELD_CLASSIFICATION)
+        .filter(([, v]) => v === cls)
+        .map(([k]) => k)
+        .sort()
+
+    expect(byClass('counter')).toEqual(
+      [
+        'paidClubs',
+        'activeClubs',
+        'totalPayments',
+        'newPayments',
+        'aprilPayments',
+        'octoberPayments',
+        'latePayments',
+        'charterPayments',
+        'distinguishedClubs',
+        'selectDistinguished',
+        'presidentsDistinguished',
+        'smedleyDistinguished',
+        'clubsWith20PlusMembers',
+        'newCharteredClubs',
+      ].sort()
+    )
+    expect(byClass('base')).toEqual(['paidClubBase', 'paymentBase'])
+    expect(byClass('identity')).toEqual([
+      'districtId',
+      'districtName',
+      'region',
+    ])
+    expect(byClass('planBoolean')).toEqual(
+      [
+        'dspSubmitted',
+        'trainingMet',
+        'marketAnalysisSubmitted',
+        'communicationPlanSubmitted',
+        'regionAdvisorVisitMet',
+      ].sort()
+    )
+    expect(byClass('derived')).toEqual(
+      [
+        'clubGrowthPercent',
+        'paymentGrowthPercent',
+        'distinguishedPercent',
+        'clubsRank',
+        'paymentsRank',
+        'distinguishedRank',
+        'overallRank',
+        'aggregateScore',
+      ].sort()
+    )
+  })
+})

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
@@ -599,3 +599,17 @@ describe('evaluatePromote CPAA wiring (#1086)', () => {
     expect(relaxed.autoAllowed).toBe('closing-monotonic')
   })
 })
+
+describe('evaluateClosingAutoAllow — absolute-floor cap boundary (review nit)', () => {
+  // On a small base (prod 100, 10% = 10) the cap resolves to the absolute
+  // floor of 50: Δ +50 is the last allowed step, Δ +51 blocks.
+  it('allows Δ = 50 and blocks Δ = 51 when the cap is the absolute floor', () => {
+    const [allowS, allowP] = syntheticPair({ paidClubs: 150 }) // prod 100, Δ +50
+    expect(evaluateClosingAutoAllow(allowS, allowP).allowed).toBe(true)
+
+    const [blockS, blockP] = syntheticPair({ paidClubs: 151 }) // prod 100, Δ +51
+    const res = evaluateClosingAutoAllow(blockS, blockP)
+    expect(res.allowed).toBe(false)
+    expect(res.reasons.join(' ')).toMatch(/cap/i)
+  })
+})

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
@@ -24,7 +24,9 @@ import {
 } from '@toastmasters/shared-contracts'
 import {
   digestDate,
+  diffSnapshots,
   evaluateClosingAutoAllow,
+  evaluatePromote,
   FIELD_CLASSIFICATION,
   isClosingPinned,
   type DateDigest,
@@ -449,5 +451,151 @@ describe('evaluateClosingAutoAllow — edges (decision doc §8.3)', () => {
       combined: s.combined,
     }
     expect(evaluateClosingAutoAllow(stripped, p).allowed).toBe(false)
+  })
+})
+
+describe('evaluatePromote CPAA wiring (#1086)', () => {
+  /** Two-sided single-date digest sets around the synthetic district. */
+  function promoteCase(
+    stagingOverrides: Partial<DistrictRanking>,
+    {
+      date = '2026-05-31',
+      stagingSourceCsvDate = '2026-06-02',
+    }: { date?: string; stagingSourceCsvDate?: string } = {}
+  ) {
+    const staging = [
+      digestDate(
+        date,
+        syntheticRankings(
+          [syntheticDistrict(stagingOverrides)],
+          stagingSourceCsvDate
+        )
+      ),
+    ]
+    const prod = [
+      digestDate(date, syntheticRankings([syntheticDistrict()], date)),
+    ]
+    return { report: diffSnapshots(staging, prod), digests: { staging, prod } }
+  }
+
+  it('auto-allows a closing-pinned monotone changed date (promote, no review)', () => {
+    const { report, digests } = promoteCase({ totalPayments: 5050 })
+    const decision = evaluatePromote(report, {}, digests)
+    expect(decision.promote).toBe(true)
+    expect(decision.requiresReview).toBe(false)
+    expect(decision.autoAllowed).toBe('closing-monotonic')
+    expect(decision.closingDeltas).toEqual([
+      {
+        date: '2026-05-31',
+        districtId: '61',
+        field: 'totalPayments',
+        prod: 5000,
+        staging: 5050,
+        delta: 50,
+      },
+    ])
+    expect(decision.reasons.join(' ')).toMatch(/auto-allow/i)
+  })
+
+  it('keeps blocking when CPAA finds a decrease, surfacing the violation', () => {
+    const { report, digests } = promoteCase({ totalPayments: 4999 })
+    const decision = evaluatePromote(report, {}, digests)
+    expect(decision.promote).toBe(false)
+    expect(decision.requiresReview).toBe(true)
+    expect(decision.autoAllowed).toBeUndefined()
+    expect(decision.reasons.join(' ')).toMatch(/decrease/i)
+  })
+
+  it('blocks when ANY changed date lacks the closing signature, even if another passes', () => {
+    const pinnedStaging = digestDate(
+      '2026-05-31',
+      syntheticRankings(
+        [syntheticDistrict({ totalPayments: 5050 })],
+        '2026-06-02'
+      )
+    )
+    const pinnedProd = digestDate(
+      '2026-05-31',
+      syntheticRankings([syntheticDistrict()], '2026-05-31')
+    )
+    // Mid-month historical date whose values changed — a re-derive of history.
+    const histStaging = digestDate(
+      '2026-05-15',
+      syntheticRankings(
+        [syntheticDistrict({ totalPayments: 4600 })],
+        '2026-05-15'
+      )
+    )
+    const histProd = digestDate(
+      '2026-05-15',
+      syntheticRankings(
+        [syntheticDistrict({ totalPayments: 4500 })],
+        '2026-05-15'
+      )
+    )
+    const digests = {
+      staging: [pinnedStaging, histStaging],
+      prod: [pinnedProd, histProd],
+    }
+    const report = diffSnapshots(digests.staging, digests.prod)
+    const decision = evaluatePromote(report, {}, digests)
+    expect(decision.promote).toBe(false)
+    expect(decision.autoAllowed).toBeUndefined()
+    expect(decision.reasons.join(' ')).toMatch(/2026-05-15/)
+  })
+
+  it('still blocks a subtractive change even when changed dates are closing-monotonic', () => {
+    const { digests } = promoteCase({ totalPayments: 5050 })
+    const extraProdDate = digestDate(
+      '2026-04-30',
+      syntheticRankings([syntheticDistrict()], '2026-04-30')
+    )
+    const report = diffSnapshots(digests.staging, [
+      ...digests.prod,
+      extraProdDate,
+    ])
+    const decision = evaluatePromote(
+      report,
+      {},
+      {
+        staging: digests.staging,
+        prod: [...digests.prod, extraProdDate],
+      }
+    )
+    expect(decision.promote).toBe(false)
+    expect(decision.reasons.join(' ')).toMatch(/subtractive/i)
+  })
+
+  it('fails closed to operator review when no digests are provided (legacy path)', () => {
+    const { report } = promoteCase({ totalPayments: 5050 })
+    const decision = evaluatePromote(report)
+    expect(decision.promote).toBe(false)
+    expect(decision.requiresReview).toBe(true)
+    expect(decision.autoAllowed).toBeUndefined()
+  })
+
+  it('keeps allowValueChanges semantics byte-for-byte (no autoAllowed tag)', () => {
+    const { report, digests } = promoteCase({ totalPayments: 4999 })
+    const decision = evaluatePromote(
+      report,
+      { allowValueChanges: true },
+      digests
+    )
+    expect(decision.promote).toBe(true)
+    expect(decision.requiresReview).toBe(true)
+    expect(decision.autoAllowed).toBeUndefined()
+  })
+
+  it('passes closingDecreaseFloor through to the per-date evaluation', () => {
+    const { report, digests } = promoteCase({ totalPayments: 4997 }) // Δ -3
+    const strict = evaluatePromote(report, {}, digests)
+    expect(strict.promote).toBe(false)
+    const relaxed = evaluatePromote(
+      report,
+      { closingDecreaseFloor: 5 },
+      digests
+    )
+    expect(relaxed.promote).toBe(true)
+    expect(relaxed.autoAllowed).toBe('closing-monotonic')
   })
 })

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffLoader.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffLoader.test.ts
@@ -120,3 +120,62 @@ describe('runValueDiff', () => {
     expect(allowed.exitCode).toBe(0)
   })
 })
+
+describe('runValueDiff — Closing-Pinned Auto-Allow end-to-end (#1086)', () => {
+  /** rankings() variant with an independent As-of date (closing signature). */
+  function closingRankings(
+    date: string,
+    sourceCsvDate: string,
+    totalPayments: number
+  ): AllDistrictsRankingsData {
+    const data = rankings(date, totalPayments)
+    return { ...data, metadata: { ...data.metadata, sourceCsvDate } }
+  }
+
+  it('auto-allows (exit 0) a closing-pinned monotone reconciliation', () => {
+    const staging = join(tmp, 'staging')
+    const prod = join(tmp, 'prod')
+    writeSnapshot(
+      prod,
+      '2026-05-31',
+      closingRankings('2026-05-31', '2026-05-31', 5000)
+    )
+    writeSnapshot(
+      staging,
+      '2026-05-31',
+      closingRankings('2026-05-31', '2026-06-02', 5050)
+    )
+    const { decision, exitCode } = runValueDiff({
+      stagingDir: staging,
+      prodDir: prod,
+    })
+    expect(decision.promote).toBe(true)
+    expect(decision.requiresReview).toBe(false)
+    expect(decision.autoAllowed).toBe('closing-monotonic')
+    expect(decision.closingDeltas).toHaveLength(1)
+    expect(exitCode).toBe(0)
+  })
+
+  it('still blocks (exit 1) a closing-period counter decrease', () => {
+    const staging = join(tmp, 'staging')
+    const prod = join(tmp, 'prod')
+    writeSnapshot(
+      prod,
+      '2026-05-31',
+      closingRankings('2026-05-31', '2026-05-31', 5000)
+    )
+    writeSnapshot(
+      staging,
+      '2026-05-31',
+      closingRankings('2026-05-31', '2026-06-02', 4999)
+    )
+    const { decision, exitCode } = runValueDiff({
+      stagingDir: staging,
+      prodDir: prod,
+    })
+    expect(decision.promote).toBe(false)
+    expect(decision.autoAllowed).toBeUndefined()
+    expect(decision.reasons.join(' ')).toMatch(/decrease/i)
+    expect(exitCode).toBe(1)
+  })
+})


### PR DESCRIPTION
Sprint 2 of epic #1083 — implements **Closing-Pinned Auto-Allow (CPAA)** in the value-promote gate, exactly per the Sprint 1 decision doc (`docs/investigations/closing-period-promote-policy-2026-06-03.md` §4–§6) and ADR-009 D3. Sub-issue: #1086 (plain reference — no auto-close).

## What

During month-end closing, the #309 remap pins the snapshot date while TI reconciles values daily, so the #1034 value gate blocked promotion every day and prod froze (5 days observed, `pipeline-stale` #1082). CPAA lets **routine, monotone reconciliation promote autonomously** while every genuine-regression class still blocks:

1. **Field-classification registry** (`FIELD_CLASSIFICATION`: 14 counters / 2 bases / 3 identity / 5 plan booleans / 8 derived) + exhaustiveness test vs `DistrictRankingSchema.shape`. Unclassified *changed* field blocks at runtime (fail-closed).
2. **Closing-pinned detection** (`isClosingPinned`): month-end + `sourceCsvDate > date` + gap ≤ 31d, pure ISO-string/UTC arithmetic (deliberately not `ClosingPeriodDetector` — TZ edge, doc §5). December cross-year covered.
3. **`evaluateClosingAutoAllow`** (pure, per changed date): identical district set; counters `0 ≤ Δ ≤ max(50, 10% × prod)`; bases/identity equal; booleans one-way `false→true`; derived excluded; optionality transitions and unknown fields block. Decrease floor is a parameter (`closingDecreaseFloor`, CLI `--closing-decrease-floor`), **default 0 = strict**.
4. **`evaluatePromote` wiring**: CPAA consulted only when the sole objection is non-empty `changed` and no override; subtractive still blocks absolutely; `allowValueChanges` semantics byte-for-byte unchanged. Decision JSON gains `autoAllowed: "closing-monotonic"` + `closingDeltas` + `derivedOnlyDistricts` (additive — gate step and `promotion-alert.ts` consumers unaffected).
5. **Workflow summary**: renders the auto-allow line + per-district delta table (display only; gate keeps consuming `.promote`).

## Evidence (fixture + real bin, both directions)

Captured 2026-05-31 staging/prod pair (`fixtures/closing-2026-05-31/`), driven through the **built CLI** (`node bin/collector-cli.js value-diff …`):

| Direction | Result |
| --- | --- |
| As-is (5 genuine reversals present) | **blocked**, exit 1, reasons name D114 / D88 / D128 / D44 / D50 |
| 5 reversal districts' prod rows substituted | **auto-allowed**, exit 0, `closing-monotonic`, 19 mover districts (82 capped monotone deltas), 78 derived-only ignored |

The fixture tests are the L150 *consequential* layer: D88/D128 block on single fields, so a mis-classified counter flips a verdict loudly.

## Tests

37 new tests in `SnapshotValueDiffClosing.test.ts` + 2 loader end-to-end (auto-allow exit 0 / decrease exit 1). Full suite green: collector-cli 878, frontend 3385, analytics-core 791, shared-contracts 153, mcp-server 50. TDD red/green commits throughout.

## Review

`/simplify` (4 agents): one shape cleanup applied (single `deltas` field in the cross-date aggregate). Fresh-context review: **APPROVE-WITH-NITS**, no high/medium; both nits applied (cap=50 boundary test, empty-delta-table guard). Third nit is a conscious choice: the workflow does **not** pass `--closing-decrease-floor` — relaxing it is a future operator ADR decision per doc §4.

## Live verification plan (DoD)

`pr-preview.yml` is path-filtered to frontend/packages-{shared-contracts,analytics-core} — this PR (collector-cli + workflow) deploys **no preview**; there is no UI surface. Per the sub-issue DoD: the May 2026 closing window has ended (staging `sourceCsvDate` advanced past it), so live verification is **code-proof via the fixture pair driven through the real bin** (table above) — the next closing window (June year-end) exercises it for real; the #1072 freshness monitor stays the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
