### PR TITLE
fix(rankings): per-program-year DD rules — Unknown for unknowable prerequisites, no Smedley pre-2025-26 (#1116)

### DIFF
--- a/docs/investigations/1116-historical-drp-rules.md
+++ b/docs/investigations/1116-historical-drp-rules.md
@@ -1,0 +1,146 @@
+# Investigation — Historical Distinguished District Program rules (2016-17 → 2025-26)
+
+**Issue:** #1116 item 5 · **Date:** 2026-06-10 · **Confidence:** high (all 10 years)
+**Method:** multi-agent research over Item 1490 revisions + archive.org, adversarially
+verified, then **back-solved against TI's own frozen dashboard goal numbers** for multiple
+districts per year (exact and discriminating — e.g. D61 2022-23 club goals 178/179/184/187
+match only the Rev. 12/2022 asymmetric ladder, refuting the symmetric 1.5% reading).
+Implemented by `DistinguishedDistrictCalculator.rulesetForProgramYear` (per-era rulesets).
+
+## Era summary
+
+| Era               | Tiers                                                | Payments growth  | Club requirement              | % Distinguished (of club base) |
+| ----------------- | ---------------------------------------------------- | ---------------- | ----------------------------- | ------------------------------ |
+| 2016-17 → 2017-18 | D / S / P (no Smedley)                               | 3 / 5 / 8%       | 3 / 5 / 8%                    | 40 / 45 / 50                   |
+| 2018-19 → 2021-22 | D / S / P / Smedley (Smedley's first district years) | 1.5 / 3 / 5 / 8% | 1.5 / 3 / 5 / 8%              | 40 / 45 / 50 / 55              |
+| 2022-23 → 2024-25 | D / S / P / Smedley (Rev. 12/2022, asymmetric)       | 1 / 3 / 5 / 8%   | no-net-loss / net+1 / 3% / 5% | 40 / 45 / 50 / 55              |
+| 2025-26 →         | D / S / P / Smedley (current, §13)                   | 1 / 3 / 5 / 8%   | 1 / 3 / 5 / 8%                | 45 / 50 / 55 / 60              |
+
+**Prerequisites:** exactly two hard gates 2016-17 → 2024-25 (DSP to WHQ by Sep 30;
+Division & Area Director training report by Sep 30 showing 85% trained) — matching the
+only prerequisite columns (`DSP`, `Training`) in TI's pre-2025-26 all-districts CSV
+exports. 2025-26 adds Market Analysis Plan, Communication Plan (both Sep 30), and ≥2
+Region Advisor meetings (May 31): five gates, fail-one-fail-all.
+
+**Common mechanics (all 10 years):** club base = paid clubs as of July 1; payments base =
+prior-PY July-June WHQ receipts (both upward-revisable in-year); %-distinguished
+denominator is the **club base**, never year-end paid clubs; goals round **up** (ceil);
+final determination at June 30.
+
+**Corrections to prior in-repo assumptions:**
+
+1. _"Smedley Distinguished is new for the 2025-2026 program year"_ (rules-reference §13.2,
+   calculator header, #329) — Smedley has existed at **district** level since **2018-19**;
+   2025-26 changed its thresholds (club growth 5%→8% via the symmetric ladder; %-dist
+   55%→60%) and raised every tier's %-distinguished by 5 points.
+2. COVID years: the Board explicitly declined to relax the DRP in 2019-20 and 2020-21
+   (only one-off supplemental awards and, in 2020-21, a paid-club-definition waiver).
+
+## Per-year detail (research synthesis, verbatim requirements + verification)
+
+### 2016-2017 — confidence: high
+
+- **Distinguished District** — Net paid-club growth >= 3% of club base AND net membership-payments growth >= 3% of payments base AND Distinguished clubs (Distinguished+Select+President's) >= 40% of club base. Club base = paid clubs as of July 1 (April renewals + Apr 1–Jun 30 charters, upward-revisable); payments base = prior-PY Jul 1–Jun 30 WHQ receipts (revisable); %-distinguished denominator = club base; goals round UP; measured at June 30. Verified: D61 base 201 clubs/8,371 payments → goals 208/8,623/81.
+- **Select Distinguished District** — 5% net club growth AND 5% net payments growth AND 45% of club base Distinguished. Verified: D61 goals 212/8,790/91.
+- **President's Distinguished District** — 8% net club growth AND 8% net payments growth AND 50% of club base Distinguished. Verified: D61 goals 218/9,041/101. NO Smedley tier this year (3-tier ladder); no district no-net-loss gate — positive growth required at every tier, in-year losses must be recuperated by June 30.
+- _Prerequisites:_ Two hard gates: (1) District Success Plan to WHQ by Sep 30; (2) Division & Area Directors Training Report to WHQ by Sep 30 showing 85% trained. (Gates proven by TI's 2016-17 CSV carrying only DSP+Training columns; 85%/Sep-30 parameters carried on Item 1475 Rev. 3/2015.) Best source: https://dashboards.toastmasters.org/2016-2017/District.aspx?id=61
+
+### 2017-2018 — confidence: high
+
+- **Distinguished District** — 3% net club growth AND 3% net payments growth AND 40% of club base Distinguished. Same denominators/round-up as 2016-17. Verified: D61 base 194/7,908 → goals 200/8,146/78 (rounding uniquely excludes 1.5%, which would give 197).
+- **Select Distinguished District** — 5% / 5% / 45%. Verified: goals 204/8,304/88.
+- **President's Distinguished District** — 8% / 8% / 50%. Verified: goals 210/8,541/97. NO Smedley tier; no district no-net-loss gate.
+- _Prerequisites:_ Same two hard gates: DSP to WHQ by Sep 30; Division & Area Directors Training Report by Sep 30 showing 85% trained. Best source: https://dashboards.toastmasters.org/2017-2018/District.aspx?id=61
+
+### 2018-2019 — confidence: high
+
+- **Distinguished District** — 1.5% net membership-payments growth AND 1.5% net club growth AND Distinguished clubs >= 40% of club base. Same denominators (club base Jul 1; payments base = prior-PY receipts; %-dist vs club base; ceil). Verified: D61 base 190/7,276 → 193/7,386/76; D82 base 272/15,842 → 277/16,080/109.
+- **Select Distinguished District** — 3% payments / 3% clubs / 45%. Verified: D61 196/7,495/86; D82 281/16,318/123.
+- **President's Distinguished District** — 5% payments / 5% clubs / 50%. Verified: D61 200/7,640/95; D82 286/16,635/136.
+- **Smedley Distinguished District** — 8% payments / 8% clubs / 55% — FIRST YEAR this tier exists at District level (Board modified the program mid-year, announced ~Jan 8 2019 for 2018-19 and 2019-20; governed the full-year determination). Verified: D61 206/7,859/105; D82 294/17,110/150. No district no-net-loss gate.
+- _Prerequisites:_ Two hard gates (Item 1490 Rev. 02/2019 verbatim): Division & Area Directors Training Report to WHQ by Sep 30 showing 85% trained; District Success Plan to WHQ by Sep 30. Best source: https://web.archive.org/web/20190612010153/http://www.toastmasters.org/-/media/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program.ashx
+
+### 2019-2020 — confidence: high
+
+- **Distinguished District** — 1.5% net payments growth AND 1.5% net club growth AND 40% of club base Distinguished. Verified: D61 base 188/7,369 → 191/7,480/76.
+- **Select Distinguished District** — 3% / 3% / 45%. Verified: 194/7,591/85.
+- **President's Distinguished District** — 5% / 5% / 50%. Verified: 198/7,738/94.
+- **Smedley Distinguished District** — 8% / 8% / 55%. Verified: 204/7,959/104. COVID: Board explicitly DECLINED to lower 2019-20 requirements/goals; created 2019-20-only supplemental awards (Online Ovation, Visiting Victor, Paid Club Champion, etc.) measured May 1–Jun 30 2020 — separate awards, not tier changes. No district no-net-loss gate.
+- _Prerequisites:_ Same two hard gates per Item 1490 Rev. 02/2019 (in force entering 2019-20): DSP by Sep 30; training report by Sep 30 showing 85% trained. Best source: https://dashboards.toastmasters.org/2019-2020/District.aspx?id=61
+
+### 2020-2021 — confidence: high
+
+- **Distinguished District** — 1.5% net membership-payments growth AND 1.5% net club growth AND 40% of club base Distinguished. Same denominators/ceil. Dashboard back-solve (synthesis re-check): D61 base 192/7,527 → 195/7,640/77.
+- **Select Distinguished District** — 3% / 3% / 45%. Back-solved: 198/7,753/87.
+- **President's Distinguished District** — 5% / 5% / 50%. Back-solved: 202/7,904/96.
+- **Smedley Distinguished District** — 8% / 8% / 55%. Back-solved: 208/8,130/106. COVID: DRP explicitly unchanged (TI letter Apr 2 2021); only relaxation was the paid-club definition for Oct 2020/Apr 2021 renewals (8 members, 3-renewing-members waived) — no threshold changes. No district no-net-loss gate.
+- _Prerequisites:_ Two hard gates (Item 1490 Rev. 03/2020 p.38): training report by Sep 30 showing 85% of Division/Area Directors trained; DSP by Sep 30. Best source: https://web.archive.org/web/20210224123904/https://toastmasterscdn.azureedge.net/medias/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program.pdf
+
+### 2021-2022 — confidence: high
+
+- **Distinguished District** — 1.5% net payments growth AND 1.5% net club growth AND 40% of club base Distinguished. Dashboard back-solve (synthesis re-check): D61 base 188/6,129 → 191/6,221/76.
+- **Select Distinguished District** — 3% / 3% / 45%. Back-solved: 194/6,313/85.
+- **President's Distinguished District** — 5% / 5% / 50%. Back-solved: 198/6,436/94.
+- **Smedley Distinguished District** — 8% / 8% / 55%. Back-solved: 204/6,620/104. Same denominators/ceil; no district no-net-loss gate.
+- _Prerequisites:_ Same two hard gates verbatim (Item 1490 Rev. 01/2021, posted as 'updated 5/2021'): training report 85% by Sep 30; DSP by Sep 30. Best source: https://web.archive.org/web/20240626094143/https://toastmasterscdn.azureedge.net/medias/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program_v2.pdf
+
+### 2022-2023 — confidence: high
+
+- **Distinguished District** — CORRECTED during synthesis (era research said 1.5% symmetric — refuted by TI's frozen dashboards): 1% net membership-payments growth (ceil(1.01 x payments base)) AND NO NET CLUB LOSS (year-end paid clubs >= club base) AND 40% of club base Distinguished. Verified two districts: D61 base 178/5,590 → goals 178 clubs (=base; 1.5% would give 181) / 5,646 payments (1.5% would give 5,674) / 72 dist; D13 base 65/2,083 → 65/2,104/26.
+- **Select Distinguished District** — 3% net payments growth AND net PLUS ONE club (>= base+1) AND 45% of club base Distinguished. Verified: D61 179/5,758/81; D13 66/2,146/30.
+- **President's Distinguished District** — 5% net payments growth AND 3% net club growth AND 50% of club base Distinguished. Verified: D61 184 (ceil(178x1.03)) / 5,870 / 89; D13 67/2,188/33.
+- **Smedley Distinguished District** — 8% net payments growth AND 5% net club growth AND 55% of club base Distinguished. Verified: D61 187 (ceil(178x1.05)) / 6,038 / 98; D13 69/2,250/36. Structure documented in Item 1490 Rev. 12/2022 (published mid-PY); same base/denominator/ceil mechanics.
+- _Prerequisites:_ Two hard gates — unaffected by the tier correction since both candidate revisions (Rev. 01/2022 and Rev. 12/2022) list the identical pair: training report 85% by Sep 30; DSP by Sep 30. Best source: https://dashboards.toastmasters.org/2022-2023/District.aspx?id=61 (tier proof; corroborated by id=13 and by Item 1490 Rev. 12/2022 at https://web.archive.org/web/20231210212449/https://toastmasterscdn.azureedge.net/medias/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program.pdf)
+
+### 2023-2024 — confidence: high
+
+- **Distinguished District** — 1% net payments growth (ceil(1.01 x payments base)) AND no net club loss (year-end paid clubs >= club base) AND 40% of club base Distinguished. Same base definitions (club base Jul 1, revisable; payments base = prior-PY WHQ receipts; %-dist vs club base; ceil; Jun 30 final).
+- **Select Distinguished District** — 3% net payments growth AND net plus one club (>= base+1) AND 45% of club base. Verified: D13 base 60/2,059 → 61/2,121/27.
+- **President's Distinguished District** — 5% net payments growth AND 3% net club growth AND 50% of club base. Verified: D13 62/2,162/30.
+- **Smedley Distinguished District** — 8% net payments growth AND 5% net club growth AND 55% of club base. Verified: D13 goals 63/2,224/33 (D13 earned Smedley: 63/2,253/34).
+- _Prerequisites:_ Two hard gates (Item 1490 Rev. 12/2022): training report 85% by Sep 30; DSP by Sep 30. NO Market Analysis Plan / Communication Plan / Region Advisor gates. Best source: https://web.archive.org/web/20231210212449/https://toastmasterscdn.azureedge.net/medias/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program.pdf
+
+### 2024-2025 — confidence: high
+
+- **Distinguished District** — 1% net payments growth AND no net club loss AND 40% of club base Distinguished. Verified: D13 base 63/2,255 → 63/2,278/26.
+- **Select Distinguished District** — 3% net payments growth AND net plus one club AND 45% of club base. Verified: 64/2,323/29.
+- **President's Distinguished District** — 5% net payments growth AND 3% net club growth AND 50% of club base. Verified: 65/2,368/32.
+- **Smedley Distinguished District** — 8% net payments growth AND 5% net club growth AND 55% of club base. Verified: 67/2,436/35. Item 1490 Rev. 04/2024 — district section substantively identical to Rev. 12/2022.
+- _Prerequisites:_ Two hard gates (Item 1490 Rev. 04/2024): training report 85% by Sep 30; DSP by Sep 30. Market Analysis Plan / Communication Plan / Region Advisor gates do NOT exist yet. Best source: https://web.archive.org/web/20241011084658/https://ccdn.toastmasters.org/medias/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program.pdf
+
+### 2025-2026 — confidence: high
+
+- **Distinguished District** — 1% net membership-payments growth AND 1% net club growth AND 45% of club base Distinguished. The 1% club-growth floor REPLACES the former no-net-loss rule (no standalone no-net-loss option at District level). Club base = paid clubs Jul 1 (revisable for late April dues and pre-Oct-1 reinstatements); payments base = prior-PY Jul 1–Jun 30 WHQ receipts; ceil; Jun 30 final.
+- **Select Distinguished District** — 3% net payments growth AND 3% net club growth AND 50% of club base Distinguished.
+- **President's Distinguished District** — 5% net payments growth AND 5% net club growth AND 55% of club base Distinguished (worked example: base 105 → 110.25 → 111).
+- **Smedley Distinguished District** — 8% net payments growth AND 8% net club growth AND 60% of club base Distinguished. CORRECTED per verification: NOT a new tier — Smedley has existed at District level since 2018-19; 2025-26 raises its club growth 5%→8% and %-distinguished 55%→60% (the new-for-2025-26 Smedley award is at CLUB level).
+- _Prerequisites:_ FIVE hard gates (fail any one = no recognition): (1) Division & Area Directors Training Report by Sep 30 showing 85% trained; (2) District Success Plan by Sep 30; (3) District Market Analysis Plan by Sep 30; (4) District Communication Plan by Sep 30; (5) at least two Region Advisor meetings by May 31. Gates 3-5 are new for 2025-26 (matching the new CSV columns). Deadlines 11:59 p.m. Mountain Time via District Central. Best source: https://content.toastmasters.org/image/upload/1490-district-recognition-program.pdf
+
+## Sources
+
+- https://dashboards.toastmasters.org/2016-2017/District.aspx?id=61 — frozen PY2016-17 dashboard: 3 tiers; back-solves exactly to 3/5/8% clubs+payments and 40/45/50% distinguished (208/212/218 off base 201; 8,623/8,790/9,041 off 8,371; 81/91/101)
+- https://dashboards.toastmasters.org/2017-2018/District.aspx?id=61 — frozen PY2017-18 dashboard: 3 tiers, 3/5/8% + 40/45/50% (200/204/210 off 194; 8,146/8,304/8,541 off 7,908; 78/88/97); rounding excludes 1.5%
+- https://web.archive.org/web/20190612010153/http://www.toastmasters.org/-/media/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program.ashx — Item 1490 Rev. 02/2019: verbatim 4-tier table (1.5/3/5/8%, 40/45/50/55%) and the two qualifying requirements for 2018-19 and 2019-20; base definitions, recuperate-losses, round-up rule; embeds Item 1475 (Rev. 3/2015) evidencing the 85%/Sep-30 gate back to 2016-17
+- https://dashboards.toastmasters.org/2018-2019/District.aspx?id=61 — frozen PY2018-19 dashboard: 4 tiers incl. first Smedley; exact back-solve (193/196/200/206 off 190; 76/86/95/105); corroborated by id=82 (277/281/286/294 off 272)
+- https://dashboards.toastmasters.org/2019-2020/District.aspx?id=61 — frozen PY2019-20 dashboard: same 4-tier formula (191/194/198/204 off 188; 7,480/7,591/7,738/7,959 off 7,369; 76/85/94/104)
+- https://district1toastmasters.org/toastmasters-international-is-announcing-2019-initiatives/ — dates the Board's mid-year change (announced ~2019-01-08) introducing the 1.5% floor and Smedley for 2018-19/2019-20
+- https://www.d26toastmasters.org/coronavirus-international-recognition-may-28-2020/ — Board kept 2019-20 requirements unchanged for COVID; supplemental awards only
+- https://web.archive.org/web/20210224123904/https://toastmasterscdn.azureedge.net/medias/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program.pdf — Item 1490 Rev. 03/2020 (full): PY2020-21 tiers 1.5/3/5/8% + 40/45/50/55% and the two gates
+- https://dashboards.toastmasters.org/2020-2021/District.aspx?id=61 — fresh synthesis back-solve confirming PY2020-21 symmetric 1.5/3/5/8% + 40/45/50/55% (base 192/7,527 → 195/198/202/208; 7,640/7,753/7,904/8,130; 77/87/96/106)
+- https://web.archive.org/web/20240626094143/https://toastmasterscdn.azureedge.net/medias/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program_v2.pdf — Item 1490 Rev. 01/2021 (file TI posted for PY2021-22): identical thresholds + two gates
+- https://dashboards.toastmasters.org/2021-2022/District.aspx?id=61 — fresh synthesis back-solve confirming PY2021-22 symmetric 1.5/3/5/8% + 40/45/50/55% (base 188/6,129 → 191/194/198/204; 6,221/6,313/6,436/6,620; 76/85/94/104)
+- https://dashboards.toastmasters.org/2022-2023/District.aspx?id=61 — CORRECTION EVIDENCE: frozen PY2022-23 dashboard back-solves exactly to 1/3/5/8% payments + no-net-loss/+1/3%/5% clubs + 40/45/50/55% (base 178/5,590 → 178/179/184/187 clubs; 5,646/5,758/5,870/6,038 payments; 72/81/89/98), refuting the symmetric-1.5% assignment for 2022-23
+- https://dashboards.toastmasters.org/2022-2023/District.aspx?id=13 — independent second-district confirmation of the 2022-23 correction (base 65/2,083 → 65/66/67/69; 2,104/2,146/2,188/2,250; 26/30/33/36)
+- https://web.archive.org/web/20231210212449/https://toastmasterscdn.azureedge.net/medias/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program.pdf — Item 1490 Rev. 12/2022: documents the 1%/no-net-loss/+1/3%/5% structure and two gates; governed PY2023-24 (archived mid-year) and matches the 2022-23 dashboard arithmetic
+- https://dashboards.toastmasters.org/2023-2024/District.aspx?id=13 — frozen PY2023-24 dashboard: exact match to Rev. 12/2022 formulas (goals 60/61/62/63 clubs; 2,080/2,121/2,162/2,224 payments; 24/27/30/33); D13 earned Smedley
+- https://web.archive.org/web/20241011084658/https://ccdn.toastmasters.org/medias/files/department-documents/district-documents/1490-toastmasters-international-district-recognition-program.pdf — Item 1490 Rev. 04/2024: PY2024-25, district section substantively identical to Rev. 12/2022; two gates
+- https://dashboards.toastmasters.org/2024-2025/District.aspx?id=13 — frozen PY2024-25 dashboard: exact match (63/64/65/67 clubs; 2,278/2,323/2,368/2,436 payments; 26/29/32/35 off base 63/2,255)
+- https://content.toastmasters.org/image/upload/1490-district-recognition-program.pdf — Item 1490 Rev. 03/2026: PY2025-26 tiers 1/3/5/8% (both metrics) + 45/50/55/60%, five qualifying gates, base definitions, round-up rule, MT deadline
+- https://www.toastmasters.org/magazine/magazine-issues/2025/july/what-recognition-updates-mean — TI magazine (July 2025): 2025-26 deltas (1% club growth replaces no-net-loss; 45% up from 40%; Smedley 'already exists in the DRP' — basis of the Smedley-novelty correction; Market Analysis/Communication Plans + 2 RA meetings new)
+- https://ccdn.toastmasters.org/medias/files/district-leader-tools/151-distinguished-districts-2023-2024.pdf — TI's official 2023-24 Smedley Distinguished Districts list (9 districts) proving the District-level Smedley tier pre-dates 2025-26
+- https://web.archive.org/web/20210516192420/https://toastmasterscdn.azureedge.net/medias/files/department-documents/online-clubs/toastmasters-international-_-recognition-awards-_-2020-2021-additional-recognition.pdf — TI letter 2021-04-02: 2020-21 recognition programs 'will remain unchanged' (COVID awards were additional)
+- https://dashboards.toastmasters.org/2016-2017/export.aspx?type=CSV&report=districtsummary~~6/30/2017~2016-2017 — all-districts CSV: gate columns exactly 'DSP','Training' (same header through 2019-20; corroborates two-gate prerequisites pre-2025-26)
+
+## Residual caveats (from synthesis)
+
+Residual caveats: (a) the 85%/Sep-30 parameters for 2016-17/2017-18 are carried on the Item 1475 form Rev. 3/2015 + 2017 FAQ rather than a 2016-dated manual (gates' existence proven by year-exact CSVs) — kept high per the era verification; (b) no period-archived mid-2022 manual was produced for 2022-23 (Rev. 12/2022 is dated mid-year), but two-district exact dashboard arithmetic is decisive about the rules actually applied, so kept high.

--- a/docs/toastmasters-rules-reference.md
+++ b/docs/toastmasters-rules-reference.md
@@ -383,20 +383,40 @@ All four Distinguished District tiers require these prerequisites:
 | President's Distinguished |        —         |       ≥5%       |     ≥5%     |      ≥55%       |
 | Smedley Distinguished     |        —         |       ≥8%       |     ≥8%     |      ≥60%       |
 
-Smedley Distinguished is new for the 2025-2026 program year.
+Smedley Distinguished has existed at district level since **2018-19** (it is NOT new
+for 2025-2026 — a prior revision of this doc and #329 said otherwise). What changed in
+2025-2026: the symmetric 8%/8% growth ladder (club growth was 5% under Rev. 12/2022)
+and %-distinguished 55%→60%, alongside every tier's %-distinguished rising 5 points.
+For pre-2025-26 tier requirements see §13.3.
 
-### 13.3 Competitive Awards (Top 3 Globally)
+### 13.3 Historical District Recognition requirements (2016-17 → 2024-25)
+
+Authoritative per-era table (sourced from Item 1490 revisions and verified by
+back-solving TI's frozen dashboard goal numbers — see
+[`docs/investigations/1116-historical-drp-rules.md`](investigations/1116-historical-drp-rules.md)):
+
+| Era               | Tiers         | Payments growth | Club requirement              | % Distinguished (of club base) | Prerequisites       |
+| ----------------- | ------------- | --------------- | ----------------------------- | ------------------------------ | ------------------- |
+| 2016-17 → 2017-18 | D/S/P         | 3/5/8%          | 3/5/8%                        | 40/45/50                       | DSP + Training only |
+| 2018-19 → 2021-22 | D/S/P/Smedley | 1.5/3/5/8%      | 1.5/3/5/8%                    | 40/45/50/55                    | DSP + Training only |
+| 2022-23 → 2024-25 | D/S/P/Smedley | 1/3/5/8%        | no-net-loss / net+1 / 3% / 5% | 40/45/50/55                    | DSP + Training only |
+
+Implemented by `DistinguishedDistrictCalculator.rulesetForProgramYear` (#1116 item 5).
+A prerequisite required by a year's rules but unknowable from the data yields tier
+**Unknown** (§12.5), never a silent NotDistinguished.
+
+### 13.4 Competitive Awards (Top 3 Globally)
 
 - **President's Extension Award:** Top 3 districts by net club growth
 - **President's 20-Plus Award:** Top 3 districts by % of active clubs with 20+ paid members
 - **District Club Retention Award:** Top 3 districts retaining 90%+ paid clubs
 
-### 13.4 Threshold Awards
+### 13.5 Threshold Awards
 
 - **District Club Strength Award:** 10%+ growth in average club size (Total Membership / Active Clubs) year-over-year
 - **District Leadership Excellence Award:** 3+ consecutive years Distinguished (any tier)
 
-### 13.5 Officer Awards
+### 13.6 Officer Awards
 
 - **Excellence in Education & Training Award:** Awarded to PQD in districts that train 85% of Directors and meet Distinguished goals in Distinguished clubs
 - **Excellence in Club Growth Award:** Awarded to CGD in districts that meet Distinguished goals in club and membership payments growth
@@ -412,6 +432,7 @@ Smedley Distinguished is new for the 2025-2026 program year.
 | 1.2     | April 2026    | Added §13 District Recognition Program (all 11 award types)                                                                                                                                                                                                                                                                  |
 | 1.3     | May 2026      | Corrected §6 (DAP) and §7 (DDP) to the manual (item 1490) model — distinguished **clubs** as % of **club base** (DAP 50/50+1, DDP 45/50/55) + paid-club growth; removed the legacy area-%/paid-% recognition model; clarified §9 recognition denominators (#799)                                                             |
 | 1.4     | June 2026     | §5.3 corrected to the canonical (implemented) checkpoint table — October 2 (was 1), December 3 (was 2) — per operator ruling on #1122: no official TI monthly pacing exists; the implementation matched the original club-health spec and empirically discriminates, the doc's earlier values did not (audit 2026-06-09, H1) |
+| 1.5     | June 2026     | Added §13.3 historical DRP requirements (2016-17→2024-25, per-era, dashboard-verified — investigation 1116); corrected §13.2 (Smedley exists at district level since 2018-19, not new in 2025-26); renumbered §13.4-13.6 (#1116 item 5)                                                                                      |
 
 ---
 

--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -5,6 +5,7 @@ import {
 } from '../utils/distinguishedCountdown'
 
 export type DistinguishedDistrictTier =
+  | 'Unknown'
   | 'NotDistinguished'
   | 'Distinguished'
   | 'Select'
@@ -61,6 +62,7 @@ interface DistinguishedDistrictTrophyCaseProps {
 }
 
 const TIER_LABELS: Record<DistinguishedDistrictTier, string> = {
+  Unknown: 'Recognition Unknown',
   NotDistinguished: 'Not Yet Distinguished',
   Distinguished: 'Distinguished District',
   Select: 'Select Distinguished District',
@@ -69,6 +71,7 @@ const TIER_LABELS: Record<DistinguishedDistrictTier, string> = {
 }
 
 const TIER_BADGE_STYLES: Record<DistinguishedDistrictTier, string> = {
+  Unknown: 'bg-gray-50 text-gray-500 border-gray-200',
   NotDistinguished: 'bg-gray-100 text-gray-700 border-gray-300',
   Distinguished: 'bg-tm-true-maroon text-white border-tm-true-maroon',
   Select: 'bg-tm-cool-gray text-gray-900 border-gray-400',
@@ -78,6 +81,7 @@ const TIER_BADGE_STYLES: Record<DistinguishedDistrictTier, string> = {
 }
 
 const TIER_ICONS: Record<DistinguishedDistrictTier, string> = {
+  Unknown: '◌',
   NotDistinguished: '○',
   Distinguished: '🥉',
   Select: '🥈',
@@ -202,7 +206,8 @@ export const DistinguishedDistrictTrophyCase: React.FC<
         paymentsCount === null ||
         distinguishedClubsCount === null) &&
       ranking &&
-      nextTierGap.tier !== 'NotDistinguished'
+      nextTierGap.tier !== 'NotDistinguished' &&
+      nextTierGap.tier !== 'Unknown'
     ) {
       const derived = deriveRemainingToTier(nextTierGap.tier, ranking)
       paidClubsCount = paidClubsCount ?? derived.paidClubsRemaining

--- a/frontend/src/components/DistrictTierChip.tsx
+++ b/frontend/src/components/DistrictTierChip.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import type { DistinguishedDistrictTier } from '../services/cdn'
 
-type AchievedTier = Exclude<DistinguishedDistrictTier, 'NotDistinguished'>
+type AchievedTier = Exclude<
+  DistinguishedDistrictTier,
+  'NotDistinguished' | 'Unknown'
+>
 
 const TIER_CONFIG: Record<AchievedTier, { label: string; className: string }> =
   {
@@ -35,7 +38,7 @@ export const DistrictTierChip: React.FC<Props> = ({ districtId, tier }) => {
   // Absence = signal: pre-Distinguished districts render nothing.
   // This keeps the row visually quiet while letting achieved districts
   // pop.
-  if (!tier || tier === 'NotDistinguished') return null
+  if (!tier || tier === 'NotDistinguished' || tier === 'Unknown') return null
   const cfg = TIER_CONFIG[tier]
   return (
     <span

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -158,7 +158,10 @@ const MetricValueTd: React.FC<{
 
 /* Per-tier display label + chip style. Pre-Distinguished districts get
    an em-dash; achieved tiers get a colored chip matching the tier. */
-type AchievedTier = Exclude<DistinguishedDistrictTier, 'NotDistinguished'>
+type AchievedTier = Exclude<
+  DistinguishedDistrictTier,
+  'NotDistinguished' | 'Unknown'
+>
 
 const TIER_DISPLAY: Record<AchievedTier, { label: string; className: string }> =
   {
@@ -183,7 +186,7 @@ const TIER_DISPLAY: Record<AchievedTier, { label: string; className: string }> =
 const TierTd: React.FC<{ tier: DistinguishedDistrictTier | null }> = ({
   tier,
 }) => {
-  if (!tier || tier === 'NotDistinguished') {
+  if (!tier || tier === 'NotDistinguished' || tier === 'Unknown') {
     return (
       <td
         data-testid="tier-cell"

--- a/frontend/src/services/cdn.ts
+++ b/frontend/src/services/cdn.ts
@@ -187,6 +187,7 @@ export interface CompetitiveAwardsByDistrict {
  * Distinguished District tier (#332)
  */
 export type DistinguishedDistrictTier =
+  | 'Unknown'
   | 'NotDistinguished'
   | 'Distinguished'
   | 'Select'

--- a/frontend/src/utils/distinguishedCountdown.ts
+++ b/frontend/src/utils/distinguishedCountdown.ts
@@ -48,7 +48,7 @@ export interface DistinguishedCountdown {
    canonical analytics values for several real districts. */
 export type DistinguishedTier = Exclude<
   DistinguishedDistrictTier,
-  'NotDistinguished'
+  'NotDistinguished' | 'Unknown'
 >
 
 interface TierThreshold {

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.test.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.test.ts
@@ -406,6 +406,123 @@ describe('DistinguishedDistrictCalculator', () => {
     })
   })
 
+  describe('Per-program-year rules (#1116 item 5)', () => {
+    describe('historical years (pre-2025-26): only DSP + Training existed', () => {
+      it('awards Distinguished when DSP+Training are Y and MA/CP/RA columns are absent', () => {
+        const ranking = buildRanking({
+          paidClubs: 101,
+          paidClubBase: 100,
+          clubGrowthPercent: 1.5,
+          paymentGrowthPercent: 1.2,
+          distinguishedPercent: 46,
+          marketAnalysisSubmitted: undefined,
+          communicationPlanSubmitted: undefined,
+          regionAdvisorVisitMet: undefined,
+        })
+
+        const result = calculator.calculate(ranking, '2017-2018')
+
+        expect(result.currentTier).toBe('Distinguished')
+        expect(result.allPrerequisitesMet).toBe(true)
+      })
+
+      it('caps at Presidents — Smedley did not exist before 2025-2026', () => {
+        const ranking = buildRanking({
+          paidClubs: 110,
+          paidClubBase: 100,
+          clubGrowthPercent: 10,
+          paymentGrowthPercent: 10,
+          distinguishedPercent: 65,
+          marketAnalysisSubmitted: undefined,
+          communicationPlanSubmitted: undefined,
+          regionAdvisorVisitMet: undefined,
+        })
+
+        expect(calculator.calculate(ranking, '2017-2018').currentTier).toBe(
+          'Presidents'
+        )
+      })
+
+      it('explicit N on a required historical prerequisite → NotDistinguished', () => {
+        const ranking = buildRanking({
+          dspSubmitted: false,
+          marketAnalysisSubmitted: undefined,
+          communicationPlanSubmitted: undefined,
+          regionAdvisorVisitMet: undefined,
+          paidClubs: 101,
+          paidClubBase: 100,
+          clubGrowthPercent: 2,
+          paymentGrowthPercent: 2,
+          distinguishedPercent: 50,
+        })
+
+        expect(calculator.calculate(ranking, '2018-2019').currentTier).toBe(
+          'NotDistinguished'
+        )
+      })
+    })
+
+    describe('Unknown (§12.5): required prerequisite unknowable, tier otherwise earned', () => {
+      it('2025-26 with a required prerequisite column absent → Unknown, not NotDistinguished', () => {
+        const ranking = buildRanking({
+          marketAnalysisSubmitted: undefined,
+          paidClubs: 101,
+          paidClubBase: 100,
+          clubGrowthPercent: 2,
+          paymentGrowthPercent: 2,
+          distinguishedPercent: 50,
+        })
+
+        expect(calculator.calculate(ranking, '2025-2026').currentTier).toBe(
+          'Unknown'
+        )
+      })
+
+      it('explicit false beats unknowable: any required prerequisite N → NotDistinguished', () => {
+        const ranking = buildRanking({
+          dspSubmitted: false,
+          marketAnalysisSubmitted: undefined,
+          paidClubs: 101,
+          paidClubBase: 100,
+          clubGrowthPercent: 2,
+          paymentGrowthPercent: 2,
+          distinguishedPercent: 50,
+        })
+
+        expect(calculator.calculate(ranking, '2025-2026').currentTier).toBe(
+          'NotDistinguished'
+        )
+      })
+
+      it('metrics below every tier → NotDistinguished even with unknowable prerequisites', () => {
+        const ranking = buildRanking({
+          marketAnalysisSubmitted: undefined,
+          distinguishedPercent: 10,
+          clubGrowthPercent: 0,
+          paymentGrowthPercent: 0,
+        })
+
+        expect(calculator.calculate(ranking, '2025-2026').currentTier).toBe(
+          'NotDistinguished'
+        )
+      })
+    })
+
+    describe('backward compatibility', () => {
+      it('no programYear argument applies current (2025-26) rules', () => {
+        const ranking = buildRanking({
+          paidClubs: 108,
+          paidClubBase: 100,
+          clubGrowthPercent: 8,
+          paymentGrowthPercent: 8,
+          distinguishedPercent: 60,
+        })
+
+        expect(calculator.calculate(ranking).currentTier).toBe('Smedley')
+      })
+    })
+  })
+
   describe('Bulk calculation', () => {
     it('should calculate tiers for multiple districts', () => {
       const rankings: DistrictRanking[] = [

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.test.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.test.ts
@@ -408,25 +408,48 @@ describe('DistinguishedDistrictCalculator', () => {
 
   describe('Per-program-year rules (#1116 item 5)', () => {
     describe('historical years (pre-2025-26): only DSP + Training existed', () => {
-      it('awards Distinguished when DSP+Training are Y and MA/CP/RA columns are absent', () => {
+      it('awards Distinguished on the era ladder when MA/CP/RA columns are absent (2018-19 D61, dashboard-verified)', () => {
+        // Real back-solved TI goals: D61 2018-19 base 190 clubs / 7,276
+        // payments → Distinguished at 193 clubs / 7,386 payments / 76
+        // distinguished (1.5%/1.5%/40% era).
         const ranking = buildRanking({
-          paidClubs: 101,
-          paidClubBase: 100,
-          clubGrowthPercent: 1.5,
-          paymentGrowthPercent: 1.2,
-          distinguishedPercent: 46,
+          paidClubBase: 190,
+          paidClubs: 193,
+          clubGrowthPercent: (3 / 190) * 100,
+          paymentBase: 7276,
+          totalPayments: 7386,
+          paymentGrowthPercent: (110 / 7276) * 100,
+          distinguishedClubs: 76,
+          distinguishedPercent: 40,
           marketAnalysisSubmitted: undefined,
           communicationPlanSubmitted: undefined,
           regionAdvisorVisitMet: undefined,
         })
 
-        const result = calculator.calculate(ranking, '2017-2018')
+        const result = calculator.calculate(ranking, '2018-2019')
 
         expect(result.currentTier).toBe('Distinguished')
         expect(result.allPrerequisitesMet).toBe(true)
       })
 
-      it('caps at Presidents — Smedley did not exist before 2025-2026', () => {
+      it('2016-17/2017-18 era requires 3% — the same +1.5% growth is NotDistinguished', () => {
+        const ranking = buildRanking({
+          paidClubBase: 190,
+          paidClubs: 193,
+          clubGrowthPercent: (3 / 190) * 100,
+          paymentGrowthPercent: 1.51,
+          distinguishedPercent: 40,
+          marketAnalysisSubmitted: undefined,
+          communicationPlanSubmitted: undefined,
+          regionAdvisorVisitMet: undefined,
+        })
+
+        expect(calculator.calculate(ranking, '2017-2018').currentTier).toBe(
+          'NotDistinguished'
+        )
+      })
+
+      it('caps at Presidents in the 3-tier 2016-17/2017-18 era — Smedley did not exist yet', () => {
         const ranking = buildRanking({
           paidClubs: 110,
           paidClubBase: 100,
@@ -440,6 +463,66 @@ describe('DistinguishedDistrictCalculator', () => {
 
         expect(calculator.calculate(ranking, '2017-2018').currentTier).toBe(
           'Presidents'
+        )
+      })
+
+      it('Smedley exists at district level from 2018-19 (8%/8%/55%)', () => {
+        const ranking = buildRanking({
+          paidClubs: 110,
+          paidClubBase: 100,
+          clubGrowthPercent: 10,
+          paymentGrowthPercent: 10,
+          distinguishedPercent: 56,
+          marketAnalysisSubmitted: undefined,
+          communicationPlanSubmitted: undefined,
+          regionAdvisorVisitMet: undefined,
+        })
+
+        expect(calculator.calculate(ranking, '2018-2019').currentTier).toBe(
+          'Smedley'
+        )
+      })
+
+      it('2022-23 asymmetric era (Rev. 12/2022): flat clubs + 1% payments + 40% earns Distinguished (D61 numbers); the same district fails 2021-22 rules', () => {
+        // Real back-solved TI goals: D61 2022-23 base 178 clubs / 5,590
+        // payments → Distinguished at no-net-loss / 5,646 / 72.
+        const ranking = buildRanking({
+          paidClubBase: 178,
+          paidClubs: 178,
+          clubGrowthPercent: 0,
+          paymentBase: 5590,
+          totalPayments: 5646,
+          paymentGrowthPercent: (56 / 5590) * 100,
+          distinguishedClubs: 72,
+          distinguishedPercent: (72 / 178) * 100,
+          marketAnalysisSubmitted: undefined,
+          communicationPlanSubmitted: undefined,
+          regionAdvisorVisitMet: undefined,
+        })
+
+        expect(calculator.calculate(ranking, '2022-2023').currentTier).toBe(
+          'Distinguished'
+        )
+        // One year earlier the same performance misses the 1.5% club floor.
+        expect(calculator.calculate(ranking, '2021-2022').currentTier).toBe(
+          'NotDistinguished'
+        )
+      })
+
+      it('2022-23 Select needs net +1 club — flat clubs with 3% payments stays Distinguished', () => {
+        const ranking = buildRanking({
+          paidClubBase: 178,
+          paidClubs: 178,
+          clubGrowthPercent: 0,
+          paymentGrowthPercent: 3.1,
+          distinguishedPercent: 46,
+          marketAnalysisSubmitted: undefined,
+          communicationPlanSubmitted: undefined,
+          regionAdvisorVisitMet: undefined,
+        })
+
+        expect(calculator.calculate(ranking, '2022-2023').currentTier).toBe(
+          'Distinguished'
         )
       })
 

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
@@ -139,6 +139,24 @@ interface TierThreshold {
  * Tier thresholds in ascending order. Order matters for tier matching:
  * we check from highest to lowest and award the first one that qualifies.
  */
+/**
+ * Per-program-year ruleset (#1116 item 5).
+ *
+ * Empirical basis: TI's all-districts CSV exports carried ONLY the `DSP`
+ * and `Training` prerequisite columns from 2017 through 2024-25; the
+ * Market Analysis / Communication Plan / Region Advisor Visit columns
+ * (and the Smedley tier) first appear in the 2025-26 program year. A
+ * year's tier can only be gated on prerequisites that existed that year.
+ *
+ * Historical tier thresholds: pending confirmation from the DRP rules
+ * research (item 1490 revisions); until a sourced per-era table lands,
+ * pre-2025-26 years use the same 1/3/5% + 45/50/55% model minus Smedley.
+ */
+interface YearRuleset {
+  requiredPrerequisites: ReadonlyArray<keyof DistinguishedDistrictPrerequisites>
+  tiers: ReadonlyArray<TierThreshold>
+}
+
 const TIER_THRESHOLDS: TierThreshold[] = [
   {
     tier: 'Smedley',
@@ -170,6 +188,34 @@ const TIER_THRESHOLDS: TierThreshold[] = [
   },
 ]
 
+const CURRENT_RULESET: YearRuleset = {
+  requiredPrerequisites: [
+    'dspSubmitted',
+    'trainingMet',
+    'marketAnalysisSubmitted',
+    'communicationPlanSubmitted',
+    'regionAdvisorVisitMet',
+  ],
+  tiers: TIER_THRESHOLDS,
+}
+
+const PRE_2025_RULESET: YearRuleset = {
+  requiredPrerequisites: ['dspSubmitted', 'trainingMet'],
+  tiers: TIER_THRESHOLDS.filter(t => t.tier !== 'Smedley'),
+}
+
+/**
+ * Resolve the ruleset for a program year ("YYYY-YYYY"). Unknown or
+ * missing input falls back to the current rules (the daily pipeline's
+ * behavior before #1116).
+ */
+function rulesetForProgramYear(programYear?: string): YearRuleset {
+  if (!programYear) return CURRENT_RULESET
+  const startYear = Number.parseInt(programYear.slice(0, 4), 10)
+  if (Number.isNaN(startYear)) return CURRENT_RULESET
+  return startYear >= 2025 ? CURRENT_RULESET : PRE_2025_RULESET
+}
+
 export class DistinguishedDistrictCalculator {
   /**
    * Calculate Distinguished District status for a single district.
@@ -181,22 +227,58 @@ export class DistinguishedDistrictCalculator {
    */
   calculate(
     ranking: DistrictRanking,
-    _programYear?: string
+    programYear?: string
   ): DistinguishedDistrictStatus {
-    const prerequisites: DistinguishedDistrictPrerequisites = {
-      dspSubmitted: ranking.dspSubmitted ?? false,
-      trainingMet: ranking.trainingMet ?? false,
-      marketAnalysisSubmitted: ranking.marketAnalysisSubmitted ?? false,
-      communicationPlanSubmitted: ranking.communicationPlanSubmitted ?? false,
-      regionAdvisorVisitMet: ranking.regionAdvisorVisitMet ?? false,
+    const ruleset = rulesetForProgramYear(programYear)
+
+    // Tri-state per prerequisite: true / false / undefined (column absent
+    // from that year's export — unknowable, NOT the same as an explicit N).
+    const raw: Record<
+      keyof DistinguishedDistrictPrerequisites,
+      boolean | undefined
+    > = {
+      dspSubmitted: ranking.dspSubmitted,
+      trainingMet: ranking.trainingMet,
+      marketAnalysisSubmitted: ranking.marketAnalysisSubmitted,
+      communicationPlanSubmitted: ranking.communicationPlanSubmitted,
+      regionAdvisorVisitMet: ranking.regionAdvisorVisitMet,
     }
-    const allPrerequisitesMet = Object.values(prerequisites).every(v => v)
+    // Display breakdown keeps the legacy 5-boolean shape (checklist UI);
+    // gating below uses the tri-state + the year's required set only.
+    const prerequisites: DistinguishedDistrictPrerequisites = {
+      dspSubmitted: raw.dspSubmitted ?? false,
+      trainingMet: raw.trainingMet ?? false,
+      marketAnalysisSubmitted: raw.marketAnalysisSubmitted ?? false,
+      communicationPlanSubmitted: raw.communicationPlanSubmitted ?? false,
+      regionAdvisorVisitMet: raw.regionAdvisorVisitMet ?? false,
+    }
 
-    const currentTier: DistinguishedDistrictTier = allPrerequisitesMet
-      ? this.determineTier(ranking)
-      : 'NotDistinguished'
+    const required = ruleset.requiredPrerequisites
+    const allPrerequisitesMet = required.every(k => raw[k] === true)
+    const anyRequiredNo = required.some(k => raw[k] === false)
 
-    const nextTierGap = this.computeNextTierGap(currentTier, ranking)
+    const earnedTier = this.determineTier(ranking, ruleset.tiers)
+    let currentTier: DistinguishedDistrictTier
+    if (earnedTier === 'NotDistinguished') {
+      // Metrics earn nothing — prerequisites are moot (§12.5 Unknown is
+      // only for "tier otherwise earned but eligibility undeterminable").
+      currentTier = 'NotDistinguished'
+    } else if (allPrerequisitesMet) {
+      currentTier = earnedTier
+    } else if (anyRequiredNo) {
+      currentTier = 'NotDistinguished'
+    } else {
+      currentTier = 'Unknown'
+    }
+
+    // Gap analysis is metric-based: for Unknown, measure from the tier the
+    // metrics earned so the UI still shows a meaningful next-tier distance.
+    const gapBasis = currentTier === 'Unknown' ? earnedTier : currentTier
+    const nextTierGap = this.computeNextTierGap(
+      gapBasis,
+      ranking,
+      ruleset.tiers
+    )
     const remaining = this.computeRemainingToMinimum(ranking)
 
     return {
@@ -227,10 +309,14 @@ export class DistinguishedDistrictCalculator {
   // ========== Private helpers ==========
 
   /**
-   * Determine the highest tier earned. Assumes prerequisites are met.
+   * Determine the highest tier earned on metrics alone (prerequisites are
+   * gated by the caller), within the given year's tier set.
    */
-  private determineTier(ranking: DistrictRanking): DistinguishedDistrictTier {
-    for (const threshold of TIER_THRESHOLDS) {
+  private determineTier(
+    ranking: DistrictRanking,
+    tiers: ReadonlyArray<TierThreshold> = TIER_THRESHOLDS
+  ): DistinguishedDistrictTier {
+    for (const threshold of tiers) {
       if (this.meetsThreshold(ranking, threshold)) {
         return threshold.tier
       }
@@ -273,12 +359,15 @@ export class DistinguishedDistrictCalculator {
    */
   private computeNextTierGap(
     currentTier: DistinguishedDistrictTier,
-    ranking: DistrictRanking
+    ranking: DistrictRanking,
+    tiers: ReadonlyArray<TierThreshold> = TIER_THRESHOLDS
   ): DistinguishedDistrictGap | null {
     const nextTier = this.getNextTier(currentTier)
     if (nextTier === null) return null
 
-    const threshold = TIER_THRESHOLDS.find(t => t.tier === nextTier)
+    // The next tier must exist in this year's tier set — pre-2025-26 the
+    // tier above Presidents is nothing, not Smedley.
+    const threshold = tiers.find(t => t.tier === nextTier)
     if (!threshold) return null
 
     const netChange = ranking.paidClubs - ranking.paidClubBase

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
@@ -28,8 +28,12 @@ import {
 /**
  * Distinguished District tier names.
  * Listed from lowest to highest. NotDistinguished means no tier earned.
+ * Unknown (#1116 item 5, rules-reference §12.5) means the metrics earn a
+ * tier but a prerequisite REQUIRED by that program year's rules is
+ * unknowable from the data (column absent) — distinct from an explicit No.
  */
 export type DistinguishedDistrictTier =
+  | 'Unknown'
   | 'NotDistinguished'
   | 'Distinguished'
   | 'Select'
@@ -169,8 +173,16 @@ const TIER_THRESHOLDS: TierThreshold[] = [
 export class DistinguishedDistrictCalculator {
   /**
    * Calculate Distinguished District status for a single district.
+   *
+   * @param ranking - the district's metrics for the snapshot date
+   * @param _programYear - the program year the snapshot belongs to
+   *   ("YYYY-YYYY"). Determines which year's ruleset applies (#1116
+   *   item 5). Omitted → current (2025-26) rules.
    */
-  calculate(ranking: DistrictRanking): DistinguishedDistrictStatus {
+  calculate(
+    ranking: DistrictRanking,
+    _programYear?: string
+  ): DistinguishedDistrictStatus {
     const prerequisites: DistinguishedDistrictPrerequisites = {
       dspSubmitted: ranking.dspSubmitted ?? false,
       trainingMet: ranking.trainingMet ?? false,
@@ -202,11 +214,12 @@ export class DistinguishedDistrictCalculator {
    * Calculate Distinguished District status for all districts, keyed by ID.
    */
   calculateAll(
-    rankings: DistrictRanking[]
+    rankings: DistrictRanking[],
+    programYear?: string
   ): Record<string, DistinguishedDistrictStatus> {
     const result: Record<string, DistinguishedDistrictStatus> = {}
     for (const ranking of rankings) {
-      result[ranking.districtId] = this.calculate(ranking)
+      result[ranking.districtId] = this.calculate(ranking, programYear)
     }
     return result
   }
@@ -301,6 +314,7 @@ export class DistinguishedDistrictCalculator {
     | 'Smedley'
     | null {
     switch (tier) {
+      case 'Unknown':
       case 'NotDistinguished':
         return 'Distinguished'
       case 'Distinguished':

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
@@ -142,15 +142,23 @@ interface TierThreshold {
 /**
  * Per-program-year ruleset (#1116 item 5).
  *
- * Empirical basis: TI's all-districts CSV exports carried ONLY the `DSP`
- * and `Training` prerequisite columns from 2017 through 2024-25; the
- * Market Analysis / Communication Plan / Region Advisor Visit columns
- * (and the Smedley tier) first appear in the 2025-26 program year. A
- * year's tier can only be gated on prerequisites that existed that year.
+ * Sourced from the 2026-06-10 DRP rules research (item 1490 revisions +
+ * archive.org, verified by back-solving TI's own frozen dashboard goal
+ * numbers for multiple districts/years — exact and discriminating). Full
+ * table + sources: docs/investigations/1116-historical-drp-rules.md.
  *
- * Historical tier thresholds: pending confirmation from the DRP rules
- * research (item 1490 revisions); until a sourced per-era table lands,
- * pre-2025-26 years use the same 1/3/5% + 45/50/55% model minus Smedley.
+ * Era structure:
+ * - 2016-17..2017-18: 3 tiers, symmetric 3/5/8% (both metrics), 40/45/50%
+ * - 2018-19..2021-22: Smedley added (Board change ~Jan 2019, applied to
+ *   the full 2018-19 PY) — symmetric 1.5/3/5/8%, 40/45/50/55%
+ * - 2022-23..2024-25: asymmetric (Rev. 12/2022) — payments 1/3/5/8%;
+ *   clubs no-net-loss / net+1 / 3% / 5%; distinguished 40/45/50/55%
+ * - 2025-26+: symmetric 1/3/5/8%, 45/50/55/60% (current; §13)
+ *
+ * Prerequisites: exactly DSP + Training (85%, Sep 30) for every year
+ * 2016-17..2024-25 (matches the only prerequisite columns in TI's
+ * pre-2025-26 all-districts CSVs); 2025-26 adds Market Analysis,
+ * Communication Plan, and 2+ Region Advisor meetings (5 gates).
  */
 interface YearRuleset {
   requiredPrerequisites: ReadonlyArray<keyof DistinguishedDistrictPrerequisites>
@@ -199,21 +207,123 @@ const CURRENT_RULESET: YearRuleset = {
   tiers: TIER_THRESHOLDS,
 }
 
-const PRE_2025_RULESET: YearRuleset = {
-  requiredPrerequisites: ['dspSubmitted', 'trainingMet'],
-  tiers: TIER_THRESHOLDS.filter(t => t.tier !== 'Smedley'),
+const HISTORICAL_PREREQUISITES: YearRuleset['requiredPrerequisites'] = [
+  'dspSubmitted',
+  'trainingMet',
+]
+
+/** 2022-23..2024-25 (Item 1490 Rev. 12/2022): asymmetric ladder. */
+const ERA_2022_RULESET: YearRuleset = {
+  requiredPrerequisites: HISTORICAL_PREREQUISITES,
+  tiers: [
+    {
+      tier: 'Smedley',
+      paymentGrowthMin: 8,
+      clubGrowthMin: 5,
+      distinguishedPercentMin: 55,
+      netGrowthRule: 'none',
+    },
+    {
+      tier: 'Presidents',
+      paymentGrowthMin: 5,
+      clubGrowthMin: 3,
+      distinguishedPercentMin: 50,
+      netGrowthRule: 'none',
+    },
+    {
+      tier: 'Select',
+      paymentGrowthMin: 3,
+      clubGrowthMin: 0,
+      distinguishedPercentMin: 45,
+      netGrowthRule: 'plus-one',
+    },
+    {
+      tier: 'Distinguished',
+      paymentGrowthMin: 1,
+      clubGrowthMin: 0,
+      distinguishedPercentMin: 40,
+      netGrowthRule: 'no-loss',
+    },
+  ],
+}
+
+/** 2018-19..2021-22: Smedley's first district-level years; symmetric. */
+const ERA_2018_RULESET: YearRuleset = {
+  requiredPrerequisites: HISTORICAL_PREREQUISITES,
+  tiers: [
+    {
+      tier: 'Smedley',
+      paymentGrowthMin: 8,
+      clubGrowthMin: 8,
+      distinguishedPercentMin: 55,
+      netGrowthRule: 'none',
+    },
+    {
+      tier: 'Presidents',
+      paymentGrowthMin: 5,
+      clubGrowthMin: 5,
+      distinguishedPercentMin: 50,
+      netGrowthRule: 'none',
+    },
+    {
+      tier: 'Select',
+      paymentGrowthMin: 3,
+      clubGrowthMin: 3,
+      distinguishedPercentMin: 45,
+      netGrowthRule: 'none',
+    },
+    {
+      tier: 'Distinguished',
+      paymentGrowthMin: 1.5,
+      clubGrowthMin: 1.5,
+      distinguishedPercentMin: 40,
+      netGrowthRule: 'none',
+    },
+  ],
+}
+
+/** 2016-17..2017-18: three tiers, no Smedley, symmetric 3/5/8%. */
+const ERA_2016_RULESET: YearRuleset = {
+  requiredPrerequisites: HISTORICAL_PREREQUISITES,
+  tiers: [
+    {
+      tier: 'Presidents',
+      paymentGrowthMin: 8,
+      clubGrowthMin: 8,
+      distinguishedPercentMin: 50,
+      netGrowthRule: 'none',
+    },
+    {
+      tier: 'Select',
+      paymentGrowthMin: 5,
+      clubGrowthMin: 5,
+      distinguishedPercentMin: 45,
+      netGrowthRule: 'none',
+    },
+    {
+      tier: 'Distinguished',
+      paymentGrowthMin: 3,
+      clubGrowthMin: 3,
+      distinguishedPercentMin: 40,
+      netGrowthRule: 'none',
+    },
+  ],
 }
 
 /**
  * Resolve the ruleset for a program year ("YYYY-YYYY"). Unknown or
  * missing input falls back to the current rules (the daily pipeline's
- * behavior before #1116).
+ * behavior before #1116). Years before 2016-17 (outside our data range)
+ * get the earliest researched era.
  */
 function rulesetForProgramYear(programYear?: string): YearRuleset {
   if (!programYear) return CURRENT_RULESET
   const startYear = Number.parseInt(programYear.slice(0, 4), 10)
   if (Number.isNaN(startYear)) return CURRENT_RULESET
-  return startYear >= 2025 ? CURRENT_RULESET : PRE_2025_RULESET
+  if (startYear >= 2025) return CURRENT_RULESET
+  if (startYear >= 2022) return ERA_2022_RULESET
+  if (startYear >= 2018) return ERA_2018_RULESET
+  return ERA_2016_RULESET
 }
 
 export class DistinguishedDistrictCalculator {

--- a/packages/analytics-core/src/rankings/LeadershipExcellenceCalculator.test.ts
+++ b/packages/analytics-core/src/rankings/LeadershipExcellenceCalculator.test.ts
@@ -151,4 +151,19 @@ describe('LeadershipExcellenceCalculator (#333)', () => {
     expect(result.allDistricts[0]?.districtId).toBe('2') // 5 years
     expect(result.allDistricts[1]?.districtId).toBe('1') // 3 years
   })
+
+  it('Unknown tier breaks a streak — unprovable years never count as Distinguished (#1116 item 5)', () => {
+    const result = calculator.calculate([
+      input({
+        yearEndTiers: [
+          tier('2022-2023', 'Distinguished'),
+          tier('2023-2024', 'Unknown'),
+          tier('2024-2025', 'Distinguished'),
+          tier('2025-2026', 'Select'),
+        ],
+      }),
+    ])
+    expect(result.qualifyingDistricts).toHaveLength(0)
+    expect(result.allDistricts[0]?.consecutiveYears).toBe(2)
+  })
 })

--- a/packages/analytics-core/src/rankings/LeadershipExcellenceCalculator.ts
+++ b/packages/analytics-core/src/rankings/LeadershipExcellenceCalculator.ts
@@ -94,7 +94,9 @@ export class LeadershipExcellenceCalculator {
 
     for (let i = sorted.length - 1; i >= 0; i--) {
       const entry = sorted[i]!
-      if (entry.tier === 'NotDistinguished') break
+      // Unknown (#1116 item 5) breaks the streak too: an unprovable year
+      // can never count toward "3+ consecutive years Distinguished".
+      if (entry.tier === 'NotDistinguished' || entry.tier === 'Unknown') break
 
       // Check for consecutive year gap
       if (i < sorted.length - 1) {

--- a/packages/analytics-core/src/rankings/OfficerAwardsCalculator.test.ts
+++ b/packages/analytics-core/src/rankings/OfficerAwardsCalculator.test.ts
@@ -155,4 +155,12 @@ describe('OfficerAwardsCalculator (#333)', () => {
       expect(result.clubGrowth[0]?.qualifies).toBe(false)
     })
   })
+
+  it('Unknown tier does not qualify for Education & Training (#1116 item 5)', () => {
+    const result = calculator.calculate(
+      [buildRanking({ districtId: '1', trainingMet: true })],
+      { '1': buildStatus({ currentTier: 'Unknown' }) }
+    )
+    expect(result.educationTraining[0]?.qualifies).toBe(false)
+  })
 })

--- a/packages/analytics-core/src/rankings/OfficerAwardsCalculator.ts
+++ b/packages/analytics-core/src/rankings/OfficerAwardsCalculator.ts
@@ -37,7 +37,9 @@ export class OfficerAwardsCalculator {
       const status = statuses[r.districtId]
       const trainingMet = r.trainingMet ?? false
       const isDistinguished =
-        status !== undefined && status.currentTier !== 'NotDistinguished'
+        status !== undefined &&
+        status.currentTier !== 'NotDistinguished' &&
+        status.currentTier !== 'Unknown'
 
       return {
         districtId: r.districtId,

--- a/packages/collector-cli/src/__tests__/TransformService.rankings.test.ts
+++ b/packages/collector-cli/src/__tests__/TransformService.rankings.test.ts
@@ -646,12 +646,15 @@ U,Undistricted,50,45,11.11%,500,450,11.11%,50,5,2,1`
         (r: { districtId: string }) => r.districtId === '42'
       )
 
-      // Legacy CSVs should default to false (unknown = not met)
-      expect(d42.dspSubmitted).toBe(false)
-      expect(d42.trainingMet).toBe(false)
-      expect(d42.marketAnalysisSubmitted).toBe(false)
-      expect(d42.communicationPlanSubmitted).toBe(false)
-      expect(d42.regionAdvisorVisitMet).toBe(false)
+      // #1116 item 5 (rules-reference §12.5): an absent prerequisite
+      // column is UNKNOWABLE, not an explicit No. The old behavior
+      // (default false → NotDistinguished) silently mis-scored every
+      // pre-2025-26 year. Absent columns serialize as absent fields.
+      expect(d42.dspSubmitted).toBeUndefined()
+      expect(d42.trainingMet).toBeUndefined()
+      expect(d42.marketAnalysisSubmitted).toBeUndefined()
+      expect(d42.communicationPlanSubmitted).toBeUndefined()
+      expect(d42.regionAdvisorVisitMet).toBeUndefined()
       expect(d42.smedleyDistinguished).toBe(0)
     })
   })

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -89,12 +89,14 @@ interface RankingMetrics {
   presidentsDistinguished: number
   // Smedley Distinguished tier (#329)
   smedleyDistinguished: number
-  // District Recognition Program prerequisites (#329)
-  dspSubmitted: boolean
-  trainingMet: boolean
-  marketAnalysisSubmitted: boolean
-  communicationPlanSubmitted: boolean
-  regionAdvisorVisitMet: boolean
+  // District Recognition Program prerequisites (#329). Tri-state since
+  // #1116 item 5: undefined = column absent from that year's export
+  // (pre-2025-26 carries only DSP + Training) — unknowable, not an N.
+  dspSubmitted: boolean | undefined
+  trainingMet: boolean | undefined
+  marketAnalysisSubmitted: boolean | undefined
+  communicationPlanSubmitted: boolean | undefined
+  regionAdvisorVisitMet: boolean | undefined
   // Clubs with 20+ paid members for President's 20-Plus Award (#330)
   clubsWith20PlusMembers: number
   // Paid clubs chartered in the current program year (#336) — used to compute
@@ -851,7 +853,11 @@ export class TransformService {
    * Defaults to false when the column is missing (legacy CSVs) or contains
    * any value other than "Y" (case-insensitive).
    */
-  private parseYesNo(value: string | undefined): boolean {
+  private parseYesNo(value: string | undefined): boolean | undefined {
+    // Absent column → undefined (unknowable; pre-2025-26 exports lack the
+    // Market Analysis / Communication Plan / Region Advisor columns —
+    // #1116 item 5). Present-but-empty → false (an explicit non-Y).
+    if (value === undefined) return undefined
     if (!value) return false
     return value.trim().toUpperCase() === 'Y'
   }
@@ -1789,9 +1795,12 @@ export class TransformService {
     const standings = competitiveCalculator.calculate(rankings.rankings)
 
     // ── Distinguished District tier status (#332) ──
+    // Per-program-year rules (#1116 item 5): historical years gate on the
+    // prerequisites that existed that year and exclude Smedley pre-2025-26.
     const distinguishedCalculator = new DistinguishedDistrictCalculator()
     const distinguishedDistrict = distinguishedCalculator.calculateAll(
-      rankings.rankings
+      rankings.rankings,
+      calculateProgramYear(snapshotDate)
     )
 
     // ── Load/create awards history store (#333) ──


### PR DESCRIPTION
Item 5 of #1116 — required before the #1147 rerun (historical years are scored during rebuild).

- Per-year ruleset in DistinguishedDistrictCalculator: pre-2025-26 gates on **DSP + Training only** (the only prerequisite columns in TI exports 2017→2024-25, verified empirically) and excludes Smedley; 2025-26+ unchanged.
- **Unknown** tier (rules-reference §12.5): metrics earn a tier but a required prerequisite is unknowable (column absent) → Unknown, never a silent NotDistinguished. Explicit N still NotDistinguished.
- `parseYesNo` tri-state (absent → undefined); TransformService threads the snapshot's program year.
- Unknown breaks the Leadership Excellence streak, does not qualify Education & Training, and renders as no-chip/em-dash in earned-tier UI.
- TDD: 5 RED tests first (055058f), GREEN in this PR. analytics-core 864/864, collector-cli 910/910, frontend unit 2711/2711.

**Note:** historical tier thresholds currently mirror the modern 1/3/5% + 45/50/55 model minus Smedley, marked in-code as pending the sourced per-era DRP research (running); will fold in before merge if it differs.

Ref #1116, #1147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)