### PR TITLE
Sprint 1 (#1097) — integer-safe recognition targets + paid-base region denominator (#1126)

### DIFF
--- a/frontend/src/utils/__tests__/aggregateRegions.test.ts
+++ b/frontend/src/utils/__tests__/aggregateRegions.test.ts
@@ -223,13 +223,50 @@ describe('aggregateRegions (#493)', () => {
     expect(rollups[0]?.paymentGrowthPercent).toBeCloseTo(8.695, 2)
   })
 
-  it('derives distinguishedPercent from sums', () => {
+  it('derives distinguishedPercent from sums over the paid club BASE (#1126 C4, lesson 60)', () => {
     const rollups = aggregateRegions([
-      mk({ region: '01', paidClubs: 100, distinguishedClubs: 50 }),
-      mk({ region: '01', paidClubs: 50, distinguishedClubs: 22 }),
+      mk({
+        region: '01',
+        paidClubs: 100,
+        paidClubBase: 110,
+        distinguishedClubs: 50,
+      }),
+      mk({
+        region: '01',
+        paidClubs: 50,
+        paidClubBase: 70,
+        distinguishedClubs: 22,
+      }),
     ])
-    // distinguished=72, paidClubs=150 → 48%
-    expect(rollups[0]?.distinguishedPercent).toBeCloseTo(48, 1)
+    // distinguished=72, paidClubBase=180 → 40%. The DDP rule
+    // (rules-reference §9, Item 1490) divides by PY-start base, NOT
+    // current paidClubs (which would inflate this to 72/150 = 48%).
+    expect(rollups[0]?.distinguishedPercent).toBeCloseTo(40, 5)
+  })
+
+  it('matches the live R13 shape: base denominator, not current paid clubs (#1126 C4)', () => {
+    // Live 2026-06-09 audit: R13 rendered 49.7% (distinguished / current
+    // paidClubs) where the canonical value is 43.8% (distinguished /
+    // paidClubBase) — every region inflated 0.3–6.0pp, feeding region
+    // ranks + Borda scores.
+    const rollups = aggregateRegions([
+      mk({
+        districtId: 'A',
+        region: '13',
+        distinguishedClubs: 80,
+        paidClubs: 160,
+        paidClubBase: 180,
+      }),
+      mk({
+        districtId: 'B',
+        region: '13',
+        distinguishedClubs: 69,
+        paidClubs: 140,
+        paidClubBase: 160,
+      }),
+    ])
+    // 149/340 = 43.82%, NOT 149/300 = 49.67%
+    expect(rollups[0]?.distinguishedPercent).toBeCloseTo((149 / 340) * 100, 10)
   })
 
   it('returns 0 (not NaN) when a denominator is zero', () => {

--- a/frontend/src/utils/__tests__/distinguishedCountdown.test.ts
+++ b/frontend/src/utils/__tests__/distinguishedCountdown.test.ts
@@ -316,3 +316,35 @@ describe('getDistinguishedCountdown — absolute remaining counts (#688 #683)', 
     expect(c!.clubGrowth).toEqual({ kind: 'boolean', met: false })
   })
 })
+
+/* #798 float-overshoot survivors (#1126 C5): the tier targets must use
+   integer-percent arithmetic. `ceil(100 * (55/100))` = 56 under floats;
+   55% of 100 is exactly 55. Must agree with the canonical
+   analytics-core calculators (see recognitionTargetParity.test.ts). */
+describe('integer-safe tier targets (#1126, #798)', () => {
+  const zeroed = (
+    overrides: Partial<RemainingInputs> = {}
+  ): RemainingInputs => ({
+    paidClubBase: 0,
+    paymentBase: 0,
+    paidClubs: 0,
+    totalPayments: 0,
+    distinguishedClubs: 0,
+    ...overrides,
+  })
+
+  it('Presidents distinguished-clubs target at base 100 is exactly 55', () => {
+    const r = deriveRemainingToTier('Presidents', zeroed({ paidClubBase: 100 }))
+    expect(r.distinguishedClubsRemaining).toBe(55)
+  })
+
+  it('Presidents distinguished-clubs target at base 200 is exactly 110', () => {
+    const r = deriveRemainingToTier('Presidents', zeroed({ paidClubBase: 200 }))
+    expect(r.distinguishedClubsRemaining).toBe(110)
+  })
+
+  it('Smedley payment target at base 225 is exactly 243 (8% growth)', () => {
+    const r = deriveRemainingToTier('Smedley', zeroed({ paymentBase: 225 }))
+    expect(r.paymentsRemaining).toBe(243)
+  })
+})

--- a/frontend/src/utils/__tests__/recognitionTargetParity.test.ts
+++ b/frontend/src/utils/__tests__/recognitionTargetParity.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateGrowthTargets,
+  calculatePercentageTargets,
+  DistinguishedDistrictCalculator,
+} from '@toastmasters/analytics-core'
+import type { DistrictRanking } from '@toastmasters/shared-contracts'
+import {
+  deriveRemainingToTier,
+  type DistinguishedTier,
+} from '../distinguishedCountdown'
+import {
+  calculateDivisionGapAnalysis,
+  calculateDivisionDistinguishedRequirement,
+} from '../divisionGapAnalysis'
+
+/* Cross-implementation parity property (#1126, epic #1097).
+
+   Four implementations compute recognition targets from a base count:
+   - analytics-core TargetCalculator (district recognition targets → CDN)
+   - analytics-core DistinguishedDistrictCalculator (countdown fields)
+   - frontend distinguishedCountdown (pre-pipeline derived countdown)
+   - frontend divisionGapAnalysis (division DDP gaps)
+
+   The program rule is one rule (Item 1490): a target is "at least X% of
+   base", i.e. ceil of an exact percentage. #798 showed the float form
+   `ceil(base * 0.55)` overshoots (100 → 56); this property pins every
+   implementation to the same integer-exact value so the drift class —
+   one copy fixed, a sibling copy regressing — is dead, not just the
+   instances named in the audit.
+
+   Targets are extracted from the countdown implementations by feeding
+   zero current counts: remaining = max(0, target − 0) = target. */
+
+/** Bases known to overshoot under the float form (#798), plus a dense
+ *  low sweep and a few large districts. 100/200 are the live D86/D94
+ *  wrong numbers; 225 is the smallest 8%-growth overshoot. */
+const SWEEP = [
+  ...Array.from({ length: 601 }, (_, i) => i),
+  825,
+  850,
+  1700,
+  2125,
+  4500,
+  5000,
+  9999,
+  10000,
+]
+
+const zeroCurrentRanking = (base: number): DistrictRanking =>
+  ({
+    districtId: 'P1',
+    districtName: 'Parity',
+    region: '01',
+    paidClubs: 0,
+    paidClubBase: base,
+    totalPayments: 0,
+    paymentBase: base,
+    distinguishedClubs: 0,
+    clubGrowthPercent: 0,
+    paymentGrowthPercent: 0,
+    distinguishedPercent: 0,
+    dspSubmitted: true,
+    trainingMet: true,
+    marketAnalysisSubmitted: true,
+    communicationPlanSubmitted: true,
+    regionAdvisorVisitMet: true,
+  }) as DistrictRanking
+
+/** TargetCalculator level ↔ countdown tier, same thresholds by rule. */
+const TIER_FOR_LEVEL: Record<
+  'distinguished' | 'select' | 'presidents' | 'smedley',
+  DistinguishedTier
+> = {
+  distinguished: 'Distinguished',
+  select: 'Select',
+  presidents: 'Presidents',
+  smedley: 'Smedley',
+}
+
+describe('recognition target parity across implementations (#1126)', () => {
+  it('distinguished-clubs targets agree: TargetCalculator ↔ distinguishedCountdown (all tiers)', () => {
+    for (const base of SWEEP) {
+      const targets = calculatePercentageTargets(base)
+      for (const level of Object.keys(TIER_FOR_LEVEL) as Array<
+        keyof typeof TIER_FOR_LEVEL
+      >) {
+        const derived = deriveRemainingToTier(TIER_FOR_LEVEL[level], {
+          paidClubBase: base,
+          paymentBase: 0,
+          paidClubs: 0,
+          totalPayments: 0,
+          distinguishedClubs: 0,
+        })
+        expect
+          .soft(derived.distinguishedClubsRemaining, `base=${base} ${level}`)
+          .toBe(targets[level])
+      }
+    }
+  })
+
+  it('growth targets agree: TargetCalculator ↔ distinguishedCountdown (all tiers)', () => {
+    for (const base of SWEEP) {
+      const targets = calculateGrowthTargets(base)
+      for (const level of Object.keys(TIER_FOR_LEVEL) as Array<
+        keyof typeof TIER_FOR_LEVEL
+      >) {
+        const derived = deriveRemainingToTier(TIER_FOR_LEVEL[level], {
+          paidClubBase: base,
+          paymentBase: base,
+          paidClubs: 0,
+          totalPayments: 0,
+          distinguishedClubs: 0,
+        })
+        expect
+          .soft(derived.paymentsRemaining, `base=${base} ${level} payments`)
+          .toBe(targets[level])
+        expect
+          .soft(derived.paidClubsRemaining, `base=${base} ${level} paidClubs`)
+          .toBe(targets[level])
+      }
+    }
+  })
+
+  it('minimum-tier targets agree: DistinguishedDistrictCalculator ↔ TargetCalculator', () => {
+    const calculator = new DistinguishedDistrictCalculator()
+    for (const base of SWEEP) {
+      const status = calculator.calculate(zeroCurrentRanking(base))
+      expect
+        .soft(status.distinguishedClubsRemaining, `base=${base} distinguished`)
+        .toBe(calculatePercentageTargets(base).distinguished)
+      expect
+        .soft(status.paymentsRemaining, `base=${base} payments`)
+        .toBe(calculateGrowthTargets(base).distinguished)
+      expect
+        .soft(status.paidClubsRemaining, `base=${base} paidClubs`)
+        .toBe(calculateGrowthTargets(base).distinguished)
+    }
+  })
+
+  it('division DDP distinguished-clubs requirements agree with TargetCalculator (45/50/55)', () => {
+    for (const base of SWEEP) {
+      const targets = calculatePercentageTargets(base)
+      const gaps = calculateDivisionGapAnalysis({
+        clubBase: base,
+        paidClubs: base, // no-net-loss met → gaps are pure requirements
+        distinguishedClubs: 0,
+      })
+      expect
+        .soft(gaps.distinguishedGap.distinguishedClubsNeeded, `base=${base} D`)
+        .toBe(targets.distinguished)
+      expect
+        .soft(gaps.selectGap.distinguishedClubsNeeded, `base=${base} S`)
+        .toBe(targets.select)
+      expect
+        .soft(gaps.presidentsGap.distinguishedClubsNeeded, `base=${base} P`)
+        .toBe(targets.presidents)
+      expect
+        .soft(calculateDivisionDistinguishedRequirement(base), `base=${base}`)
+        .toBe(targets.distinguished)
+    }
+  })
+})

--- a/frontend/src/utils/aggregateRegions.ts
+++ b/frontend/src/utils/aggregateRegions.ts
@@ -6,6 +6,7 @@
    us compute it client-side from the per-district feed we already
    publish, with no pipeline changes. */
 
+import { calculateDistinguishedPercent } from '@toastmasters/analytics-core'
 import type { DistrictRanking } from '@toastmasters/shared-contracts'
 
 export interface RequirementRatio {
@@ -25,7 +26,9 @@ export interface RegionRollup {
   /** Derived: (totalPayments − paymentBase) / paymentBase × 100. 0 when base is 0. */
   paymentGrowthPercent: number
   distinguishedClubs: number
-  /** Derived: distinguishedClubs / paidClubs × 100. 0 when paidClubs is 0. */
+  /** Derived: distinguishedClubs / paidClubBase × 100 (DDP Item 1490 §9,
+   *  lesson 60 — base denominator, NOT current paidClubs; #1126).
+   *  0 when paidClubBase is 0. */
   distinguishedPercent: number
   /** Region's rank by clubGrowthPercent. 1 = best across all regions. */
   clubsRank: number
@@ -164,7 +167,10 @@ export function aggregateRegions(
         totals.paymentBase
       ),
       distinguishedClubs: totals.distinguishedClubs,
-      distinguishedPercent: pct(totals.distinguishedClubs, totals.paidClubs),
+      distinguishedPercent: calculateDistinguishedPercent(
+        totals.distinguishedClubs,
+        totals.paidClubBase
+      ),
       leadingDistrictId: leading.districtId,
       leadingDistrictName: leading.districtName,
       requirements,

--- a/frontend/src/utils/distinguishedCountdown.ts
+++ b/frontend/src/utils/distinguishedCountdown.ts
@@ -1,3 +1,4 @@
+import { growthTarget, percentageTarget } from '@toastmasters/analytics-core'
 import type {
   CompetitiveAwardStandings,
   DistinguishedDistrictTier,
@@ -103,12 +104,14 @@ export function deriveRemainingToTier(
   distinguishedClubsRemaining: number
 } {
   const t = TIER_THRESHOLDS[tier]
-  const paymentTarget = Math.ceil(
-    r.paymentBase * (1 + t.paymentGrowthMin / 100)
-  )
-  const paidClubTarget = Math.ceil(r.paidClubBase * (1 + t.clubGrowthMin / 100))
-  const distinguishedTarget = Math.ceil(
-    r.paidClubBase * (t.distinguishedPercentMin / 100)
+  // Integer-safe targets via the shared analytics-core helpers — the
+  // float form `ceil(base * (pct/100))` overshoots (100 → 56 at 55%);
+  // see #798/#1126 and recognitionTargetParity.test.ts.
+  const paymentTarget = growthTarget(r.paymentBase, t.paymentGrowthMin)
+  const paidClubTarget = growthTarget(r.paidClubBase, t.clubGrowthMin)
+  const distinguishedTarget = percentageTarget(
+    r.paidClubBase,
+    t.distinguishedPercentMin
   )
   return {
     paidClubsRemaining: Math.max(0, paidClubTarget - r.paidClubs),

--- a/frontend/src/utils/divisionGapAnalysis.ts
+++ b/frontend/src/utils/divisionGapAnalysis.ts
@@ -20,6 +20,8 @@
  * Requirements: 5.2, 5.5, 6.1, 6.2, 6.3, 6.4, 6.5, 9.1, 9.2, 9.3, 9.4
  */
 
+import { percentageTarget } from '@toastmasters/analytics-core'
+
 /**
  * Recognition levels for divisions in the Distinguished Division Program
  *
@@ -149,7 +151,7 @@ function calculateRequiredDistinguishedClubs(
   clubBase: number,
   thresholdPercent: number
 ): number {
-  return Math.ceil((clubBase * thresholdPercent) / 100)
+  return percentageTarget(clubBase, thresholdPercent)
 }
 
 /**

--- a/frontend/src/utils/divisionGapAnalysis.ts
+++ b/frontend/src/utils/divisionGapAnalysis.ts
@@ -178,9 +178,9 @@ export function calculateDivisionDistinguishedRequirement(
  *
  * Property 1: Recognition Level Classification
  * - If paidClubs < clubBase: "none" (net club loss - not eligible)
- * - Else if paidClubs >= clubBase + 2 AND distinguishedClubs >= Math.ceil(clubBase * 0.55): "presidents"
- * - Else if paidClubs >= clubBase + 1 AND distinguishedClubs >= Math.ceil(clubBase * 0.50): "select"
- * - Else if paidClubs >= clubBase AND distinguishedClubs >= Math.ceil(clubBase * 0.45): "distinguished"
+ * - Else if paidClubs >= clubBase + 2 AND distinguishedClubs >= ceil(clubBase × 55 / 100): "presidents"
+ * - Else if paidClubs >= clubBase + 1 AND distinguishedClubs >= ceil(clubBase × 50 / 100): "select"
+ * - Else if paidClubs >= clubBase AND distinguishedClubs >= ceil(clubBase × 45 / 100): "distinguished"
  * - Else: "none"
  *
  * @param metrics - Division metrics (clubBase, paidClubs, distinguishedClubs)

--- a/packages/analytics-core/src/analytics/TargetCalculator.ts
+++ b/packages/analytics-core/src/analytics/TargetCalculator.ts
@@ -7,40 +7,74 @@
  * - Membership Payments (growth-based: base + percentage)
  * - Distinguished Clubs (percentage-based: percentage of base)
  *
+ * All targets use integer-percent arithmetic — `Math.ceil((base * pct) / 100)`
+ * — never `Math.ceil(base * (pct / 100))`. The float form overshoots whenever
+ * the true product is a whole number that the binary representation nudges up
+ * (100 × 0.55 = 55.00000000000001 → ceil → 56, when 55% of 100 is exactly 55).
+ * Live wrong numbers D86/D94 (#798, #1126). `growthTarget` / `percentageTarget`
+ * are the single source of truth for this form across the codebase — the
+ * frontend countdown/division-gap utilities and DistinguishedDistrictCalculator
+ * delegate here, pinned by the cross-implementation parity test
+ * (frontend/src/utils/__tests__/recognitionTargetParity.test.ts).
+ *
  * Requirements: 2.1-2.6, 3.1-3.6, 4.1-4.6, 5.1-5.6
  */
 
 import type { RecognitionTargets, RecognitionLevel } from '../types.js'
 
 /**
- * Recognition level percentages for paid clubs and membership payments targets.
- * Formula: base + (base * percentage), rounded up using Math.ceil
+ * Recognition level growth percentages (whole percents) for paid clubs and
+ * membership payments targets.
+ * Formula: ceil(base × (100 + pct) / 100)
  *
  * Requirements: 2.1-2.4, 3.1-3.4
  */
 export const GROWTH_PERCENTAGES = {
-  distinguished: 0.01, // +1%
-  select: 0.03, // +3%
-  presidents: 0.05, // +5%
-  smedley: 0.08, // +8%
+  distinguished: 1, // +1%
+  select: 3, // +3%
+  presidents: 5, // +5%
+  smedley: 8, // +8%
 } as const
 
 /**
- * Recognition level percentages for distinguished clubs targets.
- * Formula: base * percentage, rounded up using Math.ceil
+ * Recognition level percentages (whole percents) for distinguished clubs
+ * targets.
+ * Formula: ceil(base × pct / 100)
  *
  * Requirements: 4.1-4.4
  */
 export const DISTINGUISHED_PERCENTAGES = {
-  distinguished: 0.45, // 45%
-  select: 0.5, // 50%
-  presidents: 0.55, // 55%
-  smedley: 0.6, // 60%
+  distinguished: 45, // 45%
+  select: 50, // 50%
+  presidents: 55, // 55%
+  smedley: 60, // 60%
 } as const
 
 /**
+ * "At least X% of base" target, rounded up, computed with integer-safe
+ * arithmetic (#798). `base * wholePercent` is an exact integer, so the
+ * division is exact whenever the true result is whole — no float overshoot.
+ *
+ * @param base - The base value (e.g. paidClubBase)
+ * @param wholePercent - Threshold as a whole percent (e.g. 55 for 55%)
+ */
+export function percentageTarget(base: number, wholePercent: number): number {
+  return Math.ceil((base * wholePercent) / 100)
+}
+
+/**
+ * "Grow base by at least X%" target, rounded up, computed with integer-safe
+ * arithmetic (#798): ceil(base × (100 + growthPercent) / 100).
+ *
+ * @param base - The base value (paidClubBase or paymentBase)
+ * @param growthPercent - Required growth as a whole percent (e.g. 5 for +5%)
+ */
+export function growthTarget(base: number, growthPercent: number): number {
+  return Math.ceil((base * (100 + growthPercent)) / 100)
+}
+
+/**
  * Calculates growth-based targets for paid clubs and membership payments.
- * Formula: base + (base * percentage), rounded up using Math.ceil
  *
  * @param base - The base value (paidClubBase or paymentBase)
  * @returns Recognition targets for each level
@@ -49,16 +83,15 @@ export const DISTINGUISHED_PERCENTAGES = {
  */
 export function calculateGrowthTargets(base: number): RecognitionTargets {
   return {
-    distinguished: Math.ceil(base * (1 + GROWTH_PERCENTAGES.distinguished)),
-    select: Math.ceil(base * (1 + GROWTH_PERCENTAGES.select)),
-    presidents: Math.ceil(base * (1 + GROWTH_PERCENTAGES.presidents)),
-    smedley: Math.ceil(base * (1 + GROWTH_PERCENTAGES.smedley)),
+    distinguished: growthTarget(base, GROWTH_PERCENTAGES.distinguished),
+    select: growthTarget(base, GROWTH_PERCENTAGES.select),
+    presidents: growthTarget(base, GROWTH_PERCENTAGES.presidents),
+    smedley: growthTarget(base, GROWTH_PERCENTAGES.smedley),
   }
 }
 
 /**
  * Calculates percentage-based targets for distinguished clubs.
- * Formula: base * percentage, rounded up using Math.ceil
  *
  * @param base - The base value (paidClubBase)
  * @returns Recognition targets for each level
@@ -67,10 +100,13 @@ export function calculateGrowthTargets(base: number): RecognitionTargets {
  */
 export function calculatePercentageTargets(base: number): RecognitionTargets {
   return {
-    distinguished: Math.ceil(base * DISTINGUISHED_PERCENTAGES.distinguished),
-    select: Math.ceil(base * DISTINGUISHED_PERCENTAGES.select),
-    presidents: Math.ceil(base * DISTINGUISHED_PERCENTAGES.presidents),
-    smedley: Math.ceil(base * DISTINGUISHED_PERCENTAGES.smedley),
+    distinguished: percentageTarget(
+      base,
+      DISTINGUISHED_PERCENTAGES.distinguished
+    ),
+    select: percentageTarget(base, DISTINGUISHED_PERCENTAGES.select),
+    presidents: percentageTarget(base, DISTINGUISHED_PERCENTAGES.presidents),
+    smedley: percentageTarget(base, DISTINGUISHED_PERCENTAGES.smedley),
   }
 }
 

--- a/packages/analytics-core/src/analytics/__tests__/TargetCalculator.test.ts
+++ b/packages/analytics-core/src/analytics/__tests__/TargetCalculator.test.ts
@@ -28,10 +28,12 @@ describe('TargetCalculator', () => {
      * **Validates: Requirements 2.1-2.4, 3.1-3.4**
      */
     it('should have correct percentage values for each recognition level', () => {
-      expect(GROWTH_PERCENTAGES.distinguished).toBe(0.01) // +1%
-      expect(GROWTH_PERCENTAGES.select).toBe(0.03) // +3%
-      expect(GROWTH_PERCENTAGES.presidents).toBe(0.05) // +5%
-      expect(GROWTH_PERCENTAGES.smedley).toBe(0.08) // +8%
+      // Whole percents (#1126): integer-percent arithmetic avoids the
+      // #798 float overshoot of fractional multipliers.
+      expect(GROWTH_PERCENTAGES.distinguished).toBe(1) // +1%
+      expect(GROWTH_PERCENTAGES.select).toBe(3) // +3%
+      expect(GROWTH_PERCENTAGES.presidents).toBe(5) // +5%
+      expect(GROWTH_PERCENTAGES.smedley).toBe(8) // +8%
     })
   })
 
@@ -42,10 +44,12 @@ describe('TargetCalculator', () => {
      * **Validates: Requirements 4.1-4.4**
      */
     it('should have correct percentage values for each recognition level', () => {
-      expect(DISTINGUISHED_PERCENTAGES.distinguished).toBe(0.45) // 45%
-      expect(DISTINGUISHED_PERCENTAGES.select).toBe(0.5) // 50%
-      expect(DISTINGUISHED_PERCENTAGES.presidents).toBe(0.55) // 55%
-      expect(DISTINGUISHED_PERCENTAGES.smedley).toBe(0.6) // 60%
+      // Whole percents (#1126): integer-percent arithmetic avoids the
+      // #798 float overshoot of fractional multipliers.
+      expect(DISTINGUISHED_PERCENTAGES.distinguished).toBe(45) // 45%
+      expect(DISTINGUISHED_PERCENTAGES.select).toBe(50) // 50%
+      expect(DISTINGUISHED_PERCENTAGES.presidents).toBe(55) // 55%
+      expect(DISTINGUISHED_PERCENTAGES.smedley).toBe(60) // 60%
     })
   })
 
@@ -197,13 +201,12 @@ describe('TargetCalculator', () => {
      * Formula: base * percentage, rounded up using Math.ceil
      *
      * Expected results:
-     * - Distinguished: 100 * 0.45 = 45 → ceil → 45
-     * - Select: 100 * 0.50 = 50 → ceil → 50
-     * - President's: 100 * 0.55 = 55.00000000000001 (floating-point) → ceil → 56
-     * - Smedley: 100 * 0.60 = 60 → ceil → 60
-     *
-     * Note: Due to floating-point precision, 100 * 0.55 = 55.00000000000001,
-     * which Math.ceil() correctly rounds up to 56.
+     * - Distinguished: 45% of 100 = 45
+     * - Select: 50% of 100 = 50
+     * - President's: 55% of 100 = 55 (exactly — the old float form
+     *   `100 * 0.55 = 55.00000000000001 → ceil → 56` was the #798 bug,
+     *   live-wrong on D86; fixed by integer arithmetic in #1126)
+     * - Smedley: 60% of 100 = 60
      *
      * **Validates: Requirements 4.1-4.4, 4.6**
      */
@@ -212,7 +215,7 @@ describe('TargetCalculator', () => {
 
       expect(targets.distinguished).toBe(45)
       expect(targets.select).toBe(50)
-      expect(targets.presidents).toBe(56) // 55.00000000000001 → ceil → 56
+      expect(targets.presidents).toBe(55)
       expect(targets.smedley).toBe(60)
     })
 
@@ -580,10 +583,11 @@ describe('TargetCalculator', () => {
   describe('integration: calculatePercentageTargets + determineAchievedLevel', () => {
     /**
      * Test: End-to-end flow for distinguished clubs
-     * Base=100 → targets: 45, 50, 56, 60
+     * Base=100 → targets: 45, 50, 55, 60
      *
-     * Note: President's target is 56 (not 55) due to floating-point precision:
-     * 100 * 0.55 = 55.00000000000001 → Math.ceil() → 56
+     * 55% of 100 is exactly 55. The old float form produced 56 here
+     * (100 * 0.55 = 55.00000000000001 → ceil → 56) — the #798 bug,
+     * live-wrong on D86/D94; fixed with integer arithmetic in #1126.
      *
      * **Validates: Requirements 4.1-4.4, 5.1-5.5**
      */
@@ -594,7 +598,7 @@ describe('TargetCalculator', () => {
       expect(targets).toEqual({
         distinguished: 45,
         select: 50,
-        presidents: 56, // 55.00000000000001 → ceil → 56
+        presidents: 55,
         smedley: 60,
       })
 
@@ -602,7 +606,7 @@ describe('TargetCalculator', () => {
       expect(determineAchievedLevel(44, targets)).toBeNull()
       expect(determineAchievedLevel(45, targets)).toBe('distinguished')
       expect(determineAchievedLevel(50, targets)).toBe('select')
-      expect(determineAchievedLevel(56, targets)).toBe('presidents')
+      expect(determineAchievedLevel(55, targets)).toBe('presidents')
       expect(determineAchievedLevel(60, targets)).toBe('smedley')
       expect(determineAchievedLevel(70, targets)).toBe('smedley')
     })
@@ -637,18 +641,23 @@ describe('TargetCalculator Property Tests', () => {
     /**
      * Helper to verify ceiling rounding invariant for a single target value.
      *
-     * For any base B and percentage P, the target T = ⌈B × P⌉ SHALL satisfy:
+     * For any base B and whole percent P, the target T = ⌈B × P / 100⌉ SHALL
+     * satisfy:
      * 1. T is an integer
-     * 2. T ≥ B × P (target is at least the mathematical result)
-     * 3. T - (B × P) < 1 (target is less than 1 above the mathematical result)
+     * 2. T ≥ B × P / 100 (target is at least the mathematical result)
+     * 3. T - (B × P / 100) < 1 (target is less than 1 above it)
+     *
+     * The mathematical result is computed with the integer-safe form
+     * `(base * wholePercent) / 100` — exact whenever the true result is a
+     * whole number — never `base * (percent/100)` (#798, #1126).
      */
     function verifyCeilingInvariant(
       target: number,
       base: number,
-      percentage: number,
+      wholePercent: number,
       targetName: string
     ): void {
-      const mathematicalResult = base * percentage
+      const mathematicalResult = (base * wholePercent) / 100
 
       // Invariant 1: Target must be an integer
       expect(
@@ -688,25 +697,25 @@ describe('TargetCalculator Property Tests', () => {
           verifyCeilingInvariant(
             targets.distinguished,
             base,
-            1 + GROWTH_PERCENTAGES.distinguished,
+            100 + GROWTH_PERCENTAGES.distinguished,
             'Distinguished'
           )
           verifyCeilingInvariant(
             targets.select,
             base,
-            1 + GROWTH_PERCENTAGES.select,
+            100 + GROWTH_PERCENTAGES.select,
             'Select'
           )
           verifyCeilingInvariant(
             targets.presidents,
             base,
-            1 + GROWTH_PERCENTAGES.presidents,
+            100 + GROWTH_PERCENTAGES.presidents,
             "President's"
           )
           verifyCeilingInvariant(
             targets.smedley,
             base,
-            1 + GROWTH_PERCENTAGES.smedley,
+            100 + GROWTH_PERCENTAGES.smedley,
             'Smedley'
           )
 
@@ -848,24 +857,24 @@ describe('TargetCalculator Property Tests', () => {
           const growthPercentages = [
             {
               target: growthTargets.distinguished,
-              pct: 1 + GROWTH_PERCENTAGES.distinguished,
+              pct: 100 + GROWTH_PERCENTAGES.distinguished,
             },
             {
               target: growthTargets.select,
-              pct: 1 + GROWTH_PERCENTAGES.select,
+              pct: 100 + GROWTH_PERCENTAGES.select,
             },
             {
               target: growthTargets.presidents,
-              pct: 1 + GROWTH_PERCENTAGES.presidents,
+              pct: 100 + GROWTH_PERCENTAGES.presidents,
             },
             {
               target: growthTargets.smedley,
-              pct: 1 + GROWTH_PERCENTAGES.smedley,
+              pct: 100 + GROWTH_PERCENTAGES.smedley,
             },
           ]
 
           for (const { target, pct } of growthPercentages) {
-            const mathematicalResult = base * pct
+            const mathematicalResult = (base * pct) / 100
             const difference = target - mathematicalResult
             expect(difference).toBeGreaterThanOrEqual(0)
             expect(difference).toBeLessThan(1)
@@ -892,7 +901,7 @@ describe('TargetCalculator Property Tests', () => {
           ]
 
           for (const { target, pct } of distinguishedPercentages) {
-            const mathematicalResult = base * pct
+            const mathematicalResult = (base * pct) / 100
             const difference = target - mathematicalResult
             expect(difference).toBeGreaterThanOrEqual(0)
             expect(difference).toBeLessThan(1)

--- a/packages/analytics-core/src/analytics/__tests__/TargetCalculator.test.ts
+++ b/packages/analytics-core/src/analytics/__tests__/TargetCalculator.test.ts
@@ -1260,3 +1260,72 @@ describe('TargetCalculator Property Tests', () => {
     })
   })
 })
+
+/* #798 float-overshoot survivors (#1126 C5). `Math.ceil(base * 0.55)`
+   overshoots whenever base*55 is divisible by 100 (0.55 is not exactly
+   representable: 100 * 0.55 = 55.00000000000001 → ceil → 56). The
+   integer-safe form is `Math.ceil((base * 55) / 100)`. Same class for
+   growth targets: 225 * 1.08 = 243.00000000000003 → ceil → 244, when
+   8% growth on 225 is exactly 243. Live wrong numbers: D86 presidents
+   target 56 (correct 55), D94 111 (correct 110). */
+describe('integer-safe targets — #798 overshoot regressions (#1126)', () => {
+  it('presidents target at base 100 is exactly 55 (live D86 regression)', () => {
+    expect(calculatePercentageTargets(100).presidents).toBe(55)
+  })
+
+  it('presidents target at base 200 is exactly 110 (live D94 regression)', () => {
+    expect(calculatePercentageTargets(200).presidents).toBe(110)
+  })
+
+  it('smedley growth target at base 225 is exactly 243', () => {
+    expect(calculateGrowthTargets(225).smedley).toBe(243)
+  })
+
+  it('every percentage target matches integer arithmetic for bases 1..10000', () => {
+    const mismatches: Array<[number, string, number, number]> = []
+    for (let base = 1; base <= 10000; base++) {
+      const t = calculatePercentageTargets(base)
+      const expected = {
+        distinguished: Math.ceil((base * 45) / 100),
+        select: Math.ceil((base * 50) / 100),
+        presidents: Math.ceil((base * 55) / 100),
+        smedley: Math.ceil((base * 60) / 100),
+      }
+      for (const level of [
+        'distinguished',
+        'select',
+        'presidents',
+        'smedley',
+      ] as const) {
+        if (t[level] !== expected[level]) {
+          mismatches.push([base, level, t[level], expected[level]])
+        }
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+
+  it('every growth target matches integer arithmetic for bases 1..10000', () => {
+    const mismatches: Array<[number, string, number, number]> = []
+    for (let base = 1; base <= 10000; base++) {
+      const t = calculateGrowthTargets(base)
+      const expected = {
+        distinguished: Math.ceil((base * 101) / 100),
+        select: Math.ceil((base * 103) / 100),
+        presidents: Math.ceil((base * 105) / 100),
+        smedley: Math.ceil((base * 108) / 100),
+      }
+      for (const level of [
+        'distinguished',
+        'select',
+        'presidents',
+        'smedley',
+      ] as const) {
+        if (t[level] !== expected[level]) {
+          mismatches.push([base, level, t[level], expected[level]])
+        }
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+})

--- a/packages/analytics-core/src/analytics/index.ts
+++ b/packages/analytics-core/src/analytics/index.ts
@@ -55,6 +55,8 @@ export {
   calculateGrowthTargets,
   calculatePercentageTargets,
   determineAchievedLevel,
+  growthTarget,
+  percentageTarget,
   GROWTH_PERCENTAGES,
   DISTINGUISHED_PERCENTAGES,
 } from './TargetCalculator.js'

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -60,6 +60,8 @@ export {
   calculateGrowthTargets,
   calculatePercentageTargets,
   determineAchievedLevel,
+  growthTarget,
+  percentageTarget,
   GROWTH_PERCENTAGES,
   DISTINGUISHED_PERCENTAGES,
   // Club eligibility utilities

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
@@ -20,6 +20,10 @@
  */
 
 import type { DistrictRanking } from '@toastmasters/shared-contracts'
+import {
+  growthTarget,
+  percentageTarget,
+} from '../analytics/TargetCalculator.js'
 
 /**
  * Distinguished District tier names.
@@ -327,9 +331,11 @@ export class DistinguishedDistrictCalculator {
    * they track the same rule `meetsThreshold` enforces — a count of 0 means
    * that metric's Distinguished minimum is satisfied.
    *
-   *   payments   target = ceil(paymentBase × (1 + paymentGrowthMin/100))
-   *   paidClubs  target = ceil(paidClubBase × (1 + clubGrowthMin/100))
-   *   distinguished target = ceil(paidClubBase × distinguishedPercentMin/100)
+   *   payments   target = ceil(paymentBase × (100 + paymentGrowthMin) / 100)
+   *   paidClubs  target = ceil(paidClubBase × (100 + clubGrowthMin) / 100)
+   *   distinguished target = ceil(paidClubBase × distinguishedPercentMin / 100)
+   *
+   * Integer-safe form via the shared TargetCalculator helpers (#798, #1126).
    *
    * Distinguished % uses `paidClubBase` as the denominator, not
    * `activeClubs` (TI DDP Item 1490; lesson 60). `Math.ceil` because the
@@ -350,14 +356,14 @@ export class DistinguishedDistrictCalculator {
       }
     }
 
-    const paymentTarget = Math.ceil(
-      ranking.paymentBase * (1 + min.paymentGrowthMin / 100)
+    const paymentTarget = growthTarget(
+      ranking.paymentBase,
+      min.paymentGrowthMin
     )
-    const paidClubTarget = Math.ceil(
-      ranking.paidClubBase * (1 + min.clubGrowthMin / 100)
-    )
-    const distinguishedTarget = Math.ceil(
-      ranking.paidClubBase * (min.distinguishedPercentMin / 100)
+    const paidClubTarget = growthTarget(ranking.paidClubBase, min.clubGrowthMin)
+    const distinguishedTarget = percentageTarget(
+      ranking.paidClubBase,
+      min.distinguishedPercentMin
     )
 
     return {

--- a/tasks/lessons/158-a-test-comment-that-explains-a-surprising-expectation-by-mechanism-is-a-pinned-bug.md
+++ b/tasks/lessons/158-a-test-comment-that-explains-a-surprising-expectation-by-mechanism-is-a-pinned-bug.md
@@ -1,0 +1,66 @@
+---
+id: '158'
+category: lesson
+tags: [tests, tdd, verification, analytics, floats]
+auto_load: true
+date: 2026-06-10
+issues: [1126, 1097, 798]
+---
+
+# Lesson 158 — A test comment that justifies a surprising expectation by MECHANISM ("due to floating-point precision") instead of by RULE is a pinned bug wearing documentation
+
+**Date:** 2026-06-10
+**Issue:** #1126 (epic #1097 Sprint 1 — integer-safe recognition targets)
+**PR:** _(record on merge)_
+
+## What happened
+
+`TargetCalculator.test.ts` asserted the President's Distinguished target
+for a 100-club base as **56**, with a confident explanation:
+
+```ts
+// Note: Due to floating-point precision, 100 * 0.55 = 55.00000000000001,
+// which Math.ceil() correctly rounds up to 56.
+expect(targets.presidents).toBe(56) // 55.00000000000001 → ceil → 56
+```
+
+The comment is accurate about the mechanism and wrong about the world:
+55% of 100 clubs is exactly 55 (Item 1490). The float artifact had been
+observed, investigated, _understood_ — and then enshrined as the
+expected value, in two separate tests. The same form was fixed in
+`divisionGapAnalysis` back in #798; these survivors stayed live for
+months and published wrong targets for D86 (56) and D94 (111) because
+the tests "documented" the wrong numbers as correct.
+
+## The transferable principle
+
+**When a test expectation needs a comment explaining the
+implementation's mechanism to be believable, the expectation came FROM
+the implementation — that's assertion pinning with extra steps. A valid
+surprising expectation is justified by citing the domain rule, not the
+arithmetic that produced it.** The tell is the direction of derivation:
+"the spec says 55, here's why" is a test; "the code computes 56, here's
+why" is a bug with a caption. Review-time heuristic: any numeric test
+comment containing "due to floating-point", "because Math.ceil", or
+similar mechanism-talk should be re-derived from the rule it claims to
+encode.
+
+## How to apply
+
+- In review, treat mechanism-justified expectations as red flags: ask
+  "what does the PROGRAM RULE say this value is?" before accepting.
+- When fixing such a pin, fix every implementation of the formula
+  (lesson 61) and pin them to each other with a cross-implementation
+  parity/property test so the class dies, not the instance.
+- Property tests that re-implement the production formula inherit its
+  bugs (this file's ceiling-invariant helpers used the same float form).
+  Express the oracle in a _different_, exactness-preserving form
+  (integer arithmetic) than the code under test.
+
+## Related
+
+- [[156-a-rekeyed-conversion-field-must-match-the-target-keys-domain-not-just-its-shape]] —
+  same epic family: a plausible local justification masking a wrong value.
+- [[061-when-fixing-a-formula-audit-every-implementation]] — the fix
+  shape: one shared helper (`percentageTarget`/`growthTarget`), all
+  callers delegate.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -145,3 +145,4 @@
 - **157** [zod, schemas, data-pipeline, monorepo, verification, contracts] — In a zod union, a non-strict all-optional object schema matches (and silently EMPTIES) any object; strictness is what keeps the union falsifiable (#1123, #1096)
 - **157** [data-pipeline, analytics, transformation, fixtures, verification] — When sibling reports share one entity universe, derive every aggregate block from the single merged entity set (#1124, #1096)
 - **158** [ci, automation, monitoring, data-pipeline, verification] — A parameterized monitor's self-clear must be scoped to the signal it alarms on (#1125, #1096)
+- **158** [tests, tdd, verification, analytics, floats] — A test comment that justifies a surprising expectation by MECHANISM ("due to floating-point precision") instead of by RULE is a pinned bug wearing documentation (#1126, #1097, #798)


### PR DESCRIPTION
Sprint 1 of epic #1097 — audit findings C4 + C5 (two verified live wrong numbers). Sub-issue: #1126 (referenced, not auto-closed — R15/L106 ordering).

## What

**C4 — region %-distinguished used the wrong denominator (Lesson 60 regression).**
`aggregateRegions` divided by current `paidClubs`; the DDP rule (Item 1490 §9, canonical `distinguishedPercent.ts`) divides by **paid club base**. Live R13 rendered 49.7% vs correct 43.8%; every region inflated 0.3–6.0pp, feeding region ranks + Borda scores. Now delegates to `calculateDistinguishedPercent` (the declared single source of truth).

**C5 — #798 float-overshoot survivors.**
`Math.ceil(base * 0.55)` overshoots whenever the true product is whole (100 × 0.55 = 55.00000000000001 → 56). Live wrong: D86 presidents target 56 (correct 55), D94 111 (correct 110); 228 of bases 1..10000 affected, plus the growth form (smallest case: 8% on 225 → 244 instead of 243; 89 bases affected).

Fix shape (Lesson 61 — one rule, one implementation):
- New shared helpers in `TargetCalculator.ts`: `percentageTarget(base, wholePct)` and `growthTarget(base, growthPct)` using integer-safe `ceil((base × pct) / 100)`. Constants converted to whole percents (no external consumers — repo-wide grep verified).
- `DistinguishedDistrictCalculator.computeRemainingToMinimum`, frontend `distinguishedCountdown.deriveRemainingToTier`, and `divisionGapAnalysis.calculateRequiredDistinguishedClubs` all delegate to the shared helpers.
- **Cross-implementation parity property test** (`recognitionTargetParity.test.ts`): sweeps 600+ bases incl. all known overshoot cases across all four implementations — the drift class is dead, not just the audited instances.

**Un-pinned test expectations.** Two pre-existing tests had enshrined the float artifact as expected (`expect(targets.presidents).toBe(56) // 55.00000000000001 → ceil → 56`). Corrected to the program rule (55% of 100 = 55). This is the inverse of assertion pinning — see new Lesson 158.

## Out of scope (deliberate)

- `AnalyticsComputer.ts:1662` legacy `computePerformanceTargets` fields — Sprint 2 (#1127).
- `divisionStatus.ts` / `areaGapAnalysis.ts` / `*ProgressText.ts` float forms with 0.45/0.5/0.75 multipliers — empirically verified zero overshoot for bases 1..20000 (exactly-representable multipliers); left untouched to keep this PR single-responsibility.

## Verification

- Red commit proves all new tests failed pre-fix (e.g. parity caught divisionGapAnalysis's correct 935 vs TargetCalculator's 936 at base 1700).
- Full workspace suite green (frontend 273 files / analytics-core 40 / collector-cli 46 / shared-contracts 9 / mcp-server 7). `quality:check` green.
- R16: analytics-core dist rebuilt before frontend tests.
- Fresh-context review: APPROVE-WITH-NITS (nit applied; informational note: the TargetCalculator↔countdown parity legs are tautological post-consolidation by design — regression coverage inside the helpers lives in the 1..10000 integer-arithmetic tests, so keep both).
- Preview: /regions percentages should drop to base-denominator values (R13 ~43.8%). D86/D94 CDN targets correct after the next scheduled pipeline run — code-proof per issue AC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
