### PR TITLE
Sprint 1 (#1098) — wire ClosingDateRegistry as daily freshness guard + backfill 5 registry entries (#1128)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -466,6 +466,11 @@ jobs:
       - name: '[daily] Check closing-date registry freshness (#1128)'
         id: registrycheck
         if: steps.mode.outputs.mode == 'daily'
+        # Non-blocking even on a module-load crash: the publish/promotion
+        # steps that follow must never be skipped because a doc-file monitor
+        # broke. On a crashed step both stale outputs are unset, so neither
+        # alert step fires.
+        continue-on-error: true
         run: npx tsx scripts/closing-registry-check.ts
 
       - name: '[daily] Ensure closing-registry-stale label exists'
@@ -482,20 +487,23 @@ jobs:
         if: steps.mode.outputs.mode == 'daily' && steps.registrycheck.outputs.stale == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          # Env indirection: the title embeds dataMonth strings read from GCS
+          # metadata — never splice them into shell text via ${{ }}.
+          ALERT_TITLE: ${{ steps.registrycheck.outputs.title }}
+          ALERT_BODY_FILE: ${{ steps.registrycheck.outputs.body_file }}
         run: |
           # Deduplicate: one open alert at a time; refresh instead of spamming.
           EXISTING=$(gh issue list --label closing-registry-stale --state open \
             --json number --jq '.[0].number // empty')
           if [ -n "${EXISTING}" ]; then
             echo "Existing open alert #${EXISTING} — adding a refresh comment."
-            gh issue comment "${EXISTING}" \
-              --body-file "${{ steps.registrycheck.outputs.body_file }}"
+            gh issue comment "${EXISTING}" --body-file "${ALERT_BODY_FILE}"
           else
             echo "No open alert — creating one."
             gh issue create \
-              --title "${{ steps.registrycheck.outputs.title }}" \
+              --title "${ALERT_TITLE}" \
               --label closing-registry-stale \
-              --body-file "${{ steps.registrycheck.outputs.body_file }}"
+              --body-file "${ALERT_BODY_FILE}"
           fi
 
       - name: '[daily] Auto-close closing-registry-stale issue when fresh'

--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -453,6 +453,73 @@ jobs:
           echo "- **Snapshot/analytics files**: ${SNAPSHOT_COUNT}" >> "$GITHUB_STEP_SUMMARY"
 
       # ════════════════════════════════════════════════════════
+      # CLOSING-DATE REGISTRY FRESHNESS (#1128, epic #1098)
+      # The committed docs/month-end-closing-dates.json feeds historical
+      # rescrapes and the rebuild's closing remap, and it went 3 months
+      # stale with nothing watching (audit 2026-06-09 §9b). Compare it
+      # against what raw-csv metadata proves and turn drift into a loud,
+      # self-clearing `closing-registry-stale` issue. Decision logic is
+      # unit-tested in scripts/lib/registryFreshness.ts; thin glue here.
+      # Non-blocking by design: a stale doc file must not hold the data
+      # publish hostage.
+      # ════════════════════════════════════════════════════════
+      - name: '[daily] Check closing-date registry freshness (#1128)'
+        id: registrycheck
+        if: steps.mode.outputs.mode == 'daily'
+        run: npx tsx scripts/closing-registry-check.ts
+
+      - name: '[daily] Ensure closing-registry-stale label exists'
+        if: steps.mode.outputs.mode == 'daily' && steps.registrycheck.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create closing-registry-stale \
+            --color B60205 \
+            --description "docs/month-end-closing-dates.json is behind raw-csv metadata" \
+            2>/dev/null || echo "Label already exists"
+
+      - name: '[daily] File or refresh closing-registry-stale issue'
+        if: steps.mode.outputs.mode == 'daily' && steps.registrycheck.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Deduplicate: one open alert at a time; refresh instead of spamming.
+          EXISTING=$(gh issue list --label closing-registry-stale --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${EXISTING}" ]; then
+            echo "Existing open alert #${EXISTING} — adding a refresh comment."
+            gh issue comment "${EXISTING}" \
+              --body-file "${{ steps.registrycheck.outputs.body_file }}"
+          else
+            echo "No open alert — creating one."
+            gh issue create \
+              --title "${{ steps.registrycheck.outputs.title }}" \
+              --label closing-registry-stale \
+              --body-file "${{ steps.registrycheck.outputs.body_file }}"
+          fi
+
+      - name: '[daily] Auto-close closing-registry-stale issue when fresh'
+        if: steps.mode.outputs.mode == 'daily' && steps.registrycheck.outputs.stale == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Registry is fresh again — the committed fix landed. Close any open
+          # alert; the `concurrency: data-pipeline` group serializes runs, so
+          # a fresh verdict can't race a concurrent stale one.
+          OPEN=$(gh issue list --label closing-registry-stale --state open \
+            --json number --jq '.[].number')
+          if [ -z "${OPEN}" ]; then
+            echo "No open closing-registry-stale issue to close."
+          else
+            for n in ${OPEN}; do
+              echo "Closing closing-registry-stale issue #${n} — registry fresh."
+              gh issue close "${n}" \
+                --comment "✅ The closing-date registry matches raw-csv metadata again. Auto-closing (#1128)." \
+                --reason completed
+            done
+          fi
+
+      # ════════════════════════════════════════════════════════
       # REBUILD MODE
       # ════════════════════════════════════════════════════════
       # Streams one date at a time to stay within runner disk

--- a/docs/architecture-decisions/011-closing-date-registry-committed-file-plus-drift-guard.md
+++ b/docs/architecture-decisions/011-closing-date-registry-committed-file-plus-drift-guard.md
@@ -1,0 +1,89 @@
+# ADR-011: Closing-date registry stays a committed file; the daily pipeline guards its freshness instead of writing it
+
+- **Status:** Accepted
+- **Date:** 2026-06-10
+- **Issue:** #1128 (epic #1098, subsumes #1110; audit `docs/audits/deep-dive-review-2026-06-09.md` §9b)
+
+## Context
+
+`docs/month-end-closing-dates.json` maps each Toastmasters data month to its
+closing date — the asOf the dashboard export serves that month's final data
+under. It feeds `scripts/rescrape-historical.ts` (the historical-backfill
+tool) and, from Sprint 2 (#1129), the rebuild's fail-closed closing remap.
+
+`ClosingDateRegistry` (#203) claimed to be "used by the daily pipeline" but
+had **zero production callers**, and the registry went stale for 3 months
+(last entry 2026-01, generatedAt 2026-03-19) with nothing noticing. #1128's
+charter: wire the class into the daily pipeline so closing scrapes append
+entries, **or** delete it and document a manual process.
+
+## Decision
+
+**Keep the class. Keep the committed file as the single canonical registry.
+Do NOT auto-append from CI. Wire the daily pipeline as a freshness GUARD,
+and maintain the file with a derivation script run locally.**
+
+1. `scripts/lib/registryFreshness.ts` — pure, unit-tested decision logic:
+   derive the expected entries for **completed** closing months from raw-csv
+   metadata (a month is complete only when a later collection exists), and
+   compare against the committed registry.
+2. `scripts/update-closing-date-registry.ts` — derives + appends via
+   `ClosingDateRegistry` (its production caller). `--set YYYY-MM=YYYY-MM-DD`
+   records outage months that metadata cannot prove (provenance: TI's own
+   dashboard as-of lists). The operator commits the diff.
+3. `data-pipeline.yml` (daily mode) runs `scripts/closing-registry-check.ts`
+   after the GCS upload. Drift files/refreshes a **self-clearing**
+   `closing-registry-stale` issue (the promotion-held alert shape, #1073).
+   The step never blocks the data publish, and a feed failure alerts rather
+   than passes (L107: "cannot tell" is stale).
+
+## Why not auto-append from CI
+
+- **Auto-append is blind exactly where the registry matters most.** The
+  missing months that motivated this epic (2026-02, 2022-04) had **no
+  closing scrapes at all** (collection outages) — a pipeline appender would
+  have missed them identically. Outage months can only come from TI behavior
+  (its dashboard as-of lists), i.e. a human-reviewed entry.
+- **CI→main commits are a new, race-prone capability** (push collisions with
+  PR merges, workflow-token write scope, self-triggering CI) bought for ~12
+  events/year, every one of which is already derivable on demand from GCS
+  metadata.
+- **The real failure was silence, not labor.** Appending was never the hard
+  part; _knowing the file was behind_ was. A loud, self-clearing drift alert
+  fixes the observed failure mode directly (L107/L155).
+
+## Why not delete the class
+
+Sprint 2 (#1129) makes the registry a production input to the rebuild's
+fail-closed remap, and `rescrape-historical.ts` already consumes the file.
+The class is the single validated writer (dedupe, same-month update, sort,
+atomic write) for both derived and manual entries.
+
+## Notable evidence recorded with this decision
+
+TI's dashboard month dropdown (`district.aspx?id=61&month=N`) exposes each
+month's full as-of list; the newest option is the closing date. Validated
+against 6 known months with zero misses (2025-12, 2022-03, 2022-05,
+2026-03, 2026-04, 2026-05), then used for the backfill:
+
+- **2026-02 → 2026-03-05** (collection outage; underivable from metadata).
+- **2022-04 → 2022-04-30** — same-month: TI never archived a May-2022
+  reconciliation (its export returns header-only CSVs for every May asOf;
+  2022-05 itself closed late, 06-17). April 2022's final archived data is
+  the in-month 04-30 daily.
+- **2026-01 corrected 2026-02-13 → 2026-02-05.** TI's Jan-2026 as-of list
+  ends at 02-05, and **02-13 appears in TI's FEB-2026 as-of list** — the
+  stray `raw-csv/2026-02-13` is a February daily scrape, not a January
+  closing collection. This falsifies the audit's "remap 2026-02-13 →
+  2026-01-31" assumption; Sprint 2's stray-handling decision must use this
+  finding (the stray's raw date appears to be legitimately 2026-02-13).
+
+## Consequences
+
+- The registry's staleness is now red within one daily run instead of
+  silently unbounded.
+- Operators update the file with one command + one commit; manual entries
+  carry provenance in the file's top-level `note`.
+- The freshness check trusts a registry date LATER than the derivable one
+  (a manual entry can know more than partial metadata), and only alarms
+  when reality provably moved past the committed entry.

--- a/docs/month-end-closing-dates.json
+++ b/docs/month-end-closing-dates.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-06-10T22:41:13.700Z",
+  "generatedAt": "2026-06-10T22:51:04.820Z",
   "description": "Month-end closing dates derived from raw-csv metadata. Each entry maps a Toastmasters data month (YYYY-MM) to the last closing-period collection date in raw-csv/.",
-  "note": "April 2022 is missing — no closing-period metadata found for that month.",
+  "note": "2022-04 and 2026-02 had no closing-period raw-csv metadata (collection outages); their closing dates were established from TI's own dashboard as-of lists (dashboards.toastmasters.org month dropdown, verified 2026-06-10 against 6 known months, #1128). 2022-04 closes IN-month (2022-04-30): TI never archived a May-2022 reconciliation (TI outage; 2022-05 closed late, 06-17). 2026-01 corrected 2026-02-13 -> 2026-02-05: TI's Jan-2026 as-of list ends 02-05; the stray raw-csv/2026-02-13 is a FEBRUARY daily scrape (it appears in TI's Feb-2026 as-of list), not a Jan closing collection.",
   "months": [
     {
       "dataMonth": "2017-01",
@@ -256,6 +256,10 @@
       "closingDate": "2022-04-10"
     },
     {
+      "dataMonth": "2022-04",
+      "closingDate": "2022-04-30"
+    },
+    {
       "dataMonth": "2022-05",
       "closingDate": "2022-06-17"
     },
@@ -433,7 +437,11 @@
     },
     {
       "dataMonth": "2026-01",
-      "closingDate": "2026-02-13"
+      "closingDate": "2026-02-05"
+    },
+    {
+      "dataMonth": "2026-02",
+      "closingDate": "2026-03-05"
     },
     {
       "dataMonth": "2026-03",

--- a/docs/month-end-closing-dates.json
+++ b/docs/month-end-closing-dates.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-19T01:51:46.395Z",
+  "generatedAt": "2026-06-10T22:41:13.700Z",
   "description": "Month-end closing dates derived from raw-csv metadata. Each entry maps a Toastmasters data month (YYYY-MM) to the last closing-period collection date in raw-csv/.",
   "note": "April 2022 is missing — no closing-period metadata found for that month.",
   "months": [
@@ -434,6 +434,18 @@
     {
       "dataMonth": "2026-01",
       "closingDate": "2026-02-13"
+    },
+    {
+      "dataMonth": "2026-03",
+      "closingDate": "2026-04-07"
+    },
+    {
+      "dataMonth": "2026-04",
+      "closingDate": "2026-05-07"
+    },
+    {
+      "dataMonth": "2026-05",
+      "closingDate": "2026-06-05"
     }
   ]
 }

--- a/packages/collector-cli/src/utils/ClosingDateRegistry.ts
+++ b/packages/collector-cli/src/utils/ClosingDateRegistry.ts
@@ -1,9 +1,11 @@
 /**
- * ClosingDateRegistry — Auto-maintain month-end-closing-dates.json (#203)
+ * ClosingDateRegistry — Maintain month-end-closing-dates.json (#203, #1128)
  *
  * Reads, appends, deduplicates, and writes closing date entries to the
- * docs/month-end-closing-dates.json registry. Used by the daily pipeline
- * to auto-detect new closing periods and persist them.
+ * docs/month-end-closing-dates.json registry. Written by
+ * scripts/update-closing-date-registry.ts (derived + manual entries); the
+ * daily pipeline guards the committed file's freshness rather than writing
+ * it (ADR-011). Consumed by scripts/rescrape-historical.ts.
  */
 
 import * as fs from 'node:fs/promises'

--- a/scripts/closing-registry-check.ts
+++ b/scripts/closing-registry-check.ts
@@ -3,10 +3,11 @@
  *
  * Thin glue around the pure functions in ./lib/registryFreshness.js. Run by
  * the daily data-pipeline after the GCS upload:
- *   1. list recent raw-csv dates in the staging bucket and read their
- *      metadata.json (the same feed find-month-end-dates.ts uses),
+ *   1. read the recent raw-csv metadata window from the staging bucket (the
+ *      same feed scripts/update-closing-date-registry.ts derives from),
  *   2. compare the derivable completed closing months against the committed
- *      docs/month-end-closing-dates.json,
+ *      docs/month-end-closing-dates.json (read via ClosingDateRegistry, the
+ *      file's single owner),
  *   3. emit stale/fresh + alert title/body via $GITHUB_OUTPUT; the workflow
  *      files/refreshes or auto-closes the `closing-registry-stale` issue
  *      (same self-clearing shape as the promotion-held alert, #1073).
@@ -18,26 +19,27 @@
  * itself reported as stale (L107: "cannot tell" must alert, not pass).
  *
  * Env:
- *   GCS_BUCKET    — bucket holding raw-csv/ (default: toast-stats-data-staging)
- *   WINDOW_DAYS   — how many trailing days of raw-csv metadata to read
- *                   (default: 130 — covers ~4 closing windows)
- *   REGISTRY_PATH — registry file (default: docs/month-end-closing-dates.json)
+ *   GCS_BUCKET  — bucket holding raw-csv/ (default: toast-stats-data-staging)
+ *   WINDOW_DAYS — how many trailing raw-csv date dirs to read (default: 130,
+ *                 ~4 closing windows)
  */
 
-import { appendFileSync, readFileSync, writeFileSync } from 'node:fs'
+import { appendFileSync, writeFileSync } from 'node:fs'
+import * as path from 'node:path'
 import { Storage } from '@google-cloud/storage'
-import { listRawCSVDates, readMetadataForDates } from './lib/gcsHelpers.js'
+import { ClosingDateRegistry } from '../packages/collector-cli/src/utils/ClosingDateRegistry.js'
+import {
+  readRecentRawCSVEntries,
+  RAW_CSV_DEFAULT_BUCKET,
+  RAW_CSV_DEFAULT_WINDOW,
+} from './lib/gcsHelpers.js'
 import type { RawCSVEntry } from './lib/monthEndDates.js'
 import {
   evaluateRegistryFreshness,
   buildRegistryStaleTitle,
   buildRegistryStaleBody,
-  type RegistryMonthEntry,
 } from './lib/registryFreshness.js'
 
-const DEFAULT_BUCKET = 'toast-stats-data-staging'
-const DEFAULT_WINDOW_DAYS = 130
-const DEFAULT_REGISTRY_PATH = 'docs/month-end-closing-dates.json'
 const BODY_FILE = '/tmp/closing-registry-stale-body.md'
 
 function log(msg: string): void {
@@ -49,40 +51,26 @@ function emitOutput(key: string, value: string): void {
   if (out) appendFileSync(out, `${key}=${value}\n`)
 }
 
-function readRegistry(path: string): RegistryMonthEntry[] {
-  const parsed = JSON.parse(readFileSync(path, 'utf8')) as {
-    months?: RegistryMonthEntry[]
-  }
-  if (!Array.isArray(parsed.months)) {
-    throw new Error(`${path} has no months[] array`)
-  }
-  return parsed.months
-}
-
-async function fetchRecentEntries(
-  bucket: string,
-  windowDays: number
-): Promise<RawCSVEntry[]> {
-  const storage = new Storage()
-  const allDates = await listRawCSVDates(storage, bucket)
-  const windowDates = allDates.slice(-windowDays)
-  log(
-    `raw-csv: ${allDates.length} dates total, reading metadata for the last ${windowDates.length}`
-  )
-  return readMetadataForDates(storage, bucket, windowDates)
-}
-
 async function main(): Promise<void> {
-  const bucket = process.env.GCS_BUCKET ?? DEFAULT_BUCKET
-  const windowDays = Number(process.env.WINDOW_DAYS ?? DEFAULT_WINDOW_DAYS)
-  const registryPath = process.env.REGISTRY_PATH ?? DEFAULT_REGISTRY_PATH
+  const bucket = process.env.GCS_BUCKET ?? RAW_CSV_DEFAULT_BUCKET
+  const windowDays = Number(process.env.WINDOW_DAYS ?? RAW_CSV_DEFAULT_WINDOW)
+  const projectRoot = path.resolve(import.meta.dirname, '..')
 
-  const registryMonths = readRegistry(registryPath)
-  log(`registry: ${registryMonths.length} entries in ${registryPath}`)
+  // ClosingDateRegistry owns the file's path + shape. A missing/corrupt file
+  // reads as an empty registry, which the evaluation reports as missing
+  // months — the informative alert, not a silent pass.
+  const registry = new ClosingDateRegistry({ projectRoot })
+  const registryMonths = (await registry.read()).months
+  log(`registry: ${registryMonths.length} committed entries`)
 
   let entries: RawCSVEntry[] = []
   try {
-    entries = await fetchRecentEntries(bucket, windowDays)
+    entries = await readRecentRawCSVEntries(
+      new Storage(),
+      bucket,
+      windowDays,
+      log
+    )
   } catch (err) {
     // Feed failure → evaluate with an empty feed, which reports stale with
     // emptyFeed=true. The monitor must not pass when it cannot read.
@@ -104,8 +92,8 @@ async function main(): Promise<void> {
 }
 
 main().catch(err => {
-  // Unexpected failure (e.g. unreadable registry file): report stale rather
-  // than green-by-crash, then exit 0 so the publish itself is not blocked.
+  // Unexpected failure: report stale rather than green-by-crash, then exit 0
+  // so the publish itself is not blocked.
   log(`closing-registry-check failed: ${(err as Error).stack ?? err}`)
   writeFileSync(
     BODY_FILE,

--- a/scripts/closing-registry-check.ts
+++ b/scripts/closing-registry-check.ts
@@ -1,0 +1,124 @@
+/**
+ * Closing-Date Registry Freshness Check — Runner (#1128, epic #1098)
+ *
+ * Thin glue around the pure functions in ./lib/registryFreshness.js. Run by
+ * the daily data-pipeline after the GCS upload:
+ *   1. list recent raw-csv dates in the staging bucket and read their
+ *      metadata.json (the same feed find-month-end-dates.ts uses),
+ *   2. compare the derivable completed closing months against the committed
+ *      docs/month-end-closing-dates.json,
+ *   3. emit stale/fresh + alert title/body via $GITHUB_OUTPUT; the workflow
+ *      files/refreshes or auto-closes the `closing-registry-stale` issue
+ *      (same self-clearing shape as the promotion-held alert, #1073).
+ *
+ * No decision logic lives here — that is unit-tested in
+ * scripts/lib/__tests__/registryFreshness.test.ts. All logging goes to
+ * stderr (R4). Always exits 0 on a completed evaluation (the workflow acts
+ * on the outputs, the data publish is never held hostage); a feed failure is
+ * itself reported as stale (L107: "cannot tell" must alert, not pass).
+ *
+ * Env:
+ *   GCS_BUCKET    — bucket holding raw-csv/ (default: toast-stats-data-staging)
+ *   WINDOW_DAYS   — how many trailing days of raw-csv metadata to read
+ *                   (default: 130 — covers ~4 closing windows)
+ *   REGISTRY_PATH — registry file (default: docs/month-end-closing-dates.json)
+ */
+
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs'
+import { Storage } from '@google-cloud/storage'
+import { listRawCSVDates, readMetadataForDates } from './lib/gcsHelpers.js'
+import type { RawCSVEntry } from './lib/monthEndDates.js'
+import {
+  evaluateRegistryFreshness,
+  buildRegistryStaleTitle,
+  buildRegistryStaleBody,
+  type RegistryMonthEntry,
+} from './lib/registryFreshness.js'
+
+const DEFAULT_BUCKET = 'toast-stats-data-staging'
+const DEFAULT_WINDOW_DAYS = 130
+const DEFAULT_REGISTRY_PATH = 'docs/month-end-closing-dates.json'
+const BODY_FILE = '/tmp/closing-registry-stale-body.md'
+
+function log(msg: string): void {
+  process.stderr.write(`${msg}\n`)
+}
+
+function emitOutput(key: string, value: string): void {
+  const out = process.env.GITHUB_OUTPUT
+  if (out) appendFileSync(out, `${key}=${value}\n`)
+}
+
+function readRegistry(path: string): RegistryMonthEntry[] {
+  const parsed = JSON.parse(readFileSync(path, 'utf8')) as {
+    months?: RegistryMonthEntry[]
+  }
+  if (!Array.isArray(parsed.months)) {
+    throw new Error(`${path} has no months[] array`)
+  }
+  return parsed.months
+}
+
+async function fetchRecentEntries(
+  bucket: string,
+  windowDays: number
+): Promise<RawCSVEntry[]> {
+  const storage = new Storage()
+  const allDates = await listRawCSVDates(storage, bucket)
+  const windowDates = allDates.slice(-windowDays)
+  log(
+    `raw-csv: ${allDates.length} dates total, reading metadata for the last ${windowDates.length}`
+  )
+  return readMetadataForDates(storage, bucket, windowDates)
+}
+
+async function main(): Promise<void> {
+  const bucket = process.env.GCS_BUCKET ?? DEFAULT_BUCKET
+  const windowDays = Number(process.env.WINDOW_DAYS ?? DEFAULT_WINDOW_DAYS)
+  const registryPath = process.env.REGISTRY_PATH ?? DEFAULT_REGISTRY_PATH
+
+  const registryMonths = readRegistry(registryPath)
+  log(`registry: ${registryMonths.length} entries in ${registryPath}`)
+
+  let entries: RawCSVEntry[] = []
+  try {
+    entries = await fetchRecentEntries(bucket, windowDays)
+  } catch (err) {
+    // Feed failure → evaluate with an empty feed, which reports stale with
+    // emptyFeed=true. The monitor must not pass when it cannot read.
+    log(`GCS metadata fetch failed: ${(err as Error).message}`)
+  }
+
+  const result = evaluateRegistryFreshness(registryMonths, entries)
+  log(
+    `verdict: fresh=${result.fresh} checked=[${result.checkedMonths.join(', ')}] ` +
+      `missing=${result.missing.length} mismatched=${result.mismatched.length} emptyFeed=${result.emptyFeed}`
+  )
+
+  emitOutput('stale', result.fresh ? 'false' : 'true')
+  if (!result.fresh) {
+    writeFileSync(BODY_FILE, buildRegistryStaleBody(result), 'utf8')
+    emitOutput('title', buildRegistryStaleTitle(result))
+    emitOutput('body_file', BODY_FILE)
+  }
+}
+
+main().catch(err => {
+  // Unexpected failure (e.g. unreadable registry file): report stale rather
+  // than green-by-crash, then exit 0 so the publish itself is not blocked.
+  log(`closing-registry-check failed: ${(err as Error).stack ?? err}`)
+  writeFileSync(
+    BODY_FILE,
+    [
+      'The closing-date registry check crashed before producing a verdict:',
+      '```',
+      String((err as Error).stack ?? err),
+      '```',
+      'Treating "cannot tell" as stale (L107). See the workflow step logs.',
+    ].join('\n'),
+    'utf8'
+  )
+  emitOutput('stale', 'true')
+  emitOutput('title', '🟥 closing-date registry check crashed')
+  emitOutput('body_file', BODY_FILE)
+})

--- a/scripts/lib/__tests__/registryFreshness.test.ts
+++ b/scripts/lib/__tests__/registryFreshness.test.ts
@@ -204,9 +204,17 @@ describe('parseManualEntryArg', () => {
     expect(() => parseManualEntryArg(input)).toThrow(/--set/)
   })
 
-  it('rejects a closing date that is not after the data month', () => {
-    // A closing date inside (or before) its own data month is nonsense —
-    // closing collections happen early in the FOLLOWING month.
-    expect(() => parseManualEntryArg('2026-02=2026-02-27')).toThrow(/after/)
+  it('rejects a closing date in a month EARLIER than the data month', () => {
+    expect(() => parseManualEntryArg('2026-02=2026-01-31')).toThrow(/before/)
+  })
+
+  it('accepts a same-month closing date (TI archive-outage months)', () => {
+    // April 2022: TI never archived a May reconciliation (dashboard outage)
+    // — its own as-of list for the month ends at 2022-04-30. Verified live
+    // against dashboards.toastmasters.org/2021-2022 on 2026-06-10.
+    expect(parseManualEntryArg('2022-04=2022-04-30')).toEqual({
+      dataMonth: '2022-04',
+      closingDate: '2022-04-30',
+    })
   })
 })

--- a/scripts/lib/__tests__/registryFreshness.test.ts
+++ b/scripts/lib/__tests__/registryFreshness.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Registry Freshness — unit tests (#1128, epic #1098)
+ *
+ * The closing-date registry (docs/month-end-closing-dates.json) sat stale for
+ * 3 months with nothing watching (audit 2026-06-09 §9b). These tests pin the
+ * pure decision logic the daily pipeline's drift guard runs: derive the
+ * expected (dataMonth → lastClosingDate) entries for COMPLETED closing months
+ * from raw-csv metadata, compare against the committed registry, and demand
+ * loudness when the registry is behind reality (L107/L155).
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { RawCSVEntry } from '../monthEndDates.js'
+import {
+  deriveCompletedClosingMonths,
+  evaluateRegistryFreshness,
+  buildRegistryStaleTitle,
+  buildRegistryStaleBody,
+} from '../registryFreshness.js'
+
+/** Shorthand for a raw-csv metadata entry. */
+function entry(
+  collectionDate: string,
+  isClosingPeriod: boolean,
+  dataMonth?: string
+): RawCSVEntry {
+  return { collectionDate, isClosingPeriod, dataMonth }
+}
+
+/**
+ * Real shape (verified live against staging GCS, 2026-06-10): the May-2026
+ * closing window ran 2026-06-01..2026-06-05 and 2026-06-06 was the first
+ * non-closing day, so 2026-05's closing date is 2026-06-05.
+ */
+const MAY_2026_WINDOW: RawCSVEntry[] = [
+  entry('2026-06-01', true, '2026-05'),
+  entry('2026-06-02', true, '2026-05'),
+  entry('2026-06-03', true, '2026-05'),
+  entry('2026-06-04', true, '2026-05'),
+  entry('2026-06-05', true, '2026-05'),
+  entry('2026-06-06', false),
+]
+
+describe('deriveCompletedClosingMonths', () => {
+  it('derives the last closing date for a month whose window has ended', () => {
+    const result = deriveCompletedClosingMonths(MAY_2026_WINDOW)
+    expect(result).toEqual([
+      { dataMonth: '2026-05', closingDate: '2026-06-05' },
+    ])
+  })
+
+  it('does NOT demand a month whose closing window may still be open', () => {
+    // Last entry in the feed is itself a closing day — TI may extend the
+    // window tomorrow, so the final closing date is not yet knowable.
+    const inProgress = MAY_2026_WINDOW.slice(0, 5) // no 2026-06-06 follower
+    expect(deriveCompletedClosingMonths(inProgress)).toEqual([])
+  })
+
+  it('skips outage months that have no closing-period entries at all', () => {
+    // Collection outage: nothing scraped during the closing window
+    // (the 2026-02 / 2022-04 case) — underivable, so not demanded.
+    const entries = [entry('2026-03-22', false), entry('2026-03-23', false)]
+    expect(deriveCompletedClosingMonths(entries)).toEqual([])
+  })
+
+  it('derives multiple completed months independently', () => {
+    const entries = [
+      entry('2026-04-06', true, '2026-03'),
+      entry('2026-04-07', true, '2026-03'),
+      entry('2026-04-08', false),
+      ...MAY_2026_WINDOW,
+    ]
+    expect(deriveCompletedClosingMonths(entries)).toEqual([
+      { dataMonth: '2026-03', closingDate: '2026-04-07' },
+      { dataMonth: '2026-05', closingDate: '2026-06-05' },
+    ])
+  })
+
+  it('completes a month when a LATER closing window for another month follows', () => {
+    // No plain non-closing day between the two windows — the next month's
+    // closing entries still prove the earlier window ended.
+    const entries = [
+      entry('2026-05-07', true, '2026-04'),
+      entry('2026-06-01', true, '2026-05'),
+    ]
+    expect(deriveCompletedClosingMonths(entries)).toEqual([
+      { dataMonth: '2026-04', closingDate: '2026-05-07' },
+    ])
+  })
+})
+
+describe('evaluateRegistryFreshness', () => {
+  const registryWithMay = [{ dataMonth: '2026-05', closingDate: '2026-06-05' }]
+
+  it('is fresh when every derivable completed month is registered with a matching date', () => {
+    const result = evaluateRegistryFreshness(registryWithMay, MAY_2026_WINDOW)
+    expect(result.fresh).toBe(true)
+    expect(result.missing).toEqual([])
+    expect(result.mismatched).toEqual([])
+    expect(result.emptyFeed).toBe(false)
+  })
+
+  it('is stale when a derivable completed month is missing from the registry', () => {
+    const result = evaluateRegistryFreshness([], MAY_2026_WINDOW)
+    expect(result.fresh).toBe(false)
+    expect(result.missing).toEqual([
+      { dataMonth: '2026-05', closingDate: '2026-06-05' },
+    ])
+  })
+
+  it('is stale when reality moved past the registered closing date', () => {
+    // Registry committed mid-window (06-03), then TI kept serving May data
+    // through 06-05 — the registry is objectively behind.
+    const result = evaluateRegistryFreshness(
+      [{ dataMonth: '2026-05', closingDate: '2026-06-03' }],
+      MAY_2026_WINDOW
+    )
+    expect(result.fresh).toBe(false)
+    expect(result.mismatched).toEqual([
+      {
+        dataMonth: '2026-05',
+        registryClosingDate: '2026-06-03',
+        derivedClosingDate: '2026-06-05',
+      },
+    ])
+  })
+
+  it('trusts a registry date LATER than the derivable one (manual outage entry)', () => {
+    // Partial outage: we scraped early closing days only; the operator
+    // backfilled the true (later) closing date from TI behavior. The
+    // registry knows more than our metadata — do not alarm.
+    const result = evaluateRegistryFreshness(
+      [{ dataMonth: '2026-05', closingDate: '2026-06-08' }],
+      MAY_2026_WINDOW
+    )
+    expect(result.fresh).toBe(true)
+    expect(result.mismatched).toEqual([])
+  })
+
+  it('alerts on an empty metadata feed instead of passing vacuously (L107)', () => {
+    const result = evaluateRegistryFreshness(registryWithMay, [])
+    expect(result.fresh).toBe(false)
+    expect(result.emptyFeed).toBe(true)
+  })
+
+  it('ignores registry entries for months outside the derivable set', () => {
+    // Manual entries for outage months (2026-02, 2022-04) are not derivable
+    // and must not be flagged.
+    const registry = [
+      ...registryWithMay,
+      { dataMonth: '2026-02', closingDate: '2026-03-10' },
+      { dataMonth: '2022-04', closingDate: '2022-05-09' },
+    ]
+    const result = evaluateRegistryFreshness(registry, MAY_2026_WINDOW)
+    expect(result.fresh).toBe(true)
+  })
+})
+
+describe('alert builders', () => {
+  it('title names the stale months', () => {
+    const result = evaluateRegistryFreshness([], MAY_2026_WINDOW)
+    const title = buildRegistryStaleTitle(result)
+    expect(title).toContain('closing-date registry')
+    expect(title).toContain('2026-05')
+  })
+
+  it('body lists missing/mismatched entries and the remediation command', () => {
+    const result = evaluateRegistryFreshness(
+      [{ dataMonth: '2026-04', closingDate: '2026-05-06' }],
+      [entry('2026-05-07', true, '2026-04'), ...MAY_2026_WINDOW]
+    )
+    const body = buildRegistryStaleBody(result)
+    expect(body).toContain('2026-05')
+    expect(body).toContain('2026-06-05')
+    expect(body).toContain('2026-04') // mismatched month
+    expect(body).toContain('update-closing-date-registry')
+    expect(body).toContain('docs/month-end-closing-dates.json')
+  })
+
+  it('body explains an empty feed as a monitor failure, not a pass', () => {
+    const result = evaluateRegistryFreshness([], [])
+    const body = buildRegistryStaleBody(result)
+    expect(body).toMatch(/metadata|feed/i)
+  })
+})

--- a/scripts/lib/__tests__/registryFreshness.test.ts
+++ b/scripts/lib/__tests__/registryFreshness.test.ts
@@ -16,6 +16,7 @@ import {
   evaluateRegistryFreshness,
   buildRegistryStaleTitle,
   buildRegistryStaleBody,
+  parseManualEntryArg,
 } from '../registryFreshness.js'
 
 /** Shorthand for a raw-csv metadata entry. */
@@ -181,5 +182,31 @@ describe('alert builders', () => {
     const result = evaluateRegistryFreshness([], [])
     const body = buildRegistryStaleBody(result)
     expect(body).toMatch(/metadata|feed/i)
+  })
+})
+
+describe('parseManualEntryArg', () => {
+  it('parses a valid MONTH=DATE pair', () => {
+    expect(parseManualEntryArg('2026-02=2026-03-10')).toEqual({
+      dataMonth: '2026-02',
+      closingDate: '2026-03-10',
+    })
+  })
+
+  it.each([
+    '2026-02',
+    '2026-02=03-10',
+    '202602=2026-03-10',
+    '2026-13=2026-03-10',
+    '2026-02=2026-03-32',
+    '',
+  ])('rejects malformed input %j', input => {
+    expect(() => parseManualEntryArg(input)).toThrow(/--set/)
+  })
+
+  it('rejects a closing date that is not after the data month', () => {
+    // A closing date inside (or before) its own data month is nonsense —
+    // closing collections happen early in the FOLLOWING month.
+    expect(() => parseManualEntryArg('2026-02=2026-02-27')).toThrow(/after/)
   })
 })

--- a/scripts/lib/__tests__/registryFreshness.test.ts
+++ b/scripts/lib/__tests__/registryFreshness.test.ts
@@ -17,6 +17,7 @@ import {
   buildRegistryStaleTitle,
   buildRegistryStaleBody,
   parseManualEntryArg,
+  planRegistryUpdates,
 } from '../registryFreshness.js'
 
 /** Shorthand for a raw-csv metadata entry. */
@@ -182,6 +183,90 @@ describe('alert builders', () => {
     const result = evaluateRegistryFreshness([], [])
     const body = buildRegistryStaleBody(result)
     expect(body).toMatch(/metadata|feed/i)
+  })
+})
+
+describe('planRegistryUpdates', () => {
+  const existing = [
+    { dataMonth: '2026-01', closingDate: '2026-02-13' },
+    { dataMonth: '2026-03', closingDate: '2026-04-07' },
+  ]
+
+  it('adds a derived month absent from the registry', () => {
+    expect(
+      planRegistryUpdates(
+        existing,
+        [{ dataMonth: '2026-05', closingDate: '2026-06-05' }],
+        []
+      )
+    ).toEqual([
+      {
+        dataMonth: '2026-05',
+        closingDate: '2026-06-05',
+        source: 'derived',
+        action: 'add',
+      },
+    ])
+  })
+
+  it('skips an entry identical to the registry', () => {
+    expect(
+      planRegistryUpdates(
+        existing,
+        [{ dataMonth: '2026-03', closingDate: '2026-04-07' }],
+        []
+      )
+    ).toEqual([])
+  })
+
+  it('updates when a derived date moves past the registered one, carrying previous', () => {
+    expect(
+      planRegistryUpdates(
+        existing,
+        [{ dataMonth: '2026-03', closingDate: '2026-04-08' }],
+        []
+      )
+    ).toEqual([
+      {
+        dataMonth: '2026-03',
+        closingDate: '2026-04-08',
+        source: 'derived',
+        action: 'update',
+        previous: '2026-04-07',
+      },
+    ])
+  })
+
+  it('never lets a DERIVED date regress a later registry date', () => {
+    // Partial metadata must not undo a manual outage entry that knows more —
+    // the same trust-later rule evaluateRegistryFreshness applies.
+    expect(
+      planRegistryUpdates(
+        existing,
+        [{ dataMonth: '2026-03', closingDate: '2026-04-05' }],
+        []
+      )
+    ).toEqual([])
+  })
+
+  it('lets a MANUAL entry override in either direction (operator correction)', () => {
+    // The 2026-01 case: stray-derived 2026-02-13 corrected BACK to TI's
+    // authoritative 2026-02-05.
+    expect(
+      planRegistryUpdates(
+        existing,
+        [],
+        [{ dataMonth: '2026-01', closingDate: '2026-02-05' }]
+      )
+    ).toEqual([
+      {
+        dataMonth: '2026-01',
+        closingDate: '2026-02-05',
+        source: 'manual',
+        action: 'update',
+        previous: '2026-02-13',
+      },
+    ])
   })
 })
 

--- a/scripts/lib/__tests__/registryFreshness.test.ts
+++ b/scripts/lib/__tests__/registryFreshness.test.ts
@@ -145,6 +145,25 @@ describe('evaluateRegistryFreshness', () => {
     expect(result.emptyFeed).toBe(true)
   })
 
+  it('alerts when a non-empty feed yields ZERO derivable months (silent read failures)', () => {
+    // gcsHelpers swallows per-object read errors into non-closing entries, so
+    // an IAM/timeout storm produces a full window with no closing entry at
+    // all. A healthy ~130-dir window always contains at least one completed
+    // closing month — zero derivable months means the monitor cannot see,
+    // and "cannot tell" must alert, not pass (L107).
+    const allNonClosing = Array.from({ length: 130 }, (_, i) =>
+      entry(
+        `2026-0${1 + Math.floor(i / 28)}-${String((i % 28) + 1).padStart(2, '0')}`,
+        false
+      )
+    )
+    const result = evaluateRegistryFreshness(registryWithMay, allNonClosing)
+    expect(result.fresh).toBe(false)
+    expect(result.noDerivableMonths).toBe(true)
+    const body = buildRegistryStaleBody(result)
+    expect(body).toMatch(/derivable|closing/i)
+  })
+
   it('ignores registry entries for months outside the derivable set', () => {
     // Manual entries for outage months (2026-02, 2022-04) are not derivable
     // and must not be flagged.
@@ -284,6 +303,7 @@ describe('parseManualEntryArg', () => {
     '202602=2026-03-10',
     '2026-13=2026-03-10',
     '2026-02=2026-03-32',
+    '2026-02=2026-19-10', // closing date's MONTH must also be real
     '',
   ])('rejects malformed input %j', input => {
     expect(() => parseManualEntryArg(input)).toThrow(/--set/)

--- a/scripts/lib/gcsHelpers.ts
+++ b/scripts/lib/gcsHelpers.ts
@@ -110,6 +110,32 @@ export async function readMetadataForDate(
   }
 }
 
+/** Default bucket + trailing-window size shared by the closing-date registry
+ * check (daily pipeline) and the registry update script — the guard and its
+ * remediation tool must read the SAME feed or a filed alert can never
+ * self-clear (#1128). The window counts raw-csv date DIRECTORIES, not
+ * calendar days. */
+export const RAW_CSV_DEFAULT_BUCKET = 'toast-stats-data-staging'
+export const RAW_CSV_DEFAULT_WINDOW = 130
+
+/**
+ * Read RawCSVEntry metadata for the most recent `windowDays` raw-csv date
+ * directories in a bucket (newest-last listing, trailing slice).
+ */
+export async function readRecentRawCSVEntries(
+  storage: Storage,
+  bucketName: string,
+  windowDays: number,
+  log?: (msg: string) => void
+): Promise<RawCSVEntry[]> {
+  const allDates = await listRawCSVDates(storage, bucketName)
+  const windowDates = allDates.slice(-windowDays)
+  log?.(
+    `raw-csv: ${allDates.length} dates in gs://${bucketName}, reading metadata for the last ${windowDates.length}`
+  )
+  return readMetadataForDates(storage, bucketName, windowDates)
+}
+
 /**
  * Read metadata for a batch of dates in parallel (batch size 20).
  * Returns entries in the same order as the input dates array.

--- a/scripts/lib/registryFreshness.ts
+++ b/scripts/lib/registryFreshness.ts
@@ -18,6 +18,7 @@
  */
 
 import type { RawCSVEntry } from './monthEndDates.js'
+import { groupByDataMonth } from './monthEndDates.js'
 
 /** One (dataMonth → closingDate) registry entry, e.g. 2026-05 → 2026-06-05. */
 export interface RegistryMonthEntry {
@@ -43,27 +44,142 @@ export interface RegistryFreshnessResult {
   checkedMonths: string[]
 }
 
+/**
+ * Derive (dataMonth → lastClosingDate) for every COMPLETED closing month.
+ *
+ * A month's closing window is complete only when some collection date LATER
+ * than its last closing-period date exists in the feed (TI moved on — a
+ * non-closing day or the next month's window). A month whose last closing
+ * entry is also the newest entry overall may still be extended by TI
+ * tomorrow, so it is not yet demandable. Months with no closing entries at
+ * all (collection outages) are underivable and skipped.
+ */
 export function deriveCompletedClosingMonths(
-  _entries: RawCSVEntry[]
+  entries: RawCSVEntry[]
 ): RegistryMonthEntry[] {
-  throw new Error('not implemented')
+  const byMonth = groupByDataMonth(entries)
+  const allDates = entries.map(e => e.collectionDate).sort()
+  const newestDate = allDates[allDates.length - 1]
+
+  const completed: RegistryMonthEntry[] = []
+  for (const [dataMonth, closingDates] of byMonth) {
+    const lastClosingDate = closingDates[closingDates.length - 1]!
+    if (newestDate !== undefined && newestDate > lastClosingDate) {
+      completed.push({ dataMonth, closingDate: lastClosingDate })
+    }
+  }
+
+  completed.sort((a, b) => a.dataMonth.localeCompare(b.dataMonth))
+  return completed
 }
 
+/**
+ * Compare the committed registry against the derivable completed months.
+ *
+ * - A derivable month absent from the registry → `missing` (stale).
+ * - A registry date EARLIER than derived → `mismatched` (reality moved past
+ *   the committed entry — stale).
+ * - A registry date LATER than derived → trusted: the operator backfilled a
+ *   partial-outage month from TI behavior; our metadata knows less, not more.
+ * - An empty feed → stale with `emptyFeed` (a monitor that cannot read its
+ *   signal must alert, never pass — L107).
+ */
 export function evaluateRegistryFreshness(
-  _registryMonths: RegistryMonthEntry[],
-  _entries: RawCSVEntry[]
+  registryMonths: RegistryMonthEntry[],
+  entries: RawCSVEntry[]
 ): RegistryFreshnessResult {
-  throw new Error('not implemented')
+  if (entries.length === 0) {
+    return {
+      fresh: false,
+      missing: [],
+      mismatched: [],
+      emptyFeed: true,
+      checkedMonths: [],
+    }
+  }
+
+  const expected = deriveCompletedClosingMonths(entries)
+  const registryByMonth = new Map(
+    registryMonths.map(m => [m.dataMonth, m.closingDate])
+  )
+
+  const missing: RegistryMonthEntry[] = []
+  const mismatched: RegistryMismatch[] = []
+
+  for (const exp of expected) {
+    const registered = registryByMonth.get(exp.dataMonth)
+    if (registered === undefined) {
+      missing.push(exp)
+    } else if (registered < exp.closingDate) {
+      mismatched.push({
+        dataMonth: exp.dataMonth,
+        registryClosingDate: registered,
+        derivedClosingDate: exp.closingDate,
+      })
+    }
+  }
+
+  return {
+    fresh: missing.length === 0 && mismatched.length === 0,
+    missing,
+    mismatched,
+    emptyFeed: false,
+    checkedMonths: expected.map(e => e.dataMonth),
+  }
 }
 
 export function buildRegistryStaleTitle(
-  _result: RegistryFreshnessResult
+  result: RegistryFreshnessResult
 ): string {
-  throw new Error('not implemented')
+  if (result.emptyFeed) {
+    return '🟥 closing-date registry check could not read raw-csv metadata'
+  }
+  const months = [
+    ...result.missing.map(m => m.dataMonth),
+    ...result.mismatched.map(m => m.dataMonth),
+  ].sort()
+  return `🟥 closing-date registry stale — ${months.join(', ')}`
 }
 
 export function buildRegistryStaleBody(
-  _result: RegistryFreshnessResult
+  result: RegistryFreshnessResult
 ): string {
-  throw new Error('not implemented')
+  const lines: string[] = []
+
+  if (result.emptyFeed) {
+    lines.push(
+      'The registry freshness check received **no raw-csv metadata entries** —',
+      'the monitor feed itself failed (GCS listing/read error or empty window).',
+      'Treating "cannot tell" as stale (L107). Investigate the check step logs',
+      'before trusting `docs/month-end-closing-dates.json` for rescrapes.'
+    )
+  } else {
+    lines.push(
+      'The committed closing-date registry `docs/month-end-closing-dates.json`',
+      'is behind what raw-csv metadata proves (#1128, epic #1098):',
+      ''
+    )
+    for (const m of result.missing) {
+      lines.push(
+        `- **${m.dataMonth}** — missing; metadata shows its closing window ended on **${m.closingDate}**`
+      )
+    }
+    for (const m of result.mismatched) {
+      lines.push(
+        `- **${m.dataMonth}** — registered as ${m.registryClosingDate}, but reality moved on to **${m.derivedClosingDate}**`
+      )
+    }
+  }
+
+  lines.push(
+    '',
+    '### Remediation',
+    '```bash',
+    'npx tsx scripts/update-closing-date-registry.ts        # derive + append from GCS metadata',
+    '```',
+    'then commit the updated `docs/month-end-closing-dates.json`.',
+    'This issue self-clears on the next daily run that finds the registry fresh.'
+  )
+
+  return lines.join('\n')
 }

--- a/scripts/lib/registryFreshness.ts
+++ b/scripts/lib/registryFreshness.ts
@@ -128,6 +128,16 @@ export function evaluateRegistryFreshness(
   }
 }
 
+/**
+ * Parse a manual `--set YYYY-MM=YYYY-MM-DD` argument (outage months whose
+ * closing date cannot be derived from metadata and was established from TI
+ * behavior instead). Throws on malformed input. Typed as a stub here for the
+ * Red commit; implemented in the update-script change.
+ */
+export function parseManualEntryArg(_input: string): RegistryMonthEntry {
+  throw new Error('--set: not implemented')
+}
+
 export function buildRegistryStaleTitle(
   result: RegistryFreshnessResult
 ): string {

--- a/scripts/lib/registryFreshness.ts
+++ b/scripts/lib/registryFreshness.ts
@@ -142,9 +142,8 @@ export function evaluateRegistryFreshness(
 /**
  * Parse a manual `--set YYYY-MM=YYYY-MM-DD` argument (outage months whose
  * closing date cannot be derived from metadata and was established from TI
- * behavior instead). Throws on malformed input or a closing date that does
- * not fall after its data month — closing collections happen early in the
- * FOLLOWING month, so anything else is a typo.
+ * behavior instead). Throws on malformed input or a closing date in a month
+ * EARLIER than the data month (same-month is valid — see the rule below).
  */
 export function parseManualEntryArg(input: string): RegistryMonthEntry {
   const match = /^(\d{4}-\d{2})=(\d{4}-\d{2}-\d{2})$/.exec(input)

--- a/scripts/lib/registryFreshness.ts
+++ b/scripts/lib/registryFreshness.ts
@@ -19,11 +19,20 @@
 
 import type { RawCSVEntry } from './monthEndDates.js'
 import { groupByDataMonth } from './monthEndDates.js'
+import type { ClosingDateEntry } from '../../packages/collector-cli/src/utils/ClosingDateRegistry.js'
 
-/** One (dataMonth → closingDate) registry entry, e.g. 2026-05 → 2026-06-05. */
-export interface RegistryMonthEntry {
-  dataMonth: string
-  closingDate: string
+/**
+ * One (dataMonth → closingDate) registry entry, e.g. 2026-05 → 2026-06-05.
+ * Aliased from the registry's own writer so the file's schema lives once.
+ */
+export type RegistryMonthEntry = ClosingDateEntry
+
+/** A planned registry write, classified by provenance and effect. */
+export interface RegistryUpdate extends ClosingDateEntry {
+  source: 'derived' | 'manual'
+  action: 'add' | 'update'
+  /** The registry date being replaced (present only for updates). */
+  previous?: string
 }
 
 export interface RegistryMismatch {
@@ -58,13 +67,15 @@ export function deriveCompletedClosingMonths(
   entries: RawCSVEntry[]
 ): RegistryMonthEntry[] {
   const byMonth = groupByDataMonth(entries)
-  const allDates = entries.map(e => e.collectionDate).sort()
-  const newestDate = allDates[allDates.length - 1]
+  const newestDate = entries.reduce(
+    (max, e) => (e.collectionDate > max ? e.collectionDate : max),
+    ''
+  )
 
   const completed: RegistryMonthEntry[] = []
   for (const [dataMonth, closingDates] of byMonth) {
     const lastClosingDate = closingDates[closingDates.length - 1]!
-    if (newestDate !== undefined && newestDate > lastClosingDate) {
+    if (newestDate > lastClosingDate) {
       completed.push({ dataMonth, closingDate: lastClosingDate })
     }
   }
@@ -142,11 +153,8 @@ export function parseManualEntryArg(input: string): RegistryMonthEntry {
       `--set expects YYYY-MM=YYYY-MM-DD, got: ${JSON.stringify(input)}`
     )
   }
-  const [, dataMonth, closingDate] = match as unknown as [
-    string,
-    string,
-    string,
-  ]
+  const dataMonth = match[1]!
+  const closingDate = match[2]!
 
   const monthNum = Number(dataMonth.slice(5, 7))
   const dayNum = Number(closingDate.slice(8, 10))
@@ -165,6 +173,55 @@ export function parseManualEntryArg(input: string): RegistryMonthEntry {
   }
 
   return { dataMonth, closingDate }
+}
+
+/**
+ * Plan which registry writes to apply, given the existing registry and the
+ * derived + manual candidate entries.
+ *
+ * - Identical entries are skipped.
+ * - A DERIVED date never regresses a later registry date — partial metadata
+ *   must not undo a manual outage entry that knows more (the same
+ *   trust-later rule evaluateRegistryFreshness applies).
+ * - A MANUAL entry overrides in either direction: it is an operator
+ *   correction sourced from TI's own as-of lists (e.g. the 2026-01
+ *   stray-derived 2026-02-13 corrected back to 2026-02-05).
+ */
+export function planRegistryUpdates(
+  existing: RegistryMonthEntry[],
+  derived: RegistryMonthEntry[],
+  manual: RegistryMonthEntry[]
+): RegistryUpdate[] {
+  const existingByMonth = new Map(
+    existing.map(m => [m.dataMonth, m.closingDate])
+  )
+
+  const candidates: Array<
+    RegistryMonthEntry & { source: 'derived' | 'manual' }
+  > = [
+    ...derived.map(e => ({ ...e, source: 'derived' as const })),
+    ...manual.map(e => ({ ...e, source: 'manual' as const })),
+  ]
+
+  const plan: RegistryUpdate[] = []
+  for (const { dataMonth, closingDate, source } of candidates) {
+    const previous = existingByMonth.get(dataMonth)
+
+    if (previous === closingDate) continue
+    if (
+      source === 'derived' &&
+      previous !== undefined &&
+      previous > closingDate
+    )
+      continue
+
+    plan.push(
+      previous === undefined
+        ? { dataMonth, closingDate, source, action: 'add' }
+        : { dataMonth, closingDate, source, action: 'update', previous }
+    )
+  }
+  return plan
 }
 
 export function buildRegistryStaleTitle(

--- a/scripts/lib/registryFreshness.ts
+++ b/scripts/lib/registryFreshness.ts
@@ -131,11 +131,38 @@ export function evaluateRegistryFreshness(
 /**
  * Parse a manual `--set YYYY-MM=YYYY-MM-DD` argument (outage months whose
  * closing date cannot be derived from metadata and was established from TI
- * behavior instead). Throws on malformed input. Typed as a stub here for the
- * Red commit; implemented in the update-script change.
+ * behavior instead). Throws on malformed input or a closing date that does
+ * not fall after its data month — closing collections happen early in the
+ * FOLLOWING month, so anything else is a typo.
  */
-export function parseManualEntryArg(_input: string): RegistryMonthEntry {
-  throw new Error('--set: not implemented')
+export function parseManualEntryArg(input: string): RegistryMonthEntry {
+  const match = /^(\d{4}-\d{2})=(\d{4}-\d{2}-\d{2})$/.exec(input)
+  if (!match) {
+    throw new Error(
+      `--set expects YYYY-MM=YYYY-MM-DD, got: ${JSON.stringify(input)}`
+    )
+  }
+  const [, dataMonth, closingDate] = match as unknown as [
+    string,
+    string,
+    string,
+  ]
+
+  const monthNum = Number(dataMonth.slice(5, 7))
+  const dayNum = Number(closingDate.slice(8, 10))
+  if (monthNum < 1 || monthNum > 12 || dayNum < 1 || dayNum > 31) {
+    throw new Error(`--set: not a real calendar month/day: ${input}`)
+  }
+
+  // closingDate must be after the last day of dataMonth, i.e. its YYYY-MM
+  // prefix must sort strictly greater than the data month.
+  if (closingDate.slice(0, 7) <= dataMonth) {
+    throw new Error(
+      `--set: closing date ${closingDate} must fall after data month ${dataMonth}`
+    )
+  }
+
+  return { dataMonth, closingDate }
 }
 
 export function buildRegistryStaleTitle(

--- a/scripts/lib/registryFreshness.ts
+++ b/scripts/lib/registryFreshness.ts
@@ -137,12 +137,19 @@ export function evaluateRegistryFreshness(
     }
   }
 
+  // A healthy multi-month window always contains at least one completed
+  // closing month. Zero derivable months from a non-empty feed means the
+  // per-object metadata reads degraded to non-closing defaults (gcsHelpers
+  // swallows read errors) — the monitor cannot see, so it must alert (L107).
+  const noDerivableMonths = expected.length === 0
+
   return {
-    fresh: missing.length === 0 && mismatched.length === 0,
+    fresh:
+      !noDerivableMonths && missing.length === 0 && mismatched.length === 0,
     missing,
     mismatched,
     emptyFeed: false,
-    noDerivableMonths: false,
+    noDerivableMonths,
     checkedMonths: expected.map(e => e.dataMonth),
   }
 }
@@ -164,8 +171,16 @@ export function parseManualEntryArg(input: string): RegistryMonthEntry {
   const closingDate = match[2]!
 
   const monthNum = Number(dataMonth.slice(5, 7))
+  const closingMonthNum = Number(closingDate.slice(5, 7))
   const dayNum = Number(closingDate.slice(8, 10))
-  if (monthNum < 1 || monthNum > 12 || dayNum < 1 || dayNum > 31) {
+  if (
+    monthNum < 1 ||
+    monthNum > 12 ||
+    closingMonthNum < 1 ||
+    closingMonthNum > 12 ||
+    dayNum < 1 ||
+    dayNum > 31
+  ) {
     throw new Error(`--set: not a real calendar month/day: ${input}`)
   }
 
@@ -237,6 +252,9 @@ export function buildRegistryStaleTitle(
   if (result.emptyFeed) {
     return '🟥 closing-date registry check could not read raw-csv metadata'
   }
+  if (result.noDerivableMonths) {
+    return '🟥 closing-date registry check derived zero closing months — metadata reads degraded'
+  }
   const months = [
     ...result.missing.map(m => m.dataMonth),
     ...result.mismatched.map(m => m.dataMonth),
@@ -255,6 +273,14 @@ export function buildRegistryStaleBody(
       'the monitor feed itself failed (GCS listing/read error or empty window).',
       'Treating "cannot tell" as stale (L107). Investigate the check step logs',
       'before trusting `docs/month-end-closing-dates.json` for rescrapes.'
+    )
+  } else if (result.noDerivableMonths) {
+    lines.push(
+      'The metadata window was non-empty but yielded **zero derivable completed',
+      'closing months**. Per-object read failures degrade to non-closing entries,',
+      'so this usually means the metadata reads (not the listing) are failing —',
+      'the monitor cannot see. Treating "cannot tell" as stale (L107); check the',
+      'step logs and GCS object permissions before trusting the registry.'
     )
   } else {
     lines.push(

--- a/scripts/lib/registryFreshness.ts
+++ b/scripts/lib/registryFreshness.ts
@@ -1,0 +1,69 @@
+/**
+ * Closing-Date Registry Freshness — Pure Functions (#1128, epic #1098)
+ *
+ * The committed registry (docs/month-end-closing-dates.json) maps each
+ * Toastmasters data month to its last closing-period collection date. It is
+ * the prerequisite for accurate historical rescrapes and (Sprint 2, #1129)
+ * the rebuild's fail-closed closing remap — yet it sat 3 months stale with
+ * nothing watching (audit 2026-06-09 §9b).
+ *
+ * These pure functions are the daily pipeline's drift guard: derive the
+ * expected entries for COMPLETED closing months from raw-csv metadata and
+ * compare against the committed registry. Loud when behind (L107), quiet
+ * about what it cannot know (outage months have no metadata to derive from —
+ * those entries are maintained manually and trusted).
+ *
+ * No GCS/network I/O lives here; the runner (scripts/closing-registry-check.ts)
+ * supplies the fetched metadata window.
+ */
+
+import type { RawCSVEntry } from './monthEndDates.js'
+
+/** One (dataMonth → closingDate) registry entry, e.g. 2026-05 → 2026-06-05. */
+export interface RegistryMonthEntry {
+  dataMonth: string
+  closingDate: string
+}
+
+export interface RegistryMismatch {
+  dataMonth: string
+  registryClosingDate: string
+  derivedClosingDate: string
+}
+
+export interface RegistryFreshnessResult {
+  fresh: boolean
+  /** Derivable completed months absent from the registry. */
+  missing: RegistryMonthEntry[]
+  /** Months where reality moved past the registered closing date. */
+  mismatched: RegistryMismatch[]
+  /** True when no metadata entries were supplied — a monitor-feed failure. */
+  emptyFeed: boolean
+  /** The derivable completed months that were actually verified. */
+  checkedMonths: string[]
+}
+
+export function deriveCompletedClosingMonths(
+  _entries: RawCSVEntry[]
+): RegistryMonthEntry[] {
+  throw new Error('not implemented')
+}
+
+export function evaluateRegistryFreshness(
+  _registryMonths: RegistryMonthEntry[],
+  _entries: RawCSVEntry[]
+): RegistryFreshnessResult {
+  throw new Error('not implemented')
+}
+
+export function buildRegistryStaleTitle(
+  _result: RegistryFreshnessResult
+): string {
+  throw new Error('not implemented')
+}
+
+export function buildRegistryStaleBody(
+  _result: RegistryFreshnessResult
+): string {
+  throw new Error('not implemented')
+}

--- a/scripts/lib/registryFreshness.ts
+++ b/scripts/lib/registryFreshness.ts
@@ -49,6 +49,12 @@ export interface RegistryFreshnessResult {
   mismatched: RegistryMismatch[]
   /** True when no metadata entries were supplied — a monitor-feed failure. */
   emptyFeed: boolean
+  /**
+   * True when entries were supplied but none yielded a completed closing
+   * month — per-object read failures degrade to non-closing entries, so a
+   * full window with zero derivable months means the monitor cannot see.
+   */
+  noDerivableMonths: boolean
   /** The derivable completed months that were actually verified. */
   checkedMonths: string[]
 }
@@ -105,6 +111,7 @@ export function evaluateRegistryFreshness(
       missing: [],
       mismatched: [],
       emptyFeed: true,
+      noDerivableMonths: false,
       checkedMonths: [],
     }
   }
@@ -135,6 +142,7 @@ export function evaluateRegistryFreshness(
     missing,
     mismatched,
     emptyFeed: false,
+    noDerivableMonths: false,
     checkedMonths: expected.map(e => e.dataMonth),
   }
 }

--- a/scripts/lib/registryFreshness.ts
+++ b/scripts/lib/registryFreshness.ts
@@ -154,11 +154,13 @@ export function parseManualEntryArg(input: string): RegistryMonthEntry {
     throw new Error(`--set: not a real calendar month/day: ${input}`)
   }
 
-  // closingDate must be after the last day of dataMonth, i.e. its YYYY-MM
-  // prefix must sort strictly greater than the data month.
-  if (closingDate.slice(0, 7) <= dataMonth) {
+  // A closing date normally falls early in the FOLLOWING month, but a TI
+  // archive-outage month can end inside the data month itself (April 2022's
+  // as-of list stops at 2022-04-30 — TI never archived a May reconciliation).
+  // Same-month is therefore valid; only an EARLIER month is a typo.
+  if (closingDate.slice(0, 7) < dataMonth) {
     throw new Error(
-      `--set: closing date ${closingDate} must fall after data month ${dataMonth}`
+      `--set: closing date ${closingDate} is before data month ${dataMonth}`
     )
   }
 

--- a/scripts/update-closing-date-registry.ts
+++ b/scripts/update-closing-date-registry.ts
@@ -1,0 +1,156 @@
+/**
+ * Update Closing-Date Registry (#1128, epic #1098)
+ *
+ * Maintains docs/month-end-closing-dates.json — the registry that
+ * scripts/rescrape-historical.ts and (Sprint 2, #1129) the rebuild's
+ * fail-closed closing remap consume. Two sources, one writer:
+ *
+ *   1. DERIVED — completed closing months proven by raw-csv metadata in GCS
+ *      (the same feed the daily pipeline's freshness check reads).
+ *   2. MANUAL  — `--set YYYY-MM=YYYY-MM-DD` for collection-outage months
+ *      whose closing date had to be established from TI behavior (the
+ *      registry's value-add is exactly the months metadata cannot prove).
+ *
+ * All writes go through ClosingDateRegistry (dedupe, same-month update,
+ * sort, atomic write) — the class's production caller per the #1128
+ * decision (ADR-011). Run locally, then COMMIT the registry diff; the
+ * daily pipeline's check step self-clears once the fresh file lands.
+ *
+ * Usage:
+ *   npx tsx scripts/update-closing-date-registry.ts                # derive + append
+ *   npx tsx scripts/update-closing-date-registry.ts --dry-run
+ *   npx tsx scripts/update-closing-date-registry.ts --set 2026-02=2026-03-10
+ *
+ * Env: GCS_BUCKET (default toast-stats-data-staging), WINDOW_DAYS (default 130).
+ * Logging to stderr, JSON summary to stdout (R4).
+ */
+
+import * as path from 'node:path'
+import { Storage } from '@google-cloud/storage'
+import { ClosingDateRegistry } from '../packages/collector-cli/src/utils/ClosingDateRegistry.js'
+import { listRawCSVDates, readMetadataForDates } from './lib/gcsHelpers.js'
+import {
+  deriveCompletedClosingMonths,
+  parseManualEntryArg,
+  type RegistryMonthEntry,
+} from './lib/registryFreshness.js'
+
+const DEFAULT_BUCKET = 'toast-stats-data-staging'
+const DEFAULT_WINDOW_DAYS = 130
+
+function log(msg: string): void {
+  process.stderr.write(`${msg}\n`)
+}
+
+interface Args {
+  dryRun: boolean
+  noDerive: boolean
+  manualEntries: RegistryMonthEntry[]
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { dryRun: false, noDerive: false, manualEntries: [] }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--dry-run') args.dryRun = true
+    else if (arg === '--no-derive') args.noDerive = true
+    else if (arg === '--set' && argv[i + 1]) {
+      args.manualEntries.push(parseManualEntryArg(argv[++i]!))
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+  return args
+}
+
+async function main(): Promise<void> {
+  const { dryRun, noDerive, manualEntries } = parseArgs(process.argv.slice(2))
+  const bucket = process.env.GCS_BUCKET ?? DEFAULT_BUCKET
+  const windowDays = Number(process.env.WINDOW_DAYS ?? DEFAULT_WINDOW_DAYS)
+  const projectRoot = path.resolve(import.meta.dirname, '..')
+
+  const registry = new ClosingDateRegistry({
+    projectRoot,
+    logger: {
+      info: (m, meta) => log(`[info] ${m} ${meta ? JSON.stringify(meta) : ''}`),
+      warn: (m, meta) => log(`[warn] ${m} ${meta ? JSON.stringify(meta) : ''}`),
+      error: (m, meta) =>
+        log(`[error] ${m} ${meta ? JSON.stringify(meta) : ''}`),
+      debug: () => {},
+    },
+  })
+
+  const before = await registry.read()
+  const beforeByMonth = new Map(
+    before.months.map(m => [m.dataMonth, m.closingDate])
+  )
+
+  let derived: RegistryMonthEntry[] = []
+  if (!noDerive) {
+    const storage = new Storage()
+    const allDates = await listRawCSVDates(storage, bucket)
+    const windowDates = allDates.slice(-windowDays)
+    log(
+      `raw-csv: ${allDates.length} dates in gs://${bucket}, reading metadata for the last ${windowDates.length}`
+    )
+    const entries = await readMetadataForDates(storage, bucket, windowDates)
+    derived = deriveCompletedClosingMonths(entries)
+    log(`derived ${derived.length} completed closing months from metadata`)
+  }
+
+  const candidates = [...derived, ...manualEntries]
+  const applied: Array<
+    RegistryMonthEntry & { source: string; action: string }
+  > = []
+
+  for (const entry of candidates) {
+    const source = manualEntries.includes(entry) ? 'manual' : 'derived'
+    const existing = beforeByMonth.get(entry.dataMonth)
+
+    if (existing === entry.closingDate) continue
+    // Never let a DERIVED date regress a later registry date — a manual
+    // outage-month entry knows more than partial metadata (same rule the
+    // freshness check applies).
+    if (
+      source === 'derived' &&
+      existing !== undefined &&
+      existing > entry.closingDate
+    ) {
+      log(
+        `[skip] ${entry.dataMonth}: registry has later ${existing} > derived ${entry.closingDate}`
+      )
+      continue
+    }
+
+    const action = existing === undefined ? 'added' : `updated from ${existing}`
+    if (dryRun) {
+      log(
+        `[dry-run] would ${action === 'added' ? 'add' : action}: ${entry.dataMonth} → ${entry.closingDate} (${source})`
+      )
+    } else {
+      await registry.append(entry)
+    }
+    applied.push({ ...entry, source, action })
+  }
+
+  const after = await registry.read()
+  console.log(
+    JSON.stringify(
+      {
+        dryRun,
+        bucket,
+        derivedCount: derived.length,
+        manualCount: manualEntries.length,
+        applied,
+        totalMonths: after.months.length,
+      },
+      null,
+      2
+    )
+  )
+}
+
+main().catch(err => {
+  log(`update-closing-date-registry failed: ${(err as Error).stack ?? err}`)
+  process.exit(1)
+})

--- a/scripts/update-closing-date-registry.ts
+++ b/scripts/update-closing-date-registry.ts
@@ -11,15 +11,19 @@
  *      whose closing date had to be established from TI behavior (the
  *      registry's value-add is exactly the months metadata cannot prove).
  *
- * All writes go through ClosingDateRegistry (dedupe, same-month update,
- * sort, atomic write) — the class's production caller per the #1128
- * decision (ADR-011). Run locally, then COMMIT the registry diff; the
- * daily pipeline's check step self-clears once the fresh file lands.
+ * Which writes apply is decided by the unit-tested planRegistryUpdates
+ * (skip identical; derived never regresses a later registry date; manual
+ * overrides either way). All writes go through ClosingDateRegistry (dedupe,
+ * same-month update, sort, atomic write) — the class's production caller
+ * per ADR-011. Run locally, then COMMIT the registry diff; the daily
+ * pipeline's check step self-clears once the fresh file lands.
  *
  * Usage:
  *   npx tsx scripts/update-closing-date-registry.ts                # derive + append
  *   npx tsx scripts/update-closing-date-registry.ts --dry-run
- *   npx tsx scripts/update-closing-date-registry.ts --set 2026-02=2026-03-10
+ *   npx tsx scripts/update-closing-date-registry.ts --set 2026-02=2026-03-05
+ *   npx tsx scripts/update-closing-date-registry.ts --no-derive --set ...
+ *     (--no-derive skips the GCS read entirely — offline manual entries)
  *
  * Env: GCS_BUCKET (default toast-stats-data-staging), WINDOW_DAYS (default 130).
  * Logging to stderr, JSON summary to stdout (R4).
@@ -28,15 +32,17 @@
 import * as path from 'node:path'
 import { Storage } from '@google-cloud/storage'
 import { ClosingDateRegistry } from '../packages/collector-cli/src/utils/ClosingDateRegistry.js'
-import { listRawCSVDates, readMetadataForDates } from './lib/gcsHelpers.js'
+import {
+  readRecentRawCSVEntries,
+  RAW_CSV_DEFAULT_BUCKET,
+  RAW_CSV_DEFAULT_WINDOW,
+} from './lib/gcsHelpers.js'
 import {
   deriveCompletedClosingMonths,
   parseManualEntryArg,
+  planRegistryUpdates,
   type RegistryMonthEntry,
 } from './lib/registryFreshness.js'
-
-const DEFAULT_BUCKET = 'toast-stats-data-staging'
-const DEFAULT_WINDOW_DAYS = 130
 
 function log(msg: string): void {
   process.stderr.write(`${msg}\n`)
@@ -65,8 +71,8 @@ function parseArgs(argv: string[]): Args {
 
 async function main(): Promise<void> {
   const { dryRun, noDerive, manualEntries } = parseArgs(process.argv.slice(2))
-  const bucket = process.env.GCS_BUCKET ?? DEFAULT_BUCKET
-  const windowDays = Number(process.env.WINDOW_DAYS ?? DEFAULT_WINDOW_DAYS)
+  const bucket = process.env.GCS_BUCKET ?? RAW_CSV_DEFAULT_BUCKET
+  const windowDays = Number(process.env.WINDOW_DAYS ?? RAW_CSV_DEFAULT_WINDOW)
   const projectRoot = path.resolve(import.meta.dirname, '..')
 
   const registry = new ClosingDateRegistry({
@@ -81,59 +87,36 @@ async function main(): Promise<void> {
   })
 
   const before = await registry.read()
-  const beforeByMonth = new Map(
-    before.months.map(m => [m.dataMonth, m.closingDate])
-  )
 
   let derived: RegistryMonthEntry[] = []
   if (!noDerive) {
-    const storage = new Storage()
-    const allDates = await listRawCSVDates(storage, bucket)
-    const windowDates = allDates.slice(-windowDays)
-    log(
-      `raw-csv: ${allDates.length} dates in gs://${bucket}, reading metadata for the last ${windowDates.length}`
+    const entries = await readRecentRawCSVEntries(
+      new Storage(),
+      bucket,
+      windowDays,
+      log
     )
-    const entries = await readMetadataForDates(storage, bucket, windowDates)
     derived = deriveCompletedClosingMonths(entries)
     log(`derived ${derived.length} completed closing months from metadata`)
   }
 
-  const candidates = [...derived, ...manualEntries]
-  const applied: Array<
-    RegistryMonthEntry & { source: string; action: string }
-  > = []
+  const plan = planRegistryUpdates(before.months, derived, manualEntries)
 
-  for (const entry of candidates) {
-    const source = manualEntries.includes(entry) ? 'manual' : 'derived'
-    const existing = beforeByMonth.get(entry.dataMonth)
-
-    if (existing === entry.closingDate) continue
-    // Never let a DERIVED date regress a later registry date — a manual
-    // outage-month entry knows more than partial metadata (same rule the
-    // freshness check applies).
-    if (
-      source === 'derived' &&
-      existing !== undefined &&
-      existing > entry.closingDate
-    ) {
-      log(
-        `[skip] ${entry.dataMonth}: registry has later ${existing} > derived ${entry.closingDate}`
-      )
-      continue
-    }
-
-    const action = existing === undefined ? 'added' : `updated from ${existing}`
+  for (const update of plan) {
+    const detail =
+      update.action === 'add'
+        ? `add ${update.dataMonth} → ${update.closingDate}`
+        : `update ${update.dataMonth} → ${update.closingDate} (was ${update.previous})`
     if (dryRun) {
-      log(
-        `[dry-run] would ${action === 'added' ? 'add' : action}: ${entry.dataMonth} → ${entry.closingDate} (${source})`
-      )
+      log(`[dry-run] would ${detail} (${update.source})`)
     } else {
-      await registry.append(entry)
+      await registry.append({
+        dataMonth: update.dataMonth,
+        closingDate: update.closingDate,
+      })
     }
-    applied.push({ ...entry, source, action })
   }
 
-  const after = await registry.read()
   console.log(
     JSON.stringify(
       {
@@ -141,8 +124,10 @@ async function main(): Promise<void> {
         bucket,
         derivedCount: derived.length,
         manualCount: manualEntries.length,
-        applied,
-        totalMonths: after.months.length,
+        applied: plan,
+        totalMonths: dryRun
+          ? before.months.length
+          : (await registry.read()).months.length,
       },
       null,
       2

--- a/tasks/lessons/158-the-upstreams-own-ui-affordances-are-the-authority-for-reconstructed-metadata.md
+++ b/tasks/lessons/158-the-upstreams-own-ui-affordances-are-the-authority-for-reconstructed-metadata.md
@@ -1,0 +1,74 @@
+---
+id: '158'
+category: lesson
+tags: [data-pipeline, verification, scraping, collector-cli, process]
+auto_load: true
+date: 2026-06-10
+issues: [1128, 1098]
+---
+
+# Lesson 158 — When reconstructing an upstream system's calendar, the upstream's own UI affordances are the authority; calibrate the probe on knowns and expect it to falsify your derived records
+
+**Date:** 2026-06-10
+**Issue:** #1128 (epic #1098 Sprint 1)
+**PR:** _(record on merge)_
+
+## What happened
+
+The closing-date registry needed entries for two collection-outage months
+(2026-02, 2022-04) that no raw-csv metadata could prove. The first probe
+design reverse-engineered TI's export endpoint (`export.aspx`) — bisecting
+asOf dates for the "last date that returns data". It calibrated cleanly on a
+past program year, then produced garbage on the current one: **for the
+current PY the export ignores the monthEnd segment entirely** (same sha for
+different monthEnds), every asOf returns different content, and the CSV
+footer that would disambiguate is stripped from HTTP exports.
+
+The actual authority was one GET away the whole time: TI's own dashboard
+month view (`district.aspx?id=61&month=N`) renders an **"As of" dropdown
+whose newest option IS the month's closing date** — the upstream's own
+statement of its archive calendar. Calibrated against six known registry
+months: six matches, zero misses. It then answered both unknowns (2026-02 →
+2026-03-05; 2022-04 → 2022-04-30, an in-month close because TI never
+archived a May-2022 reconciliation) — **and falsified one of our own
+committed records**: the registry's `2026-01 → 2026-02-13` (derived from the
+stray metadata-less scrape) is wrong. TI's Jan list ends 02-05, and 02-13
+appears in TI's **February** list — the "stray Jan closing scrape" the audit
+wanted remapped to 2026-01-31 is actually a legitimately-dated February
+daily. A downstream sprint's remap premise changed because the probe was
+pointed at the source of truth instead of our partial archive.
+
+## The transferable principle
+
+**When you need an upstream system's operational metadata (closing dates,
+archive windows, publication calendars), don't reconstruct it by probing
+data endpoints from your own partial archive — first look for the upstream's
+own UI affordance that displays it (a dropdown, an archive index, a date
+picker). The UI is the system's self-description and is queryable with
+trivial GETs. Calibrate the method against several values you already know
+before trusting it on unknowns — and when the authoritative source
+contradicts one of your derived records, the finding is bidirectional:
+correct your record and re-examine every decision that was built on it.**
+
+## How to apply
+
+- Before designing an endpoint-bisection probe, fetch the human-facing page
+  and grep for `<option>`/date-picker affordances — the metadata is often
+  enumerated right there.
+- Calibrate on N known values (here: 6 registry months) and demand zero
+  misses before applying to unknowns; a probe validated on one PY can be
+  structurally wrong on another (current-PY export ignores monthEnd).
+- A record derived from your own anomalous capture (the metadata-less stray)
+  ranks below the upstream's self-description. When they disagree, the
+  upstream wins and the disagreement itself is evidence to surface (here:
+  Sprint 2's stray-remap decision).
+
+## Related
+
+- [[154-synthetic-fixtures-validate-the-code-only-a-captured-real-pair-validates-the-policy]]
+  — sibling: only real data falsifies assumptions; here the real data also
+  falsified an already-committed record.
+- [[139-a-year-end-snapshots-source-date-falls-in-july-so-a-program-year-equality-guard-drops-every-year]]
+  — same family: verify the data's actual shape, not the shape you inferred.
+- ADR-011 (`docs/architecture-decisions/011-closing-date-registry-committed-file-plus-drift-guard.md`)
+  — records the full evidence trail.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -149,4 +149,5 @@
 - **158** [ci, automation, monitoring, data-pipeline, verification] — A parameterized monitor's self-clear must be scoped to the signal it alarms on (#1125, #1096)
 - **158** [tests, tdd, verification, analytics, floats] — A test comment that justifies a surprising expectation by MECHANISM ("due to floating-point precision") instead of by RULE is a pinned bug wearing documentation (#1126, #1097, #798)
 - **158** [cls, css, frontend, responsive, mobile, verification, playwright] — Reserve a data-dependent slot with a structural skeleton (pinned widths, inherited heights), not a measured total height (#922, #1100)
+- **158** [data-pipeline, verification, scraping, collector-cli, process] — When reconstructing an upstream system's calendar, the upstream's own UI affordances are the authority; calibrate the probe on knowns and expect it to falsify your derived records (#1128, #1098)
 - **159** [verification, playwright, cdn, data-pipeline, automation, frontend] — Live-verify a pipeline-gated CDN artifact by injecting the REAL locally-built artifact via route interception (and drive the missing-artifact path un-injected) (#1135, #1101)


### PR DESCRIPTION
## Sprint 1 (#1098) — wire ClosingDateRegistry + backfill registry entries

Sub-issue: #1128 (do not auto-close; the epic tick owns ordering). Subsumes #1110 — operator closes it when this ships. Decision recorded in **ADR-011** (`docs/architecture-decisions/011-closing-date-registry-committed-file-plus-drift-guard.md`).

### Decision: keep + wire as a freshness guard (no CI auto-commit, no deletion)

- Sprint 2 (#1129) makes the registry a production input to the rebuild's fail-closed remap — deletion would be self-defeating.
- Auto-append from the daily run is blind exactly where the registry matters: the missing months (2026-02, 2022-04) had **no closing scrapes to append** (collection outages). The observed failure was *silence* (3 months stale, nothing watching), so the fix is a loud, self-clearing drift guard (L107/L155 pattern, mirroring the promotion-held alert #1073).

### What's in this PR

- `scripts/lib/registryFreshness.ts` + 30 unit tests — pure decision logic: derive completed closing months from raw-csv metadata; compare vs the committed registry; `planRegistryUpdates` (derived never regresses a later manual date; manual overrides either way). Alerts on empty feed AND on zero-derivable-months (silent per-object read failures must not auto-close the alert).
- `scripts/closing-registry-check.ts` — daily-pipeline runner (stderr logs, `$GITHUB_OUTPUT`, always exits 0; `continue-on-error` so a monitor crash can never skip the publish/promotion chain).
- `scripts/update-closing-date-registry.ts` — operator tool; derives from GCS + `--set` manual entries; **`ClosingDateRegistry`'s first production caller**.
- `data-pipeline.yml` — `[daily]` check step + self-clearing `closing-registry-stale` issue steps (title passed via env, not `${{ }}` splice).
- Registry backfill (all 5 epic entries) **+ 1 discovered correction**, provenance in the file's `note`.

### Backfilled closing dates + evidence

| dataMonth | closingDate | source |
|---|---|---|
| 2026-03 | 2026-04-07 | derived from staging raw-csv metadata (closing days 04-06..04-07, non-closing 04-08) |
| 2026-04 | 2026-05-07 | derived (05-01..05-07, non-closing 05-08) |
| 2026-05 | 2026-06-05 | derived (06-01..06-05, non-closing 06-06) |
| 2026-02 | 2026-03-05 | TI dashboard as-of list (outage month — no metadata exists) |
| 2022-04 | 2022-04-30 | TI as-of list; **in-month close** — TI never archived a May-2022 reconciliation (export returns header-only CSVs for every May-2022 asOf) |
| 2026-01 | **2026-02-05** (was 2026-02-13) | correction — see below |

TI's own dashboard month view (`district.aspx?id=61&month=N`) lists each month's valid as-of dates; the newest is the closing date. Method calibrated on **6 known registry months, 6/6 matches** (2025-12→01-08, 2022-03→04-10, 2022-05→06-17, 2026-03→04-07, 2026-04→05-07, 2026-05→06-05) before trusting it on the unknowns.

### ⚠️ Finding that changes Sprint 2's premise (#1129)

The registry's old `2026-01 → 2026-02-13` (derived from the metadata-less stray) is **wrong**: TI's Jan-2026 as-of list ends at **02-05**, and **02-13 appears in TI's FEB-2026 as-of list**. The stray `raw-csv/2026-02-13` is a legitimately-dated **February daily scrape**, not a January closing collection — the audit's "remap 2026-02-13 → 2026-01-31" assumption is falsified. Sprint 2's stray-handling decision should weigh this (likely outcome: the stray keeps its own date or is excluded; it must NOT be remapped to 2026-01-31).

### Verification

- TDD red/green pairs throughout (see commit history); 30 lib tests; 278 scripts tests; `npm run quality:check` exit 0 (frontend 3423, analytics-core 886, collector-cli 855, shared-contracts 159, mcp-server 51).
- `rescrape-historical.ts --dry-run --year 2021-2022` → **12/12 months** resolve (was 11); `--from-month 2026-01` → all 5 months resolve with correct export URLs.
- The exact pipeline step command was run locally against real staging GCS: `verdict: fresh=true checked=[2026-03, 2026-04, 2026-05]` → first scheduled daily run will be green and will auto-close nothing (no open alert).
- **No PR preview surface** (scripts/workflow/docs/data only — `pr-preview.yml` path filter does not match); live verification = the local real-GCS execution above + full suite, per the issue's data-path provision.
- TI probe volume: ~90 read-only, rate-limited (1/s) requests total — same politeness class as one daily scrape; canary deleted.

/simplify pass applied (shared type/fetch/read, tested `planRegistryUpdates`); fresh-context review verdict **ship** with 1 Medium + 3 Low findings, **all four fixed in-PR** (zero-derivable-months alert, continue-on-error, env-indirected title, closing-month range check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
