### PR TITLE
Sprint 2 (#1101) — omni-search matcher + UI groups for divisions/areas (#1135)

### DIFF
--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -10,11 +10,12 @@ import { DarkModeProvider } from '../../contexts/DarkModeContext'
 import { useIsMobile } from '../../hooks/useIsMobile'
 
 // Mock the CDN service the omni-search (#422 → #1058) lazy-fetches when the
-// palette opens — keeps these tests isolated from the network layer. Both
-// fetches are stubbed so opening the modal doesn't hit the network.
+// palette opens — keeps these tests isolated from the network layer. All
+// three fetches are stubbed so opening the modal doesn't hit the network.
 vi.mock('../../services/cdn', () => ({
   fetchCdnRankings: vi.fn().mockResolvedValue({ rankings: [], date: '' }),
   fetchCdnClubIndex: vi.fn().mockResolvedValue({ clubs: {} }),
+  fetchCdnDivisionsAreasIndex: vi.fn().mockResolvedValue({ districts: {} }),
 }))
 
 // #889: the footer is dropped at <768px (its meta moves to the nav "About"

--- a/frontend/src/components/AppShell/CommandPalette.tsx
+++ b/frontend/src/components/AppShell/CommandPalette.tsx
@@ -109,7 +109,7 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
             value={query}
             onChange={e => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Search districts, regions, clubs by name or number…"
+            placeholder="Search districts, clubs, divisions, areas…"
             aria-label="Universal search input"
             aria-controls={listboxOpen ? LISTBOX_ID : undefined}
             aria-activedescendant={
@@ -124,7 +124,7 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
           // Before the user types, guide them — listing every indexed entity
           // (14k+ clubs) is meaningless, so the empty query shows no listbox.
           <p className="command-palette__empty">
-            Type to search districts, regions, and clubs.
+            Type to search districts, regions, clubs, divisions, and areas.
           </p>
         ) : !index ? (
           <p className="command-palette__empty">Searching…</p>

--- a/frontend/src/components/AppShell/CommandPalette.tsx
+++ b/frontend/src/components/AppShell/CommandPalette.tsx
@@ -109,7 +109,7 @@ const OpenPalette: React.FC<OpenPaletteProps> = ({ onClose }) => {
             value={query}
             onChange={e => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Search districts, clubs, divisions, areas…"
+            placeholder="Search districts, regions, clubs, divisions, areas…"
             aria-label="Universal search input"
             aria-controls={listboxOpen ? LISTBOX_ID : undefined}
             aria-activedescendant={

--- a/frontend/src/components/AppShell/HeaderSearch.tsx
+++ b/frontend/src/components/AppShell/HeaderSearch.tsx
@@ -52,7 +52,7 @@ const HeaderSearch: React.FC<HeaderSearchProps> = ({ onOpenSearch }) => {
         type="button"
         className="app-shell-icon-btn header-search__trigger"
         aria-label="Search"
-        title="Search districts, regions, clubs"
+        title="Search districts, regions, clubs, divisions, areas"
         onClick={onOpenSearch}
       >
         <SearchGlyph />
@@ -139,7 +139,7 @@ const DesktopOmniCombobox: React.FC = () => {
           onFocus={() => setFocused(true)}
           onKeyDown={handleKeyDown}
           placeholder="Search…"
-          aria-label="Search districts, regions, clubs by name or number"
+          aria-label="Search districts, regions, clubs, divisions, areas by name or number"
           aria-autocomplete="list"
           aria-expanded={listboxOpen}
           aria-controls={listboxOpen ? LISTBOX_ID : undefined}

--- a/frontend/src/components/AppShell/OmniSearchResults.tsx
+++ b/frontend/src/components/AppShell/OmniSearchResults.tsx
@@ -20,6 +20,8 @@ const GROUP_LABEL: Record<SearchEntityType, string> = {
   district: 'Districts',
   region: 'Regions',
   club: 'Clubs',
+  division: 'Divisions',
+  area: 'Areas',
 }
 
 interface OmniSearchResultsProps {

--- a/frontend/src/components/AppShell/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/CommandPalette.test.tsx
@@ -10,14 +10,18 @@ import { MemoryRouter } from 'react-router-dom'
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
 import CommandPalette from '../CommandPalette'
 
-// The palette now loads the unified index, which fans out to two CDN
-// fetches (rankings → districts+regions, club-index → clubs). Mock both.
+// The palette now loads the unified index, which fans out to three CDN
+// fetches (rankings → districts+regions, club-index → clubs,
+// divisions-areas-index → divisions+areas, #1135). Mock all three.
 const fetchCdnRankings = vi.fn()
 const fetchCdnClubIndex = vi.fn()
+const fetchCdnDivisionsAreasIndex = vi.fn()
 
 vi.mock('../../../services/cdn', () => ({
   fetchCdnRankings: (...args: unknown[]) => fetchCdnRankings(...args),
   fetchCdnClubIndex: (...args: unknown[]) => fetchCdnClubIndex(...args),
+  fetchCdnDivisionsAreasIndex: (...args: unknown[]) =>
+    fetchCdnDivisionsAreasIndex(...args),
 }))
 
 const rankingRow = (
@@ -30,6 +34,7 @@ const setupCdn = (
   opts: {
     rankings?: Array<ReturnType<typeof rankingRow>>
     clubs?: Record<string, { districtId: string; clubName: string }>
+    divisionsAreas?: Record<string, Record<string, string[]>>
   } = {}
 ) => {
   fetchCdnRankings.mockResolvedValue({
@@ -43,6 +48,13 @@ const setupCdn = (
     clubs: opts.clubs ?? {
       '12345': { districtId: '61', clubName: 'Toast of the Town' },
     },
+  })
+  fetchCdnDivisionsAreasIndex.mockResolvedValue({
+    generatedAt: '2026-06-10T00:00:00Z',
+    snapshotDate: '2026-06-09',
+    totalDivisions: 1,
+    totalAreas: 1,
+    districts: opts.divisionsAreas ?? { '61': { C: ['23'] } },
   })
 }
 
@@ -148,6 +160,42 @@ describe('CommandPalette omni-search (#1057)', () => {
     })
     // At least the Clubs group is present (club name contains "o").
     await within(listbox).findByRole('group', { name: /clubs/i })
+  })
+
+  it('finds a division ("61 c") under a Divisions group and routes to the scoped division page (#1135)', async () => {
+    renderPalette(true)
+    const input = screen.getByLabelText(/universal search input/i)
+    fireEvent.change(input, { target: { value: '61 c' } })
+
+    const listbox = await screen.findByRole('listbox', {
+      name: /search results/i,
+    })
+    const divisions = await within(listbox).findByRole('group', {
+      name: /divisions/i,
+    })
+    const link = within(divisions).getByRole('link')
+    expect(link).toHaveTextContent(/Division C/)
+    // Disambiguation context (which district the division belongs to).
+    expect(link).toHaveTextContent(/District 61/)
+    // Route-keyed (Lesson 152): the stable identifier, not a CDN label.
+    expect(link.getAttribute('href')).toBe('/district/61/division/C')
+  })
+
+  it('finds an area ("area 23 61") under an Areas group and routes to the nested area page (#1135)', async () => {
+    renderPalette(true)
+    const input = screen.getByLabelText(/universal search input/i)
+    fireEvent.change(input, { target: { value: 'area 23 61' } })
+
+    const listbox = await screen.findByRole('listbox', {
+      name: /search results/i,
+    })
+    const areas = await within(listbox).findByRole('group', {
+      name: /areas/i,
+    })
+    const link = within(areas).getByRole('link')
+    expect(link).toHaveTextContent(/Area 23/)
+    expect(link).toHaveTextContent(/District 61 · Division C/)
+    expect(link.getAttribute('href')).toBe('/district/61/division/C/area/23')
   })
 
   it('shows an empty-state prompt before the user types', async () => {

--- a/frontend/src/components/AppShell/__tests__/HeaderSearch.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/HeaderSearch.test.tsx
@@ -14,10 +14,13 @@ import { useIsMobile } from '../../../hooks/useIsMobile'
 
 const fetchCdnRankings = vi.fn()
 const fetchCdnClubIndex = vi.fn()
+const fetchCdnDivisionsAreasIndex = vi.fn()
 
 vi.mock('../../../services/cdn', () => ({
   fetchCdnRankings: (...args: unknown[]) => fetchCdnRankings(...args),
   fetchCdnClubIndex: (...args: unknown[]) => fetchCdnClubIndex(...args),
+  fetchCdnDivisionsAreasIndex: (...args: unknown[]) =>
+    fetchCdnDivisionsAreasIndex(...args),
 }))
 
 vi.mock('../../../hooks/useIsMobile', () => ({
@@ -34,6 +37,9 @@ const setupCdn = () => {
   })
   fetchCdnClubIndex.mockResolvedValue({
     clubs: { '12345': { districtId: '61', clubName: 'Toast of the Town' } },
+  })
+  fetchCdnDivisionsAreasIndex.mockResolvedValue({
+    districts: { '61': { C: ['23'] } },
   })
 }
 

--- a/frontend/src/hooks/__tests__/useOmniSearch.test.tsx
+++ b/frontend/src/hooks/__tests__/useOmniSearch.test.tsx
@@ -9,15 +9,21 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React, { ReactNode } from 'react'
 import { useOmniSearch } from '../useOmniSearch'
-import { fetchCdnRankings, fetchCdnClubIndex } from '../../services/cdn'
+import {
+  fetchCdnRankings,
+  fetchCdnClubIndex,
+  fetchCdnDivisionsAreasIndex,
+} from '../../services/cdn'
 
 vi.mock('../../services/cdn', () => ({
   fetchCdnRankings: vi.fn(),
   fetchCdnClubIndex: vi.fn(),
+  fetchCdnDivisionsAreasIndex: vi.fn(),
 }))
 
 const mockedRankings = vi.mocked(fetchCdnRankings)
 const mockedClubIndex = vi.mocked(fetchCdnClubIndex)
+const mockedDivisionsAreas = vi.mocked(fetchCdnDivisionsAreasIndex)
 
 const wrapper = ({ children }: { children: ReactNode }) => {
   const client = new QueryClient({
@@ -45,6 +51,9 @@ const setupCdn = () => {
   mockedClubIndex.mockResolvedValue({
     clubs: { '12345': { districtId: '61', clubName: 'Toast of the Town' } },
   } as Awaited<ReturnType<typeof fetchCdnClubIndex>>)
+  mockedDivisionsAreas.mockResolvedValue({
+    districts: { '61': { C: ['23'] } },
+  } as Awaited<ReturnType<typeof fetchCdnDivisionsAreasIndex>>)
 }
 
 describe('useOmniSearch (#1058)', () => {

--- a/frontend/src/services/__tests__/searchIndex.loader.test.ts
+++ b/frontend/src/services/__tests__/searchIndex.loader.test.ts
@@ -81,7 +81,7 @@ describe('loadSearchIndex (lazy)', () => {
     // The artifact only lands via the scheduled pipeline (#1134) — a 404 must
     // not take down district/region/club search with it.
     fetchCdnDivisionsAreasIndex.mockRejectedValue(
-      new Error('CDN divisions/areas index fetch failed: 404')
+      new Error('CDN fetch failed: 404 for …/config/divisions-areas-index.json')
     )
     const { loadSearchIndex } = await import('../searchIndex')
     const index = await loadSearchIndex()

--- a/frontend/src/services/__tests__/searchIndex.loader.test.ts
+++ b/frontend/src/services/__tests__/searchIndex.loader.test.ts
@@ -5,15 +5,26 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // must not be pulled at import / app boot).
 const fetchCdnRankings = vi.fn()
 const fetchCdnClubIndex = vi.fn()
+const fetchCdnDivisionsAreasIndex = vi.fn()
 vi.mock('../cdn', () => ({
   fetchCdnRankings: (...args: unknown[]) => fetchCdnRankings(...args),
   fetchCdnClubIndex: (...args: unknown[]) => fetchCdnClubIndex(...args),
+  fetchCdnDivisionsAreasIndex: (...args: unknown[]) =>
+    fetchCdnDivisionsAreasIndex(...args),
 }))
 
 describe('loadSearchIndex (lazy)', () => {
   beforeEach(() => {
     fetchCdnRankings.mockReset()
     fetchCdnClubIndex.mockReset()
+    fetchCdnDivisionsAreasIndex.mockReset()
+    fetchCdnDivisionsAreasIndex.mockResolvedValue({
+      generatedAt: '2026-06-10T00:00:00Z',
+      snapshotDate: '2026-06-09',
+      totalDivisions: 1,
+      totalAreas: 1,
+      districts: { '61': { C: ['23'] } },
+    })
     fetchCdnRankings.mockResolvedValue({
       rankings: [
         { districtId: '61', districtName: 'District 61', region: '07' },
@@ -32,6 +43,7 @@ describe('loadSearchIndex (lazy)', () => {
     await import('../searchIndex')
     expect(fetchCdnRankings).not.toHaveBeenCalled()
     expect(fetchCdnClubIndex).not.toHaveBeenCalled()
+    expect(fetchCdnDivisionsAreasIndex).not.toHaveBeenCalled()
   })
 
   it('fetches rankings + club index only when invoked, and builds an index', async () => {
@@ -48,5 +60,39 @@ describe('loadSearchIndex (lazy)', () => {
     expect(
       index.entities.some(e => e.type === 'club' && e.id === '00001234')
     ).toBe(true)
+  })
+
+  // --- divisions/areas (#1135, epic #1101 Sprint 2) ---
+
+  it('fetches the divisions/areas index and indexes divisions + areas', async () => {
+    const { loadSearchIndex } = await import('../searchIndex')
+    const index = await loadSearchIndex()
+
+    expect(fetchCdnDivisionsAreasIndex).toHaveBeenCalledTimes(1)
+    expect(
+      index.entities.some(e => e.type === 'division' && e.id === '61/C')
+    ).toBe(true)
+    expect(
+      index.entities.some(e => e.type === 'area' && e.id === '61/C/23')
+    ).toBe(true)
+  })
+
+  it('degrades gracefully when the divisions/areas index is unavailable (fail-soft)', async () => {
+    // The artifact only lands via the scheduled pipeline (#1134) — a 404 must
+    // not take down district/region/club search with it.
+    fetchCdnDivisionsAreasIndex.mockRejectedValue(
+      new Error('CDN divisions/areas index fetch failed: 404')
+    )
+    const { loadSearchIndex } = await import('../searchIndex')
+    const index = await loadSearchIndex()
+
+    expect(
+      index.entities.some(e => e.type === 'district' && e.id === '61')
+    ).toBe(true)
+    expect(
+      index.entities.some(e => e.type === 'club' && e.id === '00001234')
+    ).toBe(true)
+    expect(index.entities.some(e => e.type === 'division')).toBe(false)
+    expect(index.entities.some(e => e.type === 'area')).toBe(false)
   })
 })

--- a/frontend/src/services/__tests__/searchIndex.loader.test.ts
+++ b/frontend/src/services/__tests__/searchIndex.loader.test.ts
@@ -95,4 +95,18 @@ describe('loadSearchIndex (lazy)', () => {
     expect(index.entities.some(e => e.type === 'division')).toBe(false)
     expect(index.entities.some(e => e.type === 'area')).toBe(false)
   })
+
+  it('tolerates a malformed divisions/areas payload without taking search down', async () => {
+    // Fail-soft must cover payload shape, not just fetch failure: the
+    // fetcher does no schema validation, so districts:null must degrade
+    // exactly like a 404 (review finding on #1135).
+    fetchCdnDivisionsAreasIndex.mockResolvedValue({ districts: null })
+    const { loadSearchIndex } = await import('../searchIndex')
+    const index = await loadSearchIndex()
+
+    expect(
+      index.entities.some(e => e.type === 'district' && e.id === '61')
+    ).toBe(true)
+    expect(index.entities.some(e => e.type === 'division')).toBe(false)
+  })
 })

--- a/frontend/src/services/__tests__/searchIndex.test.ts
+++ b/frontend/src/services/__tests__/searchIndex.test.ts
@@ -33,6 +33,15 @@ const CLUBS: Record<string, { districtId: string; clubName: string }> = {
   '00009999': { districtId: '6', clubName: 'Sunrise Communicators' },
 }
 
+// Shape mirrors fetchCdnDivisionsAreasIndex().districts (#1134):
+// districtId → divisionId → sorted areaIds. AreaIds are NOT district-unique
+// (61/C/23 and 57/C/23 coexist); 04/0D is a live pseudo-division shape.
+const DIVISIONS_AREAS: Record<string, Record<string, string[]>> = {
+  '61': { A: ['1', '12'], C: ['23'] },
+  '57': { C: ['23'] },
+  '04': { '0D': ['0A'] },
+}
+
 // Flatten grouped results into a single ranked list, preserving group order,
 // so "above" assertions read naturally.
 function flatten(groups: SearchResultGroup[]) {
@@ -42,7 +51,7 @@ function flatten(groups: SearchResultGroup[]) {
 describe('buildSearchIndex', () => {
   let index: SearchIndex
   beforeEach(() => {
-    index = buildSearchIndex(RANKINGS, CLUBS)
+    index = buildSearchIndex(RANKINGS, CLUBS, DIVISIONS_AREAS)
   })
 
   it('creates one district entity per ranking row with the canonical route', () => {
@@ -70,12 +79,48 @@ describe('buildSearchIndex', () => {
     expect(club!.context).toBe('District 61')
     expect(club!.route).toBe('/district/61/club/00001234')
   })
+
+  // --- divisions/areas (#1135, epic #1101 Sprint 2) ---
+
+  it('creates one division entity per (district, division) with the scoped route', () => {
+    const divisions = index.entities.filter(e => e.type === 'division')
+    expect(divisions).toHaveLength(4) // 61/A, 61/C, 57/C, 04/0D
+    const d61c = divisions.find(e => e.id === '61/C')
+    expect(d61c).toBeDefined()
+    expect(d61c!.label).toBe('Division C')
+    expect(d61c!.context).toBe('District 61')
+    expect(d61c!.route).toBe('/district/61/division/C')
+  })
+
+  it('creates one area entity per (district, division, area) with the nested scoped route', () => {
+    const areas = index.entities.filter(e => e.type === 'area')
+    expect(areas).toHaveLength(5) // 61: 1, 12, 23 · 57: 23 · 04: 0A
+    const a = areas.find(e => e.id === '61/C/23')
+    expect(a).toBeDefined()
+    expect(a!.label).toBe('Area 23')
+    expect(a!.context).toBe('District 61 · Division C')
+    expect(a!.route).toBe('/district/61/division/C/area/23')
+  })
+
+  it('indexes pseudo-divisions (e.g. 0D) verbatim — same source the division pages read', () => {
+    const div = index.entities.find(
+      e => e.type === 'division' && e.id === '04/0D'
+    )
+    expect(div).toBeDefined()
+    expect(div!.label).toBe('Division 0D')
+    expect(div!.route).toBe('/district/04/division/0D')
+    const area = index.entities.find(
+      e => e.type === 'area' && e.id === '04/0D/0A'
+    )
+    expect(area).toBeDefined()
+    expect(area!.route).toBe('/district/04/division/0D/area/0A')
+  })
 })
 
 describe('searchEntities', () => {
   let index: SearchIndex
   beforeEach(() => {
-    index = buildSearchIndex(RANKINGS, CLUBS)
+    index = buildSearchIndex(RANKINGS, CLUBS, DIVISIONS_AREAS)
   })
 
   it('returns no results for an empty or whitespace query', () => {
@@ -125,12 +170,13 @@ describe('searchEntities', () => {
     expect(flat[0]?.id).toBe('00009999')
   })
 
-  it('groups results by type in district → region → club order', () => {
+  it('groups results by type in district → region → club → division → area order', () => {
     const groups = searchEntities('6', index)
     const types = groups.map(g => g.type)
     // Every present group respects the canonical order.
-    const order = ['district', 'region', 'club']
+    const order = ['district', 'region', 'club', 'division', 'area']
     const indices = types.map(t => order.indexOf(t))
+    expect(indices).not.toContain(-1)
     expect(indices).toEqual([...indices].sort((a, b) => a - b))
   })
 
@@ -157,5 +203,84 @@ describe('searchEntities', () => {
     expect(flat.length).toBeLessThanOrEqual(8)
     // The exact-id district must survive the cap and lead the results.
     expect(flat[0]).toMatchObject({ type: 'district', id: '61' })
+  })
+})
+
+describe('searchEntities — division/area query shapes (#1135)', () => {
+  let index: SearchIndex
+  beforeEach(() => {
+    index = buildSearchIndex(RANKINGS, CLUBS, DIVISIONS_AREAS)
+  })
+
+  it('resolves "61 c" to District 61 Division C, district-scoped', () => {
+    const flat = flatten(searchEntities('61 c', index))
+    expect(flat[0]).toMatchObject({ type: 'division', id: '61/C' })
+    // The SAME division letter in another district must not match.
+    expect(flat.some(e => e.id === '57/C')).toBe(false)
+  })
+
+  it('resolves "c 61" (division-first word order) to the same division', () => {
+    const flat = flatten(searchEntities('c 61', index))
+    expect(flat.some(e => e.type === 'division' && e.id === '61/C')).toBe(true)
+  })
+
+  it('resolves "division c 61" and "61 division c" to District 61 Division C', () => {
+    for (const q of ['division c 61', '61 division c']) {
+      const flat = flatten(searchEntities(q, index))
+      expect(flat[0]).toMatchObject({ type: 'division', id: '61/C' })
+      expect(flat.some(e => e.id === '57/C')).toBe(false)
+    }
+  })
+
+  it('is case-insensitive for division queries ("Division C 61")', () => {
+    const flat = flatten(searchEntities('Division C 61', index))
+    expect(flat[0]).toMatchObject({ type: 'division', id: '61/C' })
+  })
+
+  it('matches "division c" (no district) in every district that has one', () => {
+    const ids = flatten(searchEntities('division c', index))
+      .filter(e => e.type === 'division')
+      .map(e => e.id)
+    expect(ids).toContain('61/C')
+    expect(ids).toContain('57/C')
+  })
+
+  it('resolves "area 23 61" to District 61 Area 23, district-scoped', () => {
+    const flat = flatten(searchEntities('area 23 61', index))
+    expect(flat[0]).toMatchObject({ type: 'area', id: '61/C/23' })
+    expect(flat.some(e => e.id === '57/C/23')).toBe(false)
+  })
+
+  it('resolves "61 area 23" to the same area', () => {
+    const flat = flatten(searchEntities('61 area 23', index))
+    expect(flat[0]).toMatchObject({ type: 'area', id: '61/C/23' })
+  })
+
+  it('matches "area 23" (no district) in every district that has one', () => {
+    const ids = flatten(searchEntities('area 23', index))
+      .filter(e => e.type === 'area')
+      .map(e => e.id)
+    expect(ids).toContain('61/C/23')
+    expect(ids).toContain('57/C/23')
+  })
+
+  it('keeps bare "61" district-first and clubs above divisions (no flood regression)', () => {
+    const flat = flatten(searchEntities('61', index))
+    expect(flat[0]).toMatchObject({ type: 'district', id: '61' })
+    const firstClub = flat.findIndex(e => e.type === 'club')
+    const firstDivision = flat.findIndex(e => e.type === 'division')
+    expect(firstClub).not.toBe(-1)
+    // Clubs outrank divisions for ambiguous queries (canonical group order).
+    if (firstDivision !== -1) {
+      expect(firstClub).toBeLessThan(firstDivision)
+    }
+  })
+
+  it('orders the Clubs group before the Areas group when a query spans both', () => {
+    // "23" substring-matches club id 00001234 and the Area 23 entities.
+    const types = searchEntities('23', index).map(g => g.type)
+    expect(types).toContain('club')
+    expect(types).toContain('area')
+    expect(types.indexOf('club')).toBeLessThan(types.indexOf('area'))
   })
 })

--- a/frontend/src/services/__tests__/searchIndex.test.ts
+++ b/frontend/src/services/__tests__/searchIndex.test.ts
@@ -102,6 +102,21 @@ describe('buildSearchIndex', () => {
     expect(a!.route).toBe('/district/61/division/C/area/23')
   })
 
+  it('skips malformed division/area values instead of throwing or indexing junk', () => {
+    // A string is iterable — a naive for…of over a junk areaIds value would
+    // index phantom one-character areas. Both junk shapes must contribute
+    // nothing (review finding on #1135).
+    const malformed = buildSearchIndex(RANKINGS, CLUBS, {
+      '61': { C: 'junk' as unknown as string[] },
+      '57': null as unknown as Record<string, string[]>,
+    })
+    expect(malformed.entities.some(e => e.type === 'area')).toBe(false)
+    expect(
+      malformed.entities.some(e => e.type === 'division' && e.id === '61/C')
+    ).toBe(true)
+    expect(malformed.entities.some(e => e.id.startsWith('57/'))).toBe(false)
+  })
+
   it('indexes pseudo-divisions (e.g. 0D) verbatim — same source the division pages read', () => {
     const div = index.entities.find(
       e => e.type === 'division' && e.id === '04/0D'

--- a/frontend/src/services/__tests__/searchIndex.test.ts
+++ b/frontend/src/services/__tests__/searchIndex.test.ts
@@ -251,9 +251,11 @@ describe('searchEntities — division/area query shapes (#1135)', () => {
     expect(flat.some(e => e.id === '57/C/23')).toBe(false)
   })
 
-  it('resolves "61 area 23" to the same area', () => {
-    const flat = flatten(searchEntities('61 area 23', index))
-    expect(flat[0]).toMatchObject({ type: 'area', id: '61/C/23' })
+  it('resolves "61 area 23" and the terse "61 23" to the same area', () => {
+    for (const q of ['61 area 23', '61 23']) {
+      const flat = flatten(searchEntities(q, index))
+      expect(flat[0]).toMatchObject({ type: 'area', id: '61/C/23' })
+    }
   })
 
   it('matches "area 23" (no district) in every district that has one', () => {

--- a/frontend/src/services/cdn.ts
+++ b/frontend/src/services/cdn.ts
@@ -503,6 +503,29 @@ export async function fetchCdnClubIndex(): Promise<{
   return res.json()
 }
 
+/** Shape of config/divisions-areas-index.json (#1134, epic #1101). */
+export interface CdnDivisionsAreasIndexData {
+  generatedAt: string
+  snapshotDate: string
+  totalDivisions: number
+  totalAreas: number
+  /** districtId → divisionId → sorted areaIds in that division. */
+  districts: Record<string, Record<string, string[]>>
+}
+
+/**
+ * Fetch the global divisions/areas index from CDN (#1134 → #1135).
+ */
+export async function fetchCdnDivisionsAreasIndex(): Promise<CdnDivisionsAreasIndexData> {
+  const url = `${cdnBaseUrl()}/config/divisions-areas-index.json`
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`CDN divisions/areas index fetch failed: ${res.status}`)
+  }
+  recordCdnResponse(res)
+  return res.json()
+}
+
 export async function fetchCdnRankHistory(
   districtId: string
 ): Promise<CdnRankHistoryData> {

--- a/frontend/src/services/cdn.ts
+++ b/frontend/src/services/cdn.ts
@@ -517,13 +517,9 @@ export interface CdnDivisionsAreasIndexData {
  * Fetch the global divisions/areas index from CDN (#1134 → #1135).
  */
 export async function fetchCdnDivisionsAreasIndex(): Promise<CdnDivisionsAreasIndexData> {
-  const url = `${cdnBaseUrl()}/config/divisions-areas-index.json`
-  const res = await fetch(url)
-  if (!res.ok) {
-    throw new Error(`CDN divisions/areas index fetch failed: ${res.status}`)
-  }
-  recordCdnResponse(res)
-  return res.json()
+  return fetchFromCdn<CdnDivisionsAreasIndexData>(
+    `${cdnBaseUrl()}/config/divisions-areas-index.json`
+  )
 }
 
 export async function fetchCdnRankHistory(

--- a/frontend/src/services/searchIndex.ts
+++ b/frontend/src/services/searchIndex.ts
@@ -11,7 +11,12 @@
 
 import { fetchCdnRankings, fetchCdnClubIndex } from './cdn'
 
-export type SearchEntityType = 'district' | 'region' | 'club'
+export type SearchEntityType =
+  | 'district'
+  | 'region'
+  | 'club'
+  | 'division'
+  | 'area'
 
 export interface SearchEntity {
   type: SearchEntityType
@@ -25,6 +30,10 @@ export interface SearchEntity {
   route: string
   /** Lowercased terms the query is matched against (id, name, aliases) */
   terms: string[]
+  /** Lowercased combo terms matched ONLY by full equality (e.g. "61 c") —
+      never by prefix/substring, so partial queries like "61" don't flood
+      with every division/area of that district (#1135). */
+  exactTerms?: string[]
 }
 
 export interface SearchIndex {
@@ -53,15 +62,25 @@ type ClubIndexEntry = { districtId: string; clubName: string }
 const DEFAULT_CAP = 8
 
 // Group display order: navigate-to-a-place entities (districts, regions) lead;
-// clubs follow. The matcher also weights types so this order survives the cap.
-const GROUP_ORDER: SearchEntityType[] = ['district', 'region', 'club']
+// clubs follow; divisions/areas trail (#1135 — Districts / Clubs / Divisions /
+// Areas per epic #1101). The matcher also weights types so this order
+// survives the cap.
+const GROUP_ORDER: SearchEntityType[] = [
+  'district',
+  'region',
+  'club',
+  'division',
+  'area',
+]
 
 // Higher = ranked first among equal-strength matches, and weighted to survive
 // the result cap (so a club merely containing "61" can't bury District 61).
 const TYPE_RANK: Record<SearchEntityType, number> = {
-  district: 2,
-  region: 1,
-  club: 0,
+  district: 4,
+  region: 3,
+  club: 2,
+  division: 1,
+  area: 0,
 }
 
 /**
@@ -71,7 +90,9 @@ const TYPE_RANK: Record<SearchEntityType, number> = {
  */
 export function buildSearchIndex(
   rankings: ReadonlyArray<RankingRow>,
-  clubs: Readonly<Record<string, ClubIndexEntry>>
+  clubs: Readonly<Record<string, ClubIndexEntry>>,
+  /** districtId → divisionId → areaIds, from config/divisions-areas-index.json (#1134). */
+  _divisionsAreas: Readonly<Record<string, Record<string, string[]>>> = {}
 ): SearchIndex {
   const entities: SearchEntity[] = []
 

--- a/frontend/src/services/searchIndex.ts
+++ b/frontend/src/services/searchIndex.ts
@@ -142,10 +142,13 @@ export function buildSearchIndex(
   // Divisions + areas — from the global divisions/areas index (#1134).
   // Labels are derivable (`Division {id}` / `Area {id}`, zero deviations
   // across 128 live districts) and areas nest under divisions because
-  // areaIds are not district-unique. District-scoped combo terms ("61 c")
-  // are exact-only so partial queries like "61" don't flood with every
-  // division/area of that district.
+  // areaIds are not district-unique. District-scoped combo shapes ("61 c")
+  // match by full equality only (exactTerms), so a partial query like "61"
+  // reaches these entities only at substring level — below clubs, which
+  // TYPE_RANK keeps ahead. Values are unvalidated CDN JSON: junk shapes
+  // must contribute nothing (a string is iterable — guard, don't iterate).
   for (const [districtId, divisions] of Object.entries(divisionsAreas)) {
+    if (typeof divisions !== 'object' || divisions === null) continue
     const dist = districtId.toLowerCase()
     for (const [divisionId, areaIds] of Object.entries(divisions)) {
       const div = divisionId.toLowerCase()
@@ -162,7 +165,7 @@ export function buildSearchIndex(
           `${dist} division ${div}`,
         ]),
       })
-      for (const areaId of areaIds) {
+      for (const areaId of Array.isArray(areaIds) ? areaIds : []) {
         const area = areaId.toLowerCase()
         entities.push({
           type: 'area',
@@ -255,10 +258,10 @@ export async function loadSearchIndex(): Promise<SearchIndex> {
     fetchCdnRankings(),
     fetchCdnClubIndex(),
     // Fail-soft (#1135): the divisions/areas artifact only lands via the
-    // scheduled pipeline (#1134) — a missing or failed index must not take
-    // district/region/club search down with it.
+    // scheduled pipeline (#1134) — a missing, failed, or malformed index
+    // must not take district/region/club search down with it.
     fetchCdnDivisionsAreasIndex().then(
-      idx => idx.districts,
+      idx => idx.districts ?? {},
       () => ({})
     ),
   ])

--- a/frontend/src/services/searchIndex.ts
+++ b/frontend/src/services/searchIndex.ts
@@ -9,7 +9,11 @@
    invoked, never at import / app boot. `buildSearchIndex` is pure (data in,
    index out) so it is trivially unit-testable without the network. */
 
-import { fetchCdnRankings, fetchCdnClubIndex } from './cdn'
+import {
+  fetchCdnRankings,
+  fetchCdnClubIndex,
+  fetchCdnDivisionsAreasIndex,
+} from './cdn'
 
 export type SearchEntityType =
   | 'district'
@@ -92,7 +96,7 @@ export function buildSearchIndex(
   rankings: ReadonlyArray<RankingRow>,
   clubs: Readonly<Record<string, ClubIndexEntry>>,
   /** districtId → divisionId → areaIds, from config/divisions-areas-index.json (#1134). */
-  _divisionsAreas: Readonly<Record<string, Record<string, string[]>>> = {}
+  divisionsAreas: Readonly<Record<string, Record<string, string[]>>> = {}
 ): SearchIndex {
   const entities: SearchEntity[] = []
 
@@ -135,6 +139,48 @@ export function buildSearchIndex(
     })
   }
 
+  // Divisions + areas — from the global divisions/areas index (#1134).
+  // Labels are derivable (`Division {id}` / `Area {id}`, zero deviations
+  // across 128 live districts) and areas nest under divisions because
+  // areaIds are not district-unique. District-scoped combo terms ("61 c")
+  // are exact-only so partial queries like "61" don't flood with every
+  // division/area of that district.
+  for (const [districtId, divisions] of Object.entries(divisionsAreas)) {
+    const dist = districtId.toLowerCase()
+    for (const [divisionId, areaIds] of Object.entries(divisions)) {
+      const div = divisionId.toLowerCase()
+      entities.push({
+        type: 'division',
+        id: `${districtId}/${divisionId}`,
+        label: `Division ${divisionId}`,
+        context: `District ${districtId}`,
+        route: `/district/${districtId}/division/${divisionId}`,
+        terms: dedupeTerms([`division ${div}`, `division ${div} ${dist}`]),
+        exactTerms: dedupeTerms([
+          `${dist} ${div}`,
+          `${div} ${dist}`,
+          `${dist} division ${div}`,
+        ]),
+      })
+      for (const areaId of areaIds) {
+        const area = areaId.toLowerCase()
+        entities.push({
+          type: 'area',
+          id: `${districtId}/${divisionId}/${areaId}`,
+          label: `Area ${areaId}`,
+          context: `District ${districtId} · Division ${divisionId}`,
+          route: `/district/${districtId}/division/${divisionId}/area/${areaId}`,
+          terms: dedupeTerms([`area ${area}`, `area ${area} ${dist}`]),
+          exactTerms: dedupeTerms([
+            `${dist} area ${area}`,
+            `${area} ${dist}`,
+            `${dist} ${area}`,
+          ]),
+        })
+      }
+    }
+  }
+
   return { entities }
 }
 
@@ -144,9 +190,11 @@ function dedupeTerms(raw: string[]): string[] {
 
 // Match strength of a single entity against the query: 3 exact, 2 prefix,
 // 1 substring, 0 no match (best over all of the entity's terms).
-function matchLevel(terms: string[], q: string): number {
+// `exactTerms` count only at full equality — never prefix/substring.
+function matchLevel(entity: SearchEntity, q: string): number {
+  if (entity.exactTerms?.includes(q)) return 3
   let best = 0
-  for (const term of terms) {
+  for (const term of entity.terms) {
     if (term === q) return 3
     if (term.startsWith(q)) best = Math.max(best, 2)
     else if (term.includes(q)) best = Math.max(best, 1)
@@ -172,7 +220,7 @@ export function searchEntities(
   const cap = options.cap ?? DEFAULT_CAP
 
   const scored = index.entities
-    .map(entity => ({ entity, level: matchLevel(entity.terms, q) }))
+    .map(entity => ({ entity, level: matchLevel(entity, q) }))
     .filter(s => s.level > 0)
     .sort((a, b) => {
       // 1) stronger match first
@@ -203,9 +251,16 @@ export function searchEntities(
  * fetched here — never at import — so it does not regress cold app-load.
  */
 export async function loadSearchIndex(): Promise<SearchIndex> {
-  const [rankings, clubIndex] = await Promise.all([
+  const [rankings, clubIndex, divisionsAreas] = await Promise.all([
     fetchCdnRankings(),
     fetchCdnClubIndex(),
+    // Fail-soft (#1135): the divisions/areas artifact only lands via the
+    // scheduled pipeline (#1134) — a missing or failed index must not take
+    // district/region/club search down with it.
+    fetchCdnDivisionsAreasIndex().then(
+      idx => idx.districts,
+      () => ({})
+    ),
   ])
-  return buildSearchIndex(rankings.rankings, clubIndex.clubs)
+  return buildSearchIndex(rankings.rankings, clubIndex.clubs, divisionsAreas)
 }

--- a/tasks/lessons/159-live-verify-a-pipeline-gated-artifact-by-injecting-the-real-build-via-route-interception.md
+++ b/tasks/lessons/159-live-verify-a-pipeline-gated-artifact-by-injecting-the-real-build-via-route-interception.md
@@ -1,0 +1,79 @@
+---
+id: '159'
+category: lesson
+tags: [verification, playwright, cdn, data-pipeline, automation, frontend]
+auto_load: true
+date: 2026-06-10
+issues: [1135, 1101]
+---
+
+# Lesson 159 — Live-verify a pipeline-gated CDN artifact by injecting the REAL locally-built artifact via route interception (and drive the missing-artifact path un-injected)
+
+**Date:** 2026-06-10
+**Issue:** #1135 (epic #1101 Sprint 2 — omni-search divisions/areas)
+**PR:** #1158
+
+## What happened
+
+Sprint 2's UI reads `config/divisions-areas-index.json`, which Sprint 1
+(#1134) only publishes via the scheduled daily pipeline (08:00 UTC). At
+verification time the artifact 404'd on both staging and prod CDNs, and
+manually seeding the staging bucket was classifier-blocked (correctly: a
+shared pipeline-owned file that every PR preview reads).
+
+The standing convention says "code-proof accepted" here — but a stronger
+verification was available without touching shared state: run the Sprint-1
+builder locally against the synced staging snapshots (the exact inputs the
+pipeline will use), then drive the deployed PR preview with Playwright,
+fulfilling only that one route from the local file:
+
+```ts
+await page.route('**/config/divisions-areas-index.json', route =>
+  route.fulfill({ path: DA_INDEX_PATH, contentType: 'application/json' })
+)
+```
+
+Everything else — bundle, rankings, club index — is the genuinely deployed
+surface. And because the artifact is really absent, the same smoke ran a
+**second, un-injected test** asserting the fail-soft path live: bare "61"
+still finds District 61 against the real 404, with no Divisions group.
+
+Two operational potholes en route: `gsutil -m cp` of the 128 snapshots hung
+at 0 B indefinitely (sandboxed AND unsandboxed) — plain parallel `curl`
+against `storage.googleapis.com` finished in seconds, but needs
+`--compressed` or GCS's gzip transcoding leaves raw gzip bytes on disk that
+parse as "corrupt".
+
+## The transferable principle
+
+**When a feature's data dependency only materializes via a scheduled
+pipeline you must not (or cannot) trigger, the live drive doesn't have to
+collapse to code-proof: build the artifact with the shipped builder from
+the real upstream inputs and inject exactly that one response via
+`page.route` against the deployed preview — then verify the
+artifact-absent path with no injection, because right now is the one time
+it is genuinely absent in production-like conditions.** State the injection
+explicitly in the evidence so the operator knows which byte-path was
+simulated and which was real.
+
+## How to apply
+
+- The injected file must come from the same builder + same live inputs the
+  pipeline uses (here: `scripts/build-divisions-areas-index.ts` over the
+  staging `snapshots/<latest>/district_*.json`) — not a hand-written
+  fixture, or you've verified the fixture (cf.
+  [[154-synthetic-fixtures-validate-the-code-only-a-captured-real-pair-validates-the-policy]]).
+- Treat a blocked seed of shared pipeline-owned state as a design signal,
+  not an obstacle: interception scopes the substitution to your own test
+  session.
+- A missing-artifact window is a free chaos test — drive the degraded path
+  before the pipeline closes it.
+- Prefer `curl --compressed` loops over `gsutil -m` for bulk GCS reads on
+  the runner host; verify payloads parse before blaming the data.
+
+## Related
+
+- [[152-a-live-result-locator-must-key-on-the-stable-route-not-the-cdn-derived-label]] —
+  the locator discipline this sprint's smoke reused.
+- [[154-synthetic-fixtures-validate-the-code-only-a-captured-real-pair-validates-the-policy]] —
+  the fixture-fidelity principle this extends to live drives.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -149,3 +149,4 @@
 - **158** [ci, automation, monitoring, data-pipeline, verification] — A parameterized monitor's self-clear must be scoped to the signal it alarms on (#1125, #1096)
 - **158** [tests, tdd, verification, analytics, floats] — A test comment that justifies a surprising expectation by MECHANISM ("due to floating-point precision") instead of by RULE is a pinned bug wearing documentation (#1126, #1097, #798)
 - **158** [cls, css, frontend, responsive, mobile, verification, playwright] — Reserve a data-dependent slot with a structural skeleton (pinned widths, inherited heights), not a measured total height (#922, #1100)
+- **159** [verification, playwright, cdn, data-pipeline, automation, frontend] — Live-verify a pipeline-gated CDN artifact by injecting the REAL locally-built artifact via route interception (and drive the missing-artifact path un-injected) (#1135, #1101)


### PR DESCRIPTION
Sprint 2 of epic #1101 — extends omni-search to divisions and areas. Sub-issue: #1135 (referenced, not auto-closed per R15/L106).

## What

- `buildSearchIndex` consumes the #1134 `config/divisions-areas-index.json` artifact (`districtId → divisionId → areaIds[]`) and emits `division` / `area` entities on the #1008 scoped routes (`/district/:districtId/division/:divId[/area/:areaId]`).
- New `SearchEntity.exactTerms`: district-scoped combo shapes (`"61 c"`, `"c 61"`, `"61 division c"`, `"area 23 61"`, `"61 23"`) match by **full equality only**, so partial queries like `"61"` keep their district-first, clubs-above-divisions ranking (pinned by test).
- Result groups extend to **Districts / Regions / Clubs / Divisions / Areas**; keyboard nav (`useOmniSearch` flat-array contract) untouched.
- `fetchCdnDivisionsAreasIndex` (via existing `fetchFromCdn`) is **fail-soft** in `loadSearchIndex`: the artifact only lands via the scheduled pipeline (next run 08:00 UTC), and a 404/malformed payload must not take district/club search down. Hardened against `districts: null` and junk division/area values (a string is iterable).
- Search affordance copy (header tooltip, combobox aria-label, palette placeholder + empty state) now lists divisions/areas.

## TDD

Red commit (15 failing tests) precedes Green; second Red/Green pair for the review-found malformed-payload hardening. `/simplify` pass applied (`fetchFromCdn` reuse); fresh-context review verdict APPROVE-WITH-NITS, both Medium findings fixed.

**Low findings deferred (operator triage):**
- Multi-space queries (`"61  c"`) miss exactTerms — pre-existing matcher limitation (no internal whitespace collapse).
- Route params are not `encodeURIComponent`-wrapped — consistent with existing precedent (`ChangeGroup.tsx`, `DivisionPage.tsx`); ids come from the unit-tested builder.

## Verification

- Full workspace suite: 5,374 tests green (frontend 3,423 / analytics-core 886 / collector-cli 855 / shared-contracts 159 / mcp-server 51).
- Live verification on the PR preview channel (375/768/1280 + dark, Chromium + WebKit, route-keyed locators per L152) — evidence to follow on #1135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
