### PR TITLE
Sprint 2 (#1097) — remove legacy district targets from computePerformanceTargets (#1127)

### DIFF
--- a/frontend/src/hooks/__tests__/useAggregatedAnalytics.test.tsx
+++ b/frontend/src/hooks/__tests__/useAggregatedAnalytics.test.tsx
@@ -8,7 +8,7 @@
  * - Fetches analytics from CDN (no Express fallback — #173)
  * - Converts CDN format to aggregated response format
  * - Handles loading and error states appropriately
- * - Populates yearOverYear and performanceTargets from CDN data
+ * - Populates yearOverYear from CDN data
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'

--- a/frontend/src/hooks/aggregatedAnalytics/helpers.ts
+++ b/frontend/src/hooks/aggregatedAnalytics/helpers.ts
@@ -34,9 +34,9 @@ export async function fetchIndividualAnalytics(
 /**
  * Convert individual analytics response to aggregated format.
  *
- * Populates yearOverYear and performanceTargets from the CDN analytics
- * data, fixing the Overview tab "— —" and "N/A" placeholders that appeared
- * after the Express /analytics-summary route was deleted (#173).
+ * Populates yearOverYear from the CDN analytics data, fixing the Overview
+ * tab "— —" and "N/A" placeholders that appeared after the Express
+ * /analytics-summary route was deleted (#173).
  */
 export function convertToAggregatedFormat(
   analytics: DistrictAnalytics
@@ -98,19 +98,6 @@ export function convertToAggregatedFormat(
   // Populate yearOverYear from CDN analytics data (#173)
   if (analytics.yearOverYear) {
     response.yearOverYear = analytics.yearOverYear
-  }
-
-  // Populate performanceTargets from CDN analytics data (#173)
-  if (analytics.performanceTargets) {
-    const pt = analytics.performanceTargets
-    const targets: AggregatedAnalyticsResponse['performanceTargets'] = {}
-    if (pt.membershipPayments?.base != null) {
-      targets.membershipTarget = pt.membershipPayments.base
-    }
-    if (pt.distinguishedClubs?.base != null) {
-      targets.distinguishedTarget = pt.distinguishedClubs.base
-    }
-    response.performanceTargets = targets
   }
 
   return response

--- a/frontend/src/hooks/aggregatedAnalytics/types.ts
+++ b/frontend/src/hooks/aggregatedAnalytics/types.ts
@@ -93,18 +93,6 @@ export interface YearOverYearComparison {
 }
 
 /**
- * Performance targets (optional)
- */
-export interface PerformanceTargets {
-  /** Target membership count */
-  membershipTarget?: number
-  /** Target number of distinguished clubs */
-  distinguishedTarget?: number
-  /** Target club growth */
-  clubGrowthTarget?: number
-}
-
-/**
  * Aggregated analytics response from CDN analytics-summary JSON
  */
 export interface AggregatedAnalyticsResponse {
@@ -123,8 +111,6 @@ export interface AggregatedAnalyticsResponse {
   trends: TrendData
   /** Year-over-year comparison (optional) */
   yearOverYear?: YearOverYearComparison
-  /** Performance targets (optional) */
-  performanceTargets?: PerformanceTargets
   /** Source of the data: 'precomputed' or 'computed' */
   dataSource: 'precomputed' | 'computed'
   /** ISO timestamp when the data was computed */

--- a/frontend/src/hooks/useAggregatedAnalytics.ts
+++ b/frontend/src/hooks/useAggregatedAnalytics.ts
@@ -23,7 +23,6 @@ export type {
   PaymentsTrendPoint,
   TrendData,
   YearOverYearComparison,
-  PerformanceTargets,
   AggregatedAnalyticsResponse,
   UseAggregatedAnalyticsResult,
 } from './aggregatedAnalytics/types'

--- a/frontend/src/hooks/usePerformanceTargets.ts
+++ b/frontend/src/hooks/usePerformanceTargets.ts
@@ -26,23 +26,21 @@ import type {
 
 /**
  * CDN performance-targets.json shape
+ *
+ * The legacy scalar targets (membershipTarget / distinguishedTarget /
+ * clubGrowthTarget) and projectedAchievement were removed from the
+ * published payload in #1127 — the per-metric `*Targets` fields carry the
+ * canonical §13.2 recognition targets. Older snapshot artifacts may still
+ * contain the removed fields; they were never read here.
  */
 interface CdnPerformanceTargetsData {
   districtId: string
   computedAt: string
-  membershipTarget: number
-  distinguishedTarget: number
-  clubGrowthTarget: number
   paidClubsCount: number
   currentProgress: {
     membership: number
     distinguished: number
     clubGrowth: number
-  }
-  projectedAchievement: {
-    membership: boolean
-    distinguished: boolean
-    clubGrowth: boolean
   }
   paidClubsRankings: CdnRankings
   membershipPaymentsRankings: CdnRankings

--- a/packages/analytics-core/src/__tests__/PerformanceTargetsData.test.ts
+++ b/packages/analytics-core/src/__tests__/PerformanceTargetsData.test.ts
@@ -2,8 +2,7 @@
  * Unit Tests for PerformanceTargetsData Serialization
  *
  * Verifies JSON round-trip serialization preserves all fields including
- * paidClubsCount, currentProgress, projectedAchievement, and
- * MetricRankings with nullable values.
+ * paidClubsCount, currentProgress, and MetricRankings with nullable values.
  *
  * Converted from property-based tests — PBT generated random objects;
  * replaced with representative fixed test cases covering null values,
@@ -19,19 +18,11 @@ function createPerformanceTargetsData(
   return {
     districtId: 'D42',
     computedAt: '2024-06-15T10:30:00.000Z',
-    membershipTarget: 500,
-    distinguishedTarget: 10,
-    clubGrowthTarget: 5,
     paidClubsCount: 45,
     currentProgress: {
       membership: 350,
       distinguished: 7,
       clubGrowth: 3,
-    },
-    projectedAchievement: {
-      membership: true,
-      distinguished: false,
-      clubGrowth: true,
     },
     paidClubsRankings: {
       worldRank: 25,
@@ -70,9 +61,6 @@ describe('PerformanceTargetsData Serialization', () => {
 
     expect(deserialized.districtId).toBe(original.districtId)
     expect(deserialized.computedAt).toBe(original.computedAt)
-    expect(deserialized.membershipTarget).toBe(original.membershipTarget)
-    expect(deserialized.distinguishedTarget).toBe(original.distinguishedTarget)
-    expect(deserialized.clubGrowthTarget).toBe(original.clubGrowthTarget)
     expect(deserialized.paidClubsCount).toBe(original.paidClubsCount)
   })
 
@@ -109,33 +97,6 @@ describe('PerformanceTargetsData Serialization', () => {
     expect(deserialized.currentProgress.membership).toBe(999)
     expect(deserialized.currentProgress.distinguished).toBe(42)
     expect(deserialized.currentProgress.clubGrowth).toBe(-5)
-  })
-
-  it('should preserve all projectedAchievement boolean fields', () => {
-    const combos = [
-      { membership: true, distinguished: true, clubGrowth: true },
-      { membership: false, distinguished: false, clubGrowth: false },
-      { membership: true, distinguished: false, clubGrowth: true },
-    ]
-
-    for (const projected of combos) {
-      const original = createPerformanceTargetsData({
-        projectedAchievement: projected,
-      })
-      const deserialized = JSON.parse(
-        JSON.stringify(original)
-      ) as PerformanceTargetsData
-
-      expect(deserialized.projectedAchievement.membership).toBe(
-        projected.membership
-      )
-      expect(deserialized.projectedAchievement.distinguished).toBe(
-        projected.distinguished
-      )
-      expect(deserialized.projectedAchievement.clubGrowth).toBe(
-        projected.clubGrowth
-      )
-    }
   })
 
   it('should preserve MetricRankings with non-null values', () => {
@@ -195,9 +156,6 @@ describe('PerformanceTargetsData Serialization', () => {
 
   it('should handle zero values correctly', () => {
     const original = createPerformanceTargetsData({
-      membershipTarget: 0,
-      distinguishedTarget: 0,
-      clubGrowthTarget: 0,
       paidClubsCount: 0,
       currentProgress: { membership: 0, distinguished: 0, clubGrowth: 0 },
     })
@@ -205,7 +163,6 @@ describe('PerformanceTargetsData Serialization', () => {
       JSON.stringify(original)
     ) as PerformanceTargetsData
 
-    expect(deserialized.membershipTarget).toBe(0)
     expect(deserialized.paidClubsCount).toBe(0)
     expect(deserialized.currentProgress.membership).toBe(0)
   })

--- a/packages/analytics-core/src/analytics/AnalyticsComputer.test.ts
+++ b/packages/analytics-core/src/analytics/AnalyticsComputer.test.ts
@@ -1879,15 +1879,9 @@ describe('computePerformanceTargets', () => {
 
     expect(result.districtId).toBe('D101')
     expect(result.computedAt).toBeDefined()
-    expect(result.membershipTarget).toBe(0)
-    expect(result.distinguishedTarget).toBe(0)
-    expect(result.clubGrowthTarget).toBe(0)
     expect(result.currentProgress.membership).toBe(0)
     expect(result.currentProgress.distinguished).toBe(0)
     expect(result.currentProgress.clubGrowth).toBe(0)
-    expect(result.projectedAchievement.membership).toBe(false)
-    expect(result.projectedAchievement.distinguished).toBe(false)
-    expect(result.projectedAchievement.clubGrowth).toBe(false)
   })
 
   it('should return zero values when district not found in snapshots', () => {
@@ -1899,35 +1893,10 @@ describe('computePerformanceTargets', () => {
     const result = computer.computePerformanceTargets('D101', [snapshot])
 
     expect(result.districtId).toBe('D101')
-    expect(result.membershipTarget).toBe(0)
     expect(result.currentProgress.membership).toBe(0)
   })
 
-  it('should compute membership target as 5% growth from base', () => {
-    const computer = new AnalyticsComputer()
-    const clubs = [
-      createMockClub({
-        clubId: '1',
-        areaId: 'A1',
-        areaName: 'Area A1',
-        divisionId: 'A',
-        membershipCount: 100,
-        paymentsCount: 100, // Set paymentsCount to match expected value
-        dcpGoals: 5,
-        status: 'Active',
-      }),
-    ]
-    const snapshot = createMockSnapshot('D101', '2024-01-15', clubs)
-
-    const result = computer.computePerformanceTargets('D101', [snapshot])
-
-    // Membership target = ceil(100 * 1.05) = 105
-    expect(result.membershipTarget).toBe(105)
-    // currentProgress.membership now uses totalPayments (sum of paymentsCount)
-    expect(result.currentProgress.membership).toBe(100)
-  })
-
-  it('should compute distinguished target as 50% of paid clubs', () => {
+  it('should count distinguished clubs in currentProgress', () => {
     const computer = new AnalyticsComputer()
     const clubs = [
       createMockClub({
@@ -1971,8 +1940,8 @@ describe('computePerformanceTargets', () => {
 
     const result = computer.computePerformanceTargets('D101', [snapshot])
 
-    // 4 paid clubs, distinguished target = ceil(4 * 0.5) = 2
-    expect(result.distinguishedTarget).toBe(2)
+    // 4 paid clubs
+    expect(result.paidClubsCount).toBe(4)
     // 2 clubs have 5+ DCP goals (distinguished)
     expect(result.currentProgress.distinguished).toBe(2)
   })
@@ -2009,75 +1978,6 @@ describe('computePerformanceTargets', () => {
 
     // Club growth = 5 - 3 = 2
     expect(result.currentProgress.clubGrowth).toBe(2)
-    // Club growth target = max(1, ceil(3 * 0.02)) = max(1, 1) = 1
-    expect(result.clubGrowthTarget).toBe(1)
-  })
-
-  it('should project achievement when progress >= 80%', () => {
-    const computer = new AnalyticsComputer()
-    const clubs = [
-      createMockClub({
-        clubId: '1',
-        areaId: 'A1',
-        areaName: 'Area A1',
-        divisionId: 'A',
-        membershipCount: 100,
-        dcpGoals: 6,
-        status: 'Active',
-      }),
-    ]
-    const snapshot = createMockSnapshot('D101', '2024-01-15', clubs)
-
-    const result = computer.computePerformanceTargets('D101', [snapshot])
-
-    // Membership: 100 / 105 = 95.2% >= 80% -> projected true
-    expect(result.projectedAchievement.membership).toBe(true)
-    // Distinguished: 1 / 1 = 100% >= 80% -> projected true
-    expect(result.projectedAchievement.distinguished).toBe(true)
-  })
-
-  it('should not project achievement when progress < 80%', () => {
-    const computer = new AnalyticsComputer()
-
-    // Base snapshot with high membership
-    const baseClubs = [
-      createMockClub({
-        clubId: '1',
-        areaId: 'A1',
-        divisionId: 'A',
-        membershipCount: 100,
-        dcpGoals: 2,
-        status: 'Active',
-      }),
-    ]
-    const baseSnapshot = createMockSnapshot('D101', '2024-01-01', baseClubs)
-
-    // Current snapshot with lower membership (simulating decline)
-    const currentClubs = [
-      createMockClub({
-        clubId: '1',
-        areaId: 'A1',
-        divisionId: 'A',
-        membershipCount: 70,
-        dcpGoals: 2,
-        status: 'Active',
-      }),
-    ]
-    const currentSnapshot = createMockSnapshot(
-      'D101',
-      '2024-03-15',
-      currentClubs
-    )
-
-    const result = computer.computePerformanceTargets('D101', [
-      baseSnapshot,
-      currentSnapshot,
-    ])
-
-    // Membership: 70 / 105 = 66.7% < 80% -> projected false
-    expect(result.projectedAchievement.membership).toBe(false)
-    // Distinguished: 0 / 1 = 0% < 80% -> projected false
-    expect(result.projectedAchievement.distinguished).toBe(false)
   })
 
   it('should filter snapshots by district ID', () => {
@@ -2140,8 +2040,8 @@ describe('computePerformanceTargets', () => {
 
     const result = computer.computePerformanceTargets('D101', [snapshot])
 
-    // Only 1 paid club, distinguished target = ceil(1 * 0.5) = 1
-    expect(result.distinguishedTarget).toBe(1)
+    // Only 1 paid club (the suspended club is not paid)
+    expect(result.paidClubsCount).toBe(1)
     // Only 1 distinguished club (the active one with 6 DCP goals)
     expect(result.currentProgress.distinguished).toBe(1)
   })

--- a/packages/analytics-core/src/analytics/AnalyticsComputer.ts
+++ b/packages/analytics-core/src/analytics/AnalyticsComputer.ts
@@ -1550,19 +1550,11 @@ export class AnalyticsComputer implements IAnalyticsComputer {
       return {
         districtId,
         computedAt: new Date().toISOString(),
-        membershipTarget: 0,
-        distinguishedTarget: 0,
-        clubGrowthTarget: 0,
         paidClubsCount: 0,
         currentProgress: {
           membership: 0,
           distinguished: 0,
           clubGrowth: 0,
-        },
-        projectedAchievement: {
-          membership: false,
-          distinguished: false,
-          clubGrowth: false,
         },
         paidClubsRankings,
         membershipPaymentsRankings,
@@ -1587,19 +1579,11 @@ export class AnalyticsComputer implements IAnalyticsComputer {
       return {
         districtId,
         computedAt: new Date().toISOString(),
-        membershipTarget: 0,
-        distinguishedTarget: 0,
-        clubGrowthTarget: 0,
         paidClubsCount: 0,
         currentProgress: {
           membership: 0,
           distinguished: 0,
           clubGrowth: 0,
-        },
-        projectedAchievement: {
-          membership: false,
-          distinguished: false,
-          clubGrowth: false,
         },
         paidClubsRankings,
         membershipPaymentsRankings,
@@ -1628,19 +1612,6 @@ export class AnalyticsComputer implements IAnalyticsComputer {
       districtRanking?.totalPayments ??
       this.membershipModule.getTotalPayments(latestSnapshot)
 
-    // Calculate current membership (for membership target calculation)
-    const currentMembership =
-      this.membershipModule.getTotalMembership(latestSnapshot)
-    const baseMembership = baseSnapshot
-      ? this.membershipModule.getTotalMembership(baseSnapshot)
-      : currentMembership
-
-    // Calculate membership target (5% growth from base)
-    const membershipGrowthRate = 0.05
-    const membershipTarget = Math.ceil(
-      baseMembership * (1 + membershipGrowthRate)
-    )
-
     // Use AreaDivisionRecognitionModule to get area recognition data
     const areaRecognitions =
       this.areaDivisionRecognitionModule.calculateAreaRecognition(
@@ -1657,50 +1628,23 @@ export class AnalyticsComputer implements IAnalyticsComputer {
       0
     )
 
-    // Distinguished target: 50% of paid clubs (Distinguished level threshold from DAP)
-    // This aligns with the DAP_DISTINGUISHED_THRESHOLD of 50%
-    const distinguishedTarget = Math.ceil(totalPaidClubs * 0.5)
-
-    // Calculate club growth
+    // Calculate club growth (signed actual; the growth *targets* live in
+    // paidClubsTargets — the legacy scalar targets were removed in #1127)
     const currentClubCount = latestSnapshot.clubs.length
     const baseClubCount = baseSnapshot
       ? baseSnapshot.clubs.length
       : currentClubCount
     const clubGrowth = currentClubCount - baseClubCount
 
-    // Club growth target: Net positive growth (at least 1 new club)
-    const clubGrowthTarget = Math.max(1, Math.ceil(baseClubCount * 0.02)) // 2% growth or at least 1
-
-    // Calculate projected achievements based on current progress and trends
-    const membershipProgress = currentMembership / membershipTarget
-    const distinguishedProgress =
-      distinguishedTarget > 0 ? currentDistinguished / distinguishedTarget : 0
-    const clubGrowthProgress =
-      clubGrowthTarget > 0 ? clubGrowth / clubGrowthTarget : 0
-
-    // Project achievement based on progress rate
-    // If progress is >= 80%, project achievement as likely
-    const projectedMembership = membershipProgress >= 0.8
-    const projectedDistinguished = distinguishedProgress >= 0.8
-    const projectedClubGrowth = clubGrowthProgress >= 0.8
-
     return {
       districtId,
       computedAt: new Date().toISOString(),
-      membershipTarget,
-      distinguishedTarget,
-      clubGrowthTarget,
       paidClubsCount: totalPaidClubs,
       currentProgress: {
         // Use totalPayments from rankings (official Toastmasters value) for membership payments
         membership: currentMembershipPayments,
         distinguished: currentDistinguished,
         clubGrowth,
-      },
-      projectedAchievement: {
-        membership: projectedMembership,
-        distinguished: projectedDistinguished,
-        clubGrowth: projectedClubGrowth,
       },
       paidClubsRankings,
       membershipPaymentsRankings,

--- a/packages/analytics-core/src/analytics/__tests__/AnalyticsComputer.performanceTargets.test.ts
+++ b/packages/analytics-core/src/analytics/__tests__/AnalyticsComputer.performanceTargets.test.ts
@@ -477,7 +477,6 @@ describe('computePerformanceTargets with rankings integration', () => {
 
       // Verify that performance targets are still computed correctly
       expect(result.districtId).toBe('D101')
-      expect(result.membershipTarget).toBe(105) // ceil(100 * 1.05)
       // currentProgress.membership now uses totalPayments from rankings
       expect(result.currentProgress.membership).toBe(100)
       expect(result.computedAt).toBeDefined()
@@ -510,11 +509,6 @@ describe('computePerformanceTargets with rankings integration', () => {
         [],
         allDistrictsRankings
       )
-
-      // Performance targets should be zero
-      expect(result.membershipTarget).toBe(0)
-      expect(result.distinguishedTarget).toBe(0)
-      expect(result.clubGrowthTarget).toBe(0)
 
       // But rankings should still be populated from allDistrictsRankings
       expect(result.paidClubsRankings.worldRank).toBe(5)

--- a/packages/analytics-core/src/analytics/__tests__/AnalyticsComputer.performanceTargets.test.ts
+++ b/packages/analytics-core/src/analytics/__tests__/AnalyticsComputer.performanceTargets.test.ts
@@ -1574,4 +1574,87 @@ describe('computeDistrictAnalytics membership change calculation', () => {
       expect(result.districtAnalytics.membershipChange).toBe(50)
     })
   })
+
+  /**
+   * Legacy district targets removal (#1127, epic #1097, audit §8).
+   *
+   * computePerformanceTargets published a legacy scalar block with wrong or
+   * unsourced rules: distinguishedTarget = ceil(paidClubs * 0.5) (a 50% DAP
+   * area rule with a current-paid denominator, applied to the district
+   * metric — §13.2 is 45% of paid club base), clubGrowthTarget = 2%
+   * (unsourced), membershipTarget = 5% (unsourced), and
+   * projectedAchievement derived from those targets. The §13.2-correct
+   * values already ship in the same payload as paidClubsTargets /
+   * membershipPaymentsTargets / distinguishedClubsTargets (1/3/5/8% growth
+   * tiers, 45/50/55/60% of paid club base) and are the fields the frontend
+   * consumes. The legacy block has zero consumers (R8 inventory in #1127)
+   * and is removed rather than corrected — correcting it would duplicate
+   * the canonical fields (lessons 61/76 two-copies drift).
+   */
+  describe('legacy district targets are not published (#1127)', () => {
+    const LEGACY_KEYS = [
+      'membershipTarget',
+      'distinguishedTarget',
+      'clubGrowthTarget',
+      'projectedAchievement',
+    ] as const
+
+    it('omits the legacy target fields for populated snapshots', () => {
+      const clubs = [
+        createMockClub({
+          clubId: '1',
+          membershipCount: 100,
+          dcpGoals: 6,
+          status: 'Active',
+        }),
+      ]
+      const snapshot = createMockSnapshot('D101', '2024-01-15', clubs)
+      const allDistrictsRankings = createRankingsData(
+        [
+          {
+            districtId: 'D101',
+            clubsRank: 5,
+            paymentsRank: 10,
+            distinguishedRank: 3,
+            region: 'Region 10',
+            totalPayments: 100,
+          },
+        ],
+        100
+      )
+
+      const result = computer.computePerformanceTargets(
+        'D101',
+        [snapshot],
+        allDistrictsRankings
+      )
+
+      for (const key of LEGACY_KEYS) {
+        expect(result).not.toHaveProperty(key)
+      }
+
+      // The consumed fields stay intact: actuals + canonical §13.2 targets.
+      expect(result.paidClubsCount).toBe(1)
+      expect(result.currentProgress.membership).toBe(100)
+      expect(typeof result.currentProgress.distinguished).toBe('number')
+      expect(result.paidClubsTargets).not.toBeNull()
+      expect(result.distinguishedClubsTargets).not.toBeNull()
+      expect(result.paidClubsRankings.worldRank).toBe(5)
+    })
+
+    it('omits the legacy target fields for empty snapshots', () => {
+      const result = computer.computePerformanceTargets('D101', [])
+
+      for (const key of LEGACY_KEYS) {
+        expect(result).not.toHaveProperty(key)
+      }
+
+      expect(result.paidClubsCount).toBe(0)
+      expect(result.currentProgress).toEqual({
+        membership: 0,
+        distinguished: 0,
+        clubGrowth: 0,
+      })
+    })
+  })
 })

--- a/packages/analytics-core/src/types/performanceTargets.ts
+++ b/packages/analytics-core/src/types/performanceTargets.ts
@@ -143,31 +143,21 @@ export interface PerformanceTargetsData {
   districtId: string
   /** ISO timestamp when the data was computed */
   computedAt: string
-  /** Target for membership (based on base membership + growth target) */
-  membershipTarget: number
-  /** Target for distinguished clubs count */
-  distinguishedTarget: number
-  /** Target for club growth (net new clubs) */
-  clubGrowthTarget: number
   /** Total count of paid clubs (clubs with "Active" status) */
   paidClubsCount: number
-  /** Current progress toward targets */
+  /**
+   * Current metric actuals. The recognition targets these are measured
+   * against are the per-metric `*Targets` fields below (§13.2 semantics) —
+   * the legacy scalar targets (membershipTarget / distinguishedTarget /
+   * clubGrowthTarget) and projectedAchievement were removed in #1127.
+   */
   currentProgress: {
-    /** Current membership count */
+    /** Current membership payments (official totalPayments when available) */
     membership: number
     /** Current distinguished clubs count */
     distinguished: number
     /** Current club growth (net change from base) */
     clubGrowth: number
-  }
-  /** Whether targets are projected to be achieved */
-  projectedAchievement: {
-    /** Whether membership target is projected to be achieved */
-    membership: boolean
-    /** Whether distinguished target is projected to be achieved */
-    distinguished: boolean
-    /** Whether club growth target is projected to be achieved */
-    clubGrowth: boolean
   }
   /** Rankings for paid clubs metric (Requirements 4.1, 4.4) */
   paidClubsRankings: MetricRankings

--- a/packages/collector-cli/src/__tests__/AnalyticsComputeService.test.ts
+++ b/packages/collector-cli/src/__tests__/AnalyticsComputeService.test.ts
@@ -2156,18 +2156,11 @@ describe('AnalyticsComputeService', () => {
       const file = JSON.parse(content) as PreComputedAnalyticsFile<{
         districtId: string
         computedAt: string
-        membershipTarget: number
-        distinguishedTarget: number
-        clubGrowthTarget: number
+        paidClubsCount: number
         currentProgress: {
           membership: number
           distinguished: number
           clubGrowth: number
-        }
-        projectedAchievement: {
-          membership: boolean
-          distinguished: boolean
-          clubGrowth: boolean
         }
       }>
 
@@ -2175,11 +2168,14 @@ describe('AnalyticsComputeService', () => {
       expect(file.metadata.districtId).toBe(districtId)
       expect(file.data.districtId).toBe(districtId)
       expect(file.data.computedAt).toBeDefined()
-      expect(typeof file.data.membershipTarget).toBe('number')
-      expect(typeof file.data.distinguishedTarget).toBe('number')
-      expect(typeof file.data.clubGrowthTarget).toBe('number')
+      expect(typeof file.data.paidClubsCount).toBe('number')
       expect(file.data.currentProgress).toBeDefined()
-      expect(file.data.projectedAchievement).toBeDefined()
+      // Legacy district targets were removed in #1127 — the canonical
+      // recognition targets ship as paidClubsTargets / *Targets fields.
+      expect(file.data).not.toHaveProperty('membershipTarget')
+      expect(file.data).not.toHaveProperty('distinguishedTarget')
+      expect(file.data).not.toHaveProperty('clubGrowthTarget')
+      expect(file.data).not.toHaveProperty('projectedAchievement')
     })
 
     it('should generate valid club-trends-index.json with correct structure', async () => {

--- a/packages/collector-cli/src/__tests__/AnalyticsWriter.test.ts
+++ b/packages/collector-cli/src/__tests__/AnalyticsWriter.test.ts
@@ -682,18 +682,11 @@ function createSamplePerformanceTargets(
   return {
     districtId,
     computedAt: new Date().toISOString(),
-    membershipTarget: 1600,
-    distinguishedTarget: 35,
-    clubGrowthTarget: 5,
+    paidClubsCount: 70,
     currentProgress: {
       membership: 1500,
       distinguished: 27,
       clubGrowth: 2,
-    },
-    projectedAchievement: {
-      membership: true,
-      distinguished: false,
-      clubGrowth: true,
     },
   }
 }
@@ -2173,13 +2166,9 @@ describe('AnalyticsWriter', () => {
         content
       ) as PreComputedAnalyticsFile<PerformanceTargetsData>
 
-      // Verify targets are included
-      expect(parsed.data.membershipTarget).toBeDefined()
-      expect(typeof parsed.data.membershipTarget).toBe('number')
-      expect(parsed.data.distinguishedTarget).toBeDefined()
-      expect(typeof parsed.data.distinguishedTarget).toBe('number')
-      expect(parsed.data.clubGrowthTarget).toBeDefined()
-      expect(typeof parsed.data.clubGrowthTarget).toBe('number')
+      // Verify paid clubs count is included
+      expect(parsed.data.paidClubsCount).toBeDefined()
+      expect(typeof parsed.data.paidClubsCount).toBe('number')
 
       // Verify current progress is included
       expect(parsed.data.currentProgress).toBeDefined()
@@ -2187,13 +2176,11 @@ describe('AnalyticsWriter', () => {
       expect(parsed.data.currentProgress.distinguished).toBeDefined()
       expect(parsed.data.currentProgress.clubGrowth).toBeDefined()
 
-      // Verify projected achievement is included
-      expect(parsed.data.projectedAchievement).toBeDefined()
-      expect(typeof parsed.data.projectedAchievement.membership).toBe('boolean')
-      expect(typeof parsed.data.projectedAchievement.distinguished).toBe(
-        'boolean'
-      )
-      expect(typeof parsed.data.projectedAchievement.clubGrowth).toBe('boolean')
+      // Legacy district targets were removed in #1127
+      expect(parsed.data).not.toHaveProperty('membershipTarget')
+      expect(parsed.data).not.toHaveProperty('distinguishedTarget')
+      expect(parsed.data).not.toHaveProperty('clubGrowthTarget')
+      expect(parsed.data).not.toHaveProperty('projectedAchievement')
     })
   })
 


### PR DESCRIPTION
Sprint 2 of epic #1097 — sub-issue #1127 (plain reference, not auto-closing).

## What

Removes the legacy district target scalars from the published `district_{id}_performance-targets.json` payload (`PerformanceTargetsData`):

- `distinguishedTarget = ceil(paidClubs * 0.5)` — a 50% DAP **area** rule with a **current-paid** denominator, misapplied to the district metric. Rules-reference §13.2 is **45% of paid club base**. Live D86 published `50` vs the §13.2-correct `45` that ships beside it.
- `clubGrowthTarget = max(1, ceil(baseClubCount * 0.02))` — unsourced 2% rule (§13.2 growth tiers are 1/3/5/8%).
- `membershipTarget = ceil(baseMembership * 1.05)` — unsourced 5% rule; also compared against a *payments* actual in `projectedAchievement` (apples to oranges: live D86 `membershipTarget: 2159` vs `currentProgress.membership: 4322` → `projected: true`, meaningless).
- `projectedAchievement` — derived entirely from the three targets above with an unsourced 80% heuristic.

**Decision: remove, not correct** (recorded per issue AC). The §13.2-correct values already ship in the same payload as `paidClubsTargets` / `membershipPaymentsTargets` / `distinguishedClubsTargets` (TargetCalculator: 1/3/5/8% growth tiers, 45/50/55/60% of paid-club base, integer-safe form from #1126) and are exactly what the frontend consumes. Correcting the scalars would create a second copy of the canonical rule — the lessons 61/76 two-copies drift surface.

## R8 consumer inventory (read + write paths)

| Surface | Reads removed fields? | Evidence |
| --- | --- | --- |
| `frontend/src/hooks/usePerformanceTargets.ts` (`convertToPerformanceTargets`) | **No** — reads only `paidClubsCount`, `currentProgress.{membership,distinguished}`, `*Bases`, `*Targets`, `*AchievedLevel`, `*Rankings`. The CDN mirror interface *declared* the legacy fields; declarations removed. | usePerformanceTargets.ts:110-149 |
| `frontend/src/hooks/aggregatedAnalytics/{helpers,types}.ts` | Populated a local `performanceTargets` block (names `membershipTarget`/`distinguishedTarget`, values from converted **bases**, not the legacy payload fields) that **no component ever read** — deleted as dead code (lesson 119). | repo-wide grep: zero reads of `response.performanceTargets` |
| `frontend/src/pages/*` + `DistrictOverview` + `usePaymentsTrend` | Consume only the converted `DistrictPerformanceTargets` (per-metric blocks) — no legacy fields in that shape. | useDistrictAnalytics.ts:220-224 |
| `packages/collector-cli` (`AnalyticsWriter.writePerformanceTargets`) | Sole write path; serializes whatever `computePerformanceTargets` returns. No other artifact embeds the object. | AnalyticsComputeService.ts:911-917 |
| `packages/mcp-server`, `packages/shared-contracts` (publish-time Zod gate), `scripts/`, `.github/workflows/` | **Zero references.** The publish gate validates `district-statistics-file` only; performance-targets has no schema. | repo-wide grep |
| Local vars named `distinguishedTarget` in `DistinguishedDistrictCalculator.ts:364` / `distinguishedCountdown.ts:112` | Not payload reads — locals computed via the canonical `percentageTarget` helper. | — |

**Back-compat:** older snapshot artifacts on the CDN still contain the removed fields; they were never read, and no schema rejects either shape — old (fields present) and new (fields absent) payloads both parse.

## TDD

- Red: a798a4d — `not.toHaveProperty` for all four legacy keys on populated + empty paths, plus retention checks on consumed fields (failed: keys present).
- Green: da9db6c — type + all three return sites; dead locals (`getTotalMembership` feeds, progress/projection math) deleted.
- Refactor: 4709ded, 0d55a0e — frontend mirror + dead aggregated block + collector-cli test migration + stale comment.

Test-expectation changes are spec-change migrations (fields deliberately removed at source), not assertion pinning — each migrated test retains its assertions on still-published fields and gains explicit `not.toHaveProperty` guards.

## Verification

- Full workspace suite green: frontend 3401, collector-cli 885, analytics-core 855, shared-contracts 158, mcp-server 51.
- `npm run quality:check` exit 0.
- /simplify (4 angles): clean. Fresh-context /review: APPROVE-WITH-NITS (nit fixed in 0d55a0e).
- Data lands on the CDN via the scheduled pipeline; preview-channel check covers the frontend render path (KPI cards read the canonical fields, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
