### PR TITLE
feat: shared DCP goal definitions — fix legacy L4/L5 header + Goal-10 OR in analytics-core (#1118)

### DIFF
--- a/packages/analytics-core/src/__tests__/DistinguishedClubAnalyticsModule.test.ts
+++ b/packages/analytics-core/src/__tests__/DistinguishedClubAnalyticsModule.test.ts
@@ -689,8 +689,8 @@ describe('DistinguishedClubAnalyticsModule', () => {
             'Level 2s': '0',
             'Add. Level 2s': '0',
             'Level 3s': '0',
-            'Level 4s, Level 5s, or DTM award': '0',
-            'Add. Level 4s, Level 5s, or DTM award': '0',
+            'Level 4s, Path Completions, or DTM Awards': '0',
+            'Add. Level 4s, Path Completions, or DTM award': '0',
             'New Members': '4', // Goal 7: achieved
             'Add. New Members': '0',
             'Off. Trained Round 1': '0',
@@ -713,8 +713,8 @@ describe('DistinguishedClubAnalyticsModule', () => {
             'Level 2s': '0',
             'Add. Level 2s': '0',
             'Level 3s': '0',
-            'Level 4s, Level 5s, or DTM award': '0',
-            'Add. Level 4s, Level 5s, or DTM award': '0',
+            'Level 4s, Path Completions, or DTM Awards': '0',
+            'Add. Level 4s, Path Completions, or DTM award': '0',
             'New Members': '0',
             'Add. New Members': '0',
             'Off. Trained Round 1': '4', // Goal 9a: achieved
@@ -752,6 +752,143 @@ describe('DistinguishedClubAnalyticsModule', () => {
 
       // Goal 2: neither club achieved it → count = 0
       expect(goal2?.achievementCount).toBe(0)
+    })
+
+    /**
+     * #1118 (epic #1095 C1/C2): goal evaluation must use the REAL current
+     * CSV headers and the official rule semantics:
+     * - Goals 5/6 columns are 'Level 4s, Path Completions, or DTM Awards'
+     *   (the legacy 'Level 4s, Level 5s, or DTM award' header no longer
+     *   appears in live CSVs — reading it reports goals 5/6 as 0 forever).
+     * - Goal 10 is officer list + (Oct dues OR Apr dues), not all three.
+     * - Goals 1-8 use the official thresholds (4/2/2/2/1/1/4/4), not "> 0".
+     */
+    const REAL_HEADER_GOAL_COLUMNS = {
+      'Level 1s': '0',
+      'Level 2s': '0',
+      'Add. Level 2s': '0',
+      'Level 3s': '0',
+      'Level 4s, Path Completions, or DTM Awards': '0',
+      'Add. Level 4s, Path Completions, or DTM award': '0',
+      'New Members': '0',
+      'Add. New Members': '0',
+      'Off. Trained Round 1': '0',
+      'Off. Trained Round 2': '0',
+      'Mem. dues on time Oct': '0',
+      'Mem. dues on time Apr': '0',
+      'Off. List On Time': '0',
+    }
+
+    function createRawClubRecord(
+      clubId: string,
+      goalOverrides: Record<string, string>
+    ) {
+      return {
+        'Club Number': clubId,
+        'Club Name': `Club ${clubId}`,
+        Division: 'A',
+        Area: '01',
+        'Active Members': '20',
+        'Goals Met': '0',
+        'Club Status': 'Active',
+        'Mem. Base': '20',
+        ...REAL_HEADER_GOAL_COLUMNS,
+        ...goalOverrides,
+      }
+    }
+
+    function goalCountsFor(records: Record<string, string>[]) {
+      const module = new DistinguishedClubAnalyticsModule()
+      const clubs = records.map(r =>
+        createMockClub(String(r['Club Number']), 0, 20)
+      )
+      const snapshot: DistrictStatistics = {
+        ...createMockSnapshot(clubs),
+        clubPerformance: records,
+      }
+      const analytics = module.generateDistinguishedClubAnalytics('D101', [
+        snapshot,
+      ])
+      const allGoals = [
+        ...analytics.dcpGoalAnalysis.mostCommonlyAchieved,
+        ...analytics.dcpGoalAnalysis.leastCommonlyAchieved,
+      ]
+      return (goal: number) =>
+        allGoals.find(g => g.goalNumber === goal)?.achievementCount
+    }
+
+    it('counts goals 5/6 from the real current CSV headers (#1118 C1)', () => {
+      const count = goalCountsFor([
+        createRawClubRecord('A', {
+          'Level 4s, Path Completions, or DTM Awards': '1',
+          'Add. Level 4s, Path Completions, or DTM award': '1',
+        }),
+      ])
+
+      expect(count(5)).toBe(1)
+      expect(count(6)).toBe(1)
+    })
+
+    it('counts goal 10 with Oct-only dues + officer list (#1118 C2)', () => {
+      const count = goalCountsFor([
+        createRawClubRecord('A', {
+          'Mem. dues on time Oct': '1',
+          'Off. List On Time': '1',
+        }),
+      ])
+
+      expect(count(10)).toBe(1)
+    })
+
+    it('counts goal 10 with Apr-only dues + officer list (#1118 C2)', () => {
+      const count = goalCountsFor([
+        createRawClubRecord('A', {
+          'Mem. dues on time Apr': '1',
+          'Off. List On Time': '1',
+        }),
+      ])
+
+      expect(count(10)).toBe(1)
+    })
+
+    it('does not count goal 10 when dues are on time but the officer list is not', () => {
+      const count = goalCountsFor([
+        createRawClubRecord('A', {
+          'Mem. dues on time Oct': '1',
+          'Mem. dues on time Apr': '1',
+        }),
+      ])
+
+      expect(count(10)).toBe(0)
+    })
+
+    it('does not count goal 10 when the officer list is on time but no dues are', () => {
+      const count = goalCountsFor([
+        createRawClubRecord('A', {
+          'Off. List On Time': '1',
+        }),
+      ])
+
+      expect(count(10)).toBe(0)
+    })
+
+    it('applies the official DCP thresholds to goals 1-8, not "> 0" (#1118)', () => {
+      const count = goalCountsFor([
+        createRawClubRecord('A', {
+          'Level 1s': '3', // goal 1 needs 4
+          'Level 2s': '1', // goal 2 needs 2
+          'New Members': '3', // goal 7 needs 4
+        }),
+        createRawClubRecord('B', {
+          'Level 1s': '4',
+          'Level 2s': '2',
+          'New Members': '4',
+        }),
+      ])
+
+      expect(count(1)).toBe(1)
+      expect(count(2)).toBe(1)
+      expect(count(7)).toBe(1)
     })
 
     it('should fall back to sequential approximation when raw CSV data is unavailable', () => {

--- a/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.ts
@@ -30,6 +30,10 @@ import type {
   DistinguishedProjection,
 } from '../types.js'
 import type { ScrapedRecord } from '@toastmasters/shared-contracts'
+import {
+  DCP_GOAL_DEFINITIONS,
+  isDcpGoalAchieved,
+} from './dcpGoalDefinitions.js'
 import { ensureString } from './AnalyticsUtils.js'
 import {
   calculateNetGrowth,
@@ -709,79 +713,6 @@ export class DistinguishedClubAnalyticsModule {
   }
 
   /**
-   * CSV column names for each DCP goal (1-10).
-   * Maps goal number to the column(s) that indicate achievement.
-   *
-   * Goals 1-8: single column, value > 0 means achieved
-   * Goal 9: both "Off. Trained Round 1" AND "Off. Trained Round 2" must be >= 4
-   * Goal 10: all of "Mem. dues on time Oct", "Mem. dues on time Apr", "Off. List On Time" must be > 0
-   */
-  private static readonly DCP_GOAL_COLUMNS: {
-    goal: number
-    columns: string[]
-    /** 'any' = any column > 0; 'all' = all columns must meet threshold */
-    mode: 'any' | 'all'
-    /** Minimum value for each column (default 1) */
-    threshold?: number
-  }[] = [
-    { goal: 1, columns: ['Level 1s'], mode: 'any' },
-    { goal: 2, columns: ['Level 2s'], mode: 'any' },
-    { goal: 3, columns: ['Add. Level 2s'], mode: 'any' },
-    { goal: 4, columns: ['Level 3s'], mode: 'any' },
-    {
-      goal: 5,
-      columns: ['Level 4s, Level 5s, or DTM award'],
-      mode: 'any',
-    },
-    {
-      goal: 6,
-      columns: ['Add. Level 4s, Level 5s, or DTM award'],
-      mode: 'any',
-    },
-    { goal: 7, columns: ['New Members'], mode: 'any' },
-    { goal: 8, columns: ['Add. New Members'], mode: 'any' },
-    {
-      goal: 9,
-      columns: ['Off. Trained Round 1', 'Off. Trained Round 2'],
-      mode: 'all',
-      threshold: 4,
-    },
-    {
-      goal: 10,
-      columns: [
-        'Mem. dues on time Oct',
-        'Mem. dues on time Apr',
-        'Off. List On Time',
-      ],
-      mode: 'all',
-    },
-  ]
-
-  /**
-   * Check if a raw CSV record has a particular DCP goal achieved.
-   */
-  private isGoalAchieved(
-    record: ScrapedRecord,
-    goalDef: (typeof DistinguishedClubAnalyticsModule.DCP_GOAL_COLUMNS)[number]
-  ): boolean {
-    const threshold = goalDef.threshold ?? 1
-
-    if (goalDef.mode === 'all') {
-      // All columns must meet threshold
-      return goalDef.columns.every(col => {
-        const val = parseInt(String(record[col] ?? '0'), 10)
-        return !isNaN(val) && val >= threshold
-      })
-    }
-
-    // 'any' mode: any column > 0
-    return goalDef.columns.some(col => {
-      const val = parseInt(String(record[col] ?? '0'), 10)
-      return !isNaN(val) && val >= threshold
-    })
-  }
-
-  /**
    * Analyze DCP goals to identify most/least commonly achieved (Requirement 7.5)
    *
    * When rawClubRecords are available (#135), reads actual per-goal columns
@@ -807,9 +738,10 @@ export class DistinguishedClubAnalyticsModule {
 
     if (hasGoalColumns && rawClubRecords) {
       // #135 fix: Use actual per-goal columns from raw CSV data
+      // #1118: evaluated via the shared DCP goal definitions
       for (const record of rawClubRecords) {
-        for (const goalDef of DistinguishedClubAnalyticsModule.DCP_GOAL_COLUMNS) {
-          if (this.isGoalAchieved(record, goalDef)) {
+        for (const goalDef of DCP_GOAL_DEFINITIONS) {
+          if (isDcpGoalAchieved(record, goalDef)) {
             goalCounts[goalDef.goal - 1] =
               (goalCounts[goalDef.goal - 1] ?? 0) + 1
           }

--- a/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.ts
@@ -32,6 +32,7 @@ import type {
 import type { ScrapedRecord } from '@toastmasters/shared-contracts'
 import {
   DCP_GOAL_DEFINITIONS,
+  hasDcpGoalColumns,
   isDcpGoalAchieved,
 } from './dcpGoalDefinitions.js'
 import { ensureString } from './AnalyticsUtils.js'
@@ -734,7 +735,7 @@ export class DistinguishedClubAnalyticsModule {
       rawClubRecords &&
       rawClubRecords.length > 0 &&
       rawClubRecords[0] !== undefined &&
-      'Level 1s' in rawClubRecords[0]
+      hasDcpGoalColumns(rawClubRecords[0])
 
     if (hasGoalColumns && rawClubRecords) {
       // #135 fix: Use actual per-goal columns from raw CSV data

--- a/packages/analytics-core/src/analytics/__tests__/dcpGoalDefinitions.test.ts
+++ b/packages/analytics-core/src/analytics/__tests__/dcpGoalDefinitions.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from 'vitest'
 import type { ScrapedRecord } from '@toastmasters/shared-contracts'
 import {
   DCP_GOAL_DEFINITIONS,
+  hasDcpGoalColumns,
   readDcpGoalColumn,
   isDcpGoalAchieved,
   computeDcpGoalsAchieved,
@@ -158,6 +159,20 @@ describe('DCP_GOAL_DEFINITIONS', () => {
       expect(readDcpGoalColumn({ 'Level 1s': '' }, column)).toBe(0)
       expect(readDcpGoalColumn({ 'Level 1s': 'N/A' }, column)).toBe(0)
       expect(readDcpGoalColumn({ 'Level 1s': null }, column)).toBe(0)
+    })
+  })
+
+  describe('hasDcpGoalColumns', () => {
+    it('detects records that carry the per-goal columns', () => {
+      expect(hasDcpGoalColumns({ 'Level 1s': '0' })).toBe(true)
+      expect(hasDcpGoalColumns({ 'Level 1s': 3 })).toBe(true)
+    })
+
+    it('rejects records without them (legacy data falls back)', () => {
+      expect(hasDcpGoalColumns({})).toBe(false)
+      expect(hasDcpGoalColumns({ 'Level 1s': '' })).toBe(false)
+      expect(hasDcpGoalColumns({ 'Level 1s': null })).toBe(false)
+      expect(hasDcpGoalColumns({ 'Goals Met': '5' })).toBe(false)
     })
   })
 

--- a/packages/analytics-core/src/analytics/__tests__/dcpGoalDefinitions.test.ts
+++ b/packages/analytics-core/src/analytics/__tests__/dcpGoalDefinitions.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for the shared DCP goal definitions (epic #1095, #1118).
+ *
+ * The definitions are the single source of truth for the 10 DCP goals.
+ * Boundary cases per goal beat properties here (testing.md §7.3): the
+ * official thresholds are a small fixed table.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ScrapedRecord } from '@toastmasters/shared-contracts'
+import {
+  DCP_GOAL_DEFINITIONS,
+  readDcpGoalColumn,
+  isDcpGoalAchieved,
+  computeDcpGoalsAchieved,
+} from '../dcpGoalDefinitions.js'
+
+function goal(n: number) {
+  const def = DCP_GOAL_DEFINITIONS.find(d => d.goal === n)
+  if (!def) throw new Error(`missing goal ${n}`)
+  return def
+}
+
+describe('DCP_GOAL_DEFINITIONS', () => {
+  it('defines exactly goals 1-10', () => {
+    expect(DCP_GOAL_DEFINITIONS.map(d => d.goal)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    ])
+  })
+
+  describe('official thresholds at the boundary', () => {
+    const CASES: Array<{
+      goalNumber: number
+      column: string
+      threshold: number
+    }> = [
+      { goalNumber: 1, column: 'Level 1s', threshold: 4 },
+      { goalNumber: 2, column: 'Level 2s', threshold: 2 },
+      { goalNumber: 3, column: 'Add. Level 2s', threshold: 2 },
+      { goalNumber: 4, column: 'Level 3s', threshold: 2 },
+      {
+        goalNumber: 5,
+        column: 'Level 4s, Path Completions, or DTM Awards',
+        threshold: 1,
+      },
+      {
+        goalNumber: 6,
+        column: 'Add. Level 4s, Path Completions, or DTM award',
+        threshold: 1,
+      },
+      { goalNumber: 7, column: 'New Members', threshold: 4 },
+      { goalNumber: 8, column: 'Add. New Members', threshold: 4 },
+    ]
+
+    for (const { goalNumber, column, threshold } of CASES) {
+      it(`goal ${goalNumber}: '${column}' >= ${threshold}`, () => {
+        expect(
+          isDcpGoalAchieved({ [column]: String(threshold) }, goal(goalNumber))
+        ).toBe(true)
+        expect(
+          isDcpGoalAchieved(
+            { [column]: String(threshold - 1) },
+            goal(goalNumber)
+          )
+        ).toBe(false)
+      })
+    }
+  })
+
+  describe('goal 9 — both training rounds required', () => {
+    it('achieved with 4+ trained in both rounds', () => {
+      expect(
+        isDcpGoalAchieved(
+          { 'Off. Trained Round 1': '4', 'Off. Trained Round 2': '5' },
+          goal(9)
+        )
+      ).toBe(true)
+    })
+
+    it('not achieved when either round is below 4', () => {
+      expect(
+        isDcpGoalAchieved(
+          { 'Off. Trained Round 1': '4', 'Off. Trained Round 2': '3' },
+          goal(9)
+        )
+      ).toBe(false)
+      expect(
+        isDcpGoalAchieved(
+          { 'Off. Trained Round 1': '3', 'Off. Trained Round 2': '4' },
+          goal(9)
+        )
+      ).toBe(false)
+    })
+  })
+
+  describe('goal 10 — officer list + (Oct OR Apr dues), §10.2', () => {
+    it('achieved with Oct-only dues + officer list', () => {
+      expect(
+        isDcpGoalAchieved(
+          { 'Mem. dues on time Oct': '1', 'Off. List On Time': '1' },
+          goal(10)
+        )
+      ).toBe(true)
+    })
+
+    it('achieved with Apr-only dues + officer list', () => {
+      expect(
+        isDcpGoalAchieved(
+          { 'Mem. dues on time Apr': '1', 'Off. List On Time': '1' },
+          goal(10)
+        )
+      ).toBe(true)
+    })
+
+    it('not achieved without the officer list', () => {
+      expect(
+        isDcpGoalAchieved(
+          { 'Mem. dues on time Oct': '1', 'Mem. dues on time Apr': '1' },
+          goal(10)
+        )
+      ).toBe(false)
+    })
+
+    it('not achieved with the officer list but no dues', () => {
+      expect(isDcpGoalAchieved({ 'Off. List On Time': '1' }, goal(10))).toBe(
+        false
+      )
+    })
+  })
+
+  describe('header aliases', () => {
+    it('falls back to historical aliases in order', () => {
+      expect(isDcpGoalAchieved({ 'Add Level 2s': '2' }, goal(3))).toBe(true)
+      expect(isDcpGoalAchieved({ 'Level 4s': '1' }, goal(5))).toBe(true)
+      expect(isDcpGoalAchieved({ 'Add Level 4': '1' }, goal(6))).toBe(true)
+      expect(isDcpGoalAchieved({ 'Add New Members': '4' }, goal(8))).toBe(true)
+    })
+
+    it('prefers the first present alias', () => {
+      const record: ScrapedRecord = {
+        'Level 4s, Path Completions, or DTM Awards': '0',
+        'Level 4s': '7',
+      }
+      const column = goal(5).requirements[0]!.anyOf[0]!
+      expect(readDcpGoalColumn(record, column)).toBe(0)
+    })
+  })
+
+  describe('readDcpGoalColumn value handling', () => {
+    const column = goal(1).requirements[0]!.anyOf[0]!
+
+    it('accepts number-typed values', () => {
+      expect(readDcpGoalColumn({ 'Level 1s': 5 }, column)).toBe(5)
+    })
+
+    it('returns 0 for missing, empty, or unparseable values', () => {
+      expect(readDcpGoalColumn({}, column)).toBe(0)
+      expect(readDcpGoalColumn({ 'Level 1s': '' }, column)).toBe(0)
+      expect(readDcpGoalColumn({ 'Level 1s': 'N/A' }, column)).toBe(0)
+      expect(readDcpGoalColumn({ 'Level 1s': null }, column)).toBe(0)
+    })
+  })
+
+  describe('computeDcpGoalsAchieved', () => {
+    it('returns one entry per goal, in goal order', () => {
+      const record: ScrapedRecord = {
+        'Level 1s': '4',
+        'Mem. dues on time Apr': '1',
+        'Off. List On Time': '1',
+      }
+      const achieved = computeDcpGoalsAchieved(record)
+      expect(achieved).toHaveLength(10)
+      expect(achieved[0]).toBe(true)
+      expect(achieved[9]).toBe(true)
+      expect(achieved.slice(1, 9)).toEqual(Array(8).fill(false))
+    })
+  })
+})

--- a/packages/analytics-core/src/analytics/dcpGoalDefinitions.ts
+++ b/packages/analytics-core/src/analytics/dcpGoalDefinitions.ts
@@ -216,6 +216,22 @@ export const DCP_GOAL_DEFINITIONS: readonly DcpGoalDefinition[] = [
 ]
 
 /**
+ * Whether a raw club-performance record carries the per-goal CSV columns.
+ * Keyed on goal 1's header (aliases included). Consumers without goal
+ * columns fall back: DataTransformer omits dcpGoalsAchieved, the analytics
+ * module uses its sequential approximation.
+ */
+export function hasDcpGoalColumns(record: ScrapedRecord): boolean {
+  const goalOneColumns = DCP_GOAL_DEFINITIONS[0]!.requirements[0]!.anyOf
+  return goalOneColumns.some(column =>
+    column.aliases.some(key => {
+      const value = record[key]
+      return value !== null && value !== undefined && value !== ''
+    })
+  )
+}
+
+/**
  * Read a goal column from a raw CSV record, trying aliases in order.
  * Mirrors DataTransformer.extractNumber: a present-but-unparseable value
  * falls through to the next alias; absence everywhere yields 0.

--- a/packages/analytics-core/src/analytics/dcpGoalDefinitions.ts
+++ b/packages/analytics-core/src/analytics/dcpGoalDefinitions.ts
@@ -1,0 +1,264 @@
+/**
+ * Single shared source of truth for the 10 Distinguished Club Program (DCP)
+ * goal definitions (epic #1095, #1118).
+ *
+ * Encodes, for every goal: the current dashboard CSV header (plus historical
+ * aliases, tried in order), the official achievement threshold, and the rule
+ * structure. Requirements are ANDed; columns within one requirement are ORed —
+ * goal 10 is officer list AND (Oct dues OR Apr dues), per
+ * docs/toastmasters-rules-reference.md §10.2.
+ *
+ * Semantics are verified against TI's own "Goals Met" column (2026-06-09
+ * deep-dive audit: 0 mismatches across all 162 D61 clubs) and must stay
+ * identical to what DataTransformer publishes as dcpGoalsAchieved — see the
+ * parity tests in ../transformation/DataTransformer.test.ts.
+ */
+
+import type { ScrapedRecord } from '@toastmasters/shared-contracts'
+
+export interface DcpGoalColumn {
+  /** CSV header aliases, tried in order; the first present key wins */
+  aliases: readonly string[]
+  /** Human-readable label for UI surfaces (per-goal panel sub-items) */
+  label: string
+  /** Official threshold the column value must reach for this column to count */
+  required: number
+}
+
+export interface DcpGoalDefinition {
+  /** Goal number, 1-10 */
+  goal: number
+  name: string
+  category: 'Education' | 'Membership' | 'Training' | 'Administration'
+  /**
+   * ANDed requirements; a requirement is satisfied when ANY of its columns
+   * meets that column's threshold.
+   */
+  requirements: ReadonlyArray<{ anyOf: readonly DcpGoalColumn[] }>
+}
+
+export const DCP_GOAL_DEFINITIONS: readonly DcpGoalDefinition[] = [
+  {
+    goal: 1,
+    name: 'Level 1 awards',
+    category: 'Education',
+    requirements: [
+      {
+        anyOf: [
+          { aliases: ['Level 1s'], label: 'Level 1 awards', required: 4 },
+        ],
+      },
+    ],
+  },
+  {
+    goal: 2,
+    name: 'Level 2 awards',
+    category: 'Education',
+    requirements: [
+      {
+        anyOf: [
+          { aliases: ['Level 2s'], label: 'Level 2 awards', required: 2 },
+        ],
+      },
+    ],
+  },
+  {
+    goal: 3,
+    name: 'More Level 2 awards',
+    category: 'Education',
+    requirements: [
+      {
+        anyOf: [
+          {
+            aliases: ['Add. Level 2s', 'Add Level 2s'],
+            label: 'More Level 2 awards',
+            required: 2,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    goal: 4,
+    name: 'Level 3 awards',
+    category: 'Education',
+    requirements: [
+      {
+        anyOf: [
+          { aliases: ['Level 3s'], label: 'Level 3 awards', required: 2 },
+        ],
+      },
+    ],
+  },
+  {
+    goal: 5,
+    name: 'Level 4, Path Completion, or DTM',
+    category: 'Education',
+    requirements: [
+      {
+        anyOf: [
+          {
+            aliases: [
+              'Level 4s, Path Completions, or DTM Awards',
+              'Level 4s',
+              'Level 4',
+            ],
+            label: 'Level 4/Path Completion/DTM',
+            required: 1,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    goal: 6,
+    name: 'Additional Level 4, Path Completion, or DTM',
+    category: 'Education',
+    requirements: [
+      {
+        anyOf: [
+          {
+            aliases: [
+              'Add. Level 4s, Path Completions, or DTM award',
+              'Add. Level 4s',
+              'Add Level 4',
+            ],
+            label: 'Additional Level 4/Path Completion/DTM',
+            required: 1,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    goal: 7,
+    name: 'New members',
+    category: 'Membership',
+    requirements: [
+      {
+        anyOf: [
+          { aliases: ['New Members'], label: 'New members', required: 4 },
+        ],
+      },
+    ],
+  },
+  {
+    goal: 8,
+    name: 'More new members',
+    category: 'Membership',
+    requirements: [
+      {
+        anyOf: [
+          {
+            aliases: ['Add. New Members', 'Add New Members'],
+            label: 'More new members',
+            required: 4,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    goal: 9,
+    name: 'Officer training',
+    category: 'Training',
+    requirements: [
+      {
+        anyOf: [
+          {
+            aliases: ['Off. Trained Round 1'],
+            label: 'Officers trained Jun–Aug',
+            required: 4,
+          },
+        ],
+      },
+      {
+        anyOf: [
+          {
+            aliases: ['Off. Trained Round 2'],
+            label: 'Officers trained Nov–Feb',
+            required: 4,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    goal: 10,
+    name: 'Admin requirements',
+    category: 'Administration',
+    requirements: [
+      {
+        anyOf: [
+          {
+            aliases: ['Mem. dues on time Oct'],
+            label: 'Membership dues on time (Oct)',
+            required: 1,
+          },
+          {
+            aliases: ['Mem. dues on time Apr'],
+            label: 'Membership dues on time (Apr)',
+            required: 1,
+          },
+        ],
+      },
+      {
+        anyOf: [
+          {
+            aliases: ['Off. List On Time'],
+            label: 'Officer list on time',
+            required: 1,
+          },
+        ],
+      },
+    ],
+  },
+]
+
+/**
+ * Read a goal column from a raw CSV record, trying aliases in order.
+ * Mirrors DataTransformer.extractNumber: a present-but-unparseable value
+ * falls through to the next alias; absence everywhere yields 0.
+ */
+export function readDcpGoalColumn(
+  record: ScrapedRecord,
+  column: DcpGoalColumn
+): number {
+  for (const key of column.aliases) {
+    const value = record[key]
+    if (value !== null && value !== undefined) {
+      if (typeof value === 'number') {
+        return value
+      }
+      const parsed = parseInt(String(value), 10)
+      if (!isNaN(parsed)) {
+        return parsed
+      }
+    }
+  }
+  return 0
+}
+
+/**
+ * Evaluate one DCP goal against a raw club-performance CSV record.
+ */
+export function isDcpGoalAchieved(
+  record: ScrapedRecord,
+  definition: DcpGoalDefinition
+): boolean {
+  return definition.requirements.every(requirement =>
+    requirement.anyOf.some(
+      column => readDcpGoalColumn(record, column) >= column.required
+    )
+  )
+}
+
+/**
+ * Evaluate all 10 DCP goals against a raw club-performance CSV record.
+ * Index i holds goal i+1.
+ */
+export function computeDcpGoalsAchieved(record: ScrapedRecord): boolean[] {
+  return DCP_GOAL_DEFINITIONS.map(definition =>
+    isDcpGoalAchieved(record, definition)
+  )
+}

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -20,6 +20,18 @@ export type { Logger, DataTransformerConfig } from './transformation/index.js'
 // Snapshot diff engine ("What Changed", epic #797)
 export { diffSnapshots } from './analytics/diffSnapshots.js'
 
+// Shared DCP goal definitions — single source of truth (epic #1095, #1118)
+export {
+  DCP_GOAL_DEFINITIONS,
+  readDcpGoalColumn,
+  isDcpGoalAchieved,
+  computeDcpGoalsAchieved,
+} from './analytics/dcpGoalDefinitions.js'
+export type {
+  DcpGoalColumn,
+  DcpGoalDefinition,
+} from './analytics/dcpGoalDefinitions.js'
+
 // Analytics computation
 export {
   AnalyticsComputer,

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -23,6 +23,7 @@ export { diffSnapshots } from './analytics/diffSnapshots.js'
 // Shared DCP goal definitions — single source of truth (epic #1095, #1118)
 export {
   DCP_GOAL_DEFINITIONS,
+  hasDcpGoalColumns,
   readDcpGoalColumn,
   isDcpGoalAchieved,
   computeDcpGoalsAchieved,

--- a/packages/analytics-core/src/transformation/DataTransformer.test.ts
+++ b/packages/analytics-core/src/transformation/DataTransformer.test.ts
@@ -1676,4 +1676,126 @@ describe('DataTransformer', () => {
       )
     })
   })
+
+  /**
+   * #1118 (epic #1095) parity pin: dcpGoalsAchieved encodes the official
+   * DCP rules verified against TI's own Goals Met (audit 2026-06-09).
+   * This fixture must produce the identical array before and after the
+   * migration onto the shared goal-definition module.
+   */
+  describe('dcpGoalsAchieved parity (#1118)', () => {
+    const GOAL_HEADER = [
+      'Club Number',
+      'Club Name',
+      'Division',
+      'Area',
+      'Active Members',
+      'Goals Met',
+      'Club Status',
+      'Mem. Base',
+      'Level 1s',
+      'Level 2s',
+      'Add. Level 2s',
+      'Level 3s',
+      'Level 4s, Path Completions, or DTM Awards',
+      'Add. Level 4s, Path Completions, or DTM award',
+      'New Members',
+      'Add. New Members',
+      'Off. Trained Round 1',
+      'Off. Trained Round 2',
+      'Mem. dues on time Oct',
+      'Mem. dues on time Apr',
+      'Off. List On Time',
+    ]
+
+    async function goalsFor(goalValues: string[]): Promise<boolean[]> {
+      const csvData: RawCSVData = {
+        clubPerformance: [
+          GOAL_HEADER,
+          [
+            '1234',
+            'Parity Club',
+            'A',
+            '1',
+            '20',
+            '0',
+            'Active',
+            '20',
+            ...goalValues,
+          ],
+        ],
+        divisionPerformance: [],
+        districtPerformance: [],
+      }
+      const result = await transformer.transformRawCSV(
+        '2026-06-08',
+        'D61',
+        csvData
+      )
+      const achieved = result.clubs[0]?.dcpGoalsAchieved
+      expect(achieved).toBeDefined()
+      return achieved as boolean[]
+    }
+
+    it('marks every goal achieved at exactly the official thresholds', async () => {
+      // 4 L1s, 2 L2s, 2 add. L2s, 2 L3s, 1 L4/PC/DTM, 1 add., 4 new, 4 add.,
+      // 4+4 officers trained, Oct dues + officer list (Apr not needed: OR)
+      const achieved = await goalsFor([
+        '4',
+        '2',
+        '2',
+        '2',
+        '1',
+        '1',
+        '4',
+        '4',
+        '4',
+        '4',
+        '1',
+        '0',
+        '1',
+      ])
+      expect(achieved).toEqual(Array(10).fill(true))
+    })
+
+    it('marks every goal unachieved one below the official thresholds', async () => {
+      // One short on each counted goal; goal 10 has dues but no officer list
+      const achieved = await goalsFor([
+        '3',
+        '1',
+        '1',
+        '1',
+        '0',
+        '0',
+        '3',
+        '3',
+        '4',
+        '3',
+        '1',
+        '1',
+        '0',
+      ])
+      expect(achieved).toEqual(Array(10).fill(false))
+    })
+
+    it('passes goal 10 with Apr-only dues + officer list', async () => {
+      const achieved = await goalsFor([
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+        '1',
+        '1',
+      ])
+      expect(achieved?.[9]).toBe(true)
+      expect(achieved?.slice(0, 9)).toEqual(Array(9).fill(false))
+    })
+  })
 })

--- a/packages/analytics-core/src/transformation/DataTransformer.ts
+++ b/packages/analytics-core/src/transformation/DataTransformer.ts
@@ -22,6 +22,7 @@ import type {
   SnapshotMetadata,
 } from '../interfaces.js'
 import type { ScrapedRecord } from '@toastmasters/shared-contracts'
+import { computeDcpGoalsAchieved } from '../analytics/dcpGoalDefinitions.js'
 import { ANALYTICS_SCHEMA_VERSION } from '../version.js'
 
 /**
@@ -280,36 +281,7 @@ export class DataTransformer implements IDataTransformer {
         dcpGoals: this.extractNumber(record, 'Goals Met', 'DCP Goals', 'Goals'),
         dcpGoalsAchieved:
           record['Level 1s'] != null && record['Level 1s'] !== ''
-            ? [
-                this.extractNumber(record, 'Level 1s') >= 4,
-                this.extractNumber(record, 'Level 2s') >= 2,
-                this.extractNumber(record, 'Add. Level 2s', 'Add Level 2s') >=
-                  2,
-                this.extractNumber(record, 'Level 3s') >= 2,
-                this.extractNumber(
-                  record,
-                  'Level 4s, Path Completions, or DTM Awards',
-                  'Level 4s',
-                  'Level 4'
-                ) >= 1,
-                this.extractNumber(
-                  record,
-                  'Add. Level 4s, Path Completions, or DTM award',
-                  'Add. Level 4s',
-                  'Add Level 4'
-                ) >= 1,
-                this.extractNumber(record, 'New Members') >= 4,
-                this.extractNumber(
-                  record,
-                  'Add. New Members',
-                  'Add New Members'
-                ) >= 4,
-                this.extractNumber(record, 'Off. Trained Round 1') >= 4 &&
-                  this.extractNumber(record, 'Off. Trained Round 2') >= 4,
-                (this.extractNumber(record, 'Mem. dues on time Oct') >= 1 ||
-                  this.extractNumber(record, 'Mem. dues on time Apr') >= 1) &&
-                  this.extractNumber(record, 'Off. List On Time') >= 1,
-              ]
+            ? computeDcpGoalsAchieved(record)
             : undefined,
         status: this.extractClubStatus(record),
         // Payment breakdown fields - sourced from districtPerformance when available

--- a/packages/analytics-core/src/transformation/DataTransformer.ts
+++ b/packages/analytics-core/src/transformation/DataTransformer.ts
@@ -22,7 +22,10 @@ import type {
   SnapshotMetadata,
 } from '../interfaces.js'
 import type { ScrapedRecord } from '@toastmasters/shared-contracts'
-import { computeDcpGoalsAchieved } from '../analytics/dcpGoalDefinitions.js'
+import {
+  computeDcpGoalsAchieved,
+  hasDcpGoalColumns,
+} from '../analytics/dcpGoalDefinitions.js'
 import { ANALYTICS_SCHEMA_VERSION } from '../version.js'
 
 /**
@@ -279,10 +282,9 @@ export class DataTransformer implements IDataTransformer {
           'Total'
         ),
         dcpGoals: this.extractNumber(record, 'Goals Met', 'DCP Goals', 'Goals'),
-        dcpGoalsAchieved:
-          record['Level 1s'] != null && record['Level 1s'] !== ''
-            ? computeDcpGoalsAchieved(record)
-            : undefined,
+        dcpGoalsAchieved: hasDcpGoalColumns(record)
+          ? computeDcpGoalsAchieved(record)
+          : undefined,
         status: this.extractClubStatus(record),
         // Payment breakdown fields - sourced from districtPerformance when available
         octoberRenewals: this.extractNumber(

--- a/tasks/lessons/156-an-audits-defect-list-for-a-forked-implementation-is-a-lower-bound.md
+++ b/tasks/lessons/156-an-audits-defect-list-for-a-forked-implementation-is-a-lower-bound.md
@@ -1,0 +1,63 @@
+---
+id: '156'
+category: lesson
+tags: [analytics, dcp, refactor, monorepo, verification]
+auto_load: true
+date: 2026-06-10
+issues: [1118, 1095]
+---
+
+# Lesson 156 — An audit's defect list for a forked implementation is a lower bound; consolidation must re-derive the full semantic diff
+
+**Date:** 2026-06-10
+**Issue:** #1118 (epic #1095 Sprint 1)
+**PR:** #1136
+
+## What happened
+
+The 2026-06-09 deep-dive audit verified two defects in
+`DistinguishedClubAnalyticsModule`'s forked DCP goal logic: the legacy
+Goals-5/6 CSV header (C1) and the Goal-10 AND-instead-of-OR rule (C2). The
+sprint's job was to consolidate the fork onto a shared goal-definition
+source mirroring the verified-correct `DataTransformer`.
+
+Reading the two implementations side by side surfaced a **third, unflagged
+drift**: the fork counted goals 1–8 as achieved at `> 0`, while the official
+thresholds are 4/2/2/2/1/1/4/4. Goals 5/6 happen to have threshold 1, so the
+audit's "5/6 report 0" evidence never exposed it — but "most commonly
+achieved goal" counts for goals 1,2,3,4,7,8 were silently inflated on every
+live analytics surface. The migration fixed it for free _because the shared
+module encodes the canonical semantics in full_, not because anyone was
+looking for it.
+
+## The transferable principle
+
+**An audit verifies the defects it has live evidence for; it does not prove
+the rest of the fork is clean. When a sprint consolidates a forked
+implementation onto a canonical source, the unit of work is the full
+semantic diff between fork and canon — every threshold, alias, gate, and
+mode — not a patch per reported defect.** Patching C1 and C2 in place would
+have left the threshold drift alive and "fixed" the issue. The shared-source
+migration is what actually closed the family. Corollary (extends
+[[061]] "audit every implementation of a formula"): when the fix-shape is
+"migrate onto canon," diff the _whole_ fork against canon first and write
+the red tests from the canon's semantics, not from the audit's defect list.
+
+## How to apply
+
+- Before migrating a fork onto a shared source, produce the side-by-side
+  semantic table (column names, thresholds, combination logic, presence
+  gates) and treat every divergence as a candidate defect — flagged or not.
+- Write the red tests from the canonical semantics (here: the official DCP
+  thresholds verified against TI's own Goals Met), so unflagged drift fails
+  loudly instead of surviving the consolidation.
+- A parity test against the canonical implementation (same fixture →
+  identical output before/after) pins the migration itself; boundary tests
+  at each official threshold pin the semantics.
+
+## Related
+
+- [[061]] — audit every implementation of a formula when fixing it; this
+  lesson is the consolidation-time complement.
+- `packages/analytics-core/src/analytics/dcpGoalDefinitions.ts` — the shared
+  source this sprint created.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -140,3 +140,4 @@
 - **154** [data-pipeline, analytics, collector-cli, privacy, tdd] — A pre-filtered report's MEMBERSHIP SET can itself be the datum; derive from presence, not a column (#1065, #1062)
 - **154** [data-pipeline, ci, automation, tdd, verification, fixtures] — Synthetic fixtures validate the code; only a captured real pair validates the policy (#1092, #1086, #1083)
 - **155** [ci, automation, data-pipeline, monitoring, gcs] — A recency-based freshness monitor is blind to a held-promotion "content-stale" state; freshness has two orthogonal axes (#1073, #1072)
+- **156** [analytics, dcp, refactor, monorepo, verification] — An audit's defect list for a forked implementation is a lower bound; consolidation must re-derive the full semantic diff (#1118, #1095)


### PR DESCRIPTION
Sprint 1 of epic #1095 — implements #1118 (plain reference, no auto-close per R15/L106).

## What

Creates `dcpGoalDefinitions.ts` in analytics-core as the **single shared source of truth** for the 10 DCP goal definitions (current CSV headers + historical aliases, official thresholds, AND-of-OR rule structure per rules-reference §10.2), exported from the package index. Migrates both analytics-core consumers onto it.

### Defects fixed (audit `docs/audits/deep-dive-review-2026-06-09.md`)

- **C1** — `DistinguishedClubAnalyticsModule` read the legacy header `'Level 4s, Level 5s, or DTM award'`; live CSVs carry `'Level 4s, Path Completions, or DTM Awards'`, so analytics Goals 5/6 reported 0/162 (truth: 105/162, 77/162 for D61 2026-06-08). Aliases now mirror DataTransformer's verified-correct list.
- **C2** — Goal 10 required Oct AND Apr dues; the rule is officer list + (Oct **OR** Apr) (operator-confirmed, §10.2). Live analytics Goal 10: 122 → 144.
- **Bonus drift caught during consolidation** — the old `DCP_GOAL_COLUMNS` counted goals 1–8 at `> 0` instead of the official thresholds (4/2/2/2/1/1/4/4), inflating "most commonly achieved" counts for goals 1,2,3,4,7,8. The shared definitions encode the official thresholds (verified identical to TI's own Goals Met across all 162 D61 clubs in the audit).

### Commits (TDD)

1. `test:` Red — real-header/Goal-10-OR/threshold expectations fail against old code; DataTransformer parity tests pin the verified-correct `dcpGoalsAchieved` baseline
2. `feat:` Green — shared module + `DistinguishedClubAnalyticsModule` migration
3. `refactor:` DataTransformer consumes `computeDcpGoalsAchieved` (behavior-preserving, parity-pinned)
4. `refactor:` /simplify pass — shared `hasDcpGoalColumns` presence gate

## Acceptance criteria (#1118)

- [x] Failing tests first: real-header fixture shows goals 5/6 counted; Oct-only and Apr-only fixtures pass goal 10 (commit 1, 4 red → green)
- [x] dcpGoalAnalysis on a real-shaped fixture: goal 5/6 non-zero, goal 10 = officer list + (Oct OR Apr)
- [x] DataTransformer parity test: same fixture → identical goalsMet before/after migration
- [x] R16: analytics-core dist rebuilt before frontend tests (full workspace suite green: 3385 + 884 + 822 + 153 + 50)

## Review notes (fresh-context review: APPROVE-WITH-NITS)

Two medium findings documented as deliberate scope decisions for operator triage:

1. **Legacy header not in the alias list.** The issue mandates mirroring DataTransformer's aliases exactly (done). If any archived raw snapshot still carries `'Level 4s, Level 5s, or DTM award'`, re-analysis of that snapshot would miss goals 5/6 — same behavior DataTransformer has always had. Append it as a last-resort alias in a follow-up if historical re-analysis matters.
2. **Analytics presence-gate edge case.** The gate changed from `'Level 1s' in record` to the shared `hasDcpGoalColumns` (value must be non-null/non-empty). A record carrying the column with an empty value now falls back to the sequential approximation instead of counting all-zeros — consistent with DataTransformer's long-standing gate.

Frontend `dcpGoals.ts` and `TimeSeriesDataPointBuilder` migrations are later sprints of #1095; the shared module already carries the name/category/label metadata they need.

## Live verification plan

This PR touches `packages/analytics-core/**` → preview deploys. Analytics JSON values land via the scheduled pipeline, so per the sprint brief, code-proof applies for the computed values (unit + parity tests above); preview smoke verifies the app renders against the staging CDN in both engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
