### PR TITLE
Sprint 3 (#1096) — publish-time Zod gate + live-CDN schema canary (#1125)

### DIFF
--- a/.github/workflows/cdn-schema-canary.yml
+++ b/.github/workflows/cdn-schema-canary.yml
@@ -104,7 +104,14 @@ jobs:
           fi
 
       - name: Close resolved canary alerts
-        if: steps.canary.outputs.unhealthy != 'true'
+        # Self-clear ONLY when this run checked the same signal the alert is
+        # about: the default (production) surface with no district cap. A
+        # healthy dispatch run against staging or a capped subset must not
+        # close a live prod alert (Lesson 155).
+        if: >-
+          steps.canary.outputs.unhealthy != 'true' &&
+          (inputs.base_url == null || inputs.base_url == '') &&
+          (inputs.max_districts == null || inputs.max_districts == '')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/cdn-schema-canary.yml
+++ b/.github/workflows/cdn-schema-canary.yml
@@ -1,0 +1,128 @@
+# CDN Schema Canary (#1125)
+#
+# Non-gating, propagation-axis complement of the publish-time snapshot
+# schema gate (Lesson 155: freshness has two orthogonal axes — recency
+# AND propagation). The publish gate certifies what the daily pipeline is
+# about to upload; this canary runs the real read-validation (the same
+# PerDistrictDataSchema.safeParse the mcp-server performs) against what
+# the published production CDN is ACTUALLY serving, and opens a
+# `cdn-schema-canary` issue when a validating consumer would get schema
+# not-available — the #1096 outage class.
+#
+# Self-clearing: a healthy run closes any open canary alert. Safe because
+# runs are serialized by the concurrency group.
+#
+# Decision logic is unit-tested in scripts/lib/__tests__/cdnSchemaCanary.test.ts;
+# this workflow is the scheduler + alerter around scripts/check-cdn-schema.ts.
+
+name: CDN Schema Canary
+
+on:
+  schedule:
+    # Daily pipeline runs at 08:00 UTC (backup 11:00), freshness monitor
+    # at 14:00. Check at 15:30 UTC so the day's promotion has landed.
+    - cron: '30 15 * * *'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'CDN base URL to check (default: production CDN)'
+        required: false
+        type: string
+      max_districts:
+        description: 'Cap on districts checked (default: all; skips are logged)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: cdn-schema-canary
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Validate published district snapshots
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The canary imports PerDistrictDataSchema from the workspace
+      # package, which resolves to its built dist/ (R16/R2 — the runner
+      # starts empty; nothing is implicitly built).
+      - name: Build shared contracts
+        run: npm run build:shared-contracts
+
+      - name: Validate published snapshots against shared contracts
+        id: canary
+        env:
+          CDN_BASE_URL: ${{ inputs.base_url }}
+          MAX_DISTRICTS: ${{ inputs.max_districts }}
+        run: npx tsx scripts/check-cdn-schema.ts
+
+      - name: Ensure cdn-schema-canary label exists
+        if: steps.canary.outputs.unhealthy == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create cdn-schema-canary \
+            --color B60205 \
+            --description "Published CDN snapshot fails shared-contracts read-validation" \
+            2>/dev/null || echo "Label already exists"
+
+      - name: Open or update alert issue
+        if: steps.canary.outputs.unhealthy == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Deduplicate: one open alert at a time. Comment on the existing
+          # issue rather than spamming a new one each daily check.
+          EXISTING=$(gh issue list --label cdn-schema-canary --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${EXISTING}" ]; then
+            echo "Existing open alert #${EXISTING} — adding a comment."
+            gh issue comment "${EXISTING}" \
+              --body-file "${{ steps.canary.outputs.body_file }}"
+          else
+            echo "No open alert — creating one."
+            gh issue create \
+              --title "${{ steps.canary.outputs.title }}" \
+              --label cdn-schema-canary \
+              --body-file "${{ steps.canary.outputs.body_file }}"
+          fi
+
+      - name: Close resolved canary alerts
+        if: steps.canary.outputs.unhealthy != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Self-clearing (Lesson 155): the positive event — a healthy run —
+          # closes the alert. Safe to close all open alerts because runs are
+          # serialized by the concurrency group.
+          MSG='✅ CDN schema canary healthy — published snapshots pass'
+          MSG="${MSG} read-validation again. Self-clearing (#1125)."
+          for N in $(gh issue list --label cdn-schema-canary --state open \
+            --json number --jq '.[].number'); do
+            echo "Closing resolved canary alert #${N}"
+            gh issue close "${N}" --comment "${MSG}"
+          done
+
+      - name: Fail the run when unhealthy
+        if: steps.canary.outputs.unhealthy == 'true'
+        run: |
+          MSG='Published CDN snapshots fail shared-contracts'
+          MSG="${MSG} read-validation — a cdn-schema-canary issue has been filed."
+          echo "::error::${MSG}"
+          exit 1

--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -381,6 +381,22 @@ jobs:
           SUCCEEDED=$(jq '.districts.succeeded' /tmp/analytics-output.json)
           echo "- **Districts computed**: ${SUCCEEDED}" >> "$GITHUB_STEP_SUMMARY"
 
+      # ── Daily Step 4.5: Snapshot schema gate (#1125) ──
+      # The transform write path validates, but merge-find-a-club rewrites
+      # snapshots in place WITHOUT re-validating — the exact path the #1096
+      # FAC-enrichment drift took to prod. Validate the final on-disk files
+      # against shared-contracts immediately before upload: fail-loud with
+      # district + date, staging-side. Decision logic is unit-tested in
+      # scripts/lib/__tests__/snapshotPublishGate.test.ts.
+      - name: '[daily] Validate snapshots against shared contracts'
+        if: steps.mode.outputs.mode == 'daily'
+        run: |
+          SNAPSHOT_DATE="${{ steps.daily-scrape.outputs.snapshot_date }}"
+          if [ -z "${SNAPSHOT_DATE}" ]; then
+            SNAPSHOT_DATE="${{ steps.daily-scrape.outputs.date }}"
+          fi
+          npx tsx scripts/validate-snapshots.ts "./cache/snapshots/${SNAPSHOT_DATE}"
+
       # ── Daily Step 5: Upload to GCS ──
       - name: '[daily] Upload to GCS'
         if: steps.mode.outputs.mode == 'daily'

--- a/scripts/check-cdn-schema.ts
+++ b/scripts/check-cdn-schema.ts
@@ -14,9 +14,11 @@
  * stderr (R4); $GITHUB_OUTPUT carries only the structured decision.
  *
  * Env:
- *   CDN_BASE_URL  — surface to check (default: production CDN bucket)
- *   MAX_DISTRICTS — optional cap on districts checked; skipped districts
- *                   are logged loudly (no silent caps)
+ *   CDN_BASE_URL  — surface to check (default: the production CDN edge,
+ *                   the same base the mcp-server reads)
+ *   MAX_DISTRICTS — optional cap on districts checked; unset, 0 or
+ *                   non-numeric means ALL; skipped districts are logged
+ *                   loudly (no silent caps)
  *
  * The process always exits 0; the workflow decides whether to open an
  * issue (and mark the run red) based on the `unhealthy` output. This
@@ -33,7 +35,9 @@ import {
   type DistrictFetchResult,
 } from './lib/cdnSchemaCanary.js'
 
-const DEFAULT_BASE_URL = 'https://storage.googleapis.com/toast-stats-data-ca'
+// The edge consumers actually read (mcp-server CdnClient default), not the
+// origin bucket — an LB/edge-layer failure must also trip the canary.
+const DEFAULT_BASE_URL = 'https://cdn.taverns.red'
 
 const BODY_FILE = '/tmp/cdn-schema-canary-body.md'
 

--- a/scripts/check-cdn-schema.ts
+++ b/scripts/check-cdn-schema.ts
@@ -1,0 +1,187 @@
+/**
+ * Live-CDN Schema Canary — Runner (#1125)
+ *
+ * Thin glue around the pure functions in ./lib/cdnSchemaCanary.js:
+ *   1. fetch the published v1/latest.json (production CDN by default),
+ *   2. fetch the snapshot manifest for the latest date to discover the
+ *      published districts,
+ *   3. fetch each district snapshot and run the real read-validation
+ *      (the same PerDistrictDataSchema.safeParse the mcp-server performs),
+ *   4. emit a healthy/unhealthy decision + alert body for the workflow.
+ *
+ * No decision logic lives here — that is unit-tested in
+ * scripts/lib/__tests__/cdnSchemaCanary.test.ts. All logging goes to
+ * stderr (R4); $GITHUB_OUTPUT carries only the structured decision.
+ *
+ * Env:
+ *   CDN_BASE_URL  — surface to check (default: production CDN bucket)
+ *   MAX_DISTRICTS — optional cap on districts checked; skipped districts
+ *                   are logged loudly (no silent caps)
+ *
+ * The process always exits 0; the workflow decides whether to open an
+ * issue (and mark the run red) based on the `unhealthy` output. This
+ * keeps the issue-create step reachable even when the CDN is broken.
+ */
+
+import { appendFileSync, writeFileSync } from 'node:fs'
+import { SnapshotManifestSchema } from '@toastmasters/shared-contracts'
+import {
+  evaluateCdnSchema,
+  buildCanaryIssueTitle,
+  buildCanaryIssueBody,
+  type CanaryResult,
+  type DistrictFetchResult,
+} from './lib/cdnSchemaCanary.js'
+
+const DEFAULT_BASE_URL = 'https://storage.googleapis.com/toast-stats-data-ca'
+
+const BODY_FILE = '/tmp/cdn-schema-canary-body.md'
+
+const FETCH_TIMEOUT_MS = 20_000
+
+function log(msg: string): void {
+  process.stderr.write(`${msg}\n`)
+}
+
+function emitOutput(key: string, value: string): void {
+  const out = process.env.GITHUB_OUTPUT
+  if (out) appendFileSync(out, `${key}=${value}\n`)
+}
+
+function emitDecision(result: CanaryResult, baseUrl: string, now: Date): void {
+  emitOutput('unhealthy', String(!result.healthy))
+  emitOutput('title', buildCanaryIssueTitle(result))
+  if (!result.healthy) {
+    writeFileSync(BODY_FILE, buildCanaryIssueBody(result, { baseUrl, now }))
+    emitOutput('body_file', BODY_FILE)
+    log('CDN schema is UNHEALTHY — alert body written.')
+  } else {
+    log('CDN schema is healthy — no alert.')
+  }
+}
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  })
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`)
+  }
+  return res.text()
+}
+
+async function fetchDistrict(
+  baseUrl: string,
+  date: string,
+  districtId: string
+): Promise<DistrictFetchResult> {
+  const url = `${baseUrl}/snapshots/${encodeURIComponent(date)}/district_${encodeURIComponent(districtId)}.json`
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+    if (!res.ok) {
+      return { districtId, ok: false, status: res.status }
+    }
+    return { districtId, ok: true, status: res.status, body: await res.text() }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { districtId, ok: false, error: message }
+  }
+}
+
+async function main(): Promise<void> {
+  const baseUrl = process.env.CDN_BASE_URL || DEFAULT_BASE_URL
+  const now = new Date()
+
+  log(`Checking CDN schema: ${baseUrl}`)
+
+  let latestDate: string | null = null
+  let result: CanaryResult
+
+  try {
+    const manifestRaw = await fetchText(`${baseUrl}/v1/latest.json`)
+    const manifest = JSON.parse(manifestRaw) as {
+      latestSnapshotDate?: unknown
+    }
+    latestDate =
+      typeof manifest.latestSnapshotDate === 'string'
+        ? manifest.latestSnapshotDate
+        : null
+    if (latestDate === null) {
+      throw new Error('v1/latest.json has no latestSnapshotDate')
+    }
+    log(`Latest published snapshot date: ${latestDate}`)
+
+    const snapshotManifestRaw = await fetchText(
+      `${baseUrl}/snapshots/${encodeURIComponent(latestDate)}/manifest.json`
+    )
+    const snapshotManifest = SnapshotManifestSchema.safeParse(
+      JSON.parse(snapshotManifestRaw)
+    )
+    if (!snapshotManifest.success) {
+      throw new Error(
+        `snapshots/${latestDate}/manifest.json fails its schema: ${snapshotManifest.error.issues[0]?.message ?? 'unknown'}`
+      )
+    }
+
+    let districtIds = snapshotManifest.data.districts
+      .filter(d => d.status === 'success')
+      .map(d => d.districtId)
+      .sort()
+
+    const maxDistricts = Number(process.env.MAX_DISTRICTS)
+    if (Number.isFinite(maxDistricts) && maxDistricts > 0) {
+      const skipped = districtIds.slice(maxDistricts)
+      if (skipped.length > 0) {
+        log(
+          `MAX_DISTRICTS=${maxDistricts} — checking first ${maxDistricts}, ` +
+            `SKIPPING ${skipped.length}: ${skipped.join(', ')}`
+        )
+      }
+      districtIds = districtIds.slice(0, maxDistricts)
+    }
+
+    log(`Checking ${districtIds.length} published district snapshot(s)...`)
+    const districts = await Promise.all(
+      districtIds.map(id => fetchDistrict(baseUrl, latestDate as string, id))
+    )
+
+    result = evaluateCdnSchema({ latestDate, districts })
+  } catch (err) {
+    // A fetch/parse failure on the manifest chain is itself an alert
+    // condition — the canary can't tell what consumers see, and "can't
+    // tell" must alert, never pass (Lesson 107).
+    const message = err instanceof Error ? err.message : String(err)
+    log(`Failed to resolve published snapshots: ${message}`)
+    result = evaluateCdnSchema({
+      latestDate,
+      manifestError: message,
+      districts: [],
+    })
+  }
+
+  log(`Result: ${result.reason}`)
+  for (const f of result.failures) {
+    log(`  - district ${f.districtId}: ${f.reason}`)
+  }
+  emitDecision(result, baseUrl, now)
+}
+
+main().catch(err => {
+  const message =
+    err instanceof Error ? (err.stack ?? err.message) : String(err)
+  log(`Unexpected error: ${message}`)
+  // Surface as unhealthy — with a real body — so the canary still alerts
+  // rather than passing silently.
+  emitDecision(
+    evaluateCdnSchema({
+      latestDate: null,
+      manifestError: `cdn schema canary crashed: ${message}`,
+      districts: [],
+    }),
+    process.env.CDN_BASE_URL || DEFAULT_BASE_URL,
+    new Date()
+  )
+  process.exit(0)
+})

--- a/scripts/check-cdn-schema.ts
+++ b/scripts/check-cdn-schema.ts
@@ -39,6 +39,9 @@ const BODY_FILE = '/tmp/cdn-schema-canary-body.md'
 
 const FETCH_TIMEOUT_MS = 20_000
 
+/** Bound the fan-out against GCS — ~128 published districts (#1125). */
+const FETCH_CONCURRENCY = 16
+
 function log(msg: string): void {
   process.stderr.write(`${msg}\n`)
 }
@@ -143,9 +146,15 @@ async function main(): Promise<void> {
     }
 
     log(`Checking ${districtIds.length} published district snapshot(s)...`)
-    const districts = await Promise.all(
-      districtIds.map(id => fetchDistrict(baseUrl, latestDate as string, id))
-    )
+    const districts: DistrictFetchResult[] = []
+    for (let i = 0; i < districtIds.length; i += FETCH_CONCURRENCY) {
+      const batch = districtIds.slice(i, i + FETCH_CONCURRENCY)
+      districts.push(
+        ...(await Promise.all(
+          batch.map(id => fetchDistrict(baseUrl, latestDate as string, id))
+        ))
+      )
+    }
 
     result = evaluateCdnSchema({ latestDate, districts })
   } catch (err) {

--- a/scripts/lib/__tests__/cdnSchemaCanary.test.ts
+++ b/scripts/lib/__tests__/cdnSchemaCanary.test.ts
@@ -101,6 +101,16 @@ describe('evaluateCdnSchema', () => {
     expect(result.reason).toContain('503')
   })
 
+  it('alerts on a malformed latest date instead of propagating it (output-injection guard)', () => {
+    const result = evaluateCdnSchema({
+      latestDate: 'evil\ntitle=injected',
+      districts: [fetched('61')],
+    })
+    expect(result.healthy).toBe(false)
+    expect(result.latestDate).toBeNull()
+    expect(result.reason).toMatch(/malformed/i)
+  })
+
   it('alerts when there are zero districts to check — a canary that checks nothing must not pass', () => {
     const result = evaluateCdnSchema({
       latestDate: LATEST_DATE,
@@ -137,5 +147,17 @@ describe('issue title and body', () => {
     expect(body).toContain('42')
     expect(body).toContain('clubPerformance')
     expect(body).toContain('2026-06-10T15:30:00')
+  })
+
+  it('escapes pipes in failure reasons so the markdown table stays intact', () => {
+    const result = evaluateCdnSchema({
+      latestDate: LATEST_DATE,
+      districts: [
+        { districtId: '61', ok: false, error: 'weird | piped | message' },
+      ],
+    })
+    const body = buildCanaryIssueBody(result, { baseUrl, now })
+    expect(body).not.toContain('weird | piped')
+    expect(body).toContain('weird \\| piped \\| message')
   })
 })

--- a/scripts/lib/__tests__/cdnSchemaCanary.test.ts
+++ b/scripts/lib/__tests__/cdnSchemaCanary.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Live-CDN schema canary — decision logic tests (#1125).
+ *
+ * The canary is the propagation-axis complement of the publish gate: the
+ * gate certifies what the pipeline is ABOUT to publish; the canary runs
+ * the real read-validation (the same safeParse the mcp-server performs)
+ * against what the published CDN is ACTUALLY serving, and alerts when a
+ * consumer would get schema not-available (Lessons 107/155: a "can't
+ * tell" state must alert, never pass).
+ *
+ * Happy-path bodies use the recorded real CDN payload from Sprint 1
+ * (#1123) — Lesson 154.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  evaluateCdnSchema,
+  buildCanaryIssueTitle,
+  buildCanaryIssueBody,
+  type DistrictFetchResult,
+} from '../cdnSchemaCanary.js'
+
+const FIXTURE_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../packages/mcp-server/src/__fixtures__/district-snapshot.json'
+)
+
+const realSnapshot = readFileSync(FIXTURE_PATH, 'utf-8')
+
+function fetched(districtId: string, body = realSnapshot): DistrictFetchResult {
+  return { districtId, ok: true, status: 200, body }
+}
+
+const LATEST_DATE = '2026-06-09'
+
+describe('evaluateCdnSchema', () => {
+  it('is healthy when every published district validates', () => {
+    const result = evaluateCdnSchema({
+      latestDate: LATEST_DATE,
+      districts: [fetched('61'), fetched('86')],
+    })
+    expect(result.healthy).toBe(true)
+    expect(result.checked).toBe(2)
+    expect(result.failures).toEqual([])
+    expect(result.latestDate).toBe(LATEST_DATE)
+  })
+
+  it('alerts on an injected schema-violating payload, naming the district', () => {
+    const bad = JSON.parse(realSnapshot)
+    bad.data.clubPerformance[0]['Injected Junk'] = { anything: 'at all' }
+    const result = evaluateCdnSchema({
+      latestDate: LATEST_DATE,
+      districts: [fetched('61'), fetched('42', JSON.stringify(bad))],
+    })
+    expect(result.healthy).toBe(false)
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0].districtId).toBe('42')
+    expect(result.failures[0].reason).toContain('clubPerformance')
+  })
+
+  it('alerts when a district fetch returns a non-200 — not-available is the outage', () => {
+    const result = evaluateCdnSchema({
+      latestDate: LATEST_DATE,
+      districts: [fetched('61'), { districtId: '42', ok: false, status: 404 }],
+    })
+    expect(result.healthy).toBe(false)
+    expect(result.failures[0].districtId).toBe('42')
+    expect(result.failures[0].reason).toContain('404')
+  })
+
+  it('alerts on a network-level fetch error', () => {
+    const result = evaluateCdnSchema({
+      latestDate: LATEST_DATE,
+      districts: [
+        { districtId: '61', ok: false, error: 'fetch timeout after 20s' },
+      ],
+    })
+    expect(result.healthy).toBe(false)
+    expect(result.failures[0].reason).toContain('timeout')
+  })
+
+  it('alerts on an unparseable district body', () => {
+    const result = evaluateCdnSchema({
+      latestDate: LATEST_DATE,
+      districts: [fetched('61', '<html>garbage</html>')],
+    })
+    expect(result.healthy).toBe(false)
+    expect(result.failures[0].reason).toMatch(/JSON/i)
+  })
+
+  it("alerts when the manifest chain could not be read — can't tell = alert", () => {
+    const result = evaluateCdnSchema({
+      latestDate: null,
+      manifestError: 'HTTP 503 Service Unavailable',
+      districts: [],
+    })
+    expect(result.healthy).toBe(false)
+    expect(result.reason).toContain('503')
+  })
+
+  it('alerts when there are zero districts to check — a canary that checks nothing must not pass', () => {
+    const result = evaluateCdnSchema({
+      latestDate: LATEST_DATE,
+      districts: [],
+    })
+    expect(result.healthy).toBe(false)
+    expect(result.reason).toMatch(/no district/i)
+  })
+})
+
+describe('issue title and body', () => {
+  const now = new Date('2026-06-10T15:30:00Z')
+  const baseUrl = 'https://storage.googleapis.com/toast-stats-data-ca'
+
+  it('unhealthy title names the snapshot date', () => {
+    const result = evaluateCdnSchema({
+      latestDate: LATEST_DATE,
+      districts: [fetched('61', '{}')],
+    })
+    const title = buildCanaryIssueTitle(result)
+    expect(title).toContain(LATEST_DATE)
+    expect(title).toMatch(/schema/i)
+  })
+
+  it('body lists each failing district with its reason and the checked surface', () => {
+    const bad = JSON.parse(realSnapshot)
+    bad.data.clubPerformance[0]['Injected Junk'] = { anything: 'at all' }
+    const result = evaluateCdnSchema({
+      latestDate: LATEST_DATE,
+      districts: [fetched('61'), fetched('42', JSON.stringify(bad))],
+    })
+    const body = buildCanaryIssueBody(result, { baseUrl, now })
+    expect(body).toContain(baseUrl)
+    expect(body).toContain('42')
+    expect(body).toContain('clubPerformance')
+    expect(body).toContain('2026-06-10T15:30:00')
+  })
+})

--- a/scripts/lib/__tests__/snapshotPublishGate.test.ts
+++ b/scripts/lib/__tests__/snapshotPublishGate.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Publish-time snapshot schema gate — decision logic tests (#1125).
+ *
+ * The gate validates every district_<id>.json in a snapshot directory
+ * against the shared PerDistrictDataSchema BEFORE the gsutil upload, so
+ * contract drift fails loudly at write time instead of surfacing in a
+ * downstream validating consumer (the #1096 MCP outage: merge-find-a-club
+ * rewrote validated snapshots in place with no re-validation).
+ *
+ * The happy-path fixture is the recorded real CDN payload from Sprint 1
+ * (#1123) — synthetic fixtures validate the code, only a captured real
+ * payload validates the policy (Lesson 154).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  evaluateSnapshotFiles,
+  buildGateSummary,
+} from '../snapshotPublishGate.js'
+
+const FIXTURE_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../packages/mcp-server/src/__fixtures__/district-snapshot.json'
+)
+
+/** Recorded real FAC-enriched PerDistrictData payload (#1123). */
+const realSnapshot = readFileSync(FIXTURE_PATH, 'utf-8')
+
+function validFile(districtId = '61') {
+  const parsed = JSON.parse(realSnapshot)
+  parsed.districtId = districtId
+  return {
+    fileName: `district_${districtId}.json`,
+    content: JSON.stringify(parsed),
+  }
+}
+
+describe('evaluateSnapshotFiles', () => {
+  it('passes a directory of valid recorded real snapshots', () => {
+    const result = evaluateSnapshotFiles([validFile('61'), validFile('86')])
+    expect(result.ok).toBe(true)
+    expect(result.checked).toBe(2)
+    expect(result.failures).toEqual([])
+  })
+
+  it('fails a contract-violating snapshot with district and date in the failure', () => {
+    // The exact #1096 drift class: an arbitrary object value smuggled into
+    // a clubPerformance row (rejected by the strict union — Lesson 157).
+    const parsed = JSON.parse(realSnapshot)
+    parsed.data.clubPerformance[0]['Injected Junk'] = { anything: 'at all' }
+    const bad = {
+      fileName: 'district_42.json',
+      content: JSON.stringify(parsed),
+    }
+
+    const result = evaluateSnapshotFiles([validFile('61'), bad])
+    expect(result.ok).toBe(false)
+    expect(result.checked).toBe(2)
+    expect(result.failures).toHaveLength(1)
+    const failure = result.failures[0]
+    expect(failure.fileName).toBe('district_42.json')
+    // Fail-loud with district + date (sprint AC)
+    expect(failure.districtId).toBe(parsed.districtId)
+    expect(failure.snapshotDate).toBe(parsed.data.snapshotDate)
+    expect(failure.reason).toContain('clubPerformance')
+  })
+
+  it('fails on unparseable JSON, recovering the district id from the file name', () => {
+    const result = evaluateSnapshotFiles([
+      { fileName: 'district_109.json', content: '{not json' },
+    ])
+    expect(result.ok).toBe(false)
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0].districtId).toBe('109')
+    expect(result.failures[0].snapshotDate).toBeNull()
+    expect(result.failures[0].reason).toMatch(/JSON/i)
+  })
+
+  it('fails when there are zero district files — a gate that checks nothing must not pass', () => {
+    const result = evaluateSnapshotFiles([])
+    expect(result.ok).toBe(false)
+    expect(result.checked).toBe(0)
+    expect(result.reason).toMatch(/no district snapshot files/i)
+  })
+
+  it('ignores non-district files (metadata, manifest, rankings)', () => {
+    const result = evaluateSnapshotFiles([
+      validFile('61'),
+      { fileName: 'metadata.json', content: '{not even json' },
+      { fileName: 'manifest.json', content: '{}' },
+      { fileName: 'all-districts-rankings.json', content: '[]' },
+    ])
+    expect(result.ok).toBe(true)
+    expect(result.checked).toBe(1)
+  })
+
+  it('reports every failing district, not just the first', () => {
+    const junk = (id: string) => ({
+      fileName: `district_${id}.json`,
+      content: JSON.stringify({ totally: 'wrong shape' }),
+    })
+    const result = evaluateSnapshotFiles([
+      junk('1'),
+      junk('2'),
+      validFile('61'),
+    ])
+    expect(result.ok).toBe(false)
+    expect(result.failures.map(f => f.fileName)).toEqual([
+      'district_1.json',
+      'district_2.json',
+    ])
+  })
+})
+
+describe('buildGateSummary', () => {
+  it('renders a passing summary with the checked count', () => {
+    const summary = buildGateSummary(evaluateSnapshotFiles([validFile('61')]), {
+      snapshotDir: './cache/snapshots/2026-06-09',
+    })
+    expect(summary).toContain('1')
+    expect(summary).toContain('./cache/snapshots/2026-06-09')
+    expect(summary).toMatch(/pass/i)
+  })
+
+  it('renders each failure with district and date', () => {
+    const parsed = JSON.parse(realSnapshot)
+    parsed.data.clubPerformance[0]['Injected Junk'] = { anything: 'at all' }
+    const result = evaluateSnapshotFiles([
+      { fileName: 'district_42.json', content: JSON.stringify(parsed) },
+    ])
+    const summary = buildGateSummary(result, {
+      snapshotDir: './cache/snapshots/2026-06-09',
+    })
+    expect(summary).toContain(parsed.districtId)
+    expect(summary).toContain(parsed.data.snapshotDate)
+    expect(summary).toMatch(/fail/i)
+  })
+})

--- a/scripts/lib/cdnSchemaCanary.ts
+++ b/scripts/lib/cdnSchemaCanary.ts
@@ -16,6 +16,7 @@
  */
 
 import { PerDistrictDataSchema } from '@toastmasters/shared-contracts'
+import { summarizeZodIssues } from './zodIssueSummary.js'
 
 export interface DistrictFetchResult {
   districtId: string
@@ -49,9 +50,6 @@ export interface CanaryResult {
   reason: string
 }
 
-/** Keep zod error detail bounded — first few issues tell the story. */
-const MAX_ZOD_ISSUES = 5
-
 function validateDistrict(fetch: DistrictFetchResult): CanaryFailure | null {
   if (!fetch.ok) {
     return {
@@ -73,19 +71,9 @@ function validateDistrict(fetch: DistrictFetchResult): CanaryFailure | null {
   const result = PerDistrictDataSchema.safeParse(parsed)
   if (result.success) return null
 
-  const issues = result.error.issues
-  const detail = issues
-    .slice(0, MAX_ZOD_ISSUES)
-    .map(issue => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
-    .join('; ')
-  const more =
-    issues.length > MAX_ZOD_ISSUES
-      ? ` (+${issues.length - MAX_ZOD_ISSUES} more issues)`
-      : ''
-
   return {
     districtId: fetch.districtId,
-    reason: `schema validation failed: ${detail}${more}`,
+    reason: `schema validation failed: ${summarizeZodIssues(result.error.issues)}`,
   }
 }
 
@@ -166,8 +154,10 @@ export function buildCanaryIssueBody(
     '### Remediation',
     '',
     '- Schema validation failures: the published payload has drifted from',
-    '  `shared-contracts` — find the writer that bypassed the publish gate',
-    '  (`scripts/validate-snapshots.ts`) and fix the contract or the writer.',
+    '  `shared-contracts` — find the writer that produced the invalid',
+    '  snapshot (transform, merge-find-a-club, or a newer post-processor)',
+    '  and fix the contract or the writer. Check why the publish gate',
+    '  (`scripts/validate-snapshots.ts`) did not catch it before upload.',
     '- Fetch failures: check the CDN/bucket and the daily pipeline run.',
     '- This issue self-clears: the next healthy canary run closes it.',
     ''

--- a/scripts/lib/cdnSchemaCanary.ts
+++ b/scripts/lib/cdnSchemaCanary.ts
@@ -77,7 +77,28 @@ function validateDistrict(fetch: DistrictFetchResult): CanaryFailure | null {
   }
 }
 
+/**
+ * The latest date is remote input that ends up in $GITHUB_OUTPUT lines and
+ * issue titles — only a strict YYYY-MM-DD ever propagates (injection guard).
+ */
+const SNAPSHOT_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
 export function evaluateCdnSchema(input: CanaryInput): CanaryResult {
+  if (
+    input.latestDate !== null &&
+    !SNAPSHOT_DATE_PATTERN.test(input.latestDate)
+  ) {
+    return {
+      healthy: false,
+      latestDate: null,
+      checked: 0,
+      failures: [],
+      reason: `malformed latest snapshot date from v1/latest.json: ${JSON.stringify(
+        input.latestDate.slice(0, 40)
+      )}`,
+    }
+  }
+
   if (input.manifestError || input.latestDate === null) {
     return {
       healthy: false,
@@ -143,9 +164,10 @@ export function buildCanaryIssueBody(
   ]
 
   if (result.failures.length > 0) {
+    const cell = (s: string) => s.replaceAll('|', '\\|')
     lines.push('| District | Reason |', '| --- | --- |')
     for (const f of result.failures) {
-      lines.push(`| ${f.districtId} | ${f.reason} |`)
+      lines.push(`| ${cell(f.districtId)} | ${cell(f.reason)} |`)
     }
     lines.push('')
   }

--- a/scripts/lib/cdnSchemaCanary.ts
+++ b/scripts/lib/cdnSchemaCanary.ts
@@ -1,0 +1,177 @@
+/**
+ * Live-CDN schema canary — pure decision logic (#1125).
+ *
+ * The propagation-axis complement of the publish gate (Lesson 155): the
+ * gate certifies what the pipeline is about to publish; this canary runs
+ * the real read-validation — the same `PerDistrictDataSchema.safeParse`
+ * the mcp-server performs — against what the published CDN is actually
+ * serving, and alerts when a validating consumer would get schema
+ * not-available.
+ *
+ * Failure-to-tell (unreachable manifest, zero districts, garbage JSON) is
+ * itself an alert condition, never a pass (Lesson 107).
+ *
+ * No I/O here — the runner (scripts/check-cdn-schema.ts) fetches and the
+ * workflow alerts. Mirrors the pipelineFreshness / promotionAlert pattern.
+ */
+
+import { PerDistrictDataSchema } from '@toastmasters/shared-contracts'
+
+export interface DistrictFetchResult {
+  districtId: string
+  /** HTTP-level success (fetch resolved with a 2xx). */
+  ok: boolean
+  status?: number
+  /** Raw response text when ok. */
+  body?: string
+  /** Network/transport error message when the fetch itself failed. */
+  error?: string
+}
+
+export interface CanaryInput {
+  /** `latestSnapshotDate` from v1/latest.json, null when unavailable. */
+  latestDate: string | null
+  /** Set when v1/latest.json or the snapshot manifest could not be read. */
+  manifestError?: string
+  districts: DistrictFetchResult[]
+}
+
+export interface CanaryFailure {
+  districtId: string
+  reason: string
+}
+
+export interface CanaryResult {
+  healthy: boolean
+  latestDate: string | null
+  checked: number
+  failures: CanaryFailure[]
+  reason: string
+}
+
+/** Keep zod error detail bounded — first few issues tell the story. */
+const MAX_ZOD_ISSUES = 5
+
+function validateDistrict(fetch: DistrictFetchResult): CanaryFailure | null {
+  if (!fetch.ok) {
+    return {
+      districtId: fetch.districtId,
+      reason: fetch.error
+        ? `fetch failed: ${fetch.error}`
+        : `fetch failed: HTTP ${fetch.status ?? '?'}`,
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(fetch.body ?? '')
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { districtId: fetch.districtId, reason: `invalid JSON: ${message}` }
+  }
+
+  const result = PerDistrictDataSchema.safeParse(parsed)
+  if (result.success) return null
+
+  const issues = result.error.issues
+  const detail = issues
+    .slice(0, MAX_ZOD_ISSUES)
+    .map(issue => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+    .join('; ')
+  const more =
+    issues.length > MAX_ZOD_ISSUES
+      ? ` (+${issues.length - MAX_ZOD_ISSUES} more issues)`
+      : ''
+
+  return {
+    districtId: fetch.districtId,
+    reason: `schema validation failed: ${detail}${more}`,
+  }
+}
+
+export function evaluateCdnSchema(input: CanaryInput): CanaryResult {
+  if (input.manifestError || input.latestDate === null) {
+    return {
+      healthy: false,
+      latestDate: input.latestDate,
+      checked: 0,
+      failures: [],
+      reason: `could not resolve the published snapshot to check: ${
+        input.manifestError ?? 'no latest snapshot date'
+      }`,
+    }
+  }
+
+  if (input.districts.length === 0) {
+    return {
+      healthy: false,
+      latestDate: input.latestDate,
+      checked: 0,
+      failures: [],
+      reason:
+        'no district snapshots to check — the canary cannot pass on an empty set',
+    }
+  }
+
+  const failures = input.districts
+    .map(validateDistrict)
+    .filter((f): f is CanaryFailure => f !== null)
+
+  return {
+    healthy: failures.length === 0,
+    latestDate: input.latestDate,
+    checked: input.districts.length,
+    failures,
+    reason:
+      failures.length === 0
+        ? `all ${input.districts.length} published district snapshot(s) pass the mcp-server read-validation`
+        : `${failures.length} of ${input.districts.length} published district snapshot(s) would be schema not-available to validating consumers`,
+  }
+}
+
+export function buildCanaryIssueTitle(result: CanaryResult): string {
+  return result.healthy
+    ? 'cdn schema healthy'
+    : `🚨 CDN schema canary — published snapshot ${result.latestDate ?? '(unknown date)'} fails read-validation`
+}
+
+export function buildCanaryIssueBody(
+  result: CanaryResult,
+  opts: { baseUrl: string; now: Date }
+): string {
+  const lines = [
+    '## CDN Schema Canary alert (#1125)',
+    '',
+    `- **Checked surface**: ${opts.baseUrl}`,
+    `- **Snapshot date**: ${result.latestDate ?? 'unknown'}`,
+    `- **Districts checked**: ${result.checked}`,
+    `- **Checked at**: ${opts.now.toISOString()}`,
+    `- **Result**: ${result.reason}`,
+    '',
+    'A validating consumer (mcp-server `get-district-snapshot` /',
+    '`get-club-health`) gets **not-available** for every district listed',
+    'below — the same outage class as the #1096 incident.',
+    '',
+  ]
+
+  if (result.failures.length > 0) {
+    lines.push('| District | Reason |', '| --- | --- |')
+    for (const f of result.failures) {
+      lines.push(`| ${f.districtId} | ${f.reason} |`)
+    }
+    lines.push('')
+  }
+
+  lines.push(
+    '### Remediation',
+    '',
+    '- Schema validation failures: the published payload has drifted from',
+    '  `shared-contracts` — find the writer that bypassed the publish gate',
+    '  (`scripts/validate-snapshots.ts`) and fix the contract or the writer.',
+    '- Fetch failures: check the CDN/bucket and the daily pipeline run.',
+    '- This issue self-clears: the next healthy canary run closes it.',
+    ''
+  )
+
+  return lines.join('\n')
+}

--- a/scripts/lib/snapshotPublishGate.ts
+++ b/scripts/lib/snapshotPublishGate.ts
@@ -18,6 +18,7 @@
  */
 
 import { PerDistrictDataSchema } from '@toastmasters/shared-contracts'
+import { summarizeZodIssues } from './zodIssueSummary.js'
 
 export interface SnapshotFileInput {
   /** Base file name, e.g. `district_61.json`. */
@@ -44,9 +45,6 @@ export interface SnapshotGateResult {
 }
 
 const DISTRICT_FILE_PATTERN = /^district_(.+)\.json$/
-
-/** Keep zod error detail bounded — first few issues tell the story. */
-const MAX_ZOD_ISSUES = 5
 
 export function isDistrictSnapshotFile(fileName: string): boolean {
   return DISTRICT_FILE_PATTERN.test(fileName)
@@ -88,21 +86,11 @@ function validateDistrictFile(
       ? record.data.snapshotDate
       : null
 
-  const issues = result.error.issues
-  const detail = issues
-    .slice(0, MAX_ZOD_ISSUES)
-    .map(issue => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
-    .join('; ')
-  const more =
-    issues.length > MAX_ZOD_ISSUES
-      ? ` (+${issues.length - MAX_ZOD_ISSUES} more issues)`
-      : ''
-
   return {
     fileName: file.fileName,
     districtId,
     snapshotDate,
-    reason: `schema validation failed: ${detail}${more}`,
+    reason: `schema validation failed: ${summarizeZodIssues(result.error.issues)}`,
   }
 }
 

--- a/scripts/lib/snapshotPublishGate.ts
+++ b/scripts/lib/snapshotPublishGate.ts
@@ -1,0 +1,167 @@
+/**
+ * Publish-time snapshot schema gate — pure decision logic (#1125).
+ *
+ * Validates district snapshot files against the shared
+ * `PerDistrictDataSchema` so the data pipeline can refuse to upload a
+ * contract-violating snapshot (fail-loud at publish time, staging-side).
+ *
+ * Why this exists: the transform write path already validates, but
+ * `merge-find-a-club` (and any future post-processor) rewrites the files
+ * in place WITHOUT re-validating — exactly how the #1096 FAC-enrichment
+ * drift reached prod and broke the first validating consumer (mcp-server).
+ * The gate validates the final on-disk bytes immediately before upload,
+ * covering every writer.
+ *
+ * No I/O here — the runner (scripts/validate-snapshots.ts) reads files and
+ * the workflow decides what to do. Mirrors the pipelineFreshness /
+ * promotionAlert pattern.
+ */
+
+import { PerDistrictDataSchema } from '@toastmasters/shared-contracts'
+
+export interface SnapshotFileInput {
+  /** Base file name, e.g. `district_61.json`. */
+  fileName: string
+  /** Raw file content (bytes as UTF-8 string). */
+  content: string
+}
+
+export interface SnapshotGateFailure {
+  fileName: string
+  /** From the payload when parseable, else recovered from the file name. */
+  districtId: string | null
+  /** From the payload when parseable. */
+  snapshotDate: string | null
+  reason: string
+}
+
+export interface SnapshotGateResult {
+  ok: boolean
+  /** Number of district files validated (non-district files are ignored). */
+  checked: number
+  failures: SnapshotGateFailure[]
+  reason: string
+}
+
+const DISTRICT_FILE_PATTERN = /^district_(.+)\.json$/
+
+/** Keep zod error detail bounded — first few issues tell the story. */
+const MAX_ZOD_ISSUES = 5
+
+export function isDistrictSnapshotFile(fileName: string): boolean {
+  return DISTRICT_FILE_PATTERN.test(fileName)
+}
+
+function districtIdFromFileName(fileName: string): string | null {
+  return DISTRICT_FILE_PATTERN.exec(fileName)?.[1] ?? null
+}
+
+function validateDistrictFile(
+  file: SnapshotFileInput
+): SnapshotGateFailure | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(file.content)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return {
+      fileName: file.fileName,
+      districtId: districtIdFromFileName(file.fileName),
+      snapshotDate: null,
+      reason: `invalid JSON: ${message}`,
+    }
+  }
+
+  const result = PerDistrictDataSchema.safeParse(parsed)
+  if (result.success) return null
+
+  const record = parsed as {
+    districtId?: unknown
+    data?: { snapshotDate?: unknown }
+  }
+  const districtId =
+    typeof record?.districtId === 'string'
+      ? record.districtId
+      : districtIdFromFileName(file.fileName)
+  const snapshotDate =
+    typeof record?.data?.snapshotDate === 'string'
+      ? record.data.snapshotDate
+      : null
+
+  const issues = result.error.issues
+  const detail = issues
+    .slice(0, MAX_ZOD_ISSUES)
+    .map(issue => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+    .join('; ')
+  const more =
+    issues.length > MAX_ZOD_ISSUES
+      ? ` (+${issues.length - MAX_ZOD_ISSUES} more issues)`
+      : ''
+
+  return {
+    fileName: file.fileName,
+    districtId,
+    snapshotDate,
+    reason: `schema validation failed: ${detail}${more}`,
+  }
+}
+
+/**
+ * Validate every `district_*.json` in the given file set against
+ * `PerDistrictDataSchema`. Zero district files is a FAILURE — a gate that
+ * validates nothing must not pass vacuously (Lesson 107: "can't tell" is
+ * an alert, not a pass).
+ */
+export function evaluateSnapshotFiles(
+  files: SnapshotFileInput[]
+): SnapshotGateResult {
+  const districtFiles = files.filter(f => isDistrictSnapshotFile(f.fileName))
+
+  if (districtFiles.length === 0) {
+    return {
+      ok: false,
+      checked: 0,
+      failures: [],
+      reason:
+        'no district snapshot files found — the gate cannot pass on an empty set',
+    }
+  }
+
+  const failures = districtFiles
+    .map(validateDistrictFile)
+    .filter((f): f is SnapshotGateFailure => f !== null)
+
+  return {
+    ok: failures.length === 0,
+    checked: districtFiles.length,
+    failures,
+    reason:
+      failures.length === 0
+        ? `all ${districtFiles.length} district snapshot(s) match the shared contract`
+        : `${failures.length} of ${districtFiles.length} district snapshot(s) violate the shared contract`,
+  }
+}
+
+/** Markdown block for $GITHUB_STEP_SUMMARY. */
+export function buildGateSummary(
+  result: SnapshotGateResult,
+  opts: { snapshotDir: string }
+): string {
+  const lines = [
+    '## 🛡️ Snapshot Schema Gate (#1125)',
+    '',
+    `- **Directory**: \`${opts.snapshotDir}\``,
+    `- **District files checked**: ${result.checked}`,
+    `- **Result**: ${result.ok ? '✅ PASS' : '❌ FAIL'} — ${result.reason}`,
+  ]
+  if (result.failures.length > 0) {
+    lines.push('', '| File | District | Snapshot date | Reason |')
+    lines.push('| --- | --- | --- | --- |')
+    for (const f of result.failures) {
+      lines.push(
+        `| \`${f.fileName}\` | ${f.districtId ?? '?'} | ${f.snapshotDate ?? '?'} | ${f.reason} |`
+      )
+    }
+  }
+  return lines.join('\n') + '\n'
+}

--- a/scripts/lib/zodIssueSummary.ts
+++ b/scripts/lib/zodIssueSummary.ts
@@ -1,0 +1,24 @@
+/**
+ * Bounded zod-issue summarization shared by the snapshot publish gate and
+ * the CDN schema canary (#1125). Keeps alert/annotation text readable —
+ * the first few issues tell the story.
+ */
+
+interface ZodIssueLike {
+  path: PropertyKey[]
+  message: string
+}
+
+const MAX_ZOD_ISSUES = 5
+
+export function summarizeZodIssues(issues: ZodIssueLike[]): string {
+  const detail = issues
+    .slice(0, MAX_ZOD_ISSUES)
+    .map(issue => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+    .join('; ')
+  const more =
+    issues.length > MAX_ZOD_ISSUES
+      ? ` (+${issues.length - MAX_ZOD_ISSUES} more issues)`
+      : ''
+  return `${detail}${more}`
+}

--- a/scripts/validate-snapshots.ts
+++ b/scripts/validate-snapshots.ts
@@ -1,0 +1,90 @@
+/**
+ * Snapshot Schema Gate — Runner (#1125)
+ *
+ * Thin glue around the pure functions in ./lib/snapshotPublishGate.js:
+ * read every district_<id>.json in the given snapshot director(y/ies),
+ * validate against the shared PerDistrictDataSchema, and FAIL (exit 1)
+ * if any file violates the contract — blocking the gsutil upload step
+ * that follows in data-pipeline.yml.
+ *
+ * Unlike the alert runners (promotion-alert, check-pipeline-freshness)
+ * this is a GATE: a non-zero exit is the mechanism. Decision logic is
+ * unit-tested in scripts/lib/__tests__/snapshotPublishGate.test.ts.
+ * All logging goes to stderr (R4).
+ *
+ * Usage: npx tsx scripts/validate-snapshots.ts <snapshot-dir> [...more]
+ */
+
+import { appendFileSync, existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  evaluateSnapshotFiles,
+  buildGateSummary,
+  isDistrictSnapshotFile,
+  type SnapshotGateResult,
+} from './lib/snapshotPublishGate.js'
+
+function log(msg: string): void {
+  process.stderr.write(`${msg}\n`)
+}
+
+function appendStepSummary(markdown: string): void {
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY
+  if (summaryFile) appendFileSync(summaryFile, markdown)
+}
+
+function validateDir(dir: string): SnapshotGateResult {
+  if (!existsSync(dir)) {
+    // A missing directory means there is nothing to certify — the gate
+    // must fail loudly rather than pass vacuously (Lesson 107).
+    return {
+      ok: false,
+      checked: 0,
+      failures: [],
+      reason: `snapshot directory does not exist: ${dir}`,
+    }
+  }
+
+  const files = readdirSync(dir)
+    .filter(isDistrictSnapshotFile)
+    .sort()
+    .map(fileName => ({
+      fileName,
+      content: readFileSync(join(dir, fileName), 'utf-8'),
+    }))
+
+  return evaluateSnapshotFiles(files)
+}
+
+function main(): void {
+  const dirs = process.argv.slice(2)
+  if (dirs.length === 0) {
+    log('Usage: validate-snapshots.ts <snapshot-dir> [...more dirs]')
+    process.exit(2)
+  }
+
+  let allOk = true
+  for (const dir of dirs) {
+    log(`Validating district snapshots in ${dir} ...`)
+    const result = validateDir(dir)
+    log(`${result.ok ? 'PASS' : 'FAIL'}: ${result.reason}`)
+
+    for (const f of result.failures) {
+      // ::error:: annotations surface district + date in the Actions UI
+      console.error(
+        `::error::Snapshot schema gate: district ${f.districtId ?? '?'} ` +
+          `(snapshot ${f.snapshotDate ?? '?'}) in ${f.fileName} — ${f.reason}`
+      )
+    }
+    if (!result.ok && result.failures.length === 0) {
+      console.error(`::error::Snapshot schema gate: ${result.reason} (${dir})`)
+    }
+
+    appendStepSummary(buildGateSummary(result, { snapshotDir: dir }))
+    if (!result.ok) allOk = false
+  }
+
+  process.exit(allOk ? 0 : 1)
+}
+
+main()

--- a/tasks/lessons/158-a-parameterized-monitors-self-clear-must-be-scoped-to-the-signal-it-alarms-on.md
+++ b/tasks/lessons/158-a-parameterized-monitors-self-clear-must-be-scoped-to-the-signal-it-alarms-on.md
@@ -1,0 +1,66 @@
+---
+id: '158'
+category: lesson
+tags: [ci, automation, monitoring, data-pipeline, verification]
+auto_load: true
+date: 2026-06-10
+issues: [1125, 1096]
+---
+
+# Lesson 158 — A parameterized monitor's self-clear must be scoped to the signal it alarms on
+
+**Date:** 2026-06-10
+**Issue:** #1125 (epic #1096 Sprint 3 — publish-time Zod gate + live-CDN schema canary)
+**PR:** _(record on merge)_
+
+## What happened
+
+The CDN schema canary followed Lesson 155's self-clearing pattern: a healthy
+run closes any open `cdn-schema-canary` alert, safe because the concurrency
+group serializes runs. Fresh-context review caught the hole: the workflow is
+**parameterizable** (`workflow_dispatch` accepts `base_url` and
+`max_districts`). A healthy dispatch run pointed at the _staging_ bucket — or
+capped to a district subset that happens to exclude the failing district —
+would close a live **prod** alert. The serialization guard from Lesson 155
+holds, but serialization only prevents _racing_ signals; it does nothing
+about _different_ signals flowing through the same clear step.
+
+The fix is one `if:` condition: self-clear only when the run checked the
+default surface with no cap — i.e. only when this run's signal is the same
+signal the alert is about.
+
+A sibling finding from the same review: the canary's default URL was the
+GCS **origin bucket**, but consumers (mcp-server) read the **CDN edge**
+(`cdn.taverns.red`). A monitor that certifies "what users read" must read
+through the same layers users do, or an edge/LB failure passes silently.
+
+## The transferable principle
+
+**When a monitor is parameterizable (alternate target, sampling cap, dry-run
+mode), its self-clearing path inherits a false-clear hazard: a healthy run of
+a DIFFERENT signal — different surface, partial coverage — must not close an
+alert about the canonical signal. Gate the clear step on "this run checked
+the exact signal the alert is about" (default target AND full coverage), not
+merely on "this run was healthy". Serialization (Lesson 155's guard) prevents
+concurrent races, not signal mismatch — they are independent hazards.**
+
+## How to apply
+
+- For every auto-close/auto-resolve step in a workflow, list the input
+  parameters that change _what was measured_; the close condition must pin
+  each one to the alerting configuration's value.
+- Default a read-path monitor's target to the surface consumers actually
+  read (edge, not origin) — verify against the real consumer's config
+  (here: mcp-server's `DEFAULT_CDN_BASE_URL`), not the pipeline's write
+  target.
+- Same shape elsewhere: a flake detector run on a filtered subset must not
+  reset a whole-suite health flag; a partial backfill must not clear a
+  completeness alert.
+
+## Related
+
+- [[155-a-recency-freshness-monitor-is-blind-to-a-held-promotion-content-stale-state]] —
+  the self-clearing pattern this lesson scopes; serialization vs signal
+  mismatch are different hazards.
+- `.github/workflows/cdn-schema-canary.yml` (the gated close step),
+  `scripts/check-cdn-schema.ts` (edge-URL default).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -144,3 +144,4 @@
 - **156** [analytics, dcp, refactor, monorepo, verification] — An audit's defect list for a forked implementation is a lower bound; consolidation must re-derive the full semantic diff (#1118, #1095)
 - **157** [zod, schemas, data-pipeline, monorepo, verification, contracts] — In a zod union, a non-strict all-optional object schema matches (and silently EMPTIES) any object; strictness is what keeps the union falsifiable (#1123, #1096)
 - **157** [data-pipeline, analytics, transformation, fixtures, verification] — When sibling reports share one entity universe, derive every aggregate block from the single merged entity set (#1124, #1096)
+- **158** [ci, automation, monitoring, data-pipeline, verification] — A parameterized monitor's self-clear must be scoped to the signal it alarms on (#1125, #1096)


### PR DESCRIPTION
Sprint 3 of epic #1096 — sub-issue #1125 (do not auto-close; epic tick ordering per R15).

## What

Two complementary contract-enforcement surfaces (Lesson 155's two freshness axes):

1. **Publish-time Zod gate (prevent).** `scripts/lib/snapshotPublishGate.ts` (pure, unit-tested) + `scripts/validate-snapshots.ts` (thin runner) validate every `district_*.json` against `PerDistrictDataSchema` from shared-contracts, wired into `data-pipeline.yml` daily mode **between compute-analytics and the GCS upload**. Fail-loud with district + snapshot date (`::error::` annotations + step summary). Zero district files / missing dir = FAIL (no vacuous pass).
2. **Live-CDN schema canary (detect, non-gating).** `scripts/lib/cdnSchemaCanary.ts` + `scripts/check-cdn-schema.ts` + scheduled `cdn-schema-canary.yml` (15:30 UTC) run the *same* `safeParse` the mcp-server performs against what the production CDN edge (`cdn.taverns.red`) actually serves — latest date → snapshot manifest → all published districts. Unhealthy ⇒ files/refreshes a `cdn-schema-canary` issue and reds the run; healthy ⇒ self-clears open alerts (close step is **signal-scoped**: only a default-surface, uncapped run may clear — Lesson 158). "Can't tell" (unreachable manifest, garbage JSON, zero districts) alerts, never passes (Lesson 107).

## Why this shape

The transform write path already validates — but `merge-find-a-club` rewrites snapshots **in place with no re-validation** (collector-cli `cli.ts:1444`); that is exactly how the #1096 FAC drift reached prod and silently broke `get-district-snapshot`/`get-club-health`. The gate validates the final on-disk bytes immediately before upload, covering every writer. The canary covers everything else (other pipeline modes, manual uploads, edge-layer failures).

## Acceptance criteria → evidence

- **Failing test first** ✔ Red commits precede Green (`bc292ff1`→`5ec7b4c8`, `cdb0a980`→`37ed952f`); contract-violating snapshot (arbitrary object in a clubPerformance row — the exact #1096 drift class) fails the gate.
- **Daily pipeline green with the gate on real data** ✔ ran `validate-snapshots.ts` against all **128 real staging district snapshots** (2026-06-09): PASS, exit 0. (The gate's first scheduled run is the next daily pipeline.)
- **Canary alert path proven with injected bad fixture** ✔ test-level: recorded real CDN fixture + injected junk object ⇒ unhealthy, district + zod path named. Also proven live against an unreachable bucket ⇒ unhealthy + alert body written.
- **R2** ✔ gate reads only the in-job `./cache/snapshots/<date>` produced by the same run; shared-contracts dist is built by the existing "Build packages" step; the canary workflow has its own `npm ci` + `build:shared-contracts` and reads the public CDN (no credentials).

Live verification (no PR preview — diff touches only `scripts/` + workflows, path filter doesn't trigger): canary run against the real edge: **healthy, 128/128 districts pass read-validation** — which is also the epic's live-probe criterion (same safeParse as mcp-server).

## Tests

- `npm run test:scripts`: 17 files / 232 tests green (8 new gate tests, 11 new canary tests, on the recorded real fixture per Lesson 154)
- Full workspace suite green: frontend 3393, analytics-core 885, collector-cli 852, shared-contracts 158, mcp-server 51
- Fresh-context review applied: signal-scoped self-clear (High), edge-URL default + `latestSnapshotDate` injection guard (Medium), markdown pipe escaping (Low)

## Follow-up (operator to file — classifier blocked autonomous issue creation)

Extend the gate to rebuild/rescrape/rescrape-historical upload paths (runner already accepts multiple dirs; blocking semantics inside the streaming loops need a decision: skip-date vs fail-run). Optional QoL: re-validate inside `merge-find-a-club` for local operator feedback. Until then the canary backstops those modes post-promotion.

After merge: hand #1049 (live MCP E2E) back to the operator — it should now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
