### PR TITLE
fix(pipeline): cap promotion-held alert body under GitHub's 64KB issue limit (#1168)

### DIFF
--- a/scripts/lib/__tests__/promotionAlert.test.ts
+++ b/scripts/lib/__tests__/promotionAlert.test.ts
@@ -193,4 +193,31 @@ describe('buildPromotionHeldBody', () => {
     expect(body).toMatch(/count gate/i)
     expect(body).toMatch(/value gate/i)
   })
+
+  it('caps oversized bodies under the GitHub 64KB issue limit with a truncation notice (#1168)', () => {
+    // A full-range re-derive: hundreds of reasons, every district affected —
+    // the raw body would exceed 65,536 chars and crash gh issue create.
+    const r = evaluatePromotion({
+      countPromote: true,
+      valuePromote: false,
+      valueDiff: {
+        ...CHANGED_DIFF,
+        changedDates: Array.from({ length: 160 }, (_, i) => ({
+          date: `2024-01-${String((i % 28) + 1).padStart(2, '0')}`,
+          districtsChanged: 120,
+        })),
+        reasons: Array.from(
+          { length: 2000 },
+          (_, i) =>
+            `2024-01-01 district ${i}: totalPayments 11111111 -> 22222222, paidClubs 333 -> 444 (digest mismatch on overlap date)`
+        ),
+        affectedDistricts: Array.from({ length: 130 }, (_, i) => String(i + 1)),
+      },
+    })
+    const body = buildPromotionHeldBody(r, OPTS)
+    expect(body.length).toBeLessThanOrEqual(60000)
+    expect(body).toMatch(/truncated/i)
+    // The operational core must survive truncation:
+    expect(body).toMatch(/allow_value_changes=true/)
+  })
 })

--- a/scripts/lib/promotionAlert.ts
+++ b/scripts/lib/promotionAlert.ts
@@ -156,6 +156,11 @@ export function buildPromotionHeldTitle(result: PromotionAlertResult): string {
  * before clearing). When both refused, the regression is the more serious
  * signal and leads.
  */
+/** GitHub rejects issue bodies over 65,536 chars; stay well under (#1168). */
+const MAX_BODY_CHARS = 60_000
+/** Reasons shown inline; the run's Step Summary always has the full list. */
+const MAX_REASONS = 40
+
 export function buildPromotionHeldBody(
   result: PromotionAlertResult,
   opts: PromotionAlertBodyOptions
@@ -200,7 +205,15 @@ export function buildPromotionHeldBody(
     }
     if (result.reasons.length > 0) {
       lines.push('**Value-gate reasons:**', '')
-      for (const r of result.reasons) lines.push(`- ${r}`)
+      // Bounded: a full-range re-derive emits thousands of reasons and the
+      // raw body blows GitHub's 65,536-char issue limit (#1168). The full
+      // list always lives in the run's Step Summary.
+      for (const r of result.reasons.slice(0, MAX_REASONS)) lines.push(`- ${r}`)
+      if (result.reasons.length > MAX_REASONS) {
+        lines.push(
+          `- _…and ${result.reasons.length - MAX_REASONS} more — truncated; full value-diff in the run's Step Summary._`
+        )
+      }
       lines.push('')
     }
     lines.push(
@@ -227,5 +240,19 @@ export function buildPromotionHeldBody(
     '_This issue auto-closes when a later run successfully promotes. Filed by `.github/workflows/data-pipeline.yml` (#1073)._'
   )
 
-  return lines.join('\n')
+  const body = lines.join('\n')
+  if (body.length <= MAX_BODY_CHARS) return body
+  // Hard guard (#1168): never hand `gh issue create` a body GitHub rejects.
+  // Keep the head, then re-state the operational essentials the cut may
+  // have removed (clear path + footer).
+  const tail = [
+    '',
+    "⚠️ _Body truncated to fit GitHub's 64KB issue limit — full detail in the run's Step Summary._",
+    '',
+    '**Clear path** (value gate only, after review): `gh workflow run data-pipeline.yml -f mode=daily -f allow_value_changes=true`',
+    '',
+    '---',
+    '_This issue auto-closes when a later run successfully promotes. Filed by `.github/workflows/data-pipeline.yml` (#1073)._',
+  ].join('\n')
+  return body.slice(0, MAX_BODY_CHARS - tail.length) + tail
 }


### PR DESCRIPTION
The #1147 pilot (run 27322393300) held promotion correctly, but the alerter built a 238KB body and `gh issue create` crashed (`Body is too long, maximum is 65536`), failing the run's tail. Reasons now bounded to 40 inline (+ '…and N more — full value-diff in the run's Step Summary') with a hard 60K truncation guard that re-states the clear-path command. TDD: RED with a 160-date × 2000-reason fixture, GREEN 15/15.

Must merge before the #1147 full-range rebuild (its alert body would be larger). Ref #1168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)