### PR TITLE
docs(lessons): back-solve published goal numbers as the oracle for historical rules (#1116)

### DIFF
--- a/tasks/lessons/160-the-systems-own-published-goal-numbers-are-an-oracle-for-recovering-historical-rules.md
+++ b/tasks/lessons/160-the-systems-own-published-goal-numbers-are-an-oracle-for-recovering-historical-rules.md
@@ -1,0 +1,43 @@
+---
+id: '160'
+category: lesson
+tags: [research, analytics, verification, data-pipeline]
+auto_load: true
+date: 2026-06-11
+issues: [1116, 1147]
+---
+
+# Lesson 160 — The system's own published per-entity goal numbers are an oracle for recovering historical business rules; back-solve before trusting documents
+
+**Date:** 2026-06-11
+**Issue:** #1116 item 5 (via the #1147 rerun window)
+**PR:** #1166
+
+## What happened
+
+Re-deriving nine years of district snapshots required the Distinguished
+District rules _as they stood each year_ — but TI's old rule documents are
+scattered across archive.org, undated revisions, and stale landing-page
+labels. Document research alone mis-assigned 2022-23 to the symmetric
+1.5% ladder because the landing page said "updated 1/2022". What settled
+it: TI's frozen dashboards still publish each district's per-tier **goal
+numbers** (e.g. D61 2022-23 club goals 178/179/184/187). Back-solving
+those against candidate rulesets is exact and discriminating — 179 = base+1
+proves "net plus one club", where a 1.5% rule would print 181. Two
+independent districts per year made the identification unambiguous and
+exposed the document-based error.
+
+## The takeaway
+
+When recovering historical business rules, prefer an oracle the system
+itself published per entity (goals, targets, thresholds rendered into old
+artifacts) over document archaeology: candidate rulesets either reproduce
+those numbers exactly or they don't. Documents date the _announcement_;
+published numbers date the _application_.
+
+## How to apply
+
+Before encoding a recovered historical rule, find any surviving artifact
+where the old system applied it (frozen dashboards, archived exports,
+cached reports) and require exact reproduction across ≥2 independent
+entities. A candidate that needs rounding excuses is the wrong candidate.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -152,3 +152,4 @@
 - **158** [cls, css, frontend, responsive, mobile, verification, playwright] — Reserve a data-dependent slot with a structural skeleton (pinned widths, inherited heights), not a measured total height (#922, #1100)
 - **158** [data-pipeline, verification, scraping, collector-cli, process] — When reconstructing an upstream system's calendar, the upstream's own UI affordances are the authority; calibrate the probe on knowns and expect it to falsify your derived records (#1128, #1098)
 - **159** [verification, playwright, cdn, data-pipeline, automation, frontend] — Live-verify a pipeline-gated CDN artifact by injecting the REAL locally-built artifact via route interception (and drive the missing-artifact path un-injected) (#1135, #1101)
+- **160** [research, analytics, verification, data-pipeline] — The system's own published per-entity goal numbers are an oracle for recovering historical business rules; back-solve before trusting documents (#1116, #1147)


### PR DESCRIPTION
Lesson 160 from the #1147 window: dashboard back-solving identified the true 2022-23 DRP ruleset where document research mis-dated it. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)