### PR TITLE
Sprint 1 (#1101) — global divisions/areas search index artifact in the pipeline (#1134)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -1247,6 +1247,42 @@ jobs:
           CLUB_COUNT=$(jq '.totalClubs' /tmp/club-index.json)
           echo "- **Clubs indexed**: ${CLUB_COUNT}" >> "$GITHUB_STEP_SUMMARY"
 
+      # ── Shared: Generate divisions-areas-index.json (#1134, epic #1101) ──
+      # Mirror of club-index for divisions/areas, built by the unit-tested
+      # scripts/lib/divisionsAreasIndex.ts (thin-glue step, Lesson 107).
+      # Promotion rsyncs config/ wholesale, so this reaches prod with the run.
+      - name: Generate divisions-areas index
+        if: steps.mode.outputs.mode != 'prune' || inputs.dry_run != 'true'
+        run: |
+          LATEST_DATE=$(gsutil cat "gs://${GCS_BUCKET}/v1/latest.json" 2>/dev/null \
+            | jq -r '.latestSnapshotDate' || echo "")
+          if [ -z "${LATEST_DATE}" ]; then
+            echo "::warning::No latest date found, skipping divisions-areas index"
+            exit 0
+          fi
+          echo "Building divisions-areas index from snapshots/${LATEST_DATE}/..."
+
+          # R2: explicitly sync the district files this step reads
+          mkdir -p /tmp/divisions-areas-src
+          gsutil -m cp "gs://${GCS_BUCKET}/snapshots/${LATEST_DATE}/district_*.json" \
+            /tmp/divisions-areas-src/ 2>/dev/null || true
+
+          # Fails the step when no district files were synced — an empty
+          # index must never overwrite a populated one.
+          npx tsx scripts/build-divisions-areas-index.ts \
+            --src /tmp/divisions-areas-src \
+            --out /tmp/divisions-areas-index.json \
+            --snapshot-date "${LATEST_DATE}"
+
+          gsutil \
+            -h "Content-Type:application/json" \
+            -h "Cache-Control:public, max-age=300" \
+            cp /tmp/divisions-areas-index.json "gs://${GCS_BUCKET}/config/divisions-areas-index.json"
+
+          echo "## 🗺️ Divisions/Areas Index" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Divisions indexed**: $(jq '.totalDivisions' /tmp/divisions-areas-index.json)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Areas indexed**: $(jq '.totalAreas' /tmp/divisions-areas-index.json)" >> "$GITHUB_STEP_SUMMARY"
+
       # ════════════════════════════════════════════════════════
       # STAGING → PRODUCTION PROMOTION (#316)
       # ════════════════════════════════════════════════════════

--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -1280,8 +1280,8 @@ jobs:
             cp /tmp/divisions-areas-index.json "gs://${GCS_BUCKET}/config/divisions-areas-index.json"
 
           echo "## 🗺️ Divisions/Areas Index" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Divisions indexed**: $(jq '.totalDivisions' /tmp/divisions-areas-index.json)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Areas indexed**: $(jq '.totalAreas' /tmp/divisions-areas-index.json)" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '"- **Divisions indexed**: \(.totalDivisions)\n- **Areas indexed**: \(.totalAreas)"' \
+            /tmp/divisions-areas-index.json >> "$GITHUB_STEP_SUMMARY"
 
       # ════════════════════════════════════════════════════════
       # STAGING → PRODUCTION PROMOTION (#316)

--- a/scripts/build-divisions-areas-index.ts
+++ b/scripts/build-divisions-areas-index.ts
@@ -1,0 +1,82 @@
+/**
+ * Global divisions/areas index — Runner (#1134, epic #1101)
+ *
+ * Thin glue around the pure builder in ./lib/divisionsAreasIndex.js:
+ *   1. read every district_*.json the workflow synced into --src (R2:
+ *      the caller syncs explicitly; this script reads only local files),
+ *   2. build the index,
+ *   3. write it to --out for the workflow to upload to
+ *      config/divisions-areas-index.json.
+ *
+ * No decision logic lives here — that is unit-tested in
+ * scripts/lib/__tests__/divisionsAreasIndex.test.ts. All logging goes to
+ * stderr (R4); stdout stays clean.
+ *
+ * Usage:
+ *   npx tsx scripts/build-divisions-areas-index.ts \
+ *     --src /tmp/divisions-areas-src \
+ *     --out /tmp/divisions-areas-index.json \
+ *     --snapshot-date 2026-06-09
+ *
+ * Exits non-zero when no district files could be read — an empty index
+ * uploaded over a populated one would silently break omni-search.
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  buildDivisionsAreasIndex,
+  parseDistrictFile,
+} from './lib/divisionsAreasIndex.js'
+
+function log(msg: string): void {
+  process.stderr.write(`${msg}\n`)
+}
+
+function arg(name: string): string {
+  const i = process.argv.indexOf(`--${name}`)
+  const value = i >= 0 ? process.argv[i + 1] : undefined
+  if (!value) {
+    log(`Missing required argument --${name}`)
+    process.exit(1)
+  }
+  return value
+}
+
+const srcDir = arg('src')
+const outFile = arg('out')
+const snapshotDate = arg('snapshot-date')
+
+const fileNames = readdirSync(srcDir)
+  .filter(f => f.startsWith('district_') && f.endsWith('.json'))
+  .sort()
+
+const payloads: unknown[] = []
+for (const name of fileNames) {
+  const parsed = parseDistrictFile(readFileSync(join(srcDir, name), 'utf-8'))
+  if (parsed === null) {
+    log(`Skipping corrupt file: ${name}`)
+    continue
+  }
+  payloads.push(parsed)
+}
+
+if (payloads.length === 0) {
+  log(
+    `No readable district_*.json files in ${srcDir} — refusing to write an empty index`
+  )
+  process.exit(1)
+}
+
+const index = buildDivisionsAreasIndex(
+  payloads,
+  snapshotDate,
+  new Date().toISOString()
+)
+
+writeFileSync(outFile, JSON.stringify(index))
+log(
+  `Generated divisions-areas index: ${index.totalDivisions} divisions, ` +
+    `${index.totalAreas} areas across ${Object.keys(index.districts).length} districts ` +
+    `(from ${payloads.length} files, snapshot ${snapshotDate})`
+)

--- a/scripts/lib/__tests__/divisionsAreasIndex.test.ts
+++ b/scripts/lib/__tests__/divisionsAreasIndex.test.ts
@@ -113,6 +113,13 @@ describe('buildDivisionsAreasIndex', () => {
 
 // ── Shape tolerance (mirrors the club-index step's raw.data || raw) ───────
 
+// Minimal single-district payload: one division A, caller-supplied areas.
+const payloadWithAreas = (areas: unknown[]) => ({
+  districtId: '99',
+  divisions: [{ divisionId: 'A', divisionName: 'Division A' }],
+  areas,
+})
+
 describe('buildDivisionsAreasIndex shape tolerance', () => {
   it('accepts a bare DistrictStatisticsFile payload (no collector wrapper)', () => {
     const wrapped = loadFixture('district_61.json') as { data: unknown }
@@ -126,14 +133,10 @@ describe('buildDivisionsAreasIndex shape tolerance', () => {
   })
 
   it("creates a division key for an area whose division is missing from divisions[] (faithful to areas[], TI's source of truth)", () => {
-    const payload = {
-      districtId: '99',
-      divisions: [{ divisionId: 'A', divisionName: 'Division A' }],
-      areas: [
-        { areaId: '01', areaName: 'Area 01', divisionId: 'A' },
-        { areaId: '02', areaName: 'Area 02', divisionId: 'Z' },
-      ],
-    }
+    const payload = payloadWithAreas([
+      { areaId: '01', areaName: 'Area 01', divisionId: 'A' },
+      { areaId: '02', areaName: 'Area 02', divisionId: 'Z' },
+    ])
     const index = buildDivisionsAreasIndex(
       [payload],
       SNAPSHOT_DATE,
@@ -144,14 +147,10 @@ describe('buildDivisionsAreasIndex shape tolerance', () => {
   })
 
   it('dedupes a repeated (division, area) pair', () => {
-    const payload = {
-      districtId: '99',
-      divisions: [{ divisionId: 'A', divisionName: 'Division A' }],
-      areas: [
-        { areaId: '01', areaName: 'Area 01', divisionId: 'A' },
-        { areaId: '01', areaName: 'Area 01', divisionId: 'A' },
-      ],
-    }
+    const payload = payloadWithAreas([
+      { areaId: '01', areaName: 'Area 01', divisionId: 'A' },
+      { areaId: '01', areaName: 'Area 01', divisionId: 'A' },
+    ])
     const index = buildDivisionsAreasIndex(
       [payload],
       SNAPSHOT_DATE,
@@ -162,13 +161,8 @@ describe('buildDivisionsAreasIndex shape tolerance', () => {
   })
 
   it('keeps a division that has no areas as an empty list', () => {
-    const payload = {
-      districtId: '99',
-      divisions: [{ divisionId: 'A', divisionName: 'Division A' }],
-      areas: [],
-    }
     const index = buildDivisionsAreasIndex(
-      [payload],
+      [payloadWithAreas([])],
       SNAPSHOT_DATE,
       GENERATED_AT
     )

--- a/scripts/lib/__tests__/divisionsAreasIndex.test.ts
+++ b/scripts/lib/__tests__/divisionsAreasIndex.test.ts
@@ -185,6 +185,24 @@ describe('buildDivisionsAreasIndex shape tolerance', () => {
     expect(index.totalAreas).toBe(0)
   })
 
+  it('skips a failed-scrape wrapper instead of creating a phantom empty district', () => {
+    // Collector wrapper for a failed district: status 'failed', data null,
+    // but districtId present at the WRAPPER level — must not be indexed.
+    const failed = {
+      collectedAt: '2026-06-10T14:16:46.073Z',
+      districtId: '77',
+      districtName: 'District 77',
+      status: 'failed',
+      data: null,
+    }
+    const index = buildDivisionsAreasIndex(
+      [failed, loadFixture('district_61.json')],
+      SNAPSHOT_DATE,
+      GENERATED_AT
+    )
+    expect(Object.keys(index.districts)).toEqual(['61'])
+  })
+
   it('returns an empty index for an empty file list', () => {
     const index = buildDivisionsAreasIndex([], SNAPSHOT_DATE, GENERATED_AT)
     expect(index.districts).toEqual({})

--- a/scripts/lib/__tests__/divisionsAreasIndex.test.ts
+++ b/scripts/lib/__tests__/divisionsAreasIndex.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for scripts/lib/divisionsAreasIndex.ts (#1134)
+ *
+ * The daily Data Pipeline publishes config/divisions-areas-index.json — a
+ * global index of every district's divisions and areas, mirroring
+ * config/club-index.json — so omni-search (epic #1101 Sprint 2) can resolve
+ * "District 61 Division C" / "Area 23" queries to scoped routes without
+ * fetching 128 per-district snapshots.
+ *
+ * Fixtures are TRIMMED CAPTURES of live CDN payloads (2026-06-09), not
+ * synthetic shapes (Lesson 154): district_61 (district-unique area numbering,
+ * 8 divisions / 35 areas), district_01 (areas numbered 01..04 WITHIN each
+ * division — areaId alone does not identify an area), district_04 (the
+ * TI "unassigned" pseudo-division 0D with area 0A).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import {
+  buildDivisionsAreasIndex,
+  parseDistrictFile,
+  type DivisionsAreasIndex,
+} from '../divisionsAreasIndex'
+
+const FIXTURES = join(__dirname, 'fixtures', 'divisions-areas')
+
+const loadFixture = (name: string): unknown =>
+  JSON.parse(readFileSync(join(FIXTURES, name), 'utf-8'))
+
+const GENERATED_AT = '2026-06-10T08:00:00.000Z'
+const SNAPSHOT_DATE = '2026-06-09'
+
+const buildFromFixtures = (): DivisionsAreasIndex =>
+  buildDivisionsAreasIndex(
+    [
+      loadFixture('district_61.json'),
+      loadFixture('district_01.json'),
+      loadFixture('district_04.json'),
+    ],
+    SNAPSHOT_DATE,
+    GENERATED_AT
+  )
+
+// ── buildDivisionsAreasIndex over captured live shapes ─────────────────────
+
+describe('buildDivisionsAreasIndex', () => {
+  it('indexes every fixture district by its districtId', () => {
+    const index = buildFromFixtures()
+    expect(Object.keys(index.districts).sort()).toEqual(['01', '04', '61'])
+  })
+
+  it('maps each division to its sorted area ids (D61: district-unique numbering)', () => {
+    const index = buildFromFixtures()
+    const d61 = index.districts['61']
+    expect(Object.keys(d61)).toEqual(['A', 'B', 'C', 'D', 'F', 'G', 'H', 'I'])
+    expect(d61['A']).toEqual(['01', '02', '03', '04'])
+    const areaCount = Object.values(d61).reduce((n, a) => n + a.length, 0)
+    expect(areaCount).toBe(35)
+  })
+
+  it('keeps per-division area numbering distinct (D01: every division has an Area 01)', () => {
+    const index = buildFromFixtures()
+    const d01 = index.districts['01']
+    expect(Object.keys(d01)).toEqual(['A', 'B', 'C', 'D', 'E', 'F'])
+    // Same areaId under different divisions must NOT collapse.
+    expect(d01['A']).toContain('01')
+    expect(d01['B']).toContain('01')
+    expect(Object.values(d01).reduce((n, a) => n + a.length, 0)).toBe(24)
+  })
+
+  it("preserves TI's unassigned pseudo-ids verbatim (D04: division 0D, area 0A)", () => {
+    const index = buildFromFixtures()
+    expect(index.districts['04']['0D']).toEqual(['0A'])
+  })
+
+  it('totals divisions and areas across all districts', () => {
+    const index = buildFromFixtures()
+    expect(index.totalDivisions).toBe(8 + 6 + 5)
+    expect(index.totalAreas).toBe(35 + 24 + 17)
+  })
+
+  it('stamps snapshotDate and generatedAt verbatim', () => {
+    const index = buildFromFixtures()
+    expect(index.snapshotDate).toBe(SNAPSHOT_DATE)
+    expect(index.generatedAt).toBe(GENERATED_AT)
+  })
+
+  it('sorts district and division keys for deterministic output', () => {
+    const index = buildFromFixtures()
+    const districtKeys = Object.keys(index.districts)
+    expect(districtKeys).toEqual([...districtKeys].sort())
+    for (const divisions of Object.values(index.districts)) {
+      const divKeys = Object.keys(divisions)
+      expect(divKeys).toEqual([...divKeys].sort())
+      for (const areas of Object.values(divisions)) {
+        expect(areas).toEqual([...areas].sort())
+      }
+    }
+  })
+})
+
+// ── Shape tolerance (mirrors the club-index step's raw.data || raw) ───────
+
+describe('buildDivisionsAreasIndex shape tolerance', () => {
+  it('accepts a bare DistrictStatisticsFile payload (no collector wrapper)', () => {
+    const wrapped = loadFixture('district_61.json') as { data: unknown }
+    const index = buildDivisionsAreasIndex(
+      [wrapped.data],
+      SNAPSHOT_DATE,
+      GENERATED_AT
+    )
+    expect(Object.keys(index.districts)).toEqual(['61'])
+    expect(index.totalAreas).toBe(35)
+  })
+
+  it("creates a division key for an area whose division is missing from divisions[] (faithful to areas[], TI's source of truth)", () => {
+    const payload = {
+      districtId: '99',
+      divisions: [{ divisionId: 'A', divisionName: 'Division A' }],
+      areas: [
+        { areaId: '01', areaName: 'Area 01', divisionId: 'A' },
+        { areaId: '02', areaName: 'Area 02', divisionId: 'Z' },
+      ],
+    }
+    const index = buildDivisionsAreasIndex(
+      [payload],
+      SNAPSHOT_DATE,
+      GENERATED_AT
+    )
+    expect(index.districts['99']).toEqual({ A: ['01'], Z: ['02'] })
+    expect(index.totalDivisions).toBe(2)
+  })
+
+  it('dedupes a repeated (division, area) pair', () => {
+    const payload = {
+      districtId: '99',
+      divisions: [{ divisionId: 'A', divisionName: 'Division A' }],
+      areas: [
+        { areaId: '01', areaName: 'Area 01', divisionId: 'A' },
+        { areaId: '01', areaName: 'Area 01', divisionId: 'A' },
+      ],
+    }
+    const index = buildDivisionsAreasIndex(
+      [payload],
+      SNAPSHOT_DATE,
+      GENERATED_AT
+    )
+    expect(index.districts['99']['A']).toEqual(['01'])
+    expect(index.totalAreas).toBe(1)
+  })
+
+  it('keeps a division that has no areas as an empty list', () => {
+    const payload = {
+      districtId: '99',
+      divisions: [{ divisionId: 'A', divisionName: 'Division A' }],
+      areas: [],
+    }
+    const index = buildDivisionsAreasIndex(
+      [payload],
+      SNAPSHOT_DATE,
+      GENERATED_AT
+    )
+    expect(index.districts['99']).toEqual({ A: [] })
+    expect(index.totalDivisions).toBe(1)
+    expect(index.totalAreas).toBe(0)
+  })
+
+  it('skips payloads missing a districtId or divisions/areas arrays without throwing', () => {
+    const index = buildDivisionsAreasIndex(
+      [{}, { districtId: '98' }, null, 42],
+      SNAPSHOT_DATE,
+      GENERATED_AT
+    )
+    // districtId alone with no divisions/areas contributes an empty district —
+    // it IS a real district file; shapeless junk contributes nothing.
+    expect(index.districts['98']).toEqual({})
+    expect(Object.keys(index.districts)).toEqual(['98'])
+    expect(index.totalDivisions).toBe(0)
+    expect(index.totalAreas).toBe(0)
+  })
+
+  it('returns an empty index for an empty file list', () => {
+    const index = buildDivisionsAreasIndex([], SNAPSHOT_DATE, GENERATED_AT)
+    expect(index.districts).toEqual({})
+    expect(index.totalDivisions).toBe(0)
+    expect(index.totalAreas).toBe(0)
+  })
+})
+
+// ── parseDistrictFile (corrupt-file skip policy, mirrors club-index) ──────
+
+describe('parseDistrictFile', () => {
+  it('parses valid JSON', () => {
+    expect(parseDistrictFile('{"districtId":"61"}')).toEqual({
+      districtId: '61',
+    })
+  })
+
+  it('returns null for corrupt JSON instead of throwing', () => {
+    expect(parseDistrictFile('{truncated')).toBeNull()
+  })
+})

--- a/scripts/lib/__tests__/divisionsAreasIndex.test.ts
+++ b/scripts/lib/__tests__/divisionsAreasIndex.test.ts
@@ -86,13 +86,24 @@ describe('buildDivisionsAreasIndex', () => {
     expect(index.generatedAt).toBe(GENERATED_AT)
   })
 
-  it('sorts district and division keys for deterministic output', () => {
-    const index = buildFromFixtures()
-    const districtKeys = Object.keys(index.districts)
-    expect(districtKeys).toEqual([...districtKeys].sort())
-    for (const divisions of Object.values(index.districts)) {
-      const divKeys = Object.keys(divisions)
-      expect(divKeys).toEqual([...divKeys].sort())
+  it('serializes identically regardless of input file order (deterministic daily diffs)', () => {
+    // Note: lexicographic district-key order is NOT representable — JS objects
+    // hoist integer-like keys ('61') ahead of string keys ('01' has a leading
+    // zero, so it is a string key). What matters for clean day-over-day diffs
+    // is permutation-invariance of the serialized bytes.
+    const files = [
+      loadFixture('district_61.json'),
+      loadFixture('district_01.json'),
+      loadFixture('district_04.json'),
+    ]
+    const forward = buildDivisionsAreasIndex(files, SNAPSHOT_DATE, GENERATED_AT)
+    const reversed = buildDivisionsAreasIndex(
+      [...files].reverse(),
+      SNAPSHOT_DATE,
+      GENERATED_AT
+    )
+    expect(JSON.stringify(reversed)).toBe(JSON.stringify(forward))
+    for (const divisions of Object.values(forward.districts)) {
       for (const areas of Object.values(divisions)) {
         expect(areas).toEqual([...areas].sort())
       }

--- a/scripts/lib/__tests__/fixtures/divisions-areas/district_01.json
+++ b/scripts/lib/__tests__/fixtures/divisions-areas/district_01.json
@@ -1,0 +1,336 @@
+{
+  "collectedAt": "2026-06-10T14:16:45.981Z",
+  "districtId": "01",
+  "districtName": "District 01",
+  "status": "success",
+  "data": {
+    "districtId": "01",
+    "snapshotDate": "2026-06-09",
+    "clubs": [
+      {
+        "clubId": "00000977",
+        "clubName": "Professional Women Toastmasters",
+        "divisionId": "A",
+        "areaId": "01",
+        "membershipCount": 18,
+        "paymentsCount": 40,
+        "dcpGoals": 6,
+        "status": "Active",
+        "divisionName": "Division A",
+        "areaName": "Area 01",
+        "octoberRenewals": 18,
+        "aprilRenewals": 17,
+        "newMembers": 5,
+        "membershipBase": 20,
+        "clubStatus": "Active",
+        "cspSubmitted": true,
+        "charterDate": "1990-03-01",
+        "coordinates": {
+          "lat": 34.01401,
+          "lng": -118.40319
+        },
+        "address": {
+          "street": "4095 Overland Ave",
+          "city": "Culver City",
+          "region": "CA",
+          "postalCode": "90232",
+          "country": "United States"
+        },
+        "email": "shinn.jean.ho@gmail.com",
+        "website": "https://professionalwomentoastmasters.wordpress.com/events-page/",
+        "facebookLink": "https://www.facebook.com/ProfessionalWomenToastmasters",
+        "meetingDay": "1st Thu (online) | 3rd Thu (in-person)",
+        "meetingTime": "7:00 to 8:30 PM",
+        "allowsVirtualAttendance": true,
+        "isProspective": false
+      },
+      {
+        "clubId": "00005942",
+        "clubName": "Dynamic Orators Club",
+        "divisionId": "A",
+        "areaId": "01",
+        "membershipCount": 9,
+        "paymentsCount": 18,
+        "dcpGoals": 4,
+        "status": "Active",
+        "divisionName": "Division A",
+        "areaName": "Area 01",
+        "octoberRenewals": 8,
+        "aprilRenewals": 9,
+        "newMembers": 1,
+        "membershipBase": 8,
+        "clubStatus": "Active",
+        "cspSubmitted": true,
+        "charterDate": "1990-04-01",
+        "coordinates": {
+          "lat": 33.97829,
+          "lng": -118.38531
+        },
+        "address": {
+          "street": "6666 Green Valley Circle",
+          "city": "Culver City",
+          "region": "CA",
+          "postalCode": "90230-7068",
+          "country": "United States"
+        },
+        "email": "lblackwell0621@gmail.com",
+        "phone": "+13107227238",
+        "website": "https://www.meetup.com/dynamic-90s-toastmasters-club/?eventOrigin=your_groups",
+        "meetingDay": "1st and 3rd Saturday of Each Month",
+        "meetingTime": "8:00 am",
+        "allowsVirtualAttendance": true,
+        "isProspective": false
+      }
+    ],
+    "divisions": [
+      {
+        "divisionId": "A",
+        "divisionName": "Division A",
+        "clubCount": 19,
+        "membershipTotal": 271,
+        "paymentsTotal": 595
+      },
+      {
+        "divisionId": "B",
+        "divisionName": "Division B",
+        "clubCount": 18,
+        "membershipTotal": 272,
+        "paymentsTotal": 619
+      },
+      {
+        "divisionId": "C",
+        "divisionName": "Division C",
+        "clubCount": 20,
+        "membershipTotal": 289,
+        "paymentsTotal": 681
+      },
+      {
+        "divisionId": "D",
+        "divisionName": "Division D",
+        "clubCount": 19,
+        "membershipTotal": 202,
+        "paymentsTotal": 464
+      },
+      {
+        "divisionId": "E",
+        "divisionName": "Division E",
+        "clubCount": 21,
+        "membershipTotal": 335,
+        "paymentsTotal": 751
+      },
+      {
+        "divisionId": "F",
+        "divisionName": "Division F",
+        "clubCount": 19,
+        "membershipTotal": 236,
+        "paymentsTotal": 536
+      }
+    ],
+    "areas": [
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "A",
+        "clubCount": 5,
+        "membershipTotal": 68,
+        "paymentsTotal": 136
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "A",
+        "clubCount": 5,
+        "membershipTotal": 50,
+        "paymentsTotal": 117
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "A",
+        "clubCount": 4,
+        "membershipTotal": 95,
+        "paymentsTotal": 214
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "A",
+        "clubCount": 5,
+        "membershipTotal": 58,
+        "paymentsTotal": 128
+      },
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "B",
+        "clubCount": 5,
+        "membershipTotal": 63,
+        "paymentsTotal": 140
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "B",
+        "clubCount": 5,
+        "membershipTotal": 96,
+        "paymentsTotal": 210
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "B",
+        "clubCount": 4,
+        "membershipTotal": 56,
+        "paymentsTotal": 133
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "B",
+        "clubCount": 4,
+        "membershipTotal": 57,
+        "paymentsTotal": 136
+      },
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "C",
+        "clubCount": 5,
+        "membershipTotal": 73,
+        "paymentsTotal": 154
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "C",
+        "clubCount": 5,
+        "membershipTotal": 49,
+        "paymentsTotal": 172
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "C",
+        "clubCount": 5,
+        "membershipTotal": 81,
+        "paymentsTotal": 170
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "C",
+        "clubCount": 5,
+        "membershipTotal": 86,
+        "paymentsTotal": 185
+      },
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "D",
+        "clubCount": 4,
+        "membershipTotal": 51,
+        "paymentsTotal": 120
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "D",
+        "clubCount": 5,
+        "membershipTotal": 53,
+        "paymentsTotal": 111
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "D",
+        "clubCount": 5,
+        "membershipTotal": 44,
+        "paymentsTotal": 103
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "D",
+        "clubCount": 5,
+        "membershipTotal": 54,
+        "paymentsTotal": 130
+      },
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "E",
+        "clubCount": 5,
+        "membershipTotal": 94,
+        "paymentsTotal": 211
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "E",
+        "clubCount": 4,
+        "membershipTotal": 54,
+        "paymentsTotal": 140
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "E",
+        "clubCount": 6,
+        "membershipTotal": 100,
+        "paymentsTotal": 210
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "E",
+        "clubCount": 6,
+        "membershipTotal": 87,
+        "paymentsTotal": 190
+      },
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "F",
+        "clubCount": 5,
+        "membershipTotal": 47,
+        "paymentsTotal": 107
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "F",
+        "clubCount": 4,
+        "membershipTotal": 61,
+        "paymentsTotal": 139
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "F",
+        "clubCount": 5,
+        "membershipTotal": 75,
+        "paymentsTotal": 173
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "F",
+        "clubCount": 5,
+        "membershipTotal": 53,
+        "paymentsTotal": 117
+      }
+    ],
+    "totals": {
+      "totalClubs": 116,
+      "totalMembership": 1605,
+      "totalPayments": 3646,
+      "distinguishedClubs": 9,
+      "selectDistinguishedClubs": 5,
+      "presidentDistinguishedClubs": 3,
+      "smedleyDistinguishedClubs": 3
+    },
+    "divisionPerformance": [],
+    "clubPerformance": [],
+    "districtPerformance": []
+  }
+}

--- a/scripts/lib/__tests__/fixtures/divisions-areas/district_04.json
+++ b/scripts/lib/__tests__/fixtures/divisions-areas/district_04.json
@@ -1,0 +1,273 @@
+{
+  "collectedAt": "2026-06-10T14:16:46.073Z",
+  "districtId": "04",
+  "districtName": "District 04",
+  "status": "success",
+  "data": {
+    "districtId": "04",
+    "snapshotDate": "2026-06-09",
+    "clubs": [
+      {
+        "clubId": "28679905",
+        "clubName": "Bloomberg San Francisco Toastmasters - Employees Only",
+        "divisionId": "0D",
+        "areaId": "0A",
+        "membershipCount": 20,
+        "paymentsCount": 20,
+        "dcpGoals": 1,
+        "status": "Active",
+        "divisionName": "Division 0D",
+        "areaName": "Area 0A",
+        "octoberRenewals": 0,
+        "aprilRenewals": 0,
+        "newMembers": 0,
+        "membershipBase": 20,
+        "clubStatus": "Active",
+        "cspSubmitted": true,
+        "charterDate": "2026-04-30",
+        "coordinates": {
+          "lat": 37.78667,
+          "lng": -122.39999
+        },
+        "address": {
+          "street": "140 New Montgomery St",
+          "city": "San Francisco",
+          "region": "CA",
+          "postalCode": "94105",
+          "country": "United States"
+        },
+        "email": "kpereira3@bloomberg.net",
+        "phone": "+12126175916",
+        "meetingDay": "1st & 3rd Thursdays",
+        "meetingTime": "12:00 PM",
+        "allowsVirtualAttendance": true,
+        "isProspective": false
+      },
+      {
+        "clubId": "00002117",
+        "clubName": "Early Risers Club",
+        "divisionId": "A",
+        "areaId": "01",
+        "membershipCount": 25,
+        "paymentsCount": 60,
+        "dcpGoals": 10,
+        "status": "Active",
+        "divisionName": "Division A",
+        "areaName": "Area 01",
+        "octoberRenewals": 26,
+        "aprilRenewals": 24,
+        "newMembers": 10,
+        "membershipBase": 31,
+        "clubStatus": "Active",
+        "distinguishedStatus": "M",
+        "cspSubmitted": true,
+        "charterDate": "1958-10-01",
+        "coordinates": {
+          "lat": 37.42693,
+          "lng": -122.11806
+        },
+        "address": {
+          "street": "3391 Middlefield Rd",
+          "city": "Palo Alto",
+          "region": "CA",
+          "postalCode": "94306",
+          "country": "United States"
+        },
+        "email": "contact-2117@toastmastersclubs.org",
+        "website": "http://2117.toastmastersclubs.org/",
+        "facebookLink": "www.facebook.com/earlyrisers2117",
+        "meetingDay": "Tuesday",
+        "meetingTime": "6:30 am",
+        "allowsVirtualAttendance": true,
+        "isProspective": false
+      }
+    ],
+    "divisions": [
+      {
+        "divisionId": "0D",
+        "divisionName": "Division 0D",
+        "clubCount": 1,
+        "membershipTotal": 20,
+        "paymentsTotal": 20
+      },
+      {
+        "divisionId": "A",
+        "divisionName": "Division A",
+        "clubCount": 20,
+        "membershipTotal": 289,
+        "paymentsTotal": 642
+      },
+      {
+        "divisionId": "B",
+        "divisionName": "Division B",
+        "clubCount": 20,
+        "membershipTotal": 344,
+        "paymentsTotal": 718
+      },
+      {
+        "divisionId": "C",
+        "divisionName": "Division C",
+        "clubCount": 19,
+        "membershipTotal": 272,
+        "paymentsTotal": 607
+      },
+      {
+        "divisionId": "D",
+        "divisionName": "Division D",
+        "clubCount": 20,
+        "membershipTotal": 231,
+        "paymentsTotal": 597
+      }
+    ],
+    "areas": [
+      {
+        "areaId": "0A",
+        "areaName": "Area 0A",
+        "divisionId": "0D",
+        "clubCount": 1,
+        "membershipTotal": 20,
+        "paymentsTotal": 20
+      },
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "A",
+        "clubCount": 5,
+        "membershipTotal": 62,
+        "paymentsTotal": 139
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "A",
+        "clubCount": 5,
+        "membershipTotal": 99,
+        "paymentsTotal": 208
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "A",
+        "clubCount": 5,
+        "membershipTotal": 72,
+        "paymentsTotal": 166
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "A",
+        "clubCount": 5,
+        "membershipTotal": 56,
+        "paymentsTotal": 129
+      },
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "B",
+        "clubCount": 5,
+        "membershipTotal": 57,
+        "paymentsTotal": 125
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "B",
+        "clubCount": 5,
+        "membershipTotal": 73,
+        "paymentsTotal": 165
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "B",
+        "clubCount": 5,
+        "membershipTotal": 74,
+        "paymentsTotal": 168
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "B",
+        "clubCount": 5,
+        "membershipTotal": 140,
+        "paymentsTotal": 260
+      },
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "C",
+        "clubCount": 5,
+        "membershipTotal": 76,
+        "paymentsTotal": 161
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "C",
+        "clubCount": 4,
+        "membershipTotal": 58,
+        "paymentsTotal": 128
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "C",
+        "clubCount": 5,
+        "membershipTotal": 37,
+        "paymentsTotal": 85
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "C",
+        "clubCount": 5,
+        "membershipTotal": 101,
+        "paymentsTotal": 233
+      },
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "D",
+        "clubCount": 5,
+        "membershipTotal": 62,
+        "paymentsTotal": 145
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "D",
+        "clubCount": 5,
+        "membershipTotal": 55,
+        "paymentsTotal": 174
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "D",
+        "clubCount": 5,
+        "membershipTotal": 64,
+        "paymentsTotal": 139
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "D",
+        "clubCount": 5,
+        "membershipTotal": 50,
+        "paymentsTotal": 139
+      }
+    ],
+    "totals": {
+      "totalClubs": 80,
+      "totalMembership": 1156,
+      "totalPayments": 2584,
+      "distinguishedClubs": 3,
+      "selectDistinguishedClubs": 8,
+      "presidentDistinguishedClubs": 5,
+      "smedleyDistinguishedClubs": 5
+    },
+    "divisionPerformance": [],
+    "clubPerformance": [],
+    "districtPerformance": []
+  }
+}

--- a/scripts/lib/__tests__/fixtures/divisions-areas/district_61.json
+++ b/scripts/lib/__tests__/fixtures/divisions-areas/district_61.json
@@ -1,0 +1,437 @@
+{
+  "collectedAt": "2026-06-10T14:16:46.640Z",
+  "districtId": "61",
+  "districtName": "District 61",
+  "status": "success",
+  "data": {
+    "districtId": "61",
+    "snapshotDate": "2026-06-09",
+    "clubs": [
+      {
+        "clubId": "00003045",
+        "clubName": "Limestone City Club",
+        "divisionId": "A",
+        "areaId": "01",
+        "membershipCount": 13,
+        "paymentsCount": 23,
+        "dcpGoals": 4,
+        "status": "Active",
+        "divisionName": "Division A",
+        "areaName": "Area 01",
+        "octoberRenewals": 9,
+        "aprilRenewals": 9,
+        "newMembers": 5,
+        "membershipBase": 13,
+        "clubStatus": "Active",
+        "cspSubmitted": true,
+        "charterDate": "1960-01-01",
+        "coordinates": {
+          "lat": 44.25068,
+          "lng": -76.551
+        },
+        "address": {
+          "street": "790 Edgar Street, Court Building ",
+          "city": "Kingston",
+          "region": "ON",
+          "postalCode": "K7M 9G5",
+          "country": "Canada"
+        },
+        "email": "douglas.cameron71@gmail.com",
+        "phone": "+16135323684",
+        "website": "https://limestonetm.com/",
+        "meetingDay": "Wed.1st and 3rd in person  (2nd online)",
+        "meetingTime": "7:30 pm",
+        "allowsVirtualAttendance": false,
+        "isProspective": false
+      },
+      {
+        "clubId": "00009560",
+        "clubName": "CFB Kingston Toastmasters",
+        "divisionId": "A",
+        "areaId": "01",
+        "membershipCount": 8,
+        "paymentsCount": 21,
+        "dcpGoals": 3,
+        "status": "Active",
+        "divisionName": "Division A",
+        "areaName": "Area 01",
+        "octoberRenewals": 9,
+        "aprilRenewals": 7,
+        "newMembers": 5,
+        "membershipBase": 8,
+        "clubStatus": "Active",
+        "cspSubmitted": true,
+        "charterDate": "1993-08-01",
+        "coordinates": {
+          "lat": 44.24505,
+          "lng": -76.4587
+        },
+        "address": {
+          "street": "2 Sadie Ave",
+          "city": "Kingston ",
+          "region": "ON",
+          "postalCode": "K7K 5R5",
+          "country": "Canada"
+        },
+        "email": "cfbkingstontoastmasters@gmail.com",
+        "website": "https://www.eventbrite.com/o/cfb-kingston-toastmasters-66865171583?aff=ebeseadeeplink",
+        "meetingDay": "Wednesdays",
+        "meetingTime": "08:00 am",
+        "allowsVirtualAttendance": false,
+        "isProspective": false
+      }
+    ],
+    "divisions": [
+      {
+        "divisionId": "A",
+        "divisionName": "Division A",
+        "clubCount": 18,
+        "membershipTotal": 281,
+        "paymentsTotal": 587
+      },
+      {
+        "divisionId": "B",
+        "divisionName": "Division B",
+        "clubCount": 28,
+        "membershipTotal": 374,
+        "paymentsTotal": 789
+      },
+      {
+        "divisionId": "C",
+        "divisionName": "Division C",
+        "clubCount": 23,
+        "membershipTotal": 321,
+        "paymentsTotal": 674
+      },
+      {
+        "divisionId": "D",
+        "divisionName": "Division D",
+        "clubCount": 17,
+        "membershipTotal": 268,
+        "paymentsTotal": 564
+      },
+      {
+        "divisionId": "F",
+        "divisionName": "Division F",
+        "clubCount": 20,
+        "membershipTotal": 364,
+        "paymentsTotal": 784
+      },
+      {
+        "divisionId": "G",
+        "divisionName": "Division G",
+        "clubCount": 19,
+        "membershipTotal": 466,
+        "paymentsTotal": 963
+      },
+      {
+        "divisionId": "H",
+        "divisionName": "Division H",
+        "clubCount": 18,
+        "membershipTotal": 343,
+        "paymentsTotal": 716
+      },
+      {
+        "divisionId": "I",
+        "divisionName": "Division I",
+        "clubCount": 19,
+        "membershipTotal": 370,
+        "paymentsTotal": 731
+      }
+    ],
+    "areas": [
+      {
+        "areaId": "01",
+        "areaName": "Area 01",
+        "divisionId": "A",
+        "clubCount": 5,
+        "membershipTotal": 55,
+        "paymentsTotal": 131
+      },
+      {
+        "areaId": "02",
+        "areaName": "Area 02",
+        "divisionId": "A",
+        "clubCount": 4,
+        "membershipTotal": 76,
+        "paymentsTotal": 160
+      },
+      {
+        "areaId": "03",
+        "areaName": "Area 03",
+        "divisionId": "A",
+        "clubCount": 5,
+        "membershipTotal": 93,
+        "paymentsTotal": 185
+      },
+      {
+        "areaId": "04",
+        "areaName": "Area 04",
+        "divisionId": "A",
+        "clubCount": 4,
+        "membershipTotal": 57,
+        "paymentsTotal": 111
+      },
+      {
+        "areaId": "10",
+        "areaName": "Area 10",
+        "divisionId": "B",
+        "clubCount": 4,
+        "membershipTotal": 54,
+        "paymentsTotal": 116
+      },
+      {
+        "areaId": "11",
+        "areaName": "Area 11",
+        "divisionId": "B",
+        "clubCount": 6,
+        "membershipTotal": 90,
+        "paymentsTotal": 185
+      },
+      {
+        "areaId": "12",
+        "areaName": "Area 12",
+        "divisionId": "B",
+        "clubCount": 5,
+        "membershipTotal": 63,
+        "paymentsTotal": 144
+      },
+      {
+        "areaId": "13",
+        "areaName": "Area 13",
+        "divisionId": "B",
+        "clubCount": 4,
+        "membershipTotal": 61,
+        "paymentsTotal": 121
+      },
+      {
+        "areaId": "14",
+        "areaName": "Area 14",
+        "divisionId": "B",
+        "clubCount": 5,
+        "membershipTotal": 82,
+        "paymentsTotal": 169
+      },
+      {
+        "areaId": "15",
+        "areaName": "Area 15",
+        "divisionId": "B",
+        "clubCount": 4,
+        "membershipTotal": 24,
+        "paymentsTotal": 54
+      },
+      {
+        "areaId": "20",
+        "areaName": "Area 20",
+        "divisionId": "C",
+        "clubCount": 5,
+        "membershipTotal": 77,
+        "paymentsTotal": 163
+      },
+      {
+        "areaId": "21",
+        "areaName": "Area 21",
+        "divisionId": "C",
+        "clubCount": 4,
+        "membershipTotal": 49,
+        "paymentsTotal": 99
+      },
+      {
+        "areaId": "22",
+        "areaName": "Area 22",
+        "divisionId": "C",
+        "clubCount": 6,
+        "membershipTotal": 69,
+        "paymentsTotal": 156
+      },
+      {
+        "areaId": "23",
+        "areaName": "Area 23",
+        "divisionId": "C",
+        "clubCount": 4,
+        "membershipTotal": 56,
+        "paymentsTotal": 111
+      },
+      {
+        "areaId": "24",
+        "areaName": "Area 24",
+        "divisionId": "C",
+        "clubCount": 4,
+        "membershipTotal": 70,
+        "paymentsTotal": 145
+      },
+      {
+        "areaId": "30",
+        "areaName": "Area 30",
+        "divisionId": "D",
+        "clubCount": 4,
+        "membershipTotal": 62,
+        "paymentsTotal": 136
+      },
+      {
+        "areaId": "31",
+        "areaName": "Area 31",
+        "divisionId": "D",
+        "clubCount": 5,
+        "membershipTotal": 82,
+        "paymentsTotal": 168
+      },
+      {
+        "areaId": "33",
+        "areaName": "Area 33",
+        "divisionId": "D",
+        "clubCount": 4,
+        "membershipTotal": 84,
+        "paymentsTotal": 176
+      },
+      {
+        "areaId": "34",
+        "areaName": "Area 34",
+        "divisionId": "D",
+        "clubCount": 4,
+        "membershipTotal": 40,
+        "paymentsTotal": 84
+      },
+      {
+        "areaId": "50",
+        "areaName": "Area 50",
+        "divisionId": "F",
+        "clubCount": 5,
+        "membershipTotal": 107,
+        "paymentsTotal": 232
+      },
+      {
+        "areaId": "52",
+        "areaName": "Area 52",
+        "divisionId": "F",
+        "clubCount": 6,
+        "membershipTotal": 91,
+        "paymentsTotal": 189
+      },
+      {
+        "areaId": "53",
+        "areaName": "Area 53",
+        "divisionId": "F",
+        "clubCount": 5,
+        "membershipTotal": 97,
+        "paymentsTotal": 208
+      },
+      {
+        "areaId": "54",
+        "areaName": "Area 54",
+        "divisionId": "F",
+        "clubCount": 4,
+        "membershipTotal": 69,
+        "paymentsTotal": 155
+      },
+      {
+        "areaId": "61",
+        "areaName": "Area 61",
+        "divisionId": "G",
+        "clubCount": 5,
+        "membershipTotal": 97,
+        "paymentsTotal": 178
+      },
+      {
+        "areaId": "62",
+        "areaName": "Area 62",
+        "divisionId": "G",
+        "clubCount": 5,
+        "membershipTotal": 167,
+        "paymentsTotal": 312
+      },
+      {
+        "areaId": "63",
+        "areaName": "Area 63",
+        "divisionId": "G",
+        "clubCount": 5,
+        "membershipTotal": 109,
+        "paymentsTotal": 259
+      },
+      {
+        "areaId": "64",
+        "areaName": "Area 64",
+        "divisionId": "G",
+        "clubCount": 4,
+        "membershipTotal": 93,
+        "paymentsTotal": 214
+      },
+      {
+        "areaId": "70",
+        "areaName": "Area 70",
+        "divisionId": "H",
+        "clubCount": 4,
+        "membershipTotal": 87,
+        "paymentsTotal": 191
+      },
+      {
+        "areaId": "71",
+        "areaName": "Area 71",
+        "divisionId": "H",
+        "clubCount": 5,
+        "membershipTotal": 91,
+        "paymentsTotal": 183
+      },
+      {
+        "areaId": "72",
+        "areaName": "Area 72",
+        "divisionId": "H",
+        "clubCount": 5,
+        "membershipTotal": 74,
+        "paymentsTotal": 159
+      },
+      {
+        "areaId": "73",
+        "areaName": "Area 73",
+        "divisionId": "H",
+        "clubCount": 4,
+        "membershipTotal": 91,
+        "paymentsTotal": 183
+      },
+      {
+        "areaId": "90",
+        "areaName": "Area 90",
+        "divisionId": "I",
+        "clubCount": 4,
+        "membershipTotal": 69,
+        "paymentsTotal": 139
+      },
+      {
+        "areaId": "91",
+        "areaName": "Area 91",
+        "divisionId": "I",
+        "clubCount": 4,
+        "membershipTotal": 63,
+        "paymentsTotal": 135
+      },
+      {
+        "areaId": "92",
+        "areaName": "Area 92",
+        "divisionId": "I",
+        "clubCount": 5,
+        "membershipTotal": 125,
+        "paymentsTotal": 252
+      },
+      {
+        "areaId": "93",
+        "areaName": "Area 93",
+        "divisionId": "I",
+        "clubCount": 6,
+        "membershipTotal": 113,
+        "paymentsTotal": 205
+      }
+    ],
+    "totals": {
+      "totalClubs": 162,
+      "totalMembership": 2787,
+      "totalPayments": 5808,
+      "distinguishedClubs": 20,
+      "selectDistinguishedClubs": 14,
+      "presidentDistinguishedClubs": 11,
+      "smedleyDistinguishedClubs": 12
+    },
+    "divisionPerformance": [],
+    "clubPerformance": [],
+    "districtPerformance": []
+  }
+}

--- a/scripts/lib/divisionsAreasIndex.ts
+++ b/scripts/lib/divisionsAreasIndex.ts
@@ -106,15 +106,20 @@ export function buildDivisionsAreasIndex(
   return { generatedAt, snapshotDate, totalDivisions, totalAreas, districts }
 }
 
-/** Unwrap the collector envelope ({ data: {...} }) or pass a bare payload. */
+/**
+ * Unwrap the collector envelope ({ data: {...} }) or pass a bare payload.
+ * A wrapper whose scrape failed carries districtId at the WRAPPER level with
+ * data: null — returning the wrapper would index a phantom empty district,
+ * so anything with a data key but no usable data object is skipped.
+ */
 function unwrap(file: unknown): Record<string, unknown> | null {
   if (typeof file !== 'object' || file === null) return null
   const obj = file as Record<string, unknown>
+  if (!('data' in obj)) return obj
   const data = obj['data']
-  if (typeof data === 'object' && data !== null) {
-    return data as Record<string, unknown>
-  }
-  return obj
+  return typeof data === 'object' && data !== null
+    ? (data as Record<string, unknown>)
+    : null
 }
 
 /** Read a non-empty string property off an unknown value, else null. */

--- a/scripts/lib/divisionsAreasIndex.ts
+++ b/scripts/lib/divisionsAreasIndex.ts
@@ -1,0 +1,137 @@
+/**
+ * Global divisions/areas index builder (#1134, epic #1101).
+ *
+ * The daily Data Pipeline publishes config/divisions-areas-index.json — the
+ * divisions/areas mirror of config/club-index.json — so omni-search (epic
+ * #1101 Sprint 2) can resolve "District 61 Division C" / "Area 23" queries
+ * to scoped routes without fetching every per-district snapshot.
+ *
+ * Shape note: areaIds are NOT district-unique. Many districts number areas
+ * 01..NN within each division (live 2026-06-09: 1,094 cross-division areaId
+ * collisions), so an area is identified by the (districtId, divisionId,
+ * areaId) triple — areas nest under their division. Display names are not
+ * carried: live data derives them as `Division {id}` / `Area {id}` with zero
+ * deviations across all 128 districts, and the scoped routes
+ * (/district/:districtId/division/:divId[/area/:areaId]) need only ids.
+ *
+ * Pure data-in/data-out (Lesson 107 pattern): the workflow step is thin glue
+ * around scripts/build-divisions-areas-index.ts.
+ */
+
+export interface DivisionsAreasIndex {
+  /** ISO timestamp the index was generated at. */
+  generatedAt: string
+  /** Snapshot date (YYYY-MM-DD) the index was built from. */
+  snapshotDate: string
+  /** Total division count across all districts. */
+  totalDivisions: number
+  /** Total area count across all districts. */
+  totalAreas: number
+  /** districtId → divisionId → sorted areaIds in that division. */
+  districts: Record<string, Record<string, string[]>>
+}
+
+/** The two fields the index reads from a division/area entry. */
+type IdRecord = { divisionId?: unknown; areaId?: unknown }
+
+/**
+ * Parse one district_*.json file's raw contents. Returns null for corrupt
+ * JSON so the runner can skip the file (same policy as the club-index step).
+ */
+export function parseDistrictFile(raw: string): unknown {
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Build the global divisions/areas index from parsed district_*.json
+ * payloads. Accepts both the collector wrapper ({ data: {...} }) and a bare
+ * DistrictStatisticsFile. Payloads without a string districtId are skipped;
+ * malformed division/area entries contribute nothing. Output is
+ * permutation-invariant: keys are inserted sorted (JS then hoists
+ * integer-like keys, deterministically) and area lists are sorted, so
+ * successive daily uploads diff cleanly regardless of input file order.
+ */
+export function buildDivisionsAreasIndex(
+  files: ReadonlyArray<unknown>,
+  snapshotDate: string,
+  generatedAt: string
+): DivisionsAreasIndex {
+  // districtId → divisionId → Set<areaId>
+  const collected = new Map<string, Map<string, Set<string>>>()
+
+  for (const file of files) {
+    const payload = unwrap(file)
+    if (payload === null) continue
+    const districtId = stringField(payload, 'districtId')
+    if (districtId === null) continue
+
+    const divisions =
+      collected.get(districtId) ?? new Map<string, Set<string>>()
+    collected.set(districtId, divisions)
+
+    for (const entry of recordArray(payload, 'divisions')) {
+      const divisionId = idOf(entry, 'divisionId')
+      if (divisionId === null) continue
+      if (!divisions.has(divisionId)) divisions.set(divisionId, new Set())
+    }
+
+    // areas[] is the source of truth for membership: an area whose division
+    // is missing from divisions[] still creates that division's key.
+    for (const entry of recordArray(payload, 'areas')) {
+      const divisionId = idOf(entry, 'divisionId')
+      const areaId = idOf(entry, 'areaId')
+      if (divisionId === null || areaId === null) continue
+      const areas = divisions.get(divisionId) ?? new Set<string>()
+      divisions.set(divisionId, areas)
+      areas.add(areaId)
+    }
+  }
+
+  const districts: DivisionsAreasIndex['districts'] = {}
+  let totalDivisions = 0
+  let totalAreas = 0
+  for (const districtId of [...collected.keys()].sort()) {
+    const divisions: Record<string, string[]> = {}
+    const divisionMap = collected.get(districtId)!
+    for (const divisionId of [...divisionMap.keys()].sort()) {
+      const areas = [...divisionMap.get(divisionId)!].sort()
+      divisions[divisionId] = areas
+      totalDivisions++
+      totalAreas += areas.length
+    }
+    districts[districtId] = divisions
+  }
+
+  return { generatedAt, snapshotDate, totalDivisions, totalAreas, districts }
+}
+
+/** Unwrap the collector envelope ({ data: {...} }) or pass a bare payload. */
+function unwrap(file: unknown): Record<string, unknown> | null {
+  if (typeof file !== 'object' || file === null) return null
+  const obj = file as Record<string, unknown>
+  const data = obj['data']
+  if (typeof data === 'object' && data !== null) {
+    return data as Record<string, unknown>
+  }
+  return obj
+}
+
+function stringField(obj: Record<string, unknown>, key: string): string | null {
+  const value = obj[key]
+  return typeof value === 'string' && value !== '' ? value : null
+}
+
+function recordArray(obj: Record<string, unknown>, key: string): IdRecord[] {
+  const value = obj[key]
+  return Array.isArray(value) ? (value as IdRecord[]) : []
+}
+
+function idOf(entry: IdRecord, key: keyof IdRecord): string | null {
+  if (typeof entry !== 'object' || entry === null) return null
+  const value = entry[key]
+  return typeof value === 'string' && value !== '' ? value : null
+}

--- a/scripts/lib/divisionsAreasIndex.ts
+++ b/scripts/lib/divisionsAreasIndex.ts
@@ -31,9 +31,6 @@ export interface DivisionsAreasIndex {
   districts: Record<string, Record<string, string[]>>
 }
 
-/** The two fields the index reads from a division/area entry. */
-type IdRecord = { divisionId?: unknown; areaId?: unknown }
-
 /**
  * Parse one district_*.json file's raw contents. Returns null for corrupt
  * JSON so the runner can skip the file (same policy as the club-index step).
@@ -66,7 +63,7 @@ export function buildDivisionsAreasIndex(
   for (const file of files) {
     const payload = unwrap(file)
     if (payload === null) continue
-    const districtId = stringField(payload, 'districtId')
+    const districtId = stringProp(payload, 'districtId')
     if (districtId === null) continue
 
     const divisions =
@@ -74,7 +71,7 @@ export function buildDivisionsAreasIndex(
     collected.set(districtId, divisions)
 
     for (const entry of recordArray(payload, 'divisions')) {
-      const divisionId = idOf(entry, 'divisionId')
+      const divisionId = stringProp(entry, 'divisionId')
       if (divisionId === null) continue
       if (!divisions.has(divisionId)) divisions.set(divisionId, new Set())
     }
@@ -82,8 +79,8 @@ export function buildDivisionsAreasIndex(
     // areas[] is the source of truth for membership: an area whose division
     // is missing from divisions[] still creates that division's key.
     for (const entry of recordArray(payload, 'areas')) {
-      const divisionId = idOf(entry, 'divisionId')
-      const areaId = idOf(entry, 'areaId')
+      const divisionId = stringProp(entry, 'divisionId')
+      const areaId = stringProp(entry, 'areaId')
       if (divisionId === null || areaId === null) continue
       const areas = divisions.get(divisionId) ?? new Set<string>()
       divisions.set(divisionId, areas)
@@ -120,18 +117,14 @@ function unwrap(file: unknown): Record<string, unknown> | null {
   return obj
 }
 
-function stringField(obj: Record<string, unknown>, key: string): string | null {
-  const value = obj[key]
-  return typeof value === 'string' && value !== '' ? value : null
+/** Read a non-empty string property off an unknown value, else null. */
+function stringProp(value: unknown, key: string): string | null {
+  if (typeof value !== 'object' || value === null) return null
+  const prop = (value as Record<string, unknown>)[key]
+  return typeof prop === 'string' && prop !== '' ? prop : null
 }
 
-function recordArray(obj: Record<string, unknown>, key: string): IdRecord[] {
+function recordArray(obj: Record<string, unknown>, key: string): unknown[] {
   const value = obj[key]
-  return Array.isArray(value) ? (value as IdRecord[]) : []
-}
-
-function idOf(entry: IdRecord, key: keyof IdRecord): string | null {
-  if (typeof entry !== 'object' || entry === null) return null
-  const value = entry[key]
-  return typeof value === 'string' && value !== '' ? value : null
+  return Array.isArray(value) ? value : []
 }

--- a/tasks/lessons/158-a-json-artifact-with-numeric-like-keys-cannot-promise-lexicographic-key-order.md
+++ b/tasks/lessons/158-a-json-artifact-with-numeric-like-keys-cannot-promise-lexicographic-key-order.md
@@ -1,0 +1,71 @@
+---
+id: '158'
+category: lesson
+tags: [data-pipeline, tests, tdd, verification, json, determinism]
+auto_load: true
+date: 2026-06-10
+issues: [1134, 1101]
+---
+
+# Lesson 158 — A JSON artifact with numeric-like keys cannot promise lexicographic key order; test permutation-invariance of the serialized bytes instead
+
+**Date:** 2026-06-10
+**Issue:** #1134 (epic #1101 Sprint 1 — global divisions/areas index artifact)
+**PR:** _(record on merge)_
+
+## What happened
+
+The divisions/areas index builder inserts district keys into its output
+object in sorted order, and the Red test pinned that:
+`expect(Object.keys(index.districts)).toEqual([...keys].sort())`. It failed —
+`Object.keys` returned `['61', '01', '04']` for sorted insertion of
+`['01', '04', '61']`.
+
+The ES spec orders object properties in two tiers: **array-index-like keys
+first, ascending numerically**, then string keys in insertion order. `'61'`
+is array-index-like (canonical round-trip: `String(61) === '61'`), but
+`'01'` is **not** (`String(1) === '1' ≠ '01'`) — a leading zero demotes a
+key to the string tier. So a key set mixing `'61'` with `'01'` can never be
+lexicographic in a plain object, no matter how you insert. `JSON.stringify`
+follows the same order, so the published artifact inherits it.
+
+The property that actually matters for a daily-regenerated artifact is
+**clean day-over-day diffs**, and the achievable, falsifiable form of that
+is **permutation-invariance**: same input files in any order → identical
+serialized bytes. Sorted insertion (string tier) + the spec's deterministic
+integer-tier ordering deliver exactly that. The test was amended to assert
+`JSON.stringify(build(files)) === JSON.stringify(build(reverse(files)))` —
+not to match the bug, but because the original assertion encoded an
+unrepresentable spec.
+
+## The transferable lesson
+
+**When a deterministic JSON artifact has numeric-like string keys (district
+ids, ports, years), "keys are sorted" is not a property a JS object can
+hold — the integer-hoisting tier reorders them at insertion. Specify and
+test the real requirement (identical serialized output regardless of input
+order), and document why lexicographic order is off the table so the next
+reader doesn't "fix" the key ordering into a test that can never pass.**
+Distinguish this from assertion pinning: pinning bends the expectation to
+match defective behavior; this bends the expectation to the strongest
+property the platform can represent — after verifying the original
+expectation was impossible, not merely failing.
+
+## How to apply
+
+- Emitting a keyed JSON artifact for daily diffing? Insert string-tier keys
+  sorted, then assert permutation-invariance of the bytes, not key order.
+- If true lexicographic order is a hard requirement (e.g. for a
+  line-oriented differ), use an array of `[key, value]` pairs — objects
+  cannot represent it.
+- When a Red test fails on its own expectation, check whether the
+  expectation is representable at all before touching the implementation.
+
+## Related
+
+- [[157-in-a-zod-union-a-non-strict-all-optional-object-schema-swallows-any-object]]
+  — same family: the platform's silent semantics (strip mode / key
+  hoisting) reshape what your contract can actually promise.
+- `scripts/lib/divisionsAreasIndex.ts` (the ordering note),
+  `scripts/lib/__tests__/divisionsAreasIndex.test.ts` (the
+  permutation-invariance test).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -144,6 +144,7 @@
 - **156** [analytics, dcp, refactor, monorepo, verification] — An audit's defect list for a forked implementation is a lower bound; consolidation must re-derive the full semantic diff (#1118, #1095)
 - **157** [zod, schemas, data-pipeline, monorepo, verification, contracts] — In a zod union, a non-strict all-optional object schema matches (and silently EMPTIES) any object; strictness is what keeps the union falsifiable (#1123, #1096)
 - **157** [data-pipeline, analytics, transformation, fixtures, verification] — When sibling reports share one entity universe, derive every aggregate block from the single merged entity set (#1124, #1096)
+- **158** [data-pipeline, tests, tdd, verification, json, determinism] — A JSON artifact with numeric-like keys cannot promise lexicographic key order; test permutation-invariance of the serialized bytes instead (#1134, #1101)
 - **158** [git, bash, tests, process, verification] — A literal control byte in a source file flips git and grep into binary mode; write control characters as escapes (#1080, #1156)
 - **158** [ci, automation, monitoring, data-pipeline, verification] — A parameterized monitor's self-clear must be scoped to the signal it alarms on (#1125, #1096)
 - **158** [tests, tdd, verification, analytics, floats] — A test comment that justifies a surprising expectation by MECHANISM ("due to floating-point precision") instead of by RULE is a pinned bug wearing documentation (#1126, #1097, #798)


### PR DESCRIPTION
Sprint 1 of epic #1101 — implements #1134.

## What

A global divisions/areas index pipeline artifact — the divisions/areas mirror of `config/club-index.json` — published daily to `config/divisions-areas-index.json` (staging; the existing promotion step rsyncs `config/` to prod). TDD, **no UI** in this sprint; omni-search consumption is Sprint 2 (#1135).

- `scripts/lib/divisionsAreasIndex.ts` — pure, unit-tested builder (Lesson 107 pattern)
- `scripts/build-divisions-areas-index.ts` — thin runner; refuses to write an empty index (exit 1) so a failed sync can never blank omni-search data
- `.github/workflows/data-pipeline.yml` — new step after club-index, same trigger/skip/header semantics; syncs its own inputs (R2)
- 16 unit tests over **captured live fixtures** (Lesson 154): D61 (district-unique area numbering), D01 (per-division numbering), D04 (pseudo-division `0D`/`0A`)

## Shape decision (verified against live data, all 128 districts)

- **areaIds are NOT district-unique** — 1,094 cross-division collisions live (D01 has an Area 01 in every division). Areas therefore nest under divisions: `districts[districtId][divisionId] = sortedAreaIds[]`.
- Display names are derivable (`Division {id}` / `Area {id}` — zero deviations across 128 districts), so the index carries ids only.
- Determinism: output is permutation-invariant (identical bytes regardless of input file order). Lexicographic district-key order is unrepresentable in a JS object (integer-like keys hoist) — see Lesson 158 added in this PR.

## Acceptance criteria → evidence

| Criterion | Evidence |
| --- | --- |
| Failing tests first | Red commit c35fd1ef precedes Green 2fa6472c; review-finding Red e50f2536 precedes fix |
| Artifact generated + uploaded in daily pipeline | New `Generate divisions-areas index` step; full regen (size makes R9 incremental store unnecessary) |
| Size sanity | Live run over all 128 districts: **719 divisions, 3,139 areas, 21 KB raw / 2.9 KB gzipped** — far below the issue's "tens of thousands" estimate and trivially one-shot-fetchable (club-index is ~1 MB) |
| R2 sync | Step does its own `gsutil -m cp` of `district_*.json` into `/tmp/divisions-areas-src` |

## Verification

- `npm run test:scripts` 248/248; full workspace suite 5,355 tests green, zero regressions.
- Runner driven end-to-end against all 128 live district snapshots (2026-06-09); output re-verified byte-identical after the /simplify refactor and the unwrap fix.
- **No PR preview surface**: this PR touches only `scripts/`, the workflow, and `tasks/` — `pr-preview.yml` path filters don't match, so there is no live UI to drive. The artifact itself lands via the next scheduled pipeline run (code-proof + tested-builder evidence per the data-sprint verification convention).

## Fresh-context review

Verdict APPROVE-WITH-NITS. Medium finding fixed in-branch (failed-scrape wrapper `{status:'failed', data:null}` would have indexed a phantom empty district — now skipped, with a pinned test). Nits noted, intentionally not taken: duplicate district download vs `/tmp/club-index-src` (kept for step independence/R2; ~seconds daily), lexicographic area sort (live ids are zero-padded).

## Follow-up candidate (out of scope here)

club-index is still built by an untested inline `node -e` in the workflow YAML. The tested-builder pattern this PR introduces is the right altitude; migrating club-index onto it is a future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
