### PR TITLE
Sprint 2 (#1098) — rebuild closing remap fails closed when metadata.json is absent (#1129)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       }
     },
     "frontend": {
-      "version": "3.10.0",
+      "version": "3.11.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.0",
@@ -8617,7 +8617,7 @@
     },
     "packages/analytics-core": {
       "name": "@toastmasters/analytics-core",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@toastmasters/shared-contracts": "^1.0.0",

--- a/packages/collector-cli/src/CollectorOrchestrator.ts
+++ b/packages/collector-cli/src/CollectorOrchestrator.ts
@@ -691,7 +691,10 @@ export class CollectorOrchestrator {
         .filter(r => r.success)
         .map(r => r.districtId)
       if (succeededDistricts.length > 0) {
-        let isClosingPeriod = false
+        // undefined = no footer decided it; the key is then OMITTED from
+        // metadata.json so downstream resolution (CSV footer → registry)
+        // stays undecided instead of trusting a laundered false (#1129)
+        let isClosingPeriod: boolean | undefined
         let dataMonth: string | undefined
 
         // Detect closing period from standard all-districts output
@@ -714,13 +717,16 @@ export class CollectorOrchestrator {
             })
 
             const parsed = parseClosingPeriodFromCsv(csvContent, date)
-            isClosingPeriod = parsed.isClosingPeriod
-            dataMonth = parsed.dataMonth
+            if (parsed.footerFound) {
+              isClosingPeriod = parsed.isClosingPeriod
+              dataMonth = parsed.dataMonth
+            }
 
             logger.info('Closing period detection result', {
               date,
               isClosingPeriod,
               dataMonth,
+              footerFound: parsed.footerFound,
             })
           } catch (e) {
             logger.warn('Failed to parse closing period from CSV', {
@@ -731,19 +737,20 @@ export class CollectorOrchestrator {
         }
 
         // Fallback: use closingPeriodInfo from initial parse if disk parse missed it (#309)
-        if (
-          !isClosingPeriod &&
-          allDistrictsResult.closingPeriodInfo?.isClosingPeriod
-        ) {
+        const initialParse = allDistrictsResult.closingPeriodInfo
+        if (isClosingPeriod !== true && initialParse?.isClosingPeriod) {
           logger.warn(
             'Disk re-parse missed closing period — using initial parse result',
             {
               date,
-              initialResult: allDistrictsResult.closingPeriodInfo,
+              initialResult: initialParse,
             }
           )
           isClosingPeriod = true
-          dataMonth = allDistrictsResult.closingPeriodInfo.dataMonth
+          dataMonth = initialParse.dataMonth
+        } else if (isClosingPeriod === undefined && initialParse?.footerFound) {
+          isClosingPeriod = initialParse.isClosingPeriod
+          dataMonth = initialParse.dataMonth
         }
 
         const metaPath = buildMetadataPath(this.config.cacheDir, date)
@@ -751,7 +758,7 @@ export class CollectorOrchestrator {
           date,
           timestamp: Date.now(),
           programYear: calculateProgramYear(date),
-          isClosingPeriod,
+          ...(isClosingPeriod !== undefined ? { isClosingPeriod } : {}),
           ...(dataMonth ? { dataMonth } : {}),
           csvFiles: {
             allDistricts: allDistrictsResult.success,

--- a/packages/collector-cli/src/__tests__/CollectorOrchestrator.test.ts
+++ b/packages/collector-cli/src/__tests__/CollectorOrchestrator.test.ts
@@ -16,13 +16,23 @@ import type { CollectorOrchestratorConfig } from '../types/index.js'
 // Track which districts should fail when downloadCsv is called
 let failingDistricts = new Set<string>()
 
+// CSV content the mock downloader returns (reset per test)
+const DEFAULT_MOCK_CSV = `Header\nRow1\nMonth of December, As of 01/11/2026`
+let mockCsvContent = DEFAULT_MOCK_CSV
+
 vi.mock('../services/HttpCsvDownloader.js', () => {
   return {
     parseClosingPeriodFromCsv: (content: string, fetchDate: string) => {
-      // Use real parsing logic: detect "Month of X" footer
+      // Use real parsing logic: detect "Month of X" footer.
+      // Mirrors the real contract: footerFound distinguishes "decided
+      // non-closing" from "no footer = undecided" (#1129).
       const match = content.match(/Month of\s+(\w+)/i)
       if (!match) {
-        return { isClosingPeriod: false, dataMonth: undefined }
+        return {
+          isClosingPeriod: false,
+          dataMonth: undefined,
+          footerFound: false,
+        }
       }
       const monthNames = [
         'January',
@@ -42,7 +52,11 @@ vi.mock('../services/HttpCsvDownloader.js', () => {
         m => m.toLowerCase() === match[1].toLowerCase()
       )
       if (monthIndex === -1) {
-        return { isClosingPeriod: false, dataMonth: undefined }
+        return {
+          isClosingPeriod: false,
+          dataMonth: undefined,
+          footerFound: false,
+        }
       }
       const fetchMonth = new Date(fetchDate).getMonth() // 0-indexed
       const isClosingPeriod = monthIndex !== fetchMonth
@@ -51,7 +65,7 @@ vi.mock('../services/HttpCsvDownloader.js', () => {
           ? new Date(fetchDate).getFullYear() - 1
           : new Date(fetchDate).getFullYear()
       const dataMonth = `${year}-${String(monthIndex + 1).padStart(2, '0')}`
-      return { isClosingPeriod, dataMonth }
+      return { isClosingPeriod, dataMonth, footerFound: true }
     },
     HttpCsvDownloader: class MockHttpCsvDownloader {
       private requestCount = 0
@@ -72,10 +86,10 @@ vi.mock('../services/HttpCsvDownloader.js', () => {
           throw new Error(`Simulated failure for district ${spec.districtId}`)
         }
 
-        // Return minimal CSV content with a hardcoded closing period footer for testing
+        // Return mock CSV content (default has a closing-period footer)
         return {
           url: `https://example.com/${spec.reportType}`,
-          content: `Header\nRow1\nMonth of December, As of 01/11/2026`,
+          content: mockCsvContent,
           statusCode: 200,
           byteSize: 12,
         }
@@ -102,6 +116,7 @@ describe('CollectorOrchestrator - Partial Failure Resilience (#124)', () => {
     testConfigPath = path.join(testCacheDir, 'config', 'districts.json')
     await fs.mkdir(path.dirname(testConfigPath), { recursive: true })
     failingDistricts = new Set()
+    mockCsvContent = DEFAULT_MOCK_CSV
   })
 
   afterEach(async () => {
@@ -273,5 +288,27 @@ describe('CollectorOrchestrator - Partial Failure Resilience (#124)', () => {
 
     expect(metadata['isClosingPeriod']).toBe(true)
     expect(metadata['dataMonth']).toBe('2025-12')
+  })
+
+  it('omits isClosingPeriod from metadata.json when the CSV has no footer (#1129)', async () => {
+    // A footer-less CSV is UNDECIDED, not non-closing. Writing an explicit
+    // isClosingPeriod:false here would launder "no footer" into a decision
+    // that TransformService trusts, re-opening the raw-date publish hole the
+    // fail-closed chain exists to close.
+    mockCsvContent = 'Header\nRow1\nRow2'
+
+    await runScrapeTest(['09'], new Set())
+
+    const metadataPath = path.join(
+      testCacheDir,
+      'raw-csv',
+      '2026-01-11',
+      'metadata.json'
+    )
+    const content = await fs.readFile(metadataPath, 'utf-8')
+    const metadata = JSON.parse(content) as Record<string, unknown>
+
+    expect('isClosingPeriod' in metadata).toBe(false)
+    expect('dataMonth' in metadata).toBe(false)
   })
 })

--- a/packages/collector-cli/src/__tests__/RebuildService.test.ts
+++ b/packages/collector-cli/src/__tests__/RebuildService.test.ts
@@ -235,3 +235,68 @@ describe('RebuildService', () => {
     })
   })
 })
+
+describe('RebuildService — closing-date registry pass-through (#1129)', () => {
+  let testDir: string
+
+  beforeEach(async () => {
+    testDir = path.join(
+      tmpdir(),
+      `rebuild-1129-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    )
+    await fs.mkdir(path.join(testDir, 'raw-csv'), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true })
+  })
+
+  async function createFooterlessFixture(date: string): Promise<void> {
+    const rawCsvDir = path.join(testDir, 'raw-csv', date)
+    const districtDir = path.join(rawCsvDir, 'district-42')
+    await fs.mkdir(districtDir, { recursive: true })
+    await fs.writeFile(
+      path.join(rawCsvDir, 'all-districts.csv'),
+      'DISTRICT,REGION,Paid Clubs,Paid Club Base,% Club Growth,Total YTD Payments,Payment Base,% Payment Growth,Active Clubs,Total Distinguished Clubs,Select Distinguished Clubs,Presidents Distinguished Clubs\n42,Region 2,200,190,5.26%,2000,1900,5.26%,200,20,10,5'
+    )
+    await fs.writeFile(
+      path.join(districtDir, 'club-performance.csv'),
+      'Club Number,Club Name,Division,Area,Active Members,Goals Met\n1234,Test Club,A,1,20,5'
+    )
+  }
+
+  it('remaps a metadata-less closing-window date via the injected registry', async () => {
+    await createFooterlessFixture('2026-02-03')
+
+    const service = new RebuildService({
+      cacheDir: testDir,
+      closingDateRegistry: [
+        { dataMonth: '2026-01', closingDate: '2026-02-05' },
+      ],
+    })
+
+    const result = await service.rebuildDate('2026-02-03')
+
+    expect(result.transformSuccess).toBe(true)
+    expect(result.snapshotDate).toBe('2026-01-31')
+  })
+
+  it('marks an undecided date failed instead of publishing it', async () => {
+    await createFooterlessFixture('2026-06-08')
+
+    const service = new RebuildService({
+      cacheDir: testDir,
+      closingDateRegistry: [
+        { dataMonth: '2026-01', closingDate: '2026-02-05' },
+      ],
+    })
+
+    const result = await service.rebuildDate('2026-06-08')
+
+    expect(result.transformSuccess).toBe(false)
+    expect(result.error).toMatch(/registry|undecided/i)
+    await expect(
+      fs.stat(path.join(testDir, 'snapshots', '2026-06-08'))
+    ).rejects.toThrow()
+  })
+})

--- a/packages/collector-cli/src/__tests__/RebuildService.test.ts
+++ b/packages/collector-cli/src/__tests__/RebuildService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { RebuildService } from '../services/RebuildService.js'
+import { createRawCsvFixture } from './fixtures/rawCsvFixture.js'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { tmpdir } from 'node:os'
@@ -251,22 +252,8 @@ describe('RebuildService — closing-date registry pass-through (#1129)', () => 
     await fs.rm(testDir, { recursive: true, force: true })
   })
 
-  async function createFooterlessFixture(date: string): Promise<void> {
-    const rawCsvDir = path.join(testDir, 'raw-csv', date)
-    const districtDir = path.join(rawCsvDir, 'district-42')
-    await fs.mkdir(districtDir, { recursive: true })
-    await fs.writeFile(
-      path.join(rawCsvDir, 'all-districts.csv'),
-      'DISTRICT,REGION,Paid Clubs,Paid Club Base,% Club Growth,Total YTD Payments,Payment Base,% Payment Growth,Active Clubs,Total Distinguished Clubs,Select Distinguished Clubs,Presidents Distinguished Clubs\n42,Region 2,200,190,5.26%,2000,1900,5.26%,200,20,10,5'
-    )
-    await fs.writeFile(
-      path.join(districtDir, 'club-performance.csv'),
-      'Club Number,Club Name,Division,Area,Active Members,Goals Met\n1234,Test Club,A,1,20,5'
-    )
-  }
-
   it('remaps a metadata-less closing-window date via the injected registry', async () => {
-    await createFooterlessFixture('2026-02-03')
+    await createRawCsvFixture(testDir, '2026-02-03')
 
     const service = new RebuildService({
       cacheDir: testDir,
@@ -282,7 +269,7 @@ describe('RebuildService — closing-date registry pass-through (#1129)', () => 
   })
 
   it('marks an undecided date failed instead of publishing it', async () => {
-    await createFooterlessFixture('2026-06-08')
+    await createRawCsvFixture(testDir, '2026-06-08')
 
     const service = new RebuildService({
       cacheDir: testDir,

--- a/packages/collector-cli/src/__tests__/TransformService.failClosed.test.ts
+++ b/packages/collector-cli/src/__tests__/TransformService.failClosed.test.ts
@@ -1,0 +1,199 @@
+/**
+ * TransformService — fail-closed closing remap via the closing-date registry (#1129)
+ *
+ * The 2026-04-17 rebuild published raw-csv/2026-02-13 under its raw date
+ * because ClosingPeriodDetector.detect fails open when metadata.json is
+ * absent. With a closing-date registry injected, the metadata chain becomes
+ * metadata.json → CSV "As of" footer → registry, and a date the chain cannot
+ * decide REFUSES to publish (fail closed) instead of defaulting to the raw
+ * date.
+ *
+ * Acceptance criteria (#1129):
+ * - AC1: metadata-less raw-csv dir within a registry closing window remaps
+ *        (not raw-date publish)
+ * - AC2: the 2026-02-13 stray is kept under its own date (Sprint 1 finding:
+ *        it is a February daily scrape; Jan-2026 closed 2026-02-05)
+ * - AC3: non-closing metadata-less dates still publish (don't over-block)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { TransformService } from '../services/TransformService.js'
+import { ClosingPeriodUndecidedError } from '../utils/closingWindowResolver.js'
+import type { ClosingDateEntry } from '../utils/ClosingDateRegistry.js'
+
+/** Registry slice mirroring docs/month-end-closing-dates.json (#1128) */
+const REGISTRY: ClosingDateEntry[] = [
+  { dataMonth: '2025-12', closingDate: '2026-01-08' },
+  { dataMonth: '2026-01', closingDate: '2026-02-05' },
+]
+
+/** A valid all-districts CSV with NO "Month of …, As of …" footer */
+const FOOTERLESS_ALL_DISTRICTS_CSV = `DISTRICT,REGION,Paid Clubs,Paid Club Base,% Club Growth,Total YTD Payments,Payment Base,% Payment Growth,Active Clubs,Total Distinguished Clubs,Select Distinguished Clubs,Presidents Distinguished Clubs
+42,Region 2,200,190,5.26%,2000,1900,5.26%,200,20,10,5`
+
+async function createRawCsvFixture(
+  cacheDir: string,
+  date: string,
+  options: { csv?: string | null } = {}
+): Promise<string> {
+  const rawCsvDir = path.join(cacheDir, 'raw-csv', date)
+  await fs.mkdir(rawCsvDir, { recursive: true })
+
+  const csv =
+    options.csv === undefined ? FOOTERLESS_ALL_DISTRICTS_CSV : options.csv
+  if (csv !== null) {
+    await fs.writeFile(path.join(rawCsvDir, 'all-districts.csv'), csv)
+  }
+
+  const districtDir = path.join(rawCsvDir, 'district-42')
+  await fs.mkdir(districtDir, { recursive: true })
+  await fs.writeFile(
+    path.join(districtDir, 'club-performance.csv'),
+    'Club Number,Club Name,Division,Area,Active Members,Goals Met\n1234,Test Club,A,1,20,5'
+  )
+
+  return rawCsvDir
+}
+
+describe('TransformService — fail-closed closing remap (#1129)', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'transform-failclosed-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  function serviceWithRegistry(months: ClosingDateEntry[]): TransformService {
+    return new TransformService({
+      cacheDir: tempDir,
+      closingDateRegistry: months,
+    })
+  }
+
+  it('AC1: remaps a metadata-less, footer-less dir inside a registry closing window', async () => {
+    await createRawCsvFixture(tempDir, '2026-02-03')
+    const service = serviceWithRegistry(REGISTRY)
+
+    const result = await service.transform({ date: '2026-02-03', force: true })
+
+    expect(result.success).toBe(true)
+    expect(result.date).toBe('2026-01-31')
+
+    const remapped = await fs.stat(
+      path.join(tempDir, 'snapshots', '2026-01-31')
+    )
+    expect(remapped.isDirectory()).toBe(true)
+    await expect(
+      fs.stat(path.join(tempDir, 'snapshots', '2026-02-03'))
+    ).rejects.toThrow()
+  })
+
+  it('AC2: keeps the 2026-02-13 stray under its own date (after Jan window closed 02-05)', async () => {
+    await createRawCsvFixture(tempDir, '2026-02-13')
+    const service = serviceWithRegistry(REGISTRY)
+
+    const result = await service.transform({ date: '2026-02-13', force: true })
+
+    expect(result.success).toBe(true)
+    expect(result.date).toBe('2026-02-13')
+
+    const kept = await fs.stat(path.join(tempDir, 'snapshots', '2026-02-13'))
+    expect(kept.isDirectory()).toBe(true)
+    await expect(
+      fs.stat(path.join(tempDir, 'snapshots', '2026-01-31'))
+    ).rejects.toThrow()
+  })
+
+  it('AC3 / fail closed: refuses to publish a date the registry cannot decide', async () => {
+    // 2026-06-08's previous month (2026-05) is not in the injected registry.
+    await createRawCsvFixture(tempDir, '2026-06-08')
+    const service = serviceWithRegistry(REGISTRY)
+
+    const result = await service.transform({ date: '2026-06-08', force: true })
+
+    expect(result.success).toBe(false)
+    expect(result.errors.length).toBeGreaterThan(0)
+    expect(result.errors[0]?.error).toMatch(/registry|undecided/i)
+
+    // Nothing published under any date
+    await expect(fs.stat(path.join(tempDir, 'snapshots'))).rejects.toThrow()
+  })
+
+  it('readCacheMetadata rejects with ClosingPeriodUndecidedError when undecided', async () => {
+    await createRawCsvFixture(tempDir, '2026-06-08', { csv: null })
+    const service = serviceWithRegistry(REGISTRY)
+
+    await expect(service.readCacheMetadata('2026-06-08')).rejects.toThrow(
+      ClosingPeriodUndecidedError
+    )
+  })
+
+  it('an empty configured registry fails closed (missing registry file shape)', async () => {
+    await createRawCsvFixture(tempDir, '2026-02-13')
+    const service = serviceWithRegistry([])
+
+    const result = await service.transform({ date: '2026-02-13', force: true })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('the CSV footer outranks the registry when both could decide', async () => {
+    // Footer says February data collected 02-03 (same month → non-closing),
+    // even though the registry's Jan window runs through 02-05. The payload's
+    // own As-of statement wins; the registry is only the fallback authority.
+    await createRawCsvFixture(tempDir, '2026-02-03', {
+      csv: `${FOOTERLESS_ALL_DISTRICTS_CSV}\nMonth of Feb, As of 02/03/2026`,
+    })
+    const service = serviceWithRegistry(REGISTRY)
+
+    const result = await service.transform({ date: '2026-02-03', force: true })
+
+    expect(result.success).toBe(true)
+    expect(result.date).toBe('2026-02-03')
+  })
+
+  it('explicit metadata isClosingPeriod:false is trusted when no footer exists', async () => {
+    const rawCsvDir = await createRawCsvFixture(tempDir, '2026-02-03')
+    await fs.writeFile(
+      path.join(rawCsvDir, 'metadata.json'),
+      JSON.stringify({ date: '2026-02-03', isClosingPeriod: false })
+    )
+    const service = serviceWithRegistry(REGISTRY)
+
+    const metadata = await service.readCacheMetadata('2026-02-03')
+    expect(metadata?.isClosingPeriod).toBe(false)
+  })
+
+  it('writes registry-derived metadata back to the raw-csv dir with provenance', async () => {
+    const rawCsvDir = await createRawCsvFixture(tempDir, '2026-02-03')
+    const service = serviceWithRegistry(REGISTRY)
+
+    await service.transform({ date: '2026-02-03', force: true })
+
+    const written = JSON.parse(
+      await fs.readFile(path.join(rawCsvDir, 'metadata.json'), 'utf-8')
+    ) as Record<string, unknown>
+    expect(written['isClosingPeriod']).toBe(true)
+    expect(written['dataMonth']).toBe('2026-01')
+    expect(written['closingPeriodSource']).toBe('closing-date-registry')
+  })
+
+  it('without a configured registry, legacy fail-open behavior is preserved', async () => {
+    // Documented escape hatch: only production entry points (cli, rebuild)
+    // are required to inject the registry. Constructing without it keeps the
+    // pre-#1129 behavior so unrelated fixtures don't over-block.
+    await createRawCsvFixture(tempDir, '2026-02-03')
+    const service = new TransformService({ cacheDir: tempDir })
+
+    const result = await service.transform({ date: '2026-02-03', force: true })
+
+    expect(result.success).toBe(true)
+    expect(result.date).toBe('2026-02-03')
+  })
+})

--- a/packages/collector-cli/src/__tests__/TransformService.failClosed.test.ts
+++ b/packages/collector-cli/src/__tests__/TransformService.failClosed.test.ts
@@ -146,6 +146,40 @@ describe('TransformService — fail-closed closing remap (#1129)', () => {
     expect(metadata?.isClosingPeriod).toBe(false)
   })
 
+  it('warns when a trusted explicit false contradicts a registry closing window', async () => {
+    // Pre-#1129 scrapers laundered "no footer" into isClosingPeriod:false.
+    // The value stays trusted (no behavior change) but the contradiction is
+    // surfaced for operator review.
+    const rawCsvDir = await createRawCsvFixture(tempDir, '2026-02-03', {
+      csv: null,
+    })
+    await fs.writeFile(
+      path.join(rawCsvDir, 'metadata.json'),
+      JSON.stringify({ date: '2026-02-03', isClosingPeriod: false })
+    )
+
+    const warnings: string[] = []
+    const service = new TransformService({
+      cacheDir: tempDir,
+      closingDateRegistry: REGISTRY,
+      logger: {
+        info: () => {},
+        warn: (msg: string) => {
+          warnings.push(msg)
+        },
+        error: () => {},
+        debug: () => {},
+      },
+    })
+
+    const metadata = await service.readCacheMetadata('2026-02-03')
+
+    expect(metadata?.isClosingPeriod).toBe(false)
+    expect(
+      warnings.some(w => /contradicts a registry closing window/.test(w))
+    ).toBe(true)
+  })
+
   it('writes registry-derived metadata back to the raw-csv dir with provenance', async () => {
     const rawCsvDir = await createRawCsvFixture(tempDir, '2026-02-03')
     const service = serviceWithRegistry(REGISTRY)

--- a/packages/collector-cli/src/__tests__/TransformService.failClosed.test.ts
+++ b/packages/collector-cli/src/__tests__/TransformService.failClosed.test.ts
@@ -23,40 +23,16 @@ import * as os from 'node:os'
 import { TransformService } from '../services/TransformService.js'
 import { ClosingPeriodUndecidedError } from '../utils/closingWindowResolver.js'
 import type { ClosingDateEntry } from '../utils/ClosingDateRegistry.js'
+import {
+  createRawCsvFixture,
+  FOOTERLESS_ALL_DISTRICTS_CSV,
+} from './fixtures/rawCsvFixture.js'
 
 /** Registry slice mirroring docs/month-end-closing-dates.json (#1128) */
 const REGISTRY: ClosingDateEntry[] = [
   { dataMonth: '2025-12', closingDate: '2026-01-08' },
   { dataMonth: '2026-01', closingDate: '2026-02-05' },
 ]
-
-/** A valid all-districts CSV with NO "Month of …, As of …" footer */
-const FOOTERLESS_ALL_DISTRICTS_CSV = `DISTRICT,REGION,Paid Clubs,Paid Club Base,% Club Growth,Total YTD Payments,Payment Base,% Payment Growth,Active Clubs,Total Distinguished Clubs,Select Distinguished Clubs,Presidents Distinguished Clubs
-42,Region 2,200,190,5.26%,2000,1900,5.26%,200,20,10,5`
-
-async function createRawCsvFixture(
-  cacheDir: string,
-  date: string,
-  options: { csv?: string | null } = {}
-): Promise<string> {
-  const rawCsvDir = path.join(cacheDir, 'raw-csv', date)
-  await fs.mkdir(rawCsvDir, { recursive: true })
-
-  const csv =
-    options.csv === undefined ? FOOTERLESS_ALL_DISTRICTS_CSV : options.csv
-  if (csv !== null) {
-    await fs.writeFile(path.join(rawCsvDir, 'all-districts.csv'), csv)
-  }
-
-  const districtDir = path.join(rawCsvDir, 'district-42')
-  await fs.mkdir(districtDir, { recursive: true })
-  await fs.writeFile(
-    path.join(districtDir, 'club-performance.csv'),
-    'Club Number,Club Name,Division,Area,Active Members,Goals Met\n1234,Test Club,A,1,20,5'
-  )
-
-  return rawCsvDir
-}
 
 describe('TransformService — fail-closed closing remap (#1129)', () => {
   let tempDir: string

--- a/packages/collector-cli/src/__tests__/fixtures/rawCsvFixture.ts
+++ b/packages/collector-cli/src/__tests__/fixtures/rawCsvFixture.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared raw-csv fixture builder for the #1129 fail-closed remap tests.
+ *
+ * Builds CACHE_DIR/raw-csv/{date}/ with a minimal valid all-districts CSV
+ * (footer-less by default — the undecided shape) and one district dir so
+ * TransformService.transform can run end to end.
+ */
+
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+/** A valid all-districts CSV with NO "Month of …, As of …" footer */
+export const FOOTERLESS_ALL_DISTRICTS_CSV = `DISTRICT,REGION,Paid Clubs,Paid Club Base,% Club Growth,Total YTD Payments,Payment Base,% Payment Growth,Active Clubs,Total Distinguished Clubs,Select Distinguished Clubs,Presidents Distinguished Clubs
+42,Region 2,200,190,5.26%,2000,1900,5.26%,200,20,10,5`
+
+export async function createRawCsvFixture(
+  cacheDir: string,
+  date: string,
+  options: { csv?: string | null } = {}
+): Promise<string> {
+  const rawCsvDir = path.join(cacheDir, 'raw-csv', date)
+  await fs.mkdir(rawCsvDir, { recursive: true })
+
+  const csv =
+    options.csv === undefined ? FOOTERLESS_ALL_DISTRICTS_CSV : options.csv
+  if (csv !== null) {
+    await fs.writeFile(path.join(rawCsvDir, 'all-districts.csv'), csv)
+  }
+
+  const districtDir = path.join(rawCsvDir, 'district-42')
+  await fs.mkdir(districtDir, { recursive: true })
+  await fs.writeFile(
+    path.join(districtDir, 'club-performance.csv'),
+    'Club Number,Club Name,Division,Area,Active Members,Goals Met\n1234,Test Club,A,1,20,5'
+  )
+
+  return rawCsvDir
+}

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -43,6 +43,30 @@ import {
   UploadOptions,
 } from './types/index.js'
 import { resolveConfiguration } from './utils/config.js'
+import {
+  ClosingDateRegistry,
+  type ClosingDateEntry,
+} from './utils/ClosingDateRegistry.js'
+
+/**
+ * Load closing-date registry months for the fail-closed closing remap
+ * (#1129). Resolves docs/month-end-closing-dates.json relative to cwd — the
+ * repo root in CI and local runs. A missing or empty registry yields [], so
+ * every metadata-less, footer-less date fails closed (refused) rather than
+ * being published under its raw date.
+ */
+async function loadClosingDateRegistryMonths(): Promise<ClosingDateEntry[]> {
+  const registry = new ClosingDateRegistry({ projectRoot: process.cwd() })
+  const file = await registry.read()
+  if (file.months.length === 0) {
+    console.error(
+      '[WARN] Closing-date registry is empty or missing ' +
+        '(docs/month-end-closing-dates.json) — dates undecidable from ' +
+        'metadata/CSV footer will FAIL CLOSED (#1129)'
+    )
+  }
+  return file.months
+}
 
 // Re-export configuration utilities for external use
 export {
@@ -237,6 +261,7 @@ export function createCLI(): Command {
           const transformService = new TransformService({
             cacheDir,
             logger: createVerboseLogger(options.verbose),
+            closingDateRegistry: await loadClosingDateRegistryMonths(),
           })
 
           // Transform only the successfully scraped districts
@@ -449,6 +474,7 @@ export function createCLI(): Command {
       const transformService = new TransformService({
         cacheDir,
         logger: createVerboseLogger(options.verbose),
+        closingDateRegistry: await loadClosingDateRegistryMonths(),
       })
 
       // Execute transformation
@@ -1062,6 +1088,7 @@ export function createCLI(): Command {
         const service = new RebuildService({
           cacheDir,
           logger: createVerboseLogger(options.verbose),
+          closingDateRegistry: await loadClosingDateRegistryMonths(),
         })
 
         const dates = options.dates ?? (await service.discoverDates())

--- a/packages/collector-cli/src/services/HttpCsvDownloader.ts
+++ b/packages/collector-cli/src/services/HttpCsvDownloader.ts
@@ -129,6 +129,12 @@ export interface CsvClosingPeriodInfo {
   isClosingPeriod: boolean
   /** The data month in YYYY-MM format (e.g., "2026-03") */
   dataMonth: string | undefined
+  /**
+   * Whether a "Month of …, As of …" footer was actually found. When false,
+   * isClosingPeriod:false is a DEFAULT, not a decision — callers must treat
+   * the result as undecided, never persist it as an explicit verdict (#1129).
+   */
+  footerFound: boolean
 }
 
 const MONTH_NAMES: Record<string, string> = {
@@ -195,15 +201,17 @@ export function parseClosingPeriodFromCsv(
         return {
           isClosingPeriod,
           dataMonth,
+          footerFound: true,
         }
       }
     }
   }
 
-  // No footer found — not a closing period
+  // No footer found — UNDECIDED, not a non-closing decision (#1129)
   return {
     isClosingPeriod: false,
     dataMonth: undefined,
+    footerFound: false,
   }
 }
 

--- a/packages/collector-cli/src/services/RebuildService.ts
+++ b/packages/collector-cli/src/services/RebuildService.ts
@@ -17,6 +17,7 @@ import * as path from 'node:path'
 import type { Logger } from '@toastmasters/analytics-core'
 import { TransformService } from './TransformService.js'
 import { AnalyticsComputeService } from './AnalyticsComputeService.js'
+import type { ClosingDateEntry } from '../utils/ClosingDateRegistry.js'
 
 /**
  * Options for RebuildService
@@ -78,12 +79,18 @@ export class RebuildService {
   private readonly transformService: TransformService
   private readonly analyticsService: AnalyticsComputeService
 
-  constructor(options: { cacheDir: string; logger?: Logger }) {
+  constructor(options: {
+    cacheDir: string
+    logger?: Logger
+    /** Closing-date registry months for the fail-closed remap (#1129) */
+    closingDateRegistry?: ClosingDateEntry[]
+  }) {
     this.cacheDir = options.cacheDir
     this.logger = options.logger ?? noopLogger
     this.transformService = new TransformService({
       cacheDir: options.cacheDir,
       logger: options.logger,
+      closingDateRegistry: options.closingDateRegistry,
     })
     this.analyticsService = new AnalyticsComputeService({
       cacheDir: options.cacheDir,

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -314,26 +314,46 @@ export class TransformService {
       const parsed = parseClosingPeriodFromCsv(csvContent, date)
 
       if (parsed.footerFound) {
-        const metadata: CacheMetadata = {
-          date: existing?.date ?? date,
+        return this.finalizeDerivedMetadata(date, existing, {
           isClosingPeriod: parsed.isClosingPeriod,
           dataMonth: parsed.dataMonth,
-        }
-
-        this.logger.info('Derived closing period from CSV footer', {
-          date,
-          isClosingPeriod: parsed.isClosingPeriod,
-          dataMonth: parsed.dataMonth,
+          source: 'csv-footer',
         })
-
-        await this.writeBackDerivedMetadata(date, metadata, 'csv-footer')
-        return metadata
       }
     } catch {
       // CSV unreadable — fall through to the registry
     }
 
     return this.resolveWithoutFooter(date, existing)
+  }
+
+  /**
+   * Build the derived metadata, log the decision, and persist it back to
+   * raw-csv/{date}/metadata.json with its provenance.
+   */
+  private async finalizeDerivedMetadata(
+    date: string,
+    existing: CacheMetadata | null,
+    decision: {
+      isClosingPeriod: boolean
+      dataMonth: string | undefined
+      source: 'csv-footer' | 'closing-date-registry'
+    }
+  ): Promise<CacheMetadata> {
+    const metadata: CacheMetadata = {
+      date: existing?.date ?? date,
+      isClosingPeriod: decision.isClosingPeriod,
+      dataMonth: decision.dataMonth,
+    }
+
+    this.logger.info(`Derived closing period from ${decision.source}`, {
+      date,
+      isClosingPeriod: decision.isClosingPeriod,
+      dataMonth: decision.dataMonth,
+    })
+
+    await this.writeBackDerivedMetadata(date, metadata, decision.source)
+    return metadata
   }
 
   /**
@@ -358,35 +378,22 @@ export class TransformService {
       dataMonth: undefined,
     }
 
-    if (existing?.isClosingPeriod === false) {
-      return nonClosing
-    }
-
-    if (this.closingDateRegistry === undefined) {
+    // Explicit scraper-written false is trusted; no registry = legacy mode.
+    if (
+      existing?.isClosingPeriod === false ||
+      this.closingDateRegistry === undefined
+    ) {
       return nonClosing
     }
 
     const verdict = resolveClosingWindow(date, this.closingDateRegistry)
 
     if (verdict.kind === 'closing') {
-      const metadata: CacheMetadata = {
-        date: existing?.date ?? date,
+      return this.finalizeDerivedMetadata(date, existing, {
         isClosingPeriod: true,
         dataMonth: verdict.dataMonth,
-      }
-
-      this.logger.info('Derived closing period from closing-date registry', {
-        date,
-        dataMonth: verdict.dataMonth,
-        snapshotDate: verdict.snapshotDate,
+        source: 'closing-date-registry',
       })
-
-      await this.writeBackDerivedMetadata(
-        date,
-        metadata,
-        'closing-date-registry'
-      )
-      return metadata
     }
 
     if (verdict.kind === 'non-closing') {

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -19,6 +19,10 @@ import { parse } from 'csv-parse/sync'
 import { parseClosingPeriodFromCsv } from '../utils/csvFooterParser.js'
 import type { ClosingDateEntry } from '../utils/ClosingDateRegistry.js'
 import {
+  resolveClosingWindow,
+  ClosingPeriodUndecidedError,
+} from '../utils/closingWindowResolver.js'
+import {
   DataTransformer,
   ANALYTICS_SCHEMA_VERSION,
   getConfirmedDistinguishedLevel,
@@ -195,11 +199,13 @@ export class TransformService {
   private readonly cacheDir: string
   private readonly logger: Logger
   private readonly dataTransformer: DataTransformer
+  private readonly closingDateRegistry: ClosingDateEntry[] | undefined
 
   constructor(config: TransformServiceConfig) {
     this.cacheDir = config.cacheDir
     this.logger = config.logger ?? noopLogger
     this.dataTransformer = new DataTransformer({ logger: this.logger })
+    this.closingDateRegistry = config.closingDateRegistry
   }
 
   /**
@@ -292,6 +298,10 @@ export class TransformService {
    * Derive cache metadata by parsing the all-districts.csv footer.
    * Used when metadata.json is missing or has undefined isClosingPeriod.
    * Writes the derived metadata back to disk for future runs.
+   *
+   * When the footer cannot decide (no footer line, unreadable CSV), the
+   * decision falls to the closing-date registry (#1129); see
+   * resolveWithoutFooter for the fail-closed semantics.
    */
   private async deriveMetadataFromCsv(
     date: string,
@@ -303,44 +313,117 @@ export class TransformService {
       const csvContent = await fs.readFile(csvPath, 'utf-8')
       const parsed = parseClosingPeriodFromCsv(csvContent, date)
 
+      if (parsed.footerFound) {
+        const metadata: CacheMetadata = {
+          date: existing?.date ?? date,
+          isClosingPeriod: parsed.isClosingPeriod,
+          dataMonth: parsed.dataMonth,
+        }
+
+        this.logger.info('Derived closing period from CSV footer', {
+          date,
+          isClosingPeriod: parsed.isClosingPeriod,
+          dataMonth: parsed.dataMonth,
+        })
+
+        await this.writeBackDerivedMetadata(date, metadata, 'csv-footer')
+        return metadata
+      }
+    } catch {
+      // CSV unreadable — fall through to the registry
+    }
+
+    return this.resolveWithoutFooter(date, existing)
+  }
+
+  /**
+   * Decide closing-period status when neither metadata.json nor the CSV
+   * footer could (#1129).
+   *
+   * - An explicit scraper-written isClosingPeriod:false is trusted (there is
+   *   no footer to verify it against, per the #309 verification rule).
+   * - With a registry configured, the date's closing-window membership
+   *   decides; a date the registry cannot cover FAILS CLOSED
+   *   (ClosingPeriodUndecidedError) — never published under its raw date.
+   * - Without a registry (test fixtures only — production entry points must
+   *   inject one), the pre-#1129 fail-open default is preserved.
+   */
+  private async resolveWithoutFooter(
+    date: string,
+    existing: CacheMetadata | null
+  ): Promise<CacheMetadata | null> {
+    const nonClosing: CacheMetadata = {
+      date: existing?.date ?? date,
+      isClosingPeriod: false,
+      dataMonth: undefined,
+    }
+
+    if (existing?.isClosingPeriod === false) {
+      return nonClosing
+    }
+
+    if (this.closingDateRegistry === undefined) {
+      return nonClosing
+    }
+
+    const verdict = resolveClosingWindow(date, this.closingDateRegistry)
+
+    if (verdict.kind === 'closing') {
       const metadata: CacheMetadata = {
         date: existing?.date ?? date,
-        isClosingPeriod: parsed.isClosingPeriod,
-        dataMonth: parsed.dataMonth,
+        isClosingPeriod: true,
+        dataMonth: verdict.dataMonth,
       }
 
-      this.logger.info('Derived closing period from CSV footer', {
+      this.logger.info('Derived closing period from closing-date registry', {
         date,
-        isClosingPeriod: parsed.isClosingPeriod,
-        dataMonth: parsed.dataMonth,
+        dataMonth: verdict.dataMonth,
+        snapshotDate: verdict.snapshotDate,
       })
 
-      // Write back to metadata.json for future runs
-      try {
-        const metadataPath = path.join(this.getRawCsvDir(date), 'metadata.json')
-        const existingContent = await fs
-          .readFile(metadataPath, 'utf-8')
-          .then(c => JSON.parse(c) as Record<string, unknown>)
-          .catch(() => ({}))
-        const updated = {
-          ...existingContent,
-          date: metadata.date,
-          isClosingPeriod: metadata.isClosingPeriod,
-          ...(metadata.dataMonth ? { dataMonth: metadata.dataMonth } : {}),
-        }
-        await fs.writeFile(metadataPath, JSON.stringify(updated, null, 2))
-      } catch {
-        // Non-fatal: metadata write failure doesn't block transform
-      }
-
+      await this.writeBackDerivedMetadata(
+        date,
+        metadata,
+        'closing-date-registry'
+      )
       return metadata
-    } catch {
-      // No CSV file available — return non-closing-period default
-      return {
-        date: existing?.date ?? date,
-        isClosingPeriod: false,
-        dataMonth: undefined,
+    }
+
+    if (verdict.kind === 'non-closing') {
+      this.logger.info('Closing-date registry confirms non-closing date', {
+        date,
+      })
+      return nonClosing
+    }
+
+    throw new ClosingPeriodUndecidedError(date, verdict.reason)
+  }
+
+  /**
+   * Write derived metadata back to raw-csv/{date}/metadata.json for future
+   * runs, recording which authority decided it.
+   */
+  private async writeBackDerivedMetadata(
+    date: string,
+    metadata: CacheMetadata,
+    source: 'csv-footer' | 'closing-date-registry'
+  ): Promise<void> {
+    try {
+      const metadataPath = path.join(this.getRawCsvDir(date), 'metadata.json')
+      const existingContent = await fs
+        .readFile(metadataPath, 'utf-8')
+        .then(c => JSON.parse(c) as Record<string, unknown>)
+        .catch(() => ({}))
+      const updated = {
+        ...existingContent,
+        date: metadata.date,
+        isClosingPeriod: metadata.isClosingPeriod,
+        ...(metadata.dataMonth ? { dataMonth: metadata.dataMonth } : {}),
+        closingPeriodSource: source,
       }
+      await fs.writeFile(metadataPath, JSON.stringify(updated, null, 2))
+    } catch {
+      // Non-fatal: metadata write failure doesn't block transform
     }
   }
 
@@ -1865,7 +1948,38 @@ export class TransformService {
     }
 
     // Step 1: Read cache metadata to detect closing periods (Requirement 1.1)
-    const cacheMetadata = await this.readCacheMetadata(date)
+    // Fails CLOSED (#1129): a date whose closing-period status no authority
+    // (metadata.json, CSV footer, registry) can decide is refused, never
+    // published under its raw date.
+    let cacheMetadata: CacheMetadata | null
+    try {
+      cacheMetadata = await this.readCacheMetadata(date)
+    } catch (error) {
+      if (error instanceof ClosingPeriodUndecidedError) {
+        this.logger.error(
+          'Refusing to publish: closing-period status undecided',
+          { date, error: error.message }
+        )
+        return {
+          success: false,
+          date,
+          districtsProcessed: [],
+          districtsSucceeded: [],
+          districtsFailed: [],
+          districtsSkipped: [],
+          snapshotLocations: [],
+          errors: [
+            {
+              districtId: 'all-districts',
+              error: error.message,
+              timestamp: new Date().toISOString(),
+            },
+          ],
+          duration_ms: Date.now() - startTime,
+        }
+      }
+      throw error
+    }
 
     // Step 2: Determine the correct snapshot date based on closing period detection
     // (Requirements 2.1, 2.2, 2.3, 2.4, 5.1, 5.2)

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -378,11 +378,27 @@ export class TransformService {
       dataMonth: undefined,
     }
 
-    // Explicit scraper-written false is trusted; no registry = legacy mode.
-    if (
-      existing?.isClosingPeriod === false ||
-      this.closingDateRegistry === undefined
-    ) {
+    // Explicit scraper-written false is trusted — but pre-#1129 scrapers
+    // wrote a laundered false for footer-less days, so warn when the
+    // registry says the date sits inside a closing window (operator should
+    // verify that raw-csv dir; see #1129 review).
+    if (existing?.isClosingPeriod === false) {
+      if (this.closingDateRegistry !== undefined) {
+        const check = resolveClosingWindow(date, this.closingDateRegistry)
+        if (check.kind === 'closing') {
+          this.logger.warn(
+            'Explicit isClosingPeriod:false contradicts a registry closing ' +
+              'window — trusting the metadata, but this may be a pre-#1129 ' +
+              'laundered false; verify the raw-csv dir',
+            { date, registryDataMonth: check.dataMonth }
+          )
+        }
+      }
+      return nonClosing
+    }
+
+    // No registry = legacy fail-open mode (test fixtures only).
+    if (this.closingDateRegistry === undefined) {
       return nonClosing
     }
 

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -17,6 +17,7 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { parse } from 'csv-parse/sync'
 import { parseClosingPeriodFromCsv } from '../utils/csvFooterParser.js'
+import type { ClosingDateEntry } from '../utils/ClosingDateRegistry.js'
 import {
   DataTransformer,
   ANALYTICS_SCHEMA_VERSION,
@@ -111,6 +112,16 @@ export interface TransformServiceConfig {
   cacheDir: string
   /** Optional logger for diagnostic output */
   logger?: Logger
+  /**
+   * Closing-date registry months (docs/month-end-closing-dates.json) used as
+   * the third authority in the closing-period chain: metadata.json → CSV
+   * "As of" footer → registry (#1129). When provided, a date none of the
+   * three can decide FAILS CLOSED (ClosingPeriodUndecidedError) instead of
+   * publishing under the raw date. Every production entry point (cli
+   * transform, scrape --transform, RebuildService) MUST inject this;
+   * omitting it preserves legacy fail-open behavior for test fixtures only.
+   */
+  closingDateRegistry?: ClosingDateEntry[]
 }
 
 /**

--- a/packages/collector-cli/src/utils/__tests__/closingWindowResolver.test.ts
+++ b/packages/collector-cli/src/utils/__tests__/closingWindowResolver.test.ts
@@ -16,20 +16,12 @@ describe('resolveClosingWindow', () => {
 
   it('maps a date inside the previous-month closing window to that month-end', () => {
     const verdict = resolveClosingWindow('2026-02-03', [JAN_2026])
-    expect(verdict).toEqual({
-      kind: 'closing',
-      dataMonth: '2026-01',
-      snapshotDate: '2026-01-31',
-    })
+    expect(verdict).toEqual({ kind: 'closing', dataMonth: '2026-01' })
   })
 
   it('treats the registry closingDate itself as closing (inclusive boundary)', () => {
     const verdict = resolveClosingWindow('2026-02-05', [JAN_2026])
-    expect(verdict).toEqual({
-      kind: 'closing',
-      dataMonth: '2026-01',
-      snapshotDate: '2026-01-31',
-    })
+    expect(verdict).toEqual({ kind: 'closing', dataMonth: '2026-01' })
   })
 
   it('treats the day after the closing window as non-closing', () => {
@@ -51,22 +43,14 @@ describe('resolveClosingWindow', () => {
     const verdict = resolveClosingWindow('2026-01-05', [
       { dataMonth: '2025-12', closingDate: '2026-01-08' },
     ])
-    expect(verdict).toEqual({
-      kind: 'closing',
-      dataMonth: '2025-12',
-      snapshotDate: '2025-12-31',
-    })
+    expect(verdict).toEqual({ kind: 'closing', dataMonth: '2025-12' })
   })
 
-  it('remaps to a leap-year February 29', () => {
+  it('resolves a leap-year February window to dataMonth 2024-02', () => {
     const verdict = resolveClosingWindow('2024-03-05', [
       { dataMonth: '2024-02', closingDate: '2024-03-08' },
     ])
-    expect(verdict).toEqual({
-      kind: 'closing',
-      dataMonth: '2024-02',
-      snapshotDate: '2024-02-29',
-    })
+    expect(verdict).toEqual({ kind: 'closing', dataMonth: '2024-02' })
   })
 
   it('is non-closing after an IN-month closing date (2022-04 outage shape)', () => {
@@ -94,6 +78,7 @@ describe('resolveClosingWindow', () => {
     expect(resolveClosingWindow('2026-2-3', [JAN_2026]).kind).toBe('unknown')
     expect(resolveClosingWindow('garbage', [JAN_2026]).kind).toBe('unknown')
     expect(resolveClosingWindow('2026-13-01', [JAN_2026]).kind).toBe('unknown')
+    expect(resolveClosingWindow('2026-02-30', [JAN_2026]).kind).toBe('unknown')
   })
 
   it('returns unknown when the matching entry has a malformed closingDate', () => {

--- a/packages/collector-cli/src/utils/__tests__/closingWindowResolver.test.ts
+++ b/packages/collector-cli/src/utils/__tests__/closingWindowResolver.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { resolveClosingWindow } from '../closingWindowResolver.js'
+import type { ClosingDateEntry } from '../ClosingDateRegistry.js'
+
+/**
+ * resolveClosingWindow (#1129) — registry-backed closing-window membership.
+ *
+ * Fail-closed contract: 'unknown' (not 'non-closing') whenever the registry
+ * cannot conclusively decide, so callers refuse to publish under the raw date.
+ */
+describe('resolveClosingWindow', () => {
+  const JAN_2026: ClosingDateEntry = {
+    dataMonth: '2026-01',
+    closingDate: '2026-02-05',
+  }
+
+  it('maps a date inside the previous-month closing window to that month-end', () => {
+    const verdict = resolveClosingWindow('2026-02-03', [JAN_2026])
+    expect(verdict).toEqual({
+      kind: 'closing',
+      dataMonth: '2026-01',
+      snapshotDate: '2026-01-31',
+    })
+  })
+
+  it('treats the registry closingDate itself as closing (inclusive boundary)', () => {
+    const verdict = resolveClosingWindow('2026-02-05', [JAN_2026])
+    expect(verdict).toEqual({
+      kind: 'closing',
+      dataMonth: '2026-01',
+      snapshotDate: '2026-01-31',
+    })
+  })
+
+  it('treats the day after the closing window as non-closing', () => {
+    expect(resolveClosingWindow('2026-02-06', [JAN_2026])).toEqual({
+      kind: 'non-closing',
+    })
+  })
+
+  it('keeps the 2026-02-13 stray under its own date (non-closing, #1129 AC2)', () => {
+    // Sprint 1 (#1128) finding: TI's Jan-2026 as-of list ends 2026-02-05 and
+    // 2026-02-13 appears in TI's Feb-2026 as-of list — it is a legitimate
+    // February daily scrape, NOT a January closing collection.
+    expect(resolveClosingWindow('2026-02-13', [JAN_2026])).toEqual({
+      kind: 'non-closing',
+    })
+  })
+
+  it('handles the December→January cross-year window', () => {
+    const verdict = resolveClosingWindow('2026-01-05', [
+      { dataMonth: '2025-12', closingDate: '2026-01-08' },
+    ])
+    expect(verdict).toEqual({
+      kind: 'closing',
+      dataMonth: '2025-12',
+      snapshotDate: '2025-12-31',
+    })
+  })
+
+  it('remaps to a leap-year February 29', () => {
+    const verdict = resolveClosingWindow('2024-03-05', [
+      { dataMonth: '2024-02', closingDate: '2024-03-08' },
+    ])
+    expect(verdict).toEqual({
+      kind: 'closing',
+      dataMonth: '2024-02',
+      snapshotDate: '2024-02-29',
+    })
+  })
+
+  it('is non-closing after an IN-month closing date (2022-04 outage shape)', () => {
+    // 2022-04 closed in-month (2022-04-30, TI outage). A scrape dated
+    // 2022-04-30 is after 2022-03's window (closed 2022-04-10) → publish
+    // under its own date, which is already the April month-end.
+    const verdict = resolveClosingWindow('2022-04-30', [
+      { dataMonth: '2022-03', closingDate: '2022-04-10' },
+      { dataMonth: '2022-04', closingDate: '2022-04-30' },
+    ])
+    expect(verdict).toEqual({ kind: 'non-closing' })
+  })
+
+  it('returns unknown when the previous month has no registry entry', () => {
+    const verdict = resolveClosingWindow('2026-02-03', [])
+    expect(verdict.kind).toBe('unknown')
+  })
+
+  it('returns unknown when the previous-month entry only exists for OTHER months', () => {
+    const verdict = resolveClosingWindow('2026-06-08', [JAN_2026])
+    expect(verdict.kind).toBe('unknown')
+  })
+
+  it('returns unknown for an invalid requested date', () => {
+    expect(resolveClosingWindow('2026-2-3', [JAN_2026]).kind).toBe('unknown')
+    expect(resolveClosingWindow('garbage', [JAN_2026]).kind).toBe('unknown')
+    expect(resolveClosingWindow('2026-13-01', [JAN_2026]).kind).toBe('unknown')
+  })
+
+  it('returns unknown when the matching entry has a malformed closingDate', () => {
+    const verdict = resolveClosingWindow('2026-02-03', [
+      { dataMonth: '2026-01', closingDate: 'whenever' },
+    ])
+    expect(verdict.kind).toBe('unknown')
+  })
+})

--- a/packages/collector-cli/src/utils/closingWindowResolver.ts
+++ b/packages/collector-cli/src/utils/closingWindowResolver.ts
@@ -38,15 +38,25 @@ export class ClosingPeriodUndecidedError extends Error {
 export type ClosingWindowVerdict =
   | {
       kind: 'closing'
-      /** The data month the window belongs to (YYYY-MM) */
+      /**
+       * The data month the window belongs to (YYYY-MM). The snapshot date to
+       * publish under is derived downstream by ClosingPeriodDetector — the
+       * single owner of last-day-of-month math.
+       */
       dataMonth: string
-      /** Last day of the data month — the date to publish under (YYYY-MM-DD) */
-      snapshotDate: string
     }
   | { kind: 'non-closing' }
   | { kind: 'unknown'; reason: string }
 
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+/** Real calendar date in YYYY-MM-DD (UTC round-trip rejects e.g. 02-30) */
+function isRealIsoDate(dateStr: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false
+  const parsed = new Date(`${dateStr}T00:00:00Z`)
+  return (
+    !Number.isNaN(parsed.getTime()) &&
+    parsed.toISOString().slice(0, 10) === dateStr
+  )
+}
 
 /**
  * Resolve whether `requestedDate` falls inside the previous month's closing
@@ -56,7 +66,7 @@ export function resolveClosingWindow(
   requestedDate: string,
   months: ClosingDateEntry[]
 ): ClosingWindowVerdict {
-  if (!DATE_RE.test(requestedDate)) {
+  if (!isRealIsoDate(requestedDate)) {
     return {
       kind: 'unknown',
       reason: `invalid requested date '${requestedDate}' (expected YYYY-MM-DD)`,
@@ -65,12 +75,6 @@ export function resolveClosingWindow(
 
   const year = Number(requestedDate.slice(0, 4))
   const month = Number(requestedDate.slice(5, 7))
-  if (month < 1 || month > 12) {
-    return {
-      kind: 'unknown',
-      reason: `invalid month in requested date '${requestedDate}'`,
-    }
-  }
 
   // A date in month M can only fall inside month M-1's closing window.
   const prevYear = month === 1 ? year - 1 : year
@@ -85,7 +89,7 @@ export function resolveClosingWindow(
     }
   }
 
-  if (!DATE_RE.test(entry.closingDate)) {
+  if (!isRealIsoDate(entry.closingDate)) {
     return {
       kind: 'unknown',
       reason: `registry entry for ${prevDataMonth} has malformed closingDate '${entry.closingDate}'`,
@@ -95,12 +99,7 @@ export function resolveClosingWindow(
   // ISO date strings compare correctly as strings. Inclusive boundary: the
   // registry's closingDate is the LAST closing-period collection date.
   if (requestedDate <= entry.closingDate) {
-    const lastDay = new Date(Date.UTC(prevYear, prevMonth, 0)).getUTCDate()
-    return {
-      kind: 'closing',
-      dataMonth: prevDataMonth,
-      snapshotDate: `${prevDataMonth}-${String(lastDay).padStart(2, '0')}`,
-    }
+    return { kind: 'closing', dataMonth: prevDataMonth }
   }
 
   return { kind: 'non-closing' }

--- a/packages/collector-cli/src/utils/closingWindowResolver.ts
+++ b/packages/collector-cli/src/utils/closingWindowResolver.ts
@@ -39,8 +39,52 @@ export function resolveClosingWindow(
   requestedDate: string,
   months: ClosingDateEntry[]
 ): ClosingWindowVerdict {
-  if (!DATE_RE.test(requestedDate) || months.length >= 0) {
-    return { kind: 'unknown', reason: 'not implemented' }
+  if (!DATE_RE.test(requestedDate)) {
+    return {
+      kind: 'unknown',
+      reason: `invalid requested date '${requestedDate}' (expected YYYY-MM-DD)`,
+    }
   }
-  return { kind: 'unknown', reason: 'not implemented' }
+
+  const year = Number(requestedDate.slice(0, 4))
+  const month = Number(requestedDate.slice(5, 7))
+  if (month < 1 || month > 12) {
+    return {
+      kind: 'unknown',
+      reason: `invalid month in requested date '${requestedDate}'`,
+    }
+  }
+
+  // A date in month M can only fall inside month M-1's closing window.
+  const prevYear = month === 1 ? year - 1 : year
+  const prevMonth = month === 1 ? 12 : month - 1
+  const prevDataMonth = `${prevYear}-${String(prevMonth).padStart(2, '0')}`
+
+  const entry = months.find(m => m.dataMonth === prevDataMonth)
+  if (!entry) {
+    return {
+      kind: 'unknown',
+      reason: `registry has no entry for data month ${prevDataMonth}`,
+    }
+  }
+
+  if (!DATE_RE.test(entry.closingDate)) {
+    return {
+      kind: 'unknown',
+      reason: `registry entry for ${prevDataMonth} has malformed closingDate '${entry.closingDate}'`,
+    }
+  }
+
+  // ISO date strings compare correctly as strings. Inclusive boundary: the
+  // registry's closingDate is the LAST closing-period collection date.
+  if (requestedDate <= entry.closingDate) {
+    const lastDay = new Date(Date.UTC(prevYear, prevMonth, 0)).getUTCDate()
+    return {
+      kind: 'closing',
+      dataMonth: prevDataMonth,
+      snapshotDate: `${prevDataMonth}-${String(lastDay).padStart(2, '0')}`,
+    }
+  }
+
+  return { kind: 'non-closing' }
 }

--- a/packages/collector-cli/src/utils/closingWindowResolver.ts
+++ b/packages/collector-cli/src/utils/closingWindowResolver.ts
@@ -18,6 +18,23 @@
 
 import type { ClosingDateEntry } from './ClosingDateRegistry.js'
 
+/**
+ * Thrown when no authority (metadata.json, CSV footer, registry) can decide
+ * whether a collection date falls in a closing period. Callers must treat
+ * this as "refuse to publish under the raw date" (#1129).
+ */
+export class ClosingPeriodUndecidedError extends Error {
+  constructor(date: string, reason: string) {
+    super(
+      `Cannot decide closing-period status for ${date}: ${reason}. ` +
+        'Failing closed — refusing to publish under the raw date (#1129). ' +
+        'Add the missing month to docs/month-end-closing-dates.json or ' +
+        'restore the raw-csv metadata.json to unblock this date.'
+    )
+    this.name = 'ClosingPeriodUndecidedError'
+  }
+}
+
 export type ClosingWindowVerdict =
   | {
       kind: 'closing'

--- a/packages/collector-cli/src/utils/closingWindowResolver.ts
+++ b/packages/collector-cli/src/utils/closingWindowResolver.ts
@@ -1,0 +1,46 @@
+/**
+ * closingWindowResolver — Decide closing-period membership from the
+ * closing-date registry (#1129)
+ *
+ * The rebuild's closing remap previously FAILED OPEN: a raw-csv dir with no
+ * metadata.json and no CSV "As of" footer was published under its raw date.
+ * This resolver is the registry-backed third authority in the chain
+ * (metadata.json → CSV footer → registry): given a collection date and the
+ * registry months, it answers whether the date falls inside a known closing
+ * window for the previous data month.
+ *
+ * A date in month M can only belong to the closing window of month M-1
+ * (the window runs from the 1st of M through the registry's closingDate for
+ * M-1, inclusive). When the registry has no entry for M-1 — or an entry it
+ * has is malformed — the verdict is 'unknown', and the caller must fail
+ * CLOSED (refuse to publish under the raw date), never assume non-closing.
+ */
+
+import type { ClosingDateEntry } from './ClosingDateRegistry.js'
+
+export type ClosingWindowVerdict =
+  | {
+      kind: 'closing'
+      /** The data month the window belongs to (YYYY-MM) */
+      dataMonth: string
+      /** Last day of the data month — the date to publish under (YYYY-MM-DD) */
+      snapshotDate: string
+    }
+  | { kind: 'non-closing' }
+  | { kind: 'unknown'; reason: string }
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Resolve whether `requestedDate` falls inside the previous month's closing
+ * window according to the registry.
+ */
+export function resolveClosingWindow(
+  requestedDate: string,
+  months: ClosingDateEntry[]
+): ClosingWindowVerdict {
+  if (!DATE_RE.test(requestedDate) || months.length >= 0) {
+    return { kind: 'unknown', reason: 'not implemented' }
+  }
+  return { kind: 'unknown', reason: 'not implemented' }
+}

--- a/packages/collector-cli/src/utils/csvFooterParser.ts
+++ b/packages/collector-cli/src/utils/csvFooterParser.ts
@@ -31,8 +31,12 @@ const MONTHS: Record<string, string> = {
 export function parseClosingPeriodFromCsv(
   csvContent: string,
   requestedDate: string
-): { isClosingPeriod: boolean; dataMonth?: string } {
-  if (!csvContent) return { isClosingPeriod: false }
+): { isClosingPeriod: boolean; dataMonth?: string; footerFound: boolean } {
+  // `footerFound: false` means UNDECIDED, not non-closing — a CSV without an
+  // "As of" footer says nothing about its data month. Callers needing
+  // fail-closed semantics (#1129) must consult the next authority instead of
+  // treating the default isClosingPeriod:false as a decision.
+  if (!csvContent) return { isClosingPeriod: false, footerFound: false }
 
   const lines = csvContent.split(/\r?\n/).slice(-20) // Search the end of the file
   for (const line of lines) {
@@ -71,9 +75,10 @@ export function parseClosingPeriodFromCsv(
       return {
         isClosingPeriod,
         dataMonth: isClosingPeriod ? formattedDataMonth : undefined,
+        footerFound: true,
       }
     }
   }
 
-  return { isClosingPeriod: false }
+  return { isClosingPeriod: false, footerFound: false }
 }

--- a/packages/collector-cli/src/utils/index.ts
+++ b/packages/collector-cli/src/utils/index.ts
@@ -26,3 +26,8 @@ export {
   ClosingPeriodDetector,
   type ClosingPeriodInfo,
 } from './ClosingPeriodDetector.js'
+export {
+  resolveClosingWindow,
+  ClosingPeriodUndecidedError,
+  type ClosingWindowVerdict,
+} from './closingWindowResolver.js'

--- a/tasks/lessons/158-a-fail-closed-chain-is-only-as-honest-as-its-writers-a-persisted-default-reads-as-a-decision.md
+++ b/tasks/lessons/158-a-fail-closed-chain-is-only-as-honest-as-its-writers-a-persisted-default-reads-as-a-decision.md
@@ -1,0 +1,70 @@
+---
+id: '158'
+category: lesson
+tags: [data-pipeline, collector-cli, verification, tdd, metadata]
+auto_load: true
+date: 2026-06-10
+issues: [1129, 1098]
+---
+
+# Lesson 158 — A fail-closed chain is only as honest as its writers: a persisted default reads as a decision
+
+**Date:** 2026-06-10
+**Issue:** #1129 (epic #1098 Sprint 2 — rebuild closing remap fails closed)
+**PR:** _(record on merge)_
+
+## What happened
+
+The sprint built a fail-closed closing-period chain for the rebuild:
+metadata.json → CSV "As of" footer → closing-date registry → refuse.
+The trust rule at the first link is "an explicit `isClosingPeriod: false`
+written by the scraper is a decision; honor it."
+
+The /simplify altitude review then found the hole: the scraper's own footer
+parser returned `{ isClosingPeriod: false }` both when the footer said
+"non-closing" **and when no footer existed at all**, and the orchestrator
+persisted that value verbatim into metadata.json. Every footer-less scrape
+day on disk carries an explicit-looking `false` that is actually a parser
+default — and the new chain's trust branch would have honored it, re-opening
+the exact raw-date-publish hole the sprint exists to close, through the
+daily-scrape door instead of the rebuild door.
+
+The fix had to land at the **writer**, not the reader: the parser now
+returns `footerFound`, the orchestrator omits the `isClosingPeriod` key
+entirely when nothing decided it, and the reader warns when a trusted
+explicit `false` contradicts a registry closing window (the legacy laundered
+population on disk can't be retro-fixed). A second writer with the same
+hardcoded-false pattern (`BackfillOrchestrator.buildBackfillMetadata`) was
+found by the fresh-context review and filed as #1160.
+
+## The transferable principle
+
+**Before a fail-closed consumer trusts a persisted field as an "explicit
+decision," audit every writer of that field for laundered defaults — a
+`return { value: false }` fallback in a parser becomes an explicit `false`
+on disk one writer downstream, and no reader can distinguish them after the
+fact.** The honest shapes are: tri-state at the source (`footerFound` /
+`decided`), key-omission when undecided, and provenance on every derived
+write (`closingPeriodSource`). When a legacy population of laundered values
+already exists, add a contradiction warning at the reader; you can't
+re-derive intent from a boolean.
+
+## How to apply
+
+- Adding a "trust the explicit value" branch? `grep` every writer of that
+  field first (Lesson 61 applies to writers, not just formulas). Each
+  writer must be able to say "I didn't decide" — usually by omitting the key.
+- A parser/extractor whose not-found path returns the same shape as a real
+  negative is the root enabler. Return a found-flag or a discriminated
+  union; never let the default leave the function unlabeled.
+- Stamp derived writes with their deciding authority (`source` field) so the
+  next audit can separate decisions from defaults without forensics.
+
+## Related
+
+- [[150-an-exhaustiveness-guard-on-a-classification-map-misses-a-misclassification-that-keeps-the-set-valid]]
+  — sibling: the structurally-valid value that's semantically wrong.
+- [[061-fix-the-formula-everywhere-not-just-the-one-in-the-bug-report]] — the
+  twin-writer audit this lesson extends to persistence paths.
+- `packages/collector-cli/src/utils/closingWindowResolver.ts`,
+  `CollectorOrchestrator.ts` (metadata write), #1160 (BackfillOrchestrator).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -145,6 +145,7 @@
 - **157** [zod, schemas, data-pipeline, monorepo, verification, contracts] — In a zod union, a non-strict all-optional object schema matches (and silently EMPTIES) any object; strictness is what keeps the union falsifiable (#1123, #1096)
 - **157** [data-pipeline, analytics, transformation, fixtures, verification] — When sibling reports share one entity universe, derive every aggregate block from the single merged entity set (#1124, #1096)
 - **158** [data-pipeline, tests, tdd, verification, json, determinism] — A JSON artifact with numeric-like keys cannot promise lexicographic key order; test permutation-invariance of the serialized bytes instead (#1134, #1101)
+- **158** [data-pipeline, collector-cli, verification, tdd, metadata] — A fail-closed chain is only as honest as its writers: a persisted default reads as a decision (#1129, #1098)
 - **158** [git, bash, tests, process, verification] — A literal control byte in a source file flips git and grep into binary mode; write control characters as escapes (#1080, #1156)
 - **158** [ci, automation, monitoring, data-pipeline, verification] — A parameterized monitor's self-clear must be scoped to the signal it alarms on (#1125, #1096)
 - **158** [tests, tdd, verification, analytics, floats] — A test comment that justifies a surprising expectation by MECHANISM ("due to floating-point precision") instead of by RULE is a pinned bug wearing documentation (#1126, #1097, #798)


### PR DESCRIPTION
Sprint 2 of epic #1098 — implements #1129 (reference only; close is sequenced after the epic tick per R15).

## What

The rebuild's closing remap failed OPEN: a raw-csv dir with no `metadata.json` (and no decisive CSV footer) was published under its raw date — how the 2026-04-17 rebuild published `raw-csv/2026-02-13` as a snapshot. The closing-period decision chain is now:

`metadata.json` (explicit true trusted; explicit false verified) → CSV "As of" footer → **closing-date registry (#1128)** → **FAIL CLOSED** (`ClosingPeriodUndecidedError`; transform refuses the date, exit ≠ 0, rebuild loop skips it).

- New pure resolver `closingWindowResolver.ts`: a date in month M is inside M-1's closing window iff the registry has an entry for M-1 and date ≤ closingDate (inclusive). No coverage / malformed entry → `unknown` → fail closed.
- `parseClosingPeriodFromCsv` (both copies) now returns `footerFound` — "no footer" is *undecided*, not non-closing.
- **Scraper-door fix:** `CollectorOrchestrator` no longer launders "no footer" into an explicit `isClosingPeriod: false` in metadata.json — the key is omitted when nothing decided it. Registry-derived write-backs carry `closingPeriodSource` provenance.
- Reader warns when a trusted explicit false contradicts a registry closing window (legacy laundered population, review finding).
- Registry injected at all 3 production entry points (`transform`, `scrape --transform`, `rebuild`); empty/missing registry warns and fails closed. `TransformService` without the option keeps legacy behavior (test-fixture escape hatch, documented) — structural enforcement filed as #1160.

## Acceptance criteria (#1129)

- ✅ **AC1** failing-test-first: metadata-less, footer-less dir inside a registry window remaps (e.g. 2026-02-03 → snapshot 2026-01-31), never raw-date publish (`TransformService.failClosed.test.ts`)
- ✅ **AC2** 2026-02-13 stray handling decided + encoded per the binding Sprint-1 comment: **kept under its own date** (it's a legitimate February daily scrape; Jan-2026 closed 2026-02-05). Verified against the real staging payload: `raw-csv/2026-02-13/all-districts.csv` footer reads `Month of Feb, As of 02/13/2026` → footer authority decides non-closing; the registry path agrees (02-13 > 02-05). The prod snapshot `2026-02-13` is therefore already correctly dated — no remediation needed for the stray.
- ✅ **AC3** non-closing metadata-less dates still publish (footer or registry decides; don't over-block)

## Verification

- TDD: every feature commit is a red→green pair (9 commits + simplify/review fixes).
- Full workspace suite green: frontend 3423, collector-cli 911, analytics-core 855, shared-contracts 159, mcp-server 51. `npm run quality:check` exit 0.
- /simplify (4-angle) + fresh-context review applied; verdict APPROVE-WITH-NITS, medium finding fixed in 73904e1c, remaining follow-ups → #1160.
- No `pr-preview` surface: this PR touches only `packages/collector-cli` + docs/tests (path filter excludes it) — verification is code-proof via the suite above, per the data-sprint convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)