### PR TITLE
fix(pipeline): prune joins the 240-min timeout branch (#1175 mitigation)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -96,7 +96,7 @@ jobs:
     name: '${{ inputs.mode || ''daily'' }} pipeline'
     runs-on: ubuntu-latest
     # Rebuild needs more time (110+ dates × ~1 min each + GCS sync)
-    timeout-minutes: ${{ (inputs.mode == 'rebuild' || inputs.mode == 'rescrape' || inputs.mode == 'rescrape-historical') && 240 || 30 }}
+    timeout-minutes: ${{ (inputs.mode == 'rebuild' || inputs.mode == 'rescrape' || inputs.mode == 'rescrape-historical' || inputs.mode == 'prune') && 240 || 30 }}
 
     steps:
       # ── Setup ────────────────────────────────────────────────


### PR DESCRIPTION
Run 27391582336 (the #1148 evidence dry-run) was cancelled at exactly 30:00 mid-sync — the full-content prune sync outgrew the 30-min class when #1147 grew staging to ~190 raw-csv dirs / 172 snapshot dates. One-line mitigation; #1175 tracks the proper narrow sync. Ref #1175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)