### PR TITLE
Sprint 4 (#1095) — CSP-aware thriving counts + distinguished projection (#1121)

### DIFF
--- a/packages/analytics-core/src/analytics/AnalyticsComputer.test.ts
+++ b/packages/analytics-core/src/analytics/AnalyticsComputer.test.ts
@@ -113,6 +113,30 @@ describe('AnalyticsComputer', () => {
       expect(result.districtAnalytics.allClubs).toHaveLength(3)
     })
 
+    it('excludes CSP-less clubs from the distinguished projection (#1121)', async () => {
+      // Live-shaped fixture (D61 2026-06): 58 clubs meet membership +
+      // June checkpoint, but one (Dorval City 00005600) has no CSP —
+      // ineligible per rules-reference §3.3, so the projection is 57.
+      const computer = new AnalyticsComputer()
+      const clubs = Array.from({ length: 58 }, (_, i) =>
+        createMockClub({
+          clubId: i === 0 ? '00005600' : `${1000 + i}`,
+          clubName: i === 0 ? 'Dorval City' : `Club ${i}`,
+          membershipCount: 25,
+          membershipBase: 20,
+          dcpGoals: 5,
+          cspSubmitted: i !== 0,
+        })
+      )
+      const snapshot = createMockSnapshot('D61', '2026-06-08', clubs)
+
+      const result = await computer.computeDistrictAnalytics('D61', [snapshot])
+
+      expect(
+        result.districtAnalytics.distinguishedProjection?.projectedDistinguished
+      ).toBe(57)
+    })
+
     it('should compute membership change from multiple snapshots', async () => {
       const computer = new AnalyticsComputer()
 

--- a/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.test.ts
+++ b/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.test.ts
@@ -1696,4 +1696,67 @@ describe('ClubHealthAnalyticsModule', () => {
       expect(interventionClub?.clubStatus).toBe(allSuspendedClub?.clubStatus)
     })
   })
+
+  describe('CSP-aware counting methods (#1121)', () => {
+    const module = new ClubHealthAnalyticsModule()
+
+    // June snapshot → DCP checkpoint is 5 goals. The base mock club
+    // (25 members, base 20, 5 goals) meets membership + checkpoint.
+    const JUNE_DATE = '2026-06-08'
+
+    it('countThrivingClubs does NOT count a club meeting membership + checkpoint but with CSP not submitted', () => {
+      const clubs = [
+        createMockClub({ clubId: 'csp-yes', cspSubmitted: true }),
+        createMockClub({ clubId: 'csp-no', cspSubmitted: false }),
+      ]
+      const snapshot = createMockSnapshot(JUNE_DATE, clubs)
+
+      expect(module.countThrivingClubs(snapshot)).toBe(1)
+    })
+
+    it('countVulnerableClubs counts a CSP-less club as vulnerable, matching assessClubHealth', () => {
+      const clubs = [
+        createMockClub({ clubId: 'csp-yes', cspSubmitted: true }),
+        createMockClub({ clubId: 'csp-no', cspSubmitted: false }),
+      ]
+      const snapshot = createMockSnapshot(JUNE_DATE, clubs)
+
+      expect(module.countVulnerableClubs(snapshot)).toBe(1)
+    })
+
+    it('counting methods agree with generateClubHealthData categorization for mixed CSP states', () => {
+      const clubs = [
+        createMockClub({ clubId: 'csp-yes', cspSubmitted: true }),
+        createMockClub({ clubId: 'csp-no', cspSubmitted: false }),
+        // Intervention-required regardless of CSP
+        createMockClub({
+          clubId: 'small',
+          membershipCount: 8,
+          membershipBase: 10,
+          cspSubmitted: false,
+        }),
+      ]
+      const snapshot = createMockSnapshot(JUNE_DATE, clubs)
+      const healthData = module.generateClubHealthData([snapshot])
+
+      expect(module.countThrivingClubs(snapshot)).toBe(
+        healthData.thrivingClubs.length
+      )
+      expect(module.countVulnerableClubs(snapshot)).toBe(
+        healthData.vulnerableClubs.length
+      )
+      expect(module.countInterventionRequiredClubs(snapshot)).toBe(
+        healthData.interventionRequiredClubs.length
+      )
+    })
+
+    it('treats pre-2025-26 historical data (cspSubmitted undefined) as submitted per §3.3', () => {
+      const club = createMockClub({ clubId: 'historical' })
+      delete (club as Record<string, unknown>)['cspSubmitted']
+      const snapshot = createMockSnapshot(JUNE_DATE, [club])
+
+      expect(module.countThrivingClubs(snapshot)).toBe(1)
+      expect(module.countVulnerableClubs(snapshot)).toBe(0)
+    })
+  })
 })

--- a/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
@@ -19,11 +19,7 @@
 
 import type { DistrictStatistics, ClubStatistics } from '../interfaces.js'
 import type { ClubTrend, ClubHealthData } from '../types.js'
