### PR TITLE
Sprint 3 (#1095) — time-series club health delegates to ClubHealthAnalyticsModule; fix status corruption (#1120)

### DIFF
--- a/packages/analytics-core/src/__tests__/TimeSeriesDataPointBuilder.test.ts
+++ b/packages/analytics-core/src/__tests__/TimeSeriesDataPointBuilder.test.ts
@@ -17,6 +17,12 @@ import {
   type DistrictStatisticsInput,
   type ScrapedRecord,
 } from '../timeseries/TimeSeriesDataPointBuilder.js'
+import {
+  getCurrentProgramMonth,
+  getDCPCheckpoint,
+} from '../analytics/AnalyticsUtils.js'
+import { ClubHealthAnalyticsModule } from '../analytics/ClubHealthAnalyticsModule.js'
+import type { ClubStatistics, DistrictStatistics } from '../interfaces.js'
 
 // Reference implementations for equivalence checking
 function refParseIntSafe(value: string | number | null | undefined): number {
@@ -106,8 +112,27 @@ function refCalculateDistinguishedTotal(
   return (district.clubPerformance ?? []).filter(refIsDistinguished).length
 }
 
+function refParseCspSubmitted(club: ScrapedRecord): boolean {
+  const cspValue =
+    club['CSP'] ??
+    club['Club Success Plan'] ??
+    club['CSP Submitted'] ??
+    club['Club Success Plan Submitted']
+  // Historical compatibility: field absent → assume submitted
+  if (cspValue === undefined || cspValue === null) return true
+  const csp = String(cspValue).toLowerCase().trim()
+  return !['no', 'false', '0', 'not submitted', 'n'].includes(csp)
+}
+
+/**
+ * Reference club-health classification (#1120): must match
+ * ClubHealthAnalyticsModule.assessClubHealth — monthly DCP checkpoint
+ * (§5.3) + CSP requirement, not the legacy `dcpGoals > 0` rule.
+ */
 function refCalculateClubHealthCounts(district: DistrictStatisticsInput) {
   const clubs = district.clubPerformance ?? []
+  const month = getCurrentProgramMonth(district.asOfDate)
+  const requiredCheckpoint = getDCPCheckpoint(month)
   let thriving = 0,
     vulnerable = 0,
     interventionRequired = 0
@@ -119,7 +144,12 @@ function refCalculateClubHealthCounts(district: DistrictStatisticsInput) {
     const memBase = refParseIntSafe(club['Mem. Base'])
     const netGrowth = membership - memBase
     if (membership < 12 && netGrowth < 3) interventionRequired++
-    else if ((membership >= 20 || netGrowth >= 3) && dcpGoals > 0) thriving++
+    else if (
+      (membership >= 20 || netGrowth >= 3) &&
+      dcpGoals >= requiredCheckpoint &&
+      refParseCspSubmitted(club)
+    )
+      thriving++
     else vulnerable++
   }
   return { total: clubs.length, thriving, vulnerable, interventionRequired }
@@ -384,6 +414,193 @@ describe('TimeSeriesDataPointBuilder', () => {
       expect(
         counts.thriving + counts.vulnerable + counts.interventionRequired
       ).toBe(counts.total)
+    })
+
+    it('classifies a 3-goal club in June as vulnerable, not thriving (#1120)', () => {
+      // The C3 audit disagreement fixture: the legacy `dcpGoals > 0` rule
+      // counted this club thriving; the §5.3 June checkpoint requires 5 goals.
+      const district: DistrictStatisticsInput = {
+        districtId: '61',
+        asOfDate: '2026-06-15',
+        clubPerformance: [
+          {
+            'Club Number': '1111',
+            'Club Name': 'June Three Goals',
+            'Active Members': '25',
+            'Mem. Base': '20',
+            'Goals Met': '3',
+            CSP: 'Yes',
+          },
+        ],
+      }
+      expect(builder.calculateClubHealthCounts(district)).toEqual({
+        total: 1,
+        thriving: 0,
+        vulnerable: 1,
+        interventionRequired: 0,
+      })
+    })
+
+    it('does not count a CSP-less club as thriving (#1120)', () => {
+      const district: DistrictStatisticsInput = {
+        districtId: '61',
+        asOfDate: '2026-06-15',
+        clubPerformance: [
+          {
+            'Club Number': '2222',
+            'Club Name': 'No CSP',
+            'Active Members': '25',
+            'Mem. Base': '20',
+            'Goals Met': '9',
+            CSP: 'No',
+          },
+        ],
+      }
+      expect(builder.calculateClubHealthCounts(district)).toEqual({
+        total: 1,
+        thriving: 0,
+        vulnerable: 1,
+        interventionRequired: 0,
+      })
+    })
+
+    it('treats a missing CSP field as submitted (historical data)', () => {
+      const district: DistrictStatisticsInput = {
+        districtId: '61',
+        asOfDate: '2024-06-15',
+        clubPerformance: [
+          {
+            'Club Number': '3333',
+            'Club Name': 'Pre-CSP Era',
+            'Active Members': '25',
+            'Mem. Base': '20',
+            'Goals Met': '6',
+          },
+        ],
+      }
+      expect(builder.calculateClubHealthCounts(district)).toEqual({
+        total: 1,
+        thriving: 1,
+        vulnerable: 0,
+        interventionRequired: 0,
+      })
+    })
+  })
+
+  // ---------- parity with ClubHealthAnalyticsModule (#1120) ----------
+  describe('parity with ClubHealthAnalyticsModule', () => {
+    /**
+     * Mirror of AnalyticsComputeService.convertToDistrictStatisticsInput's
+     * field mapping (the real conversion is integration-tested in
+     * collector-cli). Keys must stay in sync with that method.
+     */
+    function toScrapedRecord(club: ClubStatistics): ScrapedRecord {
+      return {
+        'Active Members': club.membershipCount,
+        'Mem. Base': club.membershipBase,
+        'Goals Met': club.dcpGoals,
+        'Club Number': club.clubId,
+        'Club Name': club.clubName,
+        CSP: (club.cspSubmitted ?? true) ? 'Yes' : 'No',
+      }
+    }
+
+    function makeClubStat(
+      overrides: Partial<ClubStatistics> & { clubId: string }
+    ): ClubStatistics {
+      return {
+        clubName: `Club ${overrides.clubId}`,
+        divisionId: 'A',
+        areaId: 'A1',
+        divisionName: 'Division A',
+        areaName: 'Area A1',
+        membershipCount: 20,
+        paymentsCount: 0,
+        dcpGoals: 0,
+        status: 'Active',
+        octoberRenewals: 0,
+        aprilRenewals: 0,
+        newMembers: 0,
+        membershipBase: 20,
+        ...overrides,
+      }
+    }
+
+    it('produces the same thriving/vulnerable/intervention counts as the module', () => {
+      const snapshotDate = '2026-06-15'
+      const clubs: ClubStatistics[] = [
+        // thriving: 25 members, 7 goals (June checkpoint 5), CSP submitted
+        makeClubStat({ clubId: '1', dcpGoals: 7, cspSubmitted: true }),
+        // vulnerable: 3 goals < June checkpoint 5
+        makeClubStat({ clubId: '2', dcpGoals: 3, cspSubmitted: true }),
+        // vulnerable: everything met except CSP
+        makeClubStat({ clubId: '3', dcpGoals: 9, cspSubmitted: false }),
+        // intervention: 8 members, base 10 → growth -2
+        makeClubStat({
+          clubId: '4',
+          membershipCount: 8,
+          membershipBase: 10,
+          dcpGoals: 9,
+          cspSubmitted: true,
+        }),
+        // vulnerable: 15 members, growth 2 → membership requirement not met
+        makeClubStat({
+          clubId: '5',
+          membershipCount: 15,
+          membershipBase: 13,
+          dcpGoals: 9,
+          cspSubmitted: true,
+        }),
+        // thriving via growth: 11 members, base 5 → growth 6
+        makeClubStat({
+          clubId: '6',
+          membershipCount: 11,
+          membershipBase: 5,
+          dcpGoals: 6,
+          cspSubmitted: true,
+        }),
+        // historical club without CSP field → treated as submitted
+        makeClubStat({ clubId: '7', dcpGoals: 5 }),
+      ]
+      const snapshot: DistrictStatistics = {
+        districtId: '61',
+        snapshotDate,
+        clubs,
+        divisions: [],
+        areas: [],
+        totals: {
+          totalClubs: clubs.length,
+          totalMembership: 0,
+          totalPayments: 0,
+          distinguishedClubs: 0,
+          selectDistinguishedClubs: 0,
+          presidentDistinguishedClubs: 0,
+        },
+        divisionPerformance: [],
+        clubPerformance: [],
+        districtPerformance: [],
+      }
+
+      const module = new ClubHealthAnalyticsModule()
+      const healthData = module.generateClubHealthData([snapshot])
+
+      const district: DistrictStatisticsInput = {
+        districtId: '61',
+        asOfDate: snapshotDate,
+        clubPerformance: clubs.map(toScrapedRecord),
+      }
+      const counts = builder.calculateClubHealthCounts(district)
+
+      expect(counts.total).toBe(healthData.allClubs.length)
+      expect(counts.thriving).toBe(healthData.thrivingClubs.length)
+      expect(counts.vulnerable).toBe(healthData.vulnerableClubs.length)
+      expect(counts.interventionRequired).toBe(
+        healthData.interventionRequiredClubs.length
+      )
+      // Sanity: the fixture covers all three classes
+      expect(counts.thriving).toBeGreaterThan(0)
+      expect(counts.vulnerable).toBeGreaterThan(0)
+      expect(counts.interventionRequired).toBeGreaterThan(0)
     })
   })
 

--- a/packages/analytics-core/src/__tests__/TimeSeriesDataPointBuilder.test.ts
+++ b/packages/analytics-core/src/__tests__/TimeSeriesDataPointBuilder.test.ts
@@ -362,6 +362,55 @@ describe('TimeSeriesDataPointBuilder', () => {
     })
   })
 
+  // ---------- isDistinguished letter codes (#1120) ----------
+  describe('isDistinguished letter codes (#1120)', () => {
+    // Live dashboard CSVs carry single-letter codes, not words.
+    // Fixture deliberately fails the DCP heuristic (2 goals, no growth)
+    // so only the status field can make it distinguished.
+    const baseClub: ScrapedRecord = {
+      'Club Number': '4444',
+      'Club Name': 'Code Club',
+      'Active Members': '15',
+      'Mem. Base': '15',
+      'Goals Met': '2',
+      CSP: 'Yes',
+    }
+
+    it.each(['D', 'S', 'P', 'M'])(
+      'counts live status code %s as distinguished',
+      code => {
+        expect(
+          builder.isDistinguished({
+            ...baseClub,
+            'Club Distinguished Status': code,
+          })
+        ).toBe(true)
+      }
+    )
+
+    it('does not treat operational status values as distinguished', () => {
+      for (const value of ['Active', 'Low', 'Suspended', 'Ineligible']) {
+        expect(
+          builder.isDistinguished({
+            ...baseClub,
+            'Club Distinguished Status': value,
+          })
+        ).toBe(false)
+      }
+    })
+
+    it('still ignores empty and none-like values', () => {
+      for (const value of ['', 'None', 'N/A']) {
+        expect(
+          builder.isDistinguished({
+            ...baseClub,
+            'Club Distinguished Status': value,
+          })
+        ).toBe(false)
+      }
+    })
+  })
+
   // ---------- calculateDistinguishedTotal equivalence ----------
   describe('calculateDistinguishedTotal equivalence', () => {
     it('should match reference for mixed clubs', () => {

--- a/packages/analytics-core/src/__tests__/TimeSeriesDataPointBuilder.test.ts
+++ b/packages/analytics-core/src/__tests__/TimeSeriesDataPointBuilder.test.ts
@@ -21,8 +21,6 @@ import {
   getCurrentProgramMonth,
   getDCPCheckpoint,
 } from '../analytics/AnalyticsUtils.js'
-import { ClubHealthAnalyticsModule } from '../analytics/ClubHealthAnalyticsModule.js'
-import type { ClubStatistics, DistrictStatistics } from '../interfaces.js'
 
 // Reference implementations for equivalence checking
 function refParseIntSafe(value: string | number | null | undefined): number {
@@ -533,123 +531,6 @@ describe('TimeSeriesDataPointBuilder', () => {
         vulnerable: 0,
         interventionRequired: 0,
       })
-    })
-  })
-
-  // ---------- parity with ClubHealthAnalyticsModule (#1120) ----------
-  describe('parity with ClubHealthAnalyticsModule', () => {
-    /**
-     * Mirror of AnalyticsComputeService.convertToDistrictStatisticsInput's
-     * field mapping (the real conversion is integration-tested in
-     * collector-cli). Keys must stay in sync with that method.
-     */
-    function toScrapedRecord(club: ClubStatistics): ScrapedRecord {
-      return {
-        'Active Members': club.membershipCount,
-        'Mem. Base': club.membershipBase,
-        'Goals Met': club.dcpGoals,
-        'Club Number': club.clubId,
-        'Club Name': club.clubName,
-        CSP: (club.cspSubmitted ?? true) ? 'Yes' : 'No',
-      }
-    }
-
-    function makeClubStat(
-      overrides: Partial<ClubStatistics> & { clubId: string }
-    ): ClubStatistics {
-      return {
-        clubName: `Club ${overrides.clubId}`,
-        divisionId: 'A',
-        areaId: 'A1',
-        divisionName: 'Division A',
-        areaName: 'Area A1',
-        membershipCount: 20,
-        paymentsCount: 0,
-        dcpGoals: 0,
-        status: 'Active',
-        octoberRenewals: 0,
-        aprilRenewals: 0,
-        newMembers: 0,
-        membershipBase: 20,
-        ...overrides,
-      }
-    }
-
-    it('produces the same thriving/vulnerable/intervention counts as the module', () => {
-      const snapshotDate = '2026-06-15'
-      const clubs: ClubStatistics[] = [
-        // thriving: 25 members, 7 goals (June checkpoint 5), CSP submitted
-        makeClubStat({ clubId: '1', dcpGoals: 7, cspSubmitted: true }),
-        // vulnerable: 3 goals < June checkpoint 5
-        makeClubStat({ clubId: '2', dcpGoals: 3, cspSubmitted: true }),
-        // vulnerable: everything met except CSP
-        makeClubStat({ clubId: '3', dcpGoals: 9, cspSubmitted: false }),
-        // intervention: 8 members, base 10 → growth -2
-        makeClubStat({
-          clubId: '4',
-          membershipCount: 8,
-          membershipBase: 10,
-          dcpGoals: 9,
-          cspSubmitted: true,
-        }),
-        // vulnerable: 15 members, growth 2 → membership requirement not met
-        makeClubStat({
-          clubId: '5',
-          membershipCount: 15,
-          membershipBase: 13,
-          dcpGoals: 9,
-          cspSubmitted: true,
-        }),
-        // thriving via growth: 11 members, base 5 → growth 6
-        makeClubStat({
-          clubId: '6',
-          membershipCount: 11,
-          membershipBase: 5,
-          dcpGoals: 6,
-          cspSubmitted: true,
-        }),
-        // historical club without CSP field → treated as submitted
-        makeClubStat({ clubId: '7', dcpGoals: 5 }),
-      ]
-      const snapshot: DistrictStatistics = {
-        districtId: '61',
-        snapshotDate,
-        clubs,
-        divisions: [],
-        areas: [],
-        totals: {
-          totalClubs: clubs.length,
-          totalMembership: 0,
-          totalPayments: 0,
-          distinguishedClubs: 0,
-          selectDistinguishedClubs: 0,
-          presidentDistinguishedClubs: 0,
-        },
-        divisionPerformance: [],
-        clubPerformance: [],
-        districtPerformance: [],
-      }
-
-      const module = new ClubHealthAnalyticsModule()
-      const healthData = module.generateClubHealthData([snapshot])
-
-      const district: DistrictStatisticsInput = {
-        districtId: '61',
-        asOfDate: snapshotDate,
-        clubPerformance: clubs.map(toScrapedRecord),
-      }
-      const counts = builder.calculateClubHealthCounts(district)
-
-      expect(counts.total).toBe(healthData.allClubs.length)
-      expect(counts.thriving).toBe(healthData.thrivingClubs.length)
-      expect(counts.vulnerable).toBe(healthData.vulnerableClubs.length)
-      expect(counts.interventionRequired).toBe(
-        healthData.interventionRequiredClubs.length
-      )
-      // Sanity: the fixture covers all three classes
-      expect(counts.thriving).toBeGreaterThan(0)
-      expect(counts.vulnerable).toBeGreaterThan(0)
-      expect(counts.interventionRequired).toBeGreaterThan(0)
     })
   })
 

--- a/packages/analytics-core/src/analytics/ClubEligibilityUtils.test.ts
+++ b/packages/analytics-core/src/analytics/ClubEligibilityUtils.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   calculateNetGrowth,
+  classifyClubHealth,
   determineDistinguishedLevel,
   getCSPStatus,
   getConfirmedDistinguishedLevel,
@@ -326,5 +327,83 @@ describe('getConfirmedDistinguishedLevel', () => {
   it('returns NotDistinguished when goals are insufficient', () => {
     // 4 goals, 25 renewals, base=15 → not enough goals for any level
     expect(getConfirmedDistinguishedLevel(4, 25, 15)).toBe('NotDistinguished')
+  })
+})
+
+// ============================================================
+// classifyClubHealth (#1120 — single source for §5 classification)
+// ============================================================
+
+describe('classifyClubHealth', () => {
+  it('classifies a 3-goal club in June as vulnerable (checkpoint is 5)', () => {
+    // The C3 audit disagreement fixture: dcpGoals > 0 said "thriving",
+    // the §5.3 monthly checkpoint says June requires 5 goals.
+    const result = classifyClubHealth(
+      { membership: 25, membershipBase: 20, dcpGoals: 3, cspSubmitted: true },
+      6
+    )
+    expect(result.status).toBe('vulnerable')
+    expect(result.requiredDcpCheckpoint).toBe(5)
+    expect(result.membershipRequirementMet).toBe(true)
+    expect(result.dcpCheckpointMet).toBe(false)
+    expect(result.cspRequirementMet).toBe(true)
+  })
+
+  it('classifies the same 3-goal club in July as thriving (checkpoint is 0)', () => {
+    const result = classifyClubHealth(
+      { membership: 25, membershipBase: 20, dcpGoals: 3, cspSubmitted: true },
+      7
+    )
+    expect(result.status).toBe('thriving')
+    expect(result.requiredDcpCheckpoint).toBe(0)
+  })
+
+  it('classifies a 5-goal club in June as thriving', () => {
+    const result = classifyClubHealth(
+      { membership: 25, membershipBase: 20, dcpGoals: 5, cspSubmitted: true },
+      6
+    )
+    expect(result.status).toBe('thriving')
+  })
+
+  it('applies the intervention override regardless of goals and CSP', () => {
+    // membership < 12 AND net growth < 3 → intervention-required
+    const result = classifyClubHealth(
+      { membership: 8, membershipBase: 10, dcpGoals: 9, cspSubmitted: true },
+      6
+    )
+    expect(result.status).toBe('intervention-required')
+    expect(result.netGrowth).toBe(-2)
+  })
+
+  it('escapes the intervention override via net growth >= 3', () => {
+    // membership 11 < 12 but netGrowth 6 >= 3 → not intervention;
+    // membership requirement met via growth, June checkpoint 5 met
+    const result = classifyClubHealth(
+      { membership: 11, membershipBase: 5, dcpGoals: 5, cspSubmitted: true },
+      6
+    )
+    expect(result.status).toBe('thriving')
+  })
+
+  it('classifies a CSP-less club as vulnerable even when all else is met', () => {
+    const result = classifyClubHealth(
+      { membership: 25, membershipBase: 20, dcpGoals: 9, cspSubmitted: false },
+      6
+    )
+    expect(result.status).toBe('vulnerable')
+    expect(result.cspRequirementMet).toBe(false)
+    expect(result.membershipRequirementMet).toBe(true)
+    expect(result.dcpCheckpointMet).toBe(true)
+  })
+
+  it('fails the membership requirement below 20 members with growth < 3', () => {
+    // membership 15 (>= 12, no intervention), growth 2 → requirement not met
+    const result = classifyClubHealth(
+      { membership: 15, membershipBase: 13, dcpGoals: 9, cspSubmitted: true },
+      6
+    )
+    expect(result.status).toBe('vulnerable')
+    expect(result.membershipRequirementMet).toBe(false)
   })
 })

--- a/packages/analytics-core/src/analytics/ClubEligibilityUtils.test.ts
+++ b/packages/analytics-core/src/analytics/ClubEligibilityUtils.test.ts
@@ -339,7 +339,7 @@ describe('classifyClubHealth', () => {
     // The C3 audit disagreement fixture: dcpGoals > 0 said "thriving",
     // the §5.3 monthly checkpoint says June requires 5 goals.
     const result = classifyClubHealth(
-      { membership: 25, membershipBase: 20, dcpGoals: 3, cspSubmitted: true },
+      { membership: 25, netGrowth: 5, dcpGoals: 3, cspSubmitted: true },
       6
     )
     expect(result.status).toBe('vulnerable')
@@ -351,7 +351,7 @@ describe('classifyClubHealth', () => {
 
   it('classifies the same 3-goal club in July as thriving (checkpoint is 0)', () => {
     const result = classifyClubHealth(
-      { membership: 25, membershipBase: 20, dcpGoals: 3, cspSubmitted: true },
+      { membership: 25, netGrowth: 5, dcpGoals: 3, cspSubmitted: true },
       7
     )
     expect(result.status).toBe('thriving')
@@ -360,7 +360,7 @@ describe('classifyClubHealth', () => {
 
   it('classifies a 5-goal club in June as thriving', () => {
     const result = classifyClubHealth(
-      { membership: 25, membershipBase: 20, dcpGoals: 5, cspSubmitted: true },
+      { membership: 25, netGrowth: 5, dcpGoals: 5, cspSubmitted: true },
       6
     )
     expect(result.status).toBe('thriving')
@@ -369,18 +369,17 @@ describe('classifyClubHealth', () => {
   it('applies the intervention override regardless of goals and CSP', () => {
     // membership < 12 AND net growth < 3 → intervention-required
     const result = classifyClubHealth(
-      { membership: 8, membershipBase: 10, dcpGoals: 9, cspSubmitted: true },
+      { membership: 8, netGrowth: -2, dcpGoals: 9, cspSubmitted: true },
       6
     )
     expect(result.status).toBe('intervention-required')
-    expect(result.netGrowth).toBe(-2)
   })
 
   it('escapes the intervention override via net growth >= 3', () => {
     // membership 11 < 12 but netGrowth 6 >= 3 → not intervention;
     // membership requirement met via growth, June checkpoint 5 met
     const result = classifyClubHealth(
-      { membership: 11, membershipBase: 5, dcpGoals: 5, cspSubmitted: true },
+      { membership: 11, netGrowth: 6, dcpGoals: 5, cspSubmitted: true },
       6
     )
     expect(result.status).toBe('thriving')
@@ -388,7 +387,7 @@ describe('classifyClubHealth', () => {
 
   it('classifies a CSP-less club as vulnerable even when all else is met', () => {
     const result = classifyClubHealth(
-      { membership: 25, membershipBase: 20, dcpGoals: 9, cspSubmitted: false },
+      { membership: 25, netGrowth: 5, dcpGoals: 9, cspSubmitted: false },
       6
     )
     expect(result.status).toBe('vulnerable')
@@ -400,7 +399,7 @@ describe('classifyClubHealth', () => {
   it('fails the membership requirement below 20 members with growth < 3', () => {
     // membership 15 (>= 12, no intervention), growth 2 → requirement not met
     const result = classifyClubHealth(
-      { membership: 15, membershipBase: 13, dcpGoals: 9, cspSubmitted: true },
+      { membership: 15, netGrowth: 2, dcpGoals: 9, cspSubmitted: true },
       6
     )
     expect(result.status).toBe('vulnerable')

--- a/packages/analytics-core/src/analytics/ClubEligibilityUtils.ts
+++ b/packages/analytics-core/src/analytics/ClubEligibilityUtils.ts
@@ -13,6 +13,7 @@
 
 import type { ClubStatistics } from '../interfaces.js'
 import type { ClubHealthStatus, DistinguishedLevel } from '../types.js'
+import { getDCPCheckpoint } from './AnalyticsUtils.js'
 
 /**
  * Scalar inputs for club-health classification.
@@ -59,9 +60,38 @@ export function classifyClubHealth(
   input: ClubHealthClassificationInput,
   month: number
 ): ClubHealthClassification {
-  void input
-  void month
-  throw new Error('Not implemented (TDD red phase, #1120)')
+  const { membership, membershipBase, dcpGoals, cspSubmitted } = input
+  const netGrowth = membership - membershipBase
+  const requiredDcpCheckpoint = getDCPCheckpoint(month)
+
+  // Membership requirement: >= 20 members OR net growth >= 3
+  const membershipRequirementMet = membership >= 20 || netGrowth >= 3
+  // DCP checkpoint requirement varies by month (§5.3)
+  const dcpCheckpointMet = dcpGoals >= requiredDcpCheckpoint
+  const cspRequirementMet = cspSubmitted
+
+  // Intervention override: membership < 12 AND net growth < 3
+  let status: ClubHealthStatus
+  if (membership < 12 && netGrowth < 3) {
+    status = 'intervention-required'
+  } else if (
+    membershipRequirementMet &&
+    dcpCheckpointMet &&
+    cspRequirementMet
+  ) {
+    status = 'thriving'
+  } else {
+    status = 'vulnerable'
+  }
+
+  return {
+    status,
+    netGrowth,
+    requiredDcpCheckpoint,
+    membershipRequirementMet,
+    dcpCheckpointMet,
+    cspRequirementMet,
+  }
 }
 
 /**

--- a/packages/analytics-core/src/analytics/ClubEligibilityUtils.ts
+++ b/packages/analytics-core/src/analytics/ClubEligibilityUtils.ts
@@ -12,7 +12,57 @@
  */
 
 import type { ClubStatistics } from '../interfaces.js'
-import type { DistinguishedLevel } from '../types.js'
+import type { ClubHealthStatus, DistinguishedLevel } from '../types.js'
+
+/**
+ * Scalar inputs for club-health classification.
+ *
+ * Value-based (not tied to ClubStatistics) so both transformed club data
+ * and raw scraped CSV records can be classified by the same rule.
+ */
+export interface ClubHealthClassificationInput {
+  /** Current active membership count */
+  membership: number
+  /** Membership base at the start of the program year */
+  membershipBase: number
+  /** DCP goals achieved to date */
+  dcpGoals: number
+  /** Normalized CSP submission status (pre-2025 data → true) */
+  cspSubmitted: boolean
+}
+
+/**
+ * Classification verdict with the per-requirement breakdown, so callers
+ * can build risk-factor messages without re-deriving the predicates.
+ */
+export interface ClubHealthClassification {
+  status: ClubHealthStatus
+  netGrowth: number
+  requiredDcpCheckpoint: number
+  membershipRequirementMet: boolean
+  dcpCheckpointMet: boolean
+  cspRequirementMet: boolean
+}
+
+/**
+ * Classify a club's health per the §5 monthly-checkpoint system.
+ *
+ * Single source of truth (#1120) — ClubHealthAnalyticsModule.assessClubHealth
+ * and TimeSeriesDataPointBuilder.calculateClubHealthCounts must both
+ * delegate here so dashboard and time-series counts cannot drift.
+ *
+ * @param input - Scalar club metrics (see ClubHealthClassificationInput)
+ * @param month - Calendar month (1-12) of the snapshot date
+ * @returns Classification with per-requirement breakdown
+ */
+export function classifyClubHealth(
+  input: ClubHealthClassificationInput,
+  month: number
+): ClubHealthClassification {
+  void input
+  void month
+  throw new Error('Not implemented (TDD red phase, #1120)')
+}
 
 /**
  * Calculate net growth for a club.

--- a/packages/analytics-core/src/analytics/ClubEligibilityUtils.ts
+++ b/packages/analytics-core/src/analytics/ClubEligibilityUtils.ts
@@ -24,8 +24,8 @@ import { getDCPCheckpoint } from './AnalyticsUtils.js'
 export interface ClubHealthClassificationInput {
   /** Current active membership count */
   membership: number
-  /** Membership base at the start of the program year */
-  membershipBase: number
+  /** Net membership growth since July (membership - base) */
+  netGrowth: number
   /** DCP goals achieved to date */
   dcpGoals: number
   /** Normalized CSP submission status (pre-2025 data → true) */
@@ -38,7 +38,6 @@ export interface ClubHealthClassificationInput {
  */
 export interface ClubHealthClassification {
   status: ClubHealthStatus
-  netGrowth: number
   requiredDcpCheckpoint: number
   membershipRequirementMet: boolean
   dcpCheckpointMet: boolean
@@ -60,8 +59,7 @@ export function classifyClubHealth(
   input: ClubHealthClassificationInput,
   month: number
 ): ClubHealthClassification {
-  const { membership, membershipBase, dcpGoals, cspSubmitted } = input
-  const netGrowth = membership - membershipBase
+  const { membership, netGrowth, dcpGoals, cspSubmitted } = input
   const requiredDcpCheckpoint = getDCPCheckpoint(month)
 
   // Membership requirement: >= 20 members OR net growth >= 3
@@ -86,12 +84,59 @@ export function classifyClubHealth(
 
   return {
     status,
-    netGrowth,
     requiredDcpCheckpoint,
     membershipRequirementMet,
     dcpCheckpointMet,
     cspRequirementMet,
   }
+}
+
+/**
+ * Distinguished-status letter codes as they appear in live dashboard
+ * CSVs' 'Club Distinguished Status' column:
+ * D = Distinguished, S = Select, P = President's, M = Smedley.
+ */
+export const DISTINGUISHED_STATUS_CODES = ['D', 'S', 'P', 'M'] as const
+
+/**
+ * Check whether a raw 'Club Distinguished Status' value is a live
+ * single-letter distinguished code (case-insensitive).
+ *
+ * @param value - Raw status value, already trimmed
+ * @returns True for 'D' | 'S' | 'P' | 'M' (any case)
+ */
+export function isDistinguishedStatusCode(value: string): boolean {
+  return (DISTINGUISHED_STATUS_CODES as readonly string[]).includes(
+    value.toUpperCase()
+  )
+}
+
+/**
+ * Parse CSP (Club Success Plan) submission status from a raw scraped
+ * record (string-form twin of getCSPStatus, which reads the normalized
+ * boolean on ClubStatistics).
+ *
+ * Historical compatibility: when the field is absent (pre-2025-2026
+ * CSVs), CSP is treated as submitted — it was not a requirement then.
+ *
+ * @param record - Raw club record with dynamic CSV columns
+ * @returns True unless the field is present and explicitly negative
+ */
+export function getCSPStatusFromRecord(
+  record: Record<string, string | number | null | undefined>
+): boolean {
+  const cspValue =
+    record['CSP'] ??
+    record['Club Success Plan'] ??
+    record['CSP Submitted'] ??
+    record['Club Success Plan Submitted']
+
+  if (cspValue === undefined || cspValue === null) {
+    return true
+  }
+
+  const cspString = String(cspValue).toLowerCase().trim()
+  return !['no', 'false', '0', 'not submitted', 'n'].includes(cspString)
 }
 
 /**

--- a/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
@@ -18,7 +18,7 @@
  */
 
 import type { DistrictStatistics, ClubStatistics } from '../interfaces.js'
-import type { ClubTrend, ClubHealthStatus, ClubHealthData } from '../types.js'
+import type { ClubTrend, ClubHealthData } from '../types.js'
 import {
   getDCPCheckpoint,
   getCurrentProgramMonth,
@@ -26,6 +26,7 @@ import {
 } from './AnalyticsUtils.js'
 import {
   calculateNetGrowth,
+  classifyClubHealth,
   determineDistinguishedLevel,
   getCSPStatus,
   isDistinguishedProvisional,
@@ -319,71 +320,59 @@ export class ClubHealthAnalyticsModule {
       clubTrend.dcpGoalsTrend[clubTrend.dcpGoalsTrend.length - 1]
         ?.goalsAchieved ?? club.dcpGoals
 
-    // Calculate net growth from club data (Requirement 5.3)
-    // Net growth = Active Members - Mem. Base
-    const netGrowth = calculateNetGrowth(club)
-
     // Get current program month for DCP checkpoint evaluation
     const currentMonth = getCurrentProgramMonth(snapshotDate)
 
-    // Get required DCP checkpoint for current month
-    const requiredDcpCheckpoint = getDCPCheckpoint(currentMonth)
+    // Delegate classification to the shared single-source rule (#1120).
+    // Membership predicates use the trend-derived currentMembership, but
+    // net growth must stay calculateNetGrowth(club) (Requirement 5.3) —
+    // so derive the base that makes the classifier reproduce it exactly.
+    const classification = classifyClubHealth(
+      {
+        membership: currentMembership,
+        membershipBase: currentMembership - calculateNetGrowth(club),
+        dcpGoals: currentDcpGoals,
+        cspSubmitted: getCSPStatus(club),
+      },
+      currentMonth
+    )
+    const {
+      status,
+      netGrowth,
+      requiredDcpCheckpoint,
+      membershipRequirementMet,
+      dcpCheckpointMet,
+      cspRequirementMet,
+    } = classification
 
-    // Get CSP status (Requirements 5.4, 5.5: CSP guaranteed in 2025-2026+, absent in prior years)
-    const cspSubmitted = getCSPStatus(club)
-
-    // Apply classification rules - mutually exclusive categories
-    let status: ClubHealthStatus
-
-    // Requirement 1.2: Intervention override rule
-    // If membership < 12 AND net growth < 3, assign "Intervention Required" regardless of other criteria
-    if (currentMembership < 12 && netGrowth < 3) {
-      status = 'intervention-required'
+    // Build risk-factor messages from the classification breakdown
+    if (status === 'intervention-required') {
       riskFactors.push('Membership below 12 (critical)')
       riskFactors.push(
         `Net growth since July: ${netGrowth} (need 3+ to override)`
       )
-    } else {
-      // Evaluate each requirement for Thriving status
+    } else if (status === 'vulnerable') {
+      // Requirement 4.2: Add specific reason for membership requirement not met
+      if (!membershipRequirementMet) {
+        riskFactors.push(
+          `Membership below threshold (${currentMembership} members, need 20+ or net growth 3+)`
+        )
+      }
 
-      // Requirement 1.3: Membership requirement (>= 20 OR net growth >= 3)
-      const membershipRequirementMet = currentMembership >= 20 || netGrowth >= 3
+      // Requirement 4.3: Add specific reason for DCP checkpoint not met
+      if (!dcpCheckpointMet) {
+        const monthName = getMonthName(currentMonth)
+        riskFactors.push(
+          `DCP checkpoint not met: ${currentDcpGoals} goal${currentDcpGoals !== 1 ? 's' : ''} achieved, ${requiredDcpCheckpoint} required for ${monthName}`
+        )
+      }
 
-      // DCP checkpoint requirement (varies by month)
-      const dcpCheckpointMet = currentDcpGoals >= requiredDcpCheckpoint
-
-      // CSP requirement (CSP guaranteed in 2025-2026+, absent in prior years)
-      const cspRequirementMet = cspSubmitted
-
-      // Requirement 1.4: Thriving if ALL requirements met
-      if (membershipRequirementMet && dcpCheckpointMet && cspRequirementMet) {
-        status = 'thriving'
-        // Requirement 4.5: Clear riskFactors for Thriving clubs
-      } else {
-        // Requirement 1.5: Vulnerable if some but not all requirements met
-        status = 'vulnerable'
-
-        // Requirement 4.2: Add specific reason for membership requirement not met
-        if (!membershipRequirementMet) {
-          riskFactors.push(
-            `Membership below threshold (${currentMembership} members, need 20+ or net growth 3+)`
-          )
-        }
-
-        // Requirement 4.3: Add specific reason for DCP checkpoint not met
-        if (!dcpCheckpointMet) {
-          const monthName = getMonthName(currentMonth)
-          riskFactors.push(
-            `DCP checkpoint not met: ${currentDcpGoals} goal${currentDcpGoals !== 1 ? 's' : ''} achieved, ${requiredDcpCheckpoint} required for ${monthName}`
-          )
-        }
-
-        // Requirement 4.4: Add specific reason for CSP not submitted
-        if (!cspRequirementMet) {
-          riskFactors.push('CSP not submitted')
-        }
+      // Requirement 4.4: Add specific reason for CSP not submitted
+      if (!cspRequirementMet) {
+        riskFactors.push('CSP not submitted')
       }
     }
+    // Requirement 4.5: riskFactors stay empty for Thriving clubs
 
     clubTrend.riskFactors = riskFactors
     clubTrend.currentStatus = status

--- a/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
@@ -320,30 +320,29 @@ export class ClubHealthAnalyticsModule {
       clubTrend.dcpGoalsTrend[clubTrend.dcpGoalsTrend.length - 1]
         ?.goalsAchieved ?? club.dcpGoals
 
+    // Calculate net growth from club data (Requirement 5.3)
+    // Net growth = Active Members - Mem. Base
+    const netGrowth = calculateNetGrowth(club)
+
     // Get current program month for DCP checkpoint evaluation
     const currentMonth = getCurrentProgramMonth(snapshotDate)
 
-    // Delegate classification to the shared single-source rule (#1120).
-    // Membership predicates use the trend-derived currentMembership, but
-    // net growth must stay calculateNetGrowth(club) (Requirement 5.3) —
-    // so derive the base that makes the classifier reproduce it exactly.
-    const classification = classifyClubHealth(
+    // Delegate classification to the shared single-source rule (#1120)
+    const {
+      status,
+      requiredDcpCheckpoint,
+      membershipRequirementMet,
+      dcpCheckpointMet,
+      cspRequirementMet,
+    } = classifyClubHealth(
       {
         membership: currentMembership,
-        membershipBase: currentMembership - calculateNetGrowth(club),
+        netGrowth,
         dcpGoals: currentDcpGoals,
         cspSubmitted: getCSPStatus(club),
       },
       currentMonth
     )
-    const {
-      status,
-      netGrowth,
-      requiredDcpCheckpoint,
-      membershipRequirementMet,
-      dcpCheckpointMet,
-      cspRequirementMet,
-    } = classification
 
     // Build risk-factor messages from the classification breakdown
     if (status === 'intervention-required') {

--- a/packages/analytics-core/src/interfaces.ts
+++ b/packages/analytics-core/src/interfaces.ts
@@ -83,6 +83,12 @@ export interface ClubStatistics {
   // Club operational status (Active, Suspended, Low, Ineligible)
   clubStatus?: string
 
+  // Raw 'Club Distinguished Status' value from the dashboard CSV.
+  // Live data uses letter codes ('' | 'D' | 'S' | 'P' | 'M'); historical
+  // data may use word forms ("President's Distinguished"). Distinct from
+  // clubStatus (operational) and status (mixed legacy field). (#1120)
+  distinguishedStatus?: string
+
   // CSP (Club Success Plan) submission status
   // Present from 2025-2026 program year onward; undefined for earlier years
   cspSubmitted?: boolean

--- a/packages/analytics-core/src/timeseries/TimeSeriesDataPointBuilder.ts
+++ b/packages/analytics-core/src/timeseries/TimeSeriesDataPointBuilder.ts
@@ -195,6 +195,10 @@ export class TimeSeriesDataPointBuilder {
    *
    * @param district - The district statistics
    * @returns Club health counts breakdown
+   * @throws Error when district.asOfDate is not a parseable date — the
+   *   §5.3 checkpoint is month-dependent, so a corrupt date must fail
+   *   loudly (same behavior as the dashboard module) rather than emit a
+   *   silently misclassified data point.
    *
    * @see Requirements 6.6
    */

--- a/packages/analytics-core/src/timeseries/TimeSeriesDataPointBuilder.ts
+++ b/packages/analytics-core/src/timeseries/TimeSeriesDataPointBuilder.ts
@@ -316,10 +316,20 @@ export class TimeSeriesDataPointBuilder {
       return false
     }
 
-    // Check Club Distinguished Status field
+    // Check Club Distinguished Status field. Live dashboard CSVs carry
+    // single-letter codes (D = Distinguished, S = Select, P = President's,
+    // M = Smedley); historical data may use the word forms. (#1120)
     const statusField = club['Club Distinguished Status']
     if (statusField !== null && statusField !== undefined) {
       const status = String(statusField).toLowerCase().trim()
+      if (
+        status === 'd' ||
+        status === 's' ||
+        status === 'p' ||
+        status === 'm'
+      ) {
+        return true
+      }
       if (
         status !== '' &&
         status !== 'none' &&

--- a/packages/analytics-core/src/timeseries/TimeSeriesDataPointBuilder.ts
+++ b/packages/analytics-core/src/timeseries/TimeSeriesDataPointBuilder.ts
@@ -16,7 +16,11 @@ import type {
   TimeSeriesDataPoint,
   ClubHealthCounts,
 } from '@toastmasters/shared-contracts'
-import { classifyClubHealth } from '../analytics/ClubEligibilityUtils.js'
+import {
+  classifyClubHealth,
+  getCSPStatusFromRecord,
+  isDistinguishedStatusCode,
+} from '../analytics/ClubEligibilityUtils.js'
 import { getCurrentProgramMonth } from '../analytics/AnalyticsUtils.js'
 
 /**
@@ -217,9 +221,9 @@ export class TimeSeriesDataPointBuilder {
       const { status } = classifyClubHealth(
         {
           membership,
-          membershipBase: memBase,
+          netGrowth: membership - memBase,
           dcpGoals,
-          cspSubmitted: this.parseCspSubmitted(club),
+          cspSubmitted: getCSPStatusFromRecord(club),
         },
         month
       )
@@ -239,36 +243,6 @@ export class TimeSeriesDataPointBuilder {
       vulnerable,
       interventionRequired,
     }
-  }
-
-  /**
-   * Parse CSP (Club Success Plan) submission status from a raw record.
-   *
-   * Historical compatibility: when the field is absent (pre-2025-2026
-   * CSVs), CSP is treated as submitted — it was not a requirement then.
-   *
-   * @param club - The club record
-   * @returns True unless the field is present and explicitly negative
-   */
-  parseCspSubmitted(club: ScrapedRecord): boolean {
-    const cspValue =
-      club['CSP'] ??
-      club['Club Success Plan'] ??
-      club['CSP Submitted'] ??
-      club['Club Success Plan Submitted']
-
-    if (cspValue === undefined || cspValue === null) {
-      return true
-    }
-
-    const cspString = String(cspValue).toLowerCase().trim()
-    return !(
-      cspString === 'no' ||
-      cspString === 'false' ||
-      cspString === '0' ||
-      cspString === 'not submitted' ||
-      cspString === 'n'
-    )
   }
 
   /**
@@ -312,7 +286,7 @@ export class TimeSeriesDataPointBuilder {
    */
   isDistinguished(club: ScrapedRecord): boolean {
     // Check CSP status first (absent field = submitted, historical data)
-    if (!this.parseCspSubmitted(club)) {
+    if (!getCSPStatusFromRecord(club)) {
       return false
     }
 
@@ -322,12 +296,7 @@ export class TimeSeriesDataPointBuilder {
     const statusField = club['Club Distinguished Status']
     if (statusField !== null && statusField !== undefined) {
       const status = String(statusField).toLowerCase().trim()
-      if (
-        status === 'd' ||
-        status === 's' ||
-        status === 'p' ||
-        status === 'm'
-      ) {
+      if (isDistinguishedStatusCode(status)) {
         return true
       }
       if (

--- a/packages/analytics-core/src/timeseries/TimeSeriesDataPointBuilder.ts
+++ b/packages/analytics-core/src/timeseries/TimeSeriesDataPointBuilder.ts
@@ -311,25 +311,9 @@ export class TimeSeriesDataPointBuilder {
    * @see Requirements 6.7
    */
   isDistinguished(club: ScrapedRecord): boolean {
-    // Check CSP status first
-    const cspValue =
-      club['CSP'] ??
-      club['Club Success Plan'] ??
-      club['CSP Submitted'] ??
-      club['Club Success Plan Submitted']
-
-    // Historical data compatibility: if field doesn't exist, assume submitted
-    if (cspValue !== undefined && cspValue !== null) {
-      const cspString = String(cspValue).toLowerCase().trim()
-      if (
-        cspString === 'no' ||
-        cspString === 'false' ||
-        cspString === '0' ||
-        cspString === 'not submitted' ||
-        cspString === 'n'
-      ) {
-        return false
-      }
+    // Check CSP status first (absent field = submitted, historical data)
+    if (!this.parseCspSubmitted(club)) {
+      return false
     }
 
     // Check Club Distinguished Status field

--- a/packages/analytics-core/src/timeseries/TimeSeriesDataPointBuilder.ts
+++ b/packages/analytics-core/src/timeseries/TimeSeriesDataPointBuilder.ts
@@ -16,6 +16,8 @@ import type {
   TimeSeriesDataPoint,
   ClubHealthCounts,
 } from '@toastmasters/shared-contracts'
+import { classifyClubHealth } from '../analytics/ClubEligibilityUtils.js'
+import { getCurrentProgramMonth } from '../analytics/AnalyticsUtils.js'
 
 /**
  * Scraped record type - represents raw CSV data with dynamic columns.
@@ -179,11 +181,12 @@ export class TimeSeriesDataPointBuilder {
   /**
    * Calculate club health counts from district statistics.
    *
-   * MIGRATED from RefreshService.calculateClubHealthCounts
-   *
-   * Classification rules from ClubHealthAnalyticsModule:
+   * Delegates per-club classification to the shared classifyClubHealth
+   * (#1120) so these counts cannot drift from the dashboard's
+   * ClubHealthAnalyticsModule.assessClubHealth:
    * - Intervention Required: membership < 12 AND net growth < 3
-   * - Thriving: (membership >= 20 OR net growth >= 3) AND dcpGoals > 0
+   * - Thriving: (membership >= 20 OR net growth >= 3) AND the §5.3
+   *   monthly DCP checkpoint is met AND CSP is submitted
    * - Vulnerable: All other clubs
    *
    * @param district - The district statistics
@@ -196,6 +199,7 @@ export class TimeSeriesDataPointBuilder {
   ): ClubHealthCounts {
     const clubs = district.clubPerformance ?? []
     const total = clubs.length
+    const month = getCurrentProgramMonth(district.asOfDate)
 
     let thriving = 0
     let vulnerable = 0
@@ -209,20 +213,23 @@ export class TimeSeriesDataPointBuilder {
       )
       const dcpGoals = this.parseIntSafe(club['Goals Met'])
       const memBase = this.parseIntSafe(club['Mem. Base'])
-      const netGrowth = membership - memBase
 
-      // Classification rules from ClubHealthAnalyticsModule
-      if (membership < 12 && netGrowth < 3) {
+      const { status } = classifyClubHealth(
+        {
+          membership,
+          membershipBase: memBase,
+          dcpGoals,
+          cspSubmitted: this.parseCspSubmitted(club),
+        },
+        month
+      )
+
+      if (status === 'intervention-required') {
         interventionRequired++
+      } else if (status === 'thriving') {
+        thriving++
       } else {
-        const membershipRequirementMet = membership >= 20 || netGrowth >= 3
-        const dcpCheckpointMet = dcpGoals > 0
-
-        if (membershipRequirementMet && dcpCheckpointMet) {
-          thriving++
-        } else {
-          vulnerable++
-        }
+        vulnerable++
       }
     }
 
@@ -232,6 +239,36 @@ export class TimeSeriesDataPointBuilder {
       vulnerable,
       interventionRequired,
     }
+  }
+
+  /**
+   * Parse CSP (Club Success Plan) submission status from a raw record.
+   *
+   * Historical compatibility: when the field is absent (pre-2025-2026
+   * CSVs), CSP is treated as submitted — it was not a requirement then.
+   *
+   * @param club - The club record
+   * @returns True unless the field is present and explicitly negative
+   */
+  parseCspSubmitted(club: ScrapedRecord): boolean {
+    const cspValue =
+      club['CSP'] ??
+      club['Club Success Plan'] ??
+      club['CSP Submitted'] ??
+      club['Club Success Plan Submitted']
+
+    if (cspValue === undefined || cspValue === null) {
+      return true
+    }
+
+    const cspString = String(cspValue).toLowerCase().trim()
+    return !(
+      cspString === 'no' ||
+      cspString === 'false' ||
+      cspString === '0' ||
+      cspString === 'not submitted' ||
+      cspString === 'n'
+    )
   }
 
   /**

--- a/packages/analytics-core/src/transformation/DataTransformer.test.ts
+++ b/packages/analytics-core/src/transformation/DataTransformer.test.ts
@@ -1343,6 +1343,63 @@ describe('DataTransformer', () => {
     })
 
     /**
+     * The transformed club model must carry the raw 'Club Distinguished
+     * Status' value (#1120). Live CSVs use letter codes ('D','S','P','M');
+     * extractClubStatus() only keeps word-form values, so without a
+     * dedicated field the letter codes were lost and downstream consumers
+     * (time-series distinguishedTotal) received the operational status.
+     */
+    it('should extract distinguishedStatus from Club Distinguished Status, including letter codes (#1120)', async () => {
+      const csvData: RawCSVData = {
+        clubPerformance: [
+          [
+            'Club Number',
+            'Club Name',
+            'Division',
+            'Area',
+            'Club Status',
+            'Club Distinguished Status',
+          ],
+          ['1234', 'Letter Code Club', 'A', '1', 'Active', 'D'],
+          ['5678', 'Word Form Club', 'A', '2', 'Active', 'Distinguished'],
+          ['9012', 'Not Yet Club', 'B', '1', 'Low', ''],
+        ],
+        divisionPerformance: [],
+        districtPerformance: [],
+      }
+
+      const result = await transformer.transformRawCSV(
+        '2026-06-08',
+        'D61',
+        csvData
+      )
+
+      expect(result.clubs[0]?.distinguishedStatus).toBe('D')
+      expect(result.clubs[1]?.distinguishedStatus).toBe('Distinguished')
+      // Empty / absent column → undefined (heuristic fallback downstream)
+      expect(result.clubs[2]?.distinguishedStatus).toBeUndefined()
+    })
+
+    it('should leave distinguishedStatus undefined when the column is absent', async () => {
+      const csvData: RawCSVData = {
+        clubPerformance: [
+          ['Club Number', 'Club Name', 'Division', 'Area'],
+          ['1234', 'Historical Club', 'A', '1'],
+        ],
+        divisionPerformance: [],
+        districtPerformance: [],
+      }
+
+      const result = await transformer.transformRawCSV(
+        '2020-01-15',
+        'D101',
+        csvData
+      )
+
+      expect(result.clubs[0]?.distinguishedStatus).toBeUndefined()
+    })
+
+    /**
      * Test empty CSV arrays produce empty arrays in output
      * Validates: Requirements 1.5
      */

--- a/packages/analytics-core/src/transformation/DataTransformer.ts
+++ b/packages/analytics-core/src/transformation/DataTransformer.ts
@@ -262,6 +262,10 @@ export class DataTransformer implements IDataTransformer {
       // falling back to clubPerformance record
       const paymentSource = dpRecord ?? record
 
+      // Raw distinguished status (#1120) — extracted once, shared by the
+      // legacy mixed `status` field and the dedicated field below
+      const distinguishedStatus = this.extractDistinguishedStatus(record)
+
       const club: ClubStatistics = {
         clubId,
         clubName,
@@ -285,7 +289,7 @@ export class DataTransformer implements IDataTransformer {
         dcpGoalsAchieved: hasDcpGoalColumns(record)
           ? computeDcpGoalsAchieved(record)
           : undefined,
-        status: this.extractClubStatus(record),
+        status: this.extractClubStatus(record, distinguishedStatus),
         // Payment breakdown fields - sourced from districtPerformance when available
         octoberRenewals: this.extractNumber(
           paymentSource,
@@ -326,16 +330,9 @@ export class DataTransformer implements IDataTransformer {
         club.clubStatus = clubStatus
       }
 
-      // Extract the raw distinguished status (#1120). Live CSVs carry
+      // Keep the verbatim distinguished status (#1120). Live CSVs carry
       // letter codes ('D','S','P','M') that extractClubStatus() discards;
-      // keep the verbatim value so downstream consumers (time-series
-      // distinguishedTotal) can count it.
-      const distinguishedStatus = this.extractString(
-        record,
-        'Club Distinguished Status',
-        'Distinguished Status',
-        'Distinguished'
-      )
+      // downstream consumers (time-series distinguishedTotal) need it.
       if (distinguishedStatus) {
         club.distinguishedStatus = distinguishedStatus
       }
@@ -641,24 +638,37 @@ export class DataTransformer implements IDataTransformer {
    * @param record - The parsed record
    * @returns Club status string
    */
-  private extractClubStatus(record: ParsedRecord): string {
-    // Check for distinguished status first
-    const distinguished = this.extractString(
-      record,
-      'Club Distinguished Status',
-      'Distinguished Status',
-      'Distinguished'
-    )
+  private extractClubStatus(
+    record: ParsedRecord,
+    distinguishedStatus: string | undefined
+  ): string {
+    // Word-form distinguished status wins (legacy behavior; letter codes
+    // intentionally fall through — they live in club.distinguishedStatus)
     if (
-      distinguished &&
-      distinguished.toLowerCase().includes('distinguished')
+      distinguishedStatus &&
+      distinguishedStatus.toLowerCase().includes('distinguished')
     ) {
-      return distinguished
+      return distinguishedStatus
     }
 
     // Fall back to general status
     const status = this.extractString(record, 'Club Status', 'Status')
     return status ?? 'Active'
+  }
+
+  /**
+   * Extracts the raw 'Club Distinguished Status' value from a record.
+   *
+   * @param record - The parsed record
+   * @returns The verbatim status value, or undefined when absent/empty
+   */
+  private extractDistinguishedStatus(record: ParsedRecord): string | undefined {
+    return this.extractString(
+      record,
+      'Club Distinguished Status',
+      'Distinguished Status',
+      'Distinguished'
+    )
   }
 
   /**

--- a/packages/analytics-core/src/transformation/DataTransformer.ts
+++ b/packages/analytics-core/src/transformation/DataTransformer.ts
@@ -326,6 +326,20 @@ export class DataTransformer implements IDataTransformer {
         club.clubStatus = clubStatus
       }
 
+      // Extract the raw distinguished status (#1120). Live CSVs carry
+      // letter codes ('D','S','P','M') that extractClubStatus() discards;
+      // keep the verbatim value so downstream consumers (time-series
+      // distinguishedTotal) can count it.
+      const distinguishedStatus = this.extractString(
+        record,
+        'Club Distinguished Status',
+        'Distinguished Status',
+        'Distinguished'
+      )
+      if (distinguishedStatus) {
+        club.distinguishedStatus = distinguishedStatus
+      }
+
       // Extract CSP (Club Success Plan) submission status
       // Present from 2025-2026 program year onward; undefined for earlier CSVs
       const cspValue = this.extractString(record, 'CSP', 'Club Success Plan')

--- a/packages/collector-cli/src/__tests__/AnalyticsComputeService.test.ts
+++ b/packages/collector-cli/src/__tests__/AnalyticsComputeService.test.ts
@@ -20,6 +20,7 @@ import * as os from 'node:os'
 import { AnalyticsComputeService } from '../services/AnalyticsComputeService.js'
 import {
   ANALYTICS_SCHEMA_VERSION,
+  ClubHealthAnalyticsModule,
   type DistrictStatistics,
   type PreComputedAnalyticsFile,
   type DistrictAnalytics,
@@ -2432,6 +2433,153 @@ describe('Time-series generation integration (Requirements 4.1, 9.1, 9.2, 9.4)',
     expect(typeof dataPoint?.clubCounts.thriving).toBe('number')
     expect(typeof dataPoint?.clubCounts.vulnerable).toBe('number')
     expect(typeof dataPoint?.clubCounts.interventionRequired).toBe('number')
+  })
+
+  it('classifies club health per ClubHealthAnalyticsModule and counts letter-code distinguished status (#1120)', async () => {
+    // Verdict-layer test (through the real compute() → conversion → builder
+    // path) for the two C3 audit defects:
+    // 1. club health used `dcpGoals > 0` instead of the §5.3 monthly
+    //    checkpoint + CSP (June requires 5 goals)
+    // 2. the conversion mapped the operational clubStatus into
+    //    'Club Distinguished Status', so live letter codes were lost
+    const date = '2026-06-15' // June → DCP checkpoint 5
+    const districtId = '61'
+
+    const makeClub = (
+      overrides: Partial<DistrictStatistics['clubs'][number]> & {
+        clubId: string
+        clubName: string
+      }
+    ): DistrictStatistics['clubs'][number] => ({
+      divisionId: 'A',
+      areaId: 'A1',
+      divisionName: 'Division A',
+      areaName: 'Area A1',
+      membershipCount: 25,
+      paymentsCount: 0,
+      dcpGoals: 0,
+      status: 'Active',
+      octoberRenewals: 0,
+      aprilRenewals: 0,
+      newMembers: 0,
+      membershipBase: 20,
+      clubStatus: 'Active',
+      ...overrides,
+    })
+
+    const clubs = [
+      // thriving + distinguished (heuristic and letter code agree)
+      makeClub({
+        clubId: '1001',
+        clubName: 'Thriving Select',
+        dcpGoals: 7,
+        cspSubmitted: true,
+        distinguishedStatus: 'S',
+      }),
+      // 3 goals in June → vulnerable (legacy dcpGoals>0 said thriving)
+      makeClub({
+        clubId: '1002',
+        clubName: 'June Three Goals',
+        dcpGoals: 3,
+        cspSubmitted: true,
+      }),
+      // distinguished ONLY via the live letter code — fails the heuristic
+      makeClub({
+        clubId: '1003',
+        clubName: 'Code Only Distinguished',
+        membershipCount: 15,
+        membershipBase: 15,
+        dcpGoals: 2,
+        cspSubmitted: true,
+        distinguishedStatus: 'D',
+      }),
+      // intervention required: 8 members, base 10
+      makeClub({
+        clubId: '1004',
+        clubName: 'Critical Club',
+        membershipCount: 8,
+        membershipBase: 10,
+        dcpGoals: 2,
+        cspSubmitted: true,
+        clubStatus: 'Low',
+      }),
+      // all metrics met but CSP not submitted → vulnerable, not distinguished
+      makeClub({
+        clubId: '1005',
+        clubName: 'No CSP Club',
+        dcpGoals: 9,
+        cspSubmitted: false,
+      }),
+    ]
+
+    const stats: DistrictStatistics = {
+      districtId,
+      snapshotDate: date,
+      clubs,
+      divisions: [],
+      areas: [],
+      totals: {
+        totalClubs: clubs.length,
+        totalMembership: 98,
+        totalPayments: 0,
+        distinguishedClubs: 0,
+        selectDistinguishedClubs: 0,
+        presidentDistinguishedClubs: 0,
+      },
+      divisionPerformance: [],
+      clubPerformance: [],
+      districtPerformance: [],
+    }
+
+    await writeDistrictSnapshot(testCache.path, date, districtId, stats)
+    const result = await analyticsComputeService.computeDistrictAnalytics(
+      date,
+      districtId
+    )
+    expect(result.timeSeriesWritten).toBe(true)
+
+    const indexPath = path.join(
+      testCache.path,
+      'time-series',
+      `district_${districtId}`,
+      '2025-2026.json'
+    )
+    const indexFile = JSON.parse(await fs.readFile(indexPath, 'utf-8')) as {
+      dataPoints: Array<{
+        distinguishedTotal: number
+        clubCounts: {
+          total: number
+          thriving: number
+          vulnerable: number
+          interventionRequired: number
+        }
+      }>
+    }
+    const dataPoint = indexFile.dataPoints[0]
+
+    // §5.3 June classification: 1001 thriving; 1002 (checkpoint), 1003
+    // (membership), 1005 (CSP) vulnerable; 1004 intervention
+    expect(dataPoint?.clubCounts).toEqual({
+      total: 5,
+      thriving: 1,
+      vulnerable: 3,
+      interventionRequired: 1,
+    })
+
+    // 1001 (code 'S' + heuristic) and 1003 (code 'D' only); 1005 blocked by CSP
+    expect(dataPoint?.distinguishedTotal).toBe(2)
+
+    // Parity: the time-series counts must equal the dashboard's
+    // ClubHealthAnalyticsModule classification for the same snapshot
+    const module = new ClubHealthAnalyticsModule()
+    const healthData = module.generateClubHealthData([stats])
+    expect(dataPoint?.clubCounts.thriving).toBe(healthData.thrivingClubs.length)
+    expect(dataPoint?.clubCounts.vulnerable).toBe(
+      healthData.vulnerableClubs.length
+    )
+    expect(dataPoint?.clubCounts.interventionRequired).toBe(
+      healthData.interventionRequiredClubs.length
+    )
   })
 
   it('should use same snapshot data as other analytics (Requirement 9.2)', async () => {

--- a/packages/collector-cli/src/services/AnalyticsComputeService.ts
+++ b/packages/collector-cli/src/services/AnalyticsComputeService.ts
@@ -346,8 +346,11 @@ export class AnalyticsComputeService {
       ClubID: club.clubId,
       'Club Name': club.clubName,
 
-      // Status fields - map clubStatus to distinguished status if available
-      'Club Distinguished Status': club.clubStatus ?? '',
+      // Status fields. clubStatus is the OPERATIONAL status (Active,
+      // Suspended, …) — mapping it into 'Club Distinguished Status' was
+      // the #1120 corruption; pass the true distinguished value through.
+      'Club Status': club.clubStatus ?? '',
+      'Club Distinguished Status': club.distinguishedStatus ?? '',
 
       // CSP field - normalized via getCSPStatus (pre-2025 defaults to true)
       CSP: getCSPStatus(club) ? 'Yes' : 'No',

--- a/packages/collector-cli/src/services/AnalyticsComputeService.ts
+++ b/packages/collector-cli/src/services/AnalyticsComputeService.ts
@@ -346,10 +346,9 @@ export class AnalyticsComputeService {
       ClubID: club.clubId,
       'Club Name': club.clubName,
 
-      // Status fields. clubStatus is the OPERATIONAL status (Active,
+      // Status field. clubStatus is the OPERATIONAL status (Active,
       // Suspended, …) — mapping it into 'Club Distinguished Status' was
       // the #1120 corruption; pass the true distinguished value through.
-      'Club Status': club.clubStatus ?? '',
       'Club Distinguished Status': club.distinguishedStatus ?? '',
 
       // CSP field - normalized via getCSPStatus (pre-2025 defaults to true)

--- a/packages/shared-contracts/src/schemas/district-statistics-file.schema.ts
+++ b/packages/shared-contracts/src/schemas/district-statistics-file.schema.ts
@@ -80,6 +80,9 @@ export const ClubStatisticsFileSchema = z.object({
   /** Club operational status (Active, Suspended, Low, Ineligible) */
   clubStatus: z.string().optional(),
 
+  /** Raw 'Club Distinguished Status' CSV value — letter codes or word forms (#1120) */
+  distinguishedStatus: z.string().optional(),
+
   /** CSP (Club Success Plan) submission status (2025-2026+) */
   cspSubmitted: z.boolean().optional(),
 

--- a/packages/shared-contracts/src/types/district-statistics-file.ts
+++ b/packages/shared-contracts/src/types/district-statistics-file.ts
@@ -181,6 +181,13 @@ export interface ClubStatisticsFile {
   clubStatus?: string
 
   /**
+   * Raw 'Club Distinguished Status' value from the dashboard CSV (#1120).
+   * Live data uses letter codes ('D' | 'S' | 'P' | 'M'); historical data
+   * may use word forms. Absent when the club has no status yet.
+   */
+  distinguishedStatus?: string
+
+  /**
    * CSP (Club Success Plan) submission status
    * Present from 2025-2026 program year onward; undefined for earlier years
    */

--- a/tasks/lessons/156-a-rekeyed-conversion-field-must-match-the-target-keys-domain-not-just-its-shape.md
+++ b/tasks/lessons/156-a-rekeyed-conversion-field-must-match-the-target-keys-domain-not-just-its-shape.md
@@ -1,0 +1,71 @@
+---
+id: '156'
+category: lesson
+tags: [data-pipeline, analytics, monorepo, transformation, verification]
+auto_load: true
+date: 2026-06-10
+issues: [1120, 1095]
+---
+
+# Lesson 156 — A re-keyed conversion field must match the target key's DOMAIN, not just its shape
+
+**Date:** 2026-06-10
+**Issue:** #1120 (epic #1095 Sprint 3 — time-series club health + status corruption)
+**PR:** _(record on merge)_
+
+## What happened
+
+`AnalyticsComputeService.convertToDistrictStatisticsInput` rebuilds raw
+CSV-shaped records from the transformed `ClubStatistics` model so
+`TimeSeriesDataPointBuilder` can consume them. One mapping read:
+
+```ts
+'Club Distinguished Status': club.clubStatus ?? '',
+```
+
+`clubStatus` is the **operational** status (Active / Suspended / Low /
+Ineligible) — a string, so the mapping type-checked and "worked". But the
+target key's domain is the distinguished tier (`'' | D | S | P | M`). Every
+downstream read of that key got the wrong universe of values: the
+letter-code branch of `isDistinguished` was permanently dead and the
+heuristic fallback silently decided every club's distinguished flag.
+
+The root enabler: the transformed model **had no field** carrying the true
+value. `extractClubStatus()` folds the distinguished column into a mixed
+legacy `status` field but only keeps word-form values
+(`.includes('distinguished')`), so live letter codes were dropped at
+transform time. The conversion author reached for the nearest
+similarly-named field — `clubStatus` — because the faithful one didn't
+exist.
+
+## The transferable principle
+
+**When a conversion writes a value under a domain-bearing key (a CSV
+header, an API field, a schema property), verify the SOURCE field's value
+domain matches the TARGET key's contract — name-similarity and
+type-compatibility are exactly what make the wrong mapping look right.**
+And when the faithful source doesn't exist on the intermediate model, the
+fix is to add the verbatim field to the model (transform → interface →
+schema → conversion), not to approximate from the nearest lookalike. A
+lossy intermediate model turns every downstream consumer into a guesser.
+
+## How to apply
+
+- Audit re-keying conversions (model → raw-shape, DTO → DTO) by listing
+  each target key's expected value set next to the source field's actual
+  value set; any `?? ''` or `?? default` on a semantically different field
+  is corruption, not back-compat.
+- When a needed field is "missing" from an intermediate model, check
+  whether the transform layer DROPS it (here: `extractClubStatus`'s
+  word-form filter) before synthesizing it from a sibling (R7 spirit).
+- Carry verbatim source values on the model (`distinguishedStatus`)
+  separately from interpreted ones (`status`, `clubStatus`); interpretation
+  belongs at the consumer, where the rule lives.
+
+## Related
+
+- [[115-a-fields-name-and-comment-can-lie-about-whether-its-populated]] —
+  sibling failure: the name promises a domain the value doesn't deliver.
+- [[061-when-fixing-a-formula-audit-every-implementation]] — the same
+  epic's classification fix: one shared rule (`classifyClubHealth`) instead
+  of three drifting copies.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -140,4 +140,5 @@
 - **154** [data-pipeline, analytics, collector-cli, privacy, tdd] — A pre-filtered report's MEMBERSHIP SET can itself be the datum; derive from presence, not a column (#1065, #1062)
 - **154** [data-pipeline, ci, automation, tdd, verification, fixtures] — Synthetic fixtures validate the code; only a captured real pair validates the policy (#1092, #1086, #1083)
 - **155** [ci, automation, data-pipeline, monitoring, gcs] — A recency-based freshness monitor is blind to a held-promotion "content-stale" state; freshness has two orthogonal axes (#1073, #1072)
+- **156** [data-pipeline, analytics, monorepo, transformation, verification] — A re-keyed conversion field must match the target key's DOMAIN, not just its shape (#1120, #1095)
 - **156** [analytics, dcp, refactor, monorepo, verification] — An audit's defect list for a forked implementation is a lower bound; consolidation must re-derive the full semantic diff (#1118, #1095)


### PR DESCRIPTION
## Summary

Sprint 3 of epic #1095 (sub-issue #1120, audit defect C3): time-series club-health counts now match the dashboard's CSP-aware §5.3 monthly-checkpoint classification, and the snapshot→time-series conversion no longer corrupts the distinguished status field.

### What changed

1. **Shared single-source classifier** — new `classifyClubHealth()` in `ClubEligibilityUtils.ts` (membership requirement + §5.3 monthly DCP checkpoint + CSP + intervention override). Both `ClubHealthAnalyticsModule.assessClubHealth` and `TimeSeriesDataPointBuilder.calculateClubHealthCounts` delegate to it, so the dashboard and trends counts structurally cannot drift. The builder previously used `dcpGoals > 0` with no CSP and no monthly table (live D61 2026-06-08: 78 thriving in trends vs 57 on the dashboard).
2. **Status-field corruption fixed at the source** — `convertToDistrictStatisticsInput` mapped the *operational* `clubStatus` ("Active") into `'Club Distinguished Status'`. The transformed model now carries a verbatim `distinguishedStatus` field (DataTransformer → `ClubStatistics` → shared-contracts type+schema), and the conversion passes it through.
3. **Letter codes counted** — live CSVs carry `'D' | 'S' | 'P' | 'M'`; `isDistinguished` only matched word forms. New shared `isDistinguishedStatusCode()` + `getCSPStatusFromRecord()` helpers in `ClubEligibilityUtils.ts`.

### Out of scope (later sprints)

- `countThrivingClubs`/`countVulnerableClubs` CSP hardcode → Sprint 4 (#1121)
- Oct/Dec checkpoint doc-vs-code ruling → Sprint 5 (#1122)

## TDD evidence

- Red commits f8e07c89, ffda1dab — failing tests first (June 3-goal disagreement fixture, CSP-less club, letter codes, verdict-layer integration through real `compute()`).
- Parity AC: `AnalyticsComputeService.test.ts` asserts builder counts equal `ClubHealthAnalyticsModule.generateClubHealthData` on the same snapshot through the **real** conversion path.
- Updating the old `dcpGoals > 0` reference tests is the audit-mandated spec change, not assertion pinning.

## Verification

- Full workspace suite green: frontend 3393, collector-cli 885, analytics-core 840, shared-contracts 153, mcp-server 50. `npm run quality:check` exit 0.
- Back-compat: old persisted snapshots lack `distinguishedStatus` → conversion emits `''` → heuristic fallback (identical to prior effective behavior, since the operational value never matched the word check).
- Data-sprint convention (#1120 AC note): rebuilt historical time-series points only change after a pipeline rebuild — code-proof + preview verification accepted.

## Fresh-context review

Verdict: APPROVE-WITH-NITS (no High findings). Medium (addressed): documented the new `@throws` on `calculateClubHealthCounts` for malformed `asOfDate` (fail-loud parity with the dashboard module). Low findings (noted, not actioned): test reference impls import production month/checkpoint helpers (mitigated by direct `classifyClubHealth` unit pins); hypothetical single-letter operational values in the distinguished column would false-positive (no evidence in real data; the four real operational words are tested negative).

Refs #1120 (epic #1095)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