-import {
-  getDCPCheckpoint,
-  getCurrentProgramMonth,
-  getMonthName,
-} from './AnalyticsUtils.js'
+import { getCurrentProgramMonth, getMonthName } from './AnalyticsUtils.js'
 import {
   calculateNetGrowth,
   classifyClubHealth,
@@ -407,103 +403,71 @@ export class ClubHealthAnalyticsModule {
    * Count vulnerable clubs in a snapshot
    *
    * Requirement 3.2: Vulnerable if some but not all requirements met
-   * Uses new classification logic based on monthly DCP checkpoints
-   *
-   * This method MUST use the same logic as assessClubHealth() to ensure consistency.
+   * (membership, monthly DCP checkpoint, CSP). Delegates to the same
+   * shared classification rule as assessClubHealth().
    *
    * @param snapshot - District statistics snapshot
    * @returns Count of vulnerable clubs
    */
   countVulnerableClubs(snapshot: DistrictStatistics): number {
-    // Get current program month from snapshot date for DCP checkpoint evaluation
-    const currentMonth = getCurrentProgramMonth(snapshot.snapshotDate)
-    const requiredDcpCheckpoint = getDCPCheckpoint(currentMonth)
-
-    return snapshot.clubs.filter(club => {
-      const membership = club.membershipCount
-      const dcpGoals = club.dcpGoals
-      const netGrowth = calculateNetGrowth(club)
-
-      // Intervention override: membership < 12 AND net growth < 3 is NOT vulnerable
-      if (membership < 12 && netGrowth < 3) {
-        return false
-      }
-
-      // Membership requirement: >= 20 OR net growth >= 3
-      const membershipRequirementMet = membership >= 20 || netGrowth >= 3
-
-      // DCP checkpoint requirement (varies by month) - MUST match assessClubHealth logic
-      const dcpCheckpointMet = dcpGoals >= requiredDcpCheckpoint
-
-      // CSP requirement — same normalized status assessClubHealth uses
-      // (pre-2025-26 historical data defaults to submitted, §3.3)
-      const cspSubmitted = getCSPStatus(club)
-
-      // Vulnerable: some but not all requirements met
-      const allRequirementsMet =
-        membershipRequirementMet && dcpCheckpointMet && cspSubmitted
-      return !allRequirementsMet
-    }).length
+    return this.countClubsWithStatus(snapshot, 'vulnerable')
   }
 
   /**
    * Count intervention-required clubs
    *
-   * Requirement 3.2: Intervention Required if membership < 12 AND net growth < 3
-   * Uses new classification logic based on intervention override rule
+   * Requirement 3.2: Intervention Required if membership < 12 AND net
+   * growth < 3. Delegates to the same shared classification rule as
+   * assessClubHealth().
    *
    * @param snapshot - District statistics snapshot
    * @returns Count of intervention-required clubs
    */
   countInterventionRequiredClubs(snapshot: DistrictStatistics): number {
-    return snapshot.clubs.filter(club => {
-      const membership = club.membershipCount
-      const netGrowth = calculateNetGrowth(club)
-
-      // Intervention required: membership < 12 AND net growth < 3
-      return membership < 12 && netGrowth < 3
-    }).length
+    return this.countClubsWithStatus(snapshot, 'intervention-required')
   }
 
   /**
    * Count thriving clubs in a snapshot
    *
-   * Requirement 3.2: Thriving if all requirements met (membership, DCP checkpoint, CSP)
-   * Uses new classification logic based on monthly DCP checkpoints
-   *
-   * This method MUST use the same logic as assessClubHealth() to ensure consistency
-   * between the thriving count used for projections and the actual club health status.
+   * Requirement 3.2: Thriving if all requirements met (membership,
+   * monthly DCP checkpoint, CSP). Delegates to the same shared
+   * classification rule as assessClubHealth(), so the thriving count
+   * used for the distinguished projection matches club health status.
    *
    * @param snapshot - District statistics snapshot
    * @returns Count of thriving clubs
    */
   countThrivingClubs(snapshot: DistrictStatistics): number {
-    // Get current program month from snapshot date for DCP checkpoint evaluation
+    return this.countClubsWithStatus(snapshot, 'thriving')
+  }
+
+  /**
+   * Count clubs classified into a given health status by the shared
+   * single-source rule (#1120), so the counting methods cannot drift
+   * from assessClubHealth(). CSP-aware (#1121): the classification
+   * reads each club's real normalized CSP status; getCSPStatus()
+   * defaults pre-2025-26 historical data (field absent) to submitted
+   * per rules-reference §3.3.
+   */
+  private countClubsWithStatus(
+    snapshot: DistrictStatistics,
+    status: 'thriving' | 'vulnerable' | 'intervention-required'
+  ): number {
     const currentMonth = getCurrentProgramMonth(snapshot.snapshotDate)
-    const requiredDcpCheckpoint = getDCPCheckpoint(currentMonth)
 
-    return snapshot.clubs.filter(club => {
-      const membership = club.membershipCount
-      const dcpGoals = club.dcpGoals
-      const netGrowth = calculateNetGrowth(club)
-
-      // Intervention override: membership < 12 AND net growth < 3 is NOT thriving
-      if (membership < 12 && netGrowth < 3) {
-        return false
-      }
-
-      // Membership requirement: >= 20 OR net growth >= 3
-      const membershipRequirementMet = membership >= 20 || netGrowth >= 3
-
-      // DCP checkpoint requirement (varies by month) - MUST match assessClubHealth logic
-      const dcpCheckpointMet = dcpGoals >= requiredDcpCheckpoint
-
-      // CSP requirement — same normalized status assessClubHealth uses
-      // (pre-2025-26 historical data defaults to submitted, §3.3)
-      const cspSubmitted = getCSPStatus(club)
-
-      return membershipRequirementMet && dcpCheckpointMet && cspSubmitted
-    }).length
+    return snapshot.clubs.filter(
+      club =>
+        classifyClubHealth(
+          {
+            membership: club.membershipCount,
+            netGrowth: calculateNetGrowth(club),
+            dcpGoals: club.dcpGoals,
+            cspSubmitted: getCSPStatus(club),
+          },
+          currentMonth
+        ).status === status
+    ).length
   }
 
   // NOTE: calculateNetGrowth, getCSPStatus, and determineDistinguishedLevel

--- a/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/ClubHealthAnalyticsModule.ts
@@ -435,8 +435,9 @@ export class ClubHealthAnalyticsModule {
       // DCP checkpoint requirement (varies by month) - MUST match assessClubHealth logic
       const dcpCheckpointMet = dcpGoals >= requiredDcpCheckpoint
 
-      // CSP: for counting methods, assume submitted (actual CSP check is in assessClubHealth)
-      const cspSubmitted = true
+      // CSP requirement — same normalized status assessClubHealth uses
+      // (pre-2025-26 historical data defaults to submitted, §3.3)
+      const cspSubmitted = getCSPStatus(club)
 
       // Vulnerable: some but not all requirements met
       const allRequirementsMet =
@@ -497,8 +498,9 @@ export class ClubHealthAnalyticsModule {
       // DCP checkpoint requirement (varies by month) - MUST match assessClubHealth logic
       const dcpCheckpointMet = dcpGoals >= requiredDcpCheckpoint
 
-      // CSP: for counting methods, assume submitted (actual CSP check is in assessClubHealth)
-      const cspSubmitted = true
+      // CSP requirement — same normalized status assessClubHealth uses
+      // (pre-2025-26 historical data defaults to submitted, §3.3)
+      const cspSubmitted = getCSPStatus(club)
 
       return membershipRequirementMet && dcpCheckpointMet && cspSubmitted
     }).length


### PR DESCRIPTION
Sprint 4 of epic #1095 (audit defect H2). Sub-issue: #1121.

## Problem
`countThrivingClubs`/`countVulnerableClubs` hardcoded `cspSubmitted = true` despite their own comments requiring parity with `assessClubHealth()`. Since `projectedDistinguished` IS the thriving count, the projection included CSP-less clubs — live D61 showed 58 including Dorval City (00005600, no CSP, ineligible per rules-reference §3.3); the CSP-aware count is 57.

## Fix
- Counting methods read each club's real normalized CSP status via `getCSPStatus()` (red → green commits).
- Refactor: all three counting methods now delegate to the shared `classifyClubHealth()` rule (#1120) through one private `countClubsWithStatus()` — the "MUST match assessClubHealth" comments are now structural, not aspirational (Lessons 76/103). Net −36 lines.
- Historical pre-2025-26 data unaffected: `getCSPStatus()` defaults an absent field to submitted (§3.3) — pinned by test.

## Acceptance criteria
- ✅ Failing test first: club meeting membership+checkpoint but CSP=false is NOT counted thriving (red commit 6813761c, 4 tests failed for the right reason)
- ✅ `generateDistinguishedProjection` excludes CSP-less clubs: 58→57 on a live-shaped D61 fixture, asserted through `AnalyticsComputer.computeDistrictAnalytics` (the path the pipeline calls)
- ✅ Historical pre-2025-26 data unaffected (undefined → submitted, pinned)

## Verification
- analytics-core: 845/845. Full workspace suite: 5,326 tests green, zero regressions.
- Fresh-context review: APPROVE-WITH-NITS, no High findings. Verified output-equivalence of the delegation for all non-CSP input classes (Lesson 117), bit-identical intervention predicate, and a Lesson-61 sweep finding no other hardcoded `cspSubmitted` copies.
- Medium finding (pre-existing, out of scope): frontend `dcpProjections.ts`/`provisionalDistinguished.ts` are CSP-blind mirrors of `determineDistinguishedLevel` — filed as #1139.
- Low nits (noted, not changed): the historical test's `delete cspSubmitted` is a defensive no-op since the mock never sets the field; shared `module` at describe scope (stateless, safe).

Refs #1121 (epic #1095)

🤖 Generated with [Claude Code](https://claude.com/claude-code)