### PR TITLE
Sprint 4 (#1102) — prune syncs listings + metadata.json only; timeout back to 30 min (#1175)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -96,7 +96,7 @@ jobs:
     name: '${{ inputs.mode || ''daily'' }} pipeline'
     runs-on: ubuntu-latest
     # Rebuild needs more time (110+ dates × ~1 min each + GCS sync)
-    timeout-minutes: ${{ (inputs.mode == 'rebuild' || inputs.mode == 'rescrape' || inputs.mode == 'rescrape-historical' || inputs.mode == 'prune') && 240 || 30 }}
+    timeout-minutes: ${{ (inputs.mode == 'rebuild' || inputs.mode == 'rescrape' || inputs.mode == 'rescrape-historical') && 240 || 30 }}
 
     steps:
       # ── Setup ────────────────────────────────────────────────
@@ -994,18 +994,43 @@ jobs:
       # PRUNE MODE
       # ════════════════════════════════════════════════════════
 
-      # ── Prune Step 1: Sync all data from GCS ──
-      - name: '[prune] Sync all data from GCS'
+      # ── Prune Step 1: Skeleton sync from GCS (#1175) ──
+      # Classification needs only the raw-csv date-dir SET plus each date's
+      # metadata.json; the previous full-content rsync outgrew the runner's
+      # disk after #1147 (run 27393189818: No space left on device). The
+      # skeleton sync materializes EVERY date dir from the listing first —
+      # a metadata-less dir must stay VISIBLE for the #1131 protection —
+      # then overlays metadata.json files only.
+      - name: '[prune] Skeleton sync from GCS (listings + metadata.json)'
         if: steps.mode.outputs.mode == 'prune'
         run: |
-          echo "Syncing all data from GCS for pruning..."
+          echo "Skeleton sync from GCS for pruning (listings + metadata.json only)..."
           mkdir -p ./cache/raw-csv ./cache/snapshots
-          gsutil -m rsync -r "gs://${GCS_BUCKET}/raw-csv/" "./cache/raw-csv/"
-          gsutil -m rsync -r "gs://${GCS_BUCKET}/snapshots/" "./cache/snapshots/"
 
-          echo "## ⏬ Sync for Prune" >> "$GITHUB_STEP_SUMMARY"
+          gsutil ls "gs://${GCS_BUCKET}/raw-csv/" > /tmp/prune-raw-listing.txt
+          gsutil ls "gs://${GCS_BUCKET}/snapshots/" > /tmp/prune-snapshot-listing.txt
+
+          # Materialize ALL date dirs (fails closed on a zero-date raw-csv
+          # listing — classifying an empty cache would silently prune nothing)
+          npx tsx scripts/prune-skeleton-sync.ts \
+            --raw-listing /tmp/prune-raw-listing.txt \
+            --snapshot-listing /tmp/prune-snapshot-listing.txt \
+            --cache-dir ./cache
+
+          # Overlay metadata.json files only (exclude regex is single-sourced
+          # from the tested scripts/lib constant; rsync never downloads CSVs)
+          EXCLUDE_REGEX=$(npx tsx scripts/prune-skeleton-sync.ts --print-exclude-regex)
+          gsutil -m rsync -r -x "${EXCLUDE_REGEX}" \
+            "gs://${GCS_BUCKET}/raw-csv/" "./cache/raw-csv/"
+
+          echo "## ⏬ Skeleton Sync for Prune (#1175)" >> "$GITHUB_STEP_SUMMARY"
           DATE_COUNT=$(find ./cache/raw-csv -maxdepth 1 -type d -name '????-??-??' | wc -l | tr -d ' ')
+          META_COUNT=$(find ./cache/raw-csv -mindepth 2 -maxdepth 2 -name 'metadata.json' | wc -l | tr -d ' ')
+          CACHE_SIZE=$(du -sh ./cache | cut -f1)
           echo "- **Raw-csv dates**: ${DATE_COUNT}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **metadata.json overlaid**: ${META_COUNT}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Metadata-less (protected #1131)**: $((DATE_COUNT - META_COUNT))" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Local cache size**: ${CACHE_SIZE} (<1 GB acceptance bound, #1175)" >> "$GITHUB_STEP_SUMMARY"
 
       # ── Prune Step 2: Run collector-cli prune ──
       - name: '[prune] Identify and remove non-month-end dates'

--- a/packages/collector-cli/src/__tests__/PruneService.test.ts
+++ b/packages/collector-cli/src/__tests__/PruneService.test.ts
@@ -526,6 +526,111 @@ describe('PruneService', () => {
       expect(rawCsvEntries).not.toContain('2026-01-15')
     })
   })
+
+  describe('skeleton-shape cache contract (#1175)', () => {
+    // The prune sync no longer downloads CSV payloads or snapshot contents
+    // (post-#1147 the full bucket exceeds the runner's disk). The skeleton
+    // sync materializes every raw-csv date dir from the `gsutil ls` listing
+    // and overlays ONLY metadata.json. This contract pins that
+    // classification depends on nothing the skeleton omits — and that a
+    // metadata-less dir (locally an EMPTY dir under the new shape, since
+    // there is no metadata.json to overlay) stays VISIBLE and protected,
+    // not invisible (#1131 constraint).
+    const registryMonths: ClosingDateEntry[] = [
+      { dataMonth: '2025-12', closingDate: '2026-01-08' },
+      { dataMonth: '2026-01', closingDate: '2026-02-05' },
+    ]
+
+    /** Same logical bucket state in both shapes. */
+    async function populate(
+      dir: string,
+      shape: 'full' | 'skeleton'
+    ): Promise<void> {
+      const writeDate = async (
+        date: string,
+        metadata: { isClosingPeriod?: boolean; dataMonth?: string } | null
+      ) => {
+        const dateDir = path.join(dir, 'raw-csv', date)
+        await fs.mkdir(dateDir, { recursive: true })
+        if (metadata !== null) {
+          await fs.writeFile(
+            path.join(dateDir, 'metadata.json'),
+            JSON.stringify({ date, ...metadata })
+          )
+        }
+        if (shape === 'full') {
+          await fs.writeFile(path.join(dateDir, 'all-districts.csv'), 'dummy')
+          await fs.writeFile(path.join(dateDir, 'district_61.csv'), 'dummy')
+        }
+      }
+
+      // Month-end keeper, mid-month non-keeper, closing-period remap,
+      // and the live #1131 case: a metadata-less date dir.
+      await writeDate('2026-01-31', { isClosingPeriod: false })
+      await writeDate('2026-03-15', { isClosingPeriod: false })
+      await writeDate('2026-02-03', {
+        isClosingPeriod: true,
+        dataMonth: '2026-01',
+      })
+      await writeDate('2026-02-13', null)
+
+      const snapshotDir = path.join(dir, 'snapshots', '2026-01-31')
+      await fs.mkdir(snapshotDir, { recursive: true })
+      if (shape === 'full') {
+        await fs.writeFile(path.join(snapshotDir, 'district_61.json'), '{}')
+      }
+    }
+
+    it('classifies a skeleton-shape cache identically to a full-shape cache, including the metadata-less protection', async () => {
+      const fullDir = path.join(testDir, 'full')
+      const skeletonDir = path.join(testDir, 'skeleton')
+      await populate(fullDir, 'full')
+      await populate(skeletonDir, 'skeleton')
+
+      const classify = (cacheDir: string) =>
+        new PruneService({
+          cacheDir,
+          closingDateRegistry: registryMonths,
+        }).classifyAll()
+
+      const full = await classify(fullDir)
+      const skeleton = await classify(skeletonDir)
+
+      expect(skeleton).toEqual(full)
+
+      // Spot-pin the decisions themselves so the equivalence can't be
+      // vacuously satisfied by two empty/broken caches.
+      expect(skeleton).toHaveLength(4)
+      const byDate = new Map(skeleton.map(c => [c.rawCsvDate, c]))
+      expect(byDate.get('2026-01-31')?.keep).toBe(true)
+      expect(byDate.get('2026-03-15')?.keep).toBe(false)
+      expect(byDate.get('2026-02-03')?.snapshotDate).toBe('2026-01-31')
+      expect(byDate.get('2026-02-13')?.keep).toBe(true)
+      expect(byDate.get('2026-02-13')?.reason).toContain('Protected')
+    })
+
+    it('dry-run prune on a skeleton cache reports the same counts as on a full cache', async () => {
+      const fullDir = path.join(testDir, 'full')
+      const skeletonDir = path.join(testDir, 'skeleton')
+      await populate(fullDir, 'full')
+      await populate(skeletonDir, 'skeleton')
+
+      const run = (cacheDir: string) =>
+        new PruneService({
+          cacheDir,
+          closingDateRegistry: registryMonths,
+          today: '2026-06-12',
+        }).prune(true)
+
+      const full = await run(fullDir)
+      const skeleton = await run(skeletonDir)
+
+      expect(skeleton.totalDates).toBe(full.totalDates)
+      expect(skeleton.keptDates).toBe(full.keptDates)
+      expect(skeleton.prunedDates).toBe(full.prunedDates)
+      expect(skeleton.classifications).toEqual(full.classifications)
+    })
+  })
 })
 
 describe('isPenultimateDayOfMonth', () => {

--- a/scripts/lib/__tests__/pruneSkeletonSync.test.ts
+++ b/scripts/lib/__tests__/pruneSkeletonSync.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for scripts/lib/pruneSkeletonSync.ts (#1175)
+ *
+ * The prune sync previously downloaded every raw-csv and snapshot byte;
+ * post-#1147 that no longer fits a GitHub runner's disk. Classification
+ * needs only the date-dir SET plus each date's metadata.json, so the sync
+ * becomes: materialize ALL date dirs from `gsutil ls` (a metadata-less dir
+ * must stay VISIBLE — the #1131 protection depends on prune seeing it),
+ * then overlay metadata.json files via `gsutil rsync -x <exclude>`.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  datesFromGcsListing,
+  planSkeletonDirs,
+  RAW_CSV_METADATA_ONLY_EXCLUDE,
+} from '../pruneSkeletonSync'
+
+describe('datesFromGcsListing', () => {
+  it('extracts date-dir names from a gsutil ls prefix listing', () => {
+    const lines = [
+      'gs://toast-stats-data-staging/raw-csv/2026-02-13/',
+      'gs://toast-stats-data-staging/raw-csv/2026-01-31/',
+      'gs://toast-stats-data-staging/raw-csv/2025-12-31/',
+    ]
+    expect(datesFromGcsListing(lines)).toEqual([
+      '2025-12-31',
+      '2026-01-31',
+      '2026-02-13',
+    ])
+  })
+
+  it('ignores non-date prefixes, bare files at the root, and blank lines', () => {
+    const lines = [
+      'gs://bucket/raw-csv/2026-02-13/',
+      'gs://bucket/raw-csv/index.json',
+      'gs://bucket/raw-csv/temp-debug/',
+      'gs://bucket/raw-csv/2026-2-3/',
+      '',
+      '  ',
+    ]
+    expect(datesFromGcsListing(lines)).toEqual(['2026-02-13'])
+  })
+
+  it('dedupes repeated prefixes', () => {
+    const lines = [
+      'gs://bucket/snapshots/2026-01-31/',
+      'gs://bucket/snapshots/2026-01-31/',
+    ]
+    expect(datesFromGcsListing(lines)).toEqual(['2026-01-31'])
+  })
+
+  it('returns [] for an empty listing', () => {
+    expect(datesFromGcsListing([])).toEqual([])
+  })
+})
+
+describe('planSkeletonDirs', () => {
+  const raw = ['gs://b/raw-csv/2026-02-13/', 'gs://b/raw-csv/2026-01-31/']
+  const snap = ['gs://b/snapshots/2026-01-31/']
+
+  it('plans dirs for every raw-csv and snapshot date in the listings', () => {
+    const plan = planSkeletonDirs(raw, snap)
+    expect(plan.rawCsvDates).toEqual(['2026-01-31', '2026-02-13'])
+    expect(plan.snapshotDates).toEqual(['2026-01-31'])
+  })
+
+  it('fails closed on a zero-date raw-csv listing — an empty ls on a populated bucket means the listing failed, and proceeding would silently classify nothing', () => {
+    expect(() => planSkeletonDirs([], snap)).toThrow(/raw-csv listing/)
+    expect(() => planSkeletonDirs(['gs://b/raw-csv/junk.txt'], snap)).toThrow(
+      /raw-csv listing/
+    )
+  })
+
+  it('tolerates an empty snapshots listing — snapshots are not a classification input', () => {
+    const plan = planSkeletonDirs(raw, [])
+    expect(plan.snapshotDates).toEqual([])
+  })
+})
+
+describe('RAW_CSV_METADATA_ONLY_EXCLUDE', () => {
+  // gsutil rsync -x matches a Python regex against paths RELATIVE to the
+  // source URL, and an exclude that matches a directory path prunes the
+  // whole directory from traversal. The pattern must therefore NOT match
+  // the bare date-dir path, or the metadata.json inside is never compared.
+  const re = new RegExp(RAW_CSV_METADATA_ONLY_EXCLUDE)
+  const excluded = (p: string) => re.test(p)
+
+  it('keeps bare date-dir paths (traversal must descend into them)', () => {
+    expect(excluded('2026-02-13')).toBe(false)
+  })
+
+  it('keeps <date>/metadata.json', () => {
+    expect(excluded('2026-02-13/metadata.json')).toBe(false)
+  })
+
+  it('excludes CSV payloads under a date dir', () => {
+    expect(excluded('2026-02-13/district_61.csv')).toBe(true)
+    expect(excluded('2026-02-13/all-districts.csv')).toBe(true)
+  })
+
+  it('excludes nested metadata.json deeper than one level', () => {
+    expect(excluded('2026-02-13/sub/metadata.json')).toBe(true)
+  })
+
+  it('excludes metadata.json outside a date dir and root-level files', () => {
+    expect(excluded('metadata.json')).toBe(true)
+    expect(excluded('not-a-date/metadata.json')).toBe(true)
+    expect(excluded('index.json')).toBe(true)
+  })
+
+  it('is a Python-compatible regex: uses no JS-only constructs', () => {
+    // Lookahead is the only extension used; it parses identically in
+    // Python `re`. Constructing the RegExp above already proves JS-side
+    // validity; this pins that the pattern stays anchored end-to-end.
+    expect(RAW_CSV_METADATA_ONLY_EXCLUDE.startsWith('^')).toBe(true)
+  })
+})

--- a/scripts/lib/__tests__/pruneSkeletonSync.test.ts
+++ b/scripts/lib/__tests__/pruneSkeletonSync.test.ts
@@ -11,53 +11,20 @@
 
 import { describe, it, expect } from 'vitest'
 import {
-  datesFromGcsListing,
   planSkeletonDirs,
   RAW_CSV_METADATA_ONLY_EXCLUDE,
 } from '../pruneSkeletonSync'
 
-describe('datesFromGcsListing', () => {
-  it('extracts date-dir names from a gsutil ls prefix listing', () => {
-    const lines = [
-      'gs://toast-stats-data-staging/raw-csv/2026-02-13/',
-      'gs://toast-stats-data-staging/raw-csv/2026-01-31/',
-      'gs://toast-stats-data-staging/raw-csv/2025-12-31/',
-    ]
-    expect(datesFromGcsListing(lines)).toEqual([
-      '2025-12-31',
-      '2026-01-31',
-      '2026-02-13',
-    ])
-  })
-
-  it('ignores non-date prefixes, bare files at the root, and blank lines', () => {
-    const lines = [
-      'gs://bucket/raw-csv/2026-02-13/',
-      'gs://bucket/raw-csv/index.json',
-      'gs://bucket/raw-csv/temp-debug/',
-      'gs://bucket/raw-csv/2026-2-3/',
-      '',
-      '  ',
-    ]
-    expect(datesFromGcsListing(lines)).toEqual(['2026-02-13'])
-  })
-
-  it('dedupes repeated prefixes', () => {
-    const lines = [
-      'gs://bucket/snapshots/2026-01-31/',
-      'gs://bucket/snapshots/2026-01-31/',
-    ]
-    expect(datesFromGcsListing(lines)).toEqual(['2026-01-31'])
-  })
-
-  it('returns [] for an empty listing', () => {
-    expect(datesFromGcsListing([])).toEqual([])
-  })
-})
-
+// Listing parsing is shared with the prod-reconcile plan:
+// parseGcsDatedDirListing (pruneProdReconcile.ts) owns — and its tests pin —
+// the non-date/dedupe/blank-line edge cases.
 describe('planSkeletonDirs', () => {
-  const raw = ['gs://b/raw-csv/2026-02-13/', 'gs://b/raw-csv/2026-01-31/']
-  const snap = ['gs://b/snapshots/2026-01-31/']
+  const raw = [
+    'gs://b/raw-csv/2026-02-13/',
+    'gs://b/raw-csv/2026-01-31/',
+    'gs://b/raw-csv/index.json',
+  ].join('\n')
+  const snap = 'gs://b/snapshots/2026-01-31/'
 
   it('plans dirs for every raw-csv and snapshot date in the listings', () => {
     const plan = planSkeletonDirs(raw, snap)
@@ -66,14 +33,14 @@ describe('planSkeletonDirs', () => {
   })
 
   it('fails closed on a zero-date raw-csv listing — an empty ls on a populated bucket means the listing failed, and proceeding would silently classify nothing', () => {
-    expect(() => planSkeletonDirs([], snap)).toThrow(/raw-csv listing/)
-    expect(() => planSkeletonDirs(['gs://b/raw-csv/junk.txt'], snap)).toThrow(
+    expect(() => planSkeletonDirs('', snap)).toThrow(/raw-csv listing/)
+    expect(() => planSkeletonDirs('gs://b/raw-csv/junk.txt', snap)).toThrow(
       /raw-csv listing/
     )
   })
 
   it('tolerates an empty snapshots listing — snapshots are not a classification input', () => {
-    const plan = planSkeletonDirs(raw, [])
+    const plan = planSkeletonDirs(raw, '')
     expect(plan.snapshotDates).toEqual([])
   })
 })

--- a/scripts/lib/pruneSkeletonSync.ts
+++ b/scripts/lib/pruneSkeletonSync.ts
@@ -1,0 +1,84 @@
+/**
+ * Prune Skeleton Sync — Pure Functions (#1175)
+ *
+ * The prune workflow previously full-content-rsynced raw-csv/ AND
+ * snapshots/ before classifying; post-#1147 the bucket no longer fits a
+ * GitHub runner's disk (run 27393189818 died: No space left on device).
+ * Classification (PruneService) reads only the raw-csv date-dir SET and
+ * each date's metadata.json — so the sync becomes a skeleton:
+ *
+ *   1. `gsutil ls` the raw-csv/ and snapshots/ prefixes
+ *   2. materialize ALL date dirs locally (a metadata-less dir must stay
+ *      VISIBLE — the #1131 fail-closed protection works by SEEING a
+ *      raw-csv date dir without metadata.json; a metadata-only sync that
+ *      skipped those dirs would make protected dates invisible instead
+ *      of protected)
+ *   3. overlay metadata.json files via `gsutil -m rsync -r -x <exclude>`
+ *
+ * No GCS I/O lives here; scripts/prune-skeleton-sync.ts is the runner
+ * glue and the workflow supplies the listings.
+ */
+
+/** Matches one `gsutil ls` prefix line, capturing a date-dir name. */
+const DATE_PREFIX = /\/(\d{4}-\d{2}-\d{2})\/\s*$/
+
+/**
+ * Extract the date-dir names from a `gsutil ls gs://bucket/<layer>/`
+ * listing. Non-date prefixes, bare files at the layer root, blank lines
+ * and duplicates are ignored. Sorted ascending.
+ */
+export function datesFromGcsListing(lines: string[]): string[] {
+  const dates = new Set<string>()
+  for (const line of lines) {
+    const match = DATE_PREFIX.exec(line.trim())
+    if (match?.[1]) dates.add(match[1])
+  }
+  return [...dates].sort()
+}
+
+/** Date-dir sets the skeleton sync must materialize locally. */
+export interface SkeletonDirPlan {
+  rawCsvDates: string[]
+  snapshotDates: string[]
+}
+
+/**
+ * Plan the local skeleton from the two `gsutil ls` listings.
+ *
+ * Fails closed when the raw-csv listing parses to zero date dirs: the
+ * staging bucket is never legitimately empty, so an empty listing means
+ * the `gsutil ls` itself failed (wrong bucket, auth, transient error) —
+ * and proceeding would classify nothing while reporting success.
+ * An empty snapshots listing is tolerated: snapshots are not a
+ * classification input (PruneService reads only raw-csv).
+ */
+export function planSkeletonDirs(
+  rawCsvListing: string[],
+  snapshotListing: string[]
+): SkeletonDirPlan {
+  const rawCsvDates = datesFromGcsListing(rawCsvListing)
+  if (rawCsvDates.length === 0) {
+    throw new Error(
+      'prune skeleton sync (#1175): raw-csv listing parsed to zero date dirs — ' +
+        'refusing to proceed; an empty listing on a populated bucket means the ' +
+        '`gsutil ls` failed, and classifying an empty cache would silently prune nothing'
+    )
+  }
+  return {
+    rawCsvDates,
+    snapshotDates: datesFromGcsListing(snapshotListing),
+  }
+}
+
+/**
+ * `gsutil rsync -x` exclusion regex (Python `re` syntax) that keeps ONLY
+ * `<date>/metadata.json` when overlaying gs://bucket/raw-csv/ onto the
+ * local skeleton.
+ *
+ * gsutil matches the pattern against paths RELATIVE to the source URL,
+ * and a pattern that matches a DIRECTORY path excludes the whole
+ * directory from traversal — so the bare `<date>` path must also be kept
+ * (not matched), or the metadata.json inside is never even compared.
+ */
+export const RAW_CSV_METADATA_ONLY_EXCLUDE =
+  '^(?!\\d{4}-\\d{2}-\\d{2}(/metadata\\.json)?$).*'

--- a/scripts/lib/pruneSkeletonSync.ts
+++ b/scripts/lib/pruneSkeletonSync.ts
@@ -19,22 +19,7 @@
  * glue and the workflow supplies the listings.
  */
 
-/** Matches one `gsutil ls` prefix line, capturing a date-dir name. */
-const DATE_PREFIX = /\/(\d{4}-\d{2}-\d{2})\/\s*$/
-
-/**
- * Extract the date-dir names from a `gsutil ls gs://bucket/<layer>/`
- * listing. Non-date prefixes, bare files at the layer root, blank lines
- * and duplicates are ignored. Sorted ascending.
- */
-export function datesFromGcsListing(lines: string[]): string[] {
-  const dates = new Set<string>()
-  for (const line of lines) {
-    const match = DATE_PREFIX.exec(line.trim())
-    if (match?.[1]) dates.add(match[1])
-  }
-  return [...dates].sort()
-}
+import { parseGcsDatedDirListing } from './pruneProdReconcile.js'
 
 /** Date-dir sets the skeleton sync must materialize locally. */
 export interface SkeletonDirPlan {
@@ -53,10 +38,10 @@ export interface SkeletonDirPlan {
  * classification input (PruneService reads only raw-csv).
  */
 export function planSkeletonDirs(
-  rawCsvListing: string[],
-  snapshotListing: string[]
+  rawCsvListing: string,
+  snapshotListing: string
 ): SkeletonDirPlan {
-  const rawCsvDates = datesFromGcsListing(rawCsvListing)
+  const rawCsvDates = parseGcsDatedDirListing(rawCsvListing)
   if (rawCsvDates.length === 0) {
     throw new Error(
       'prune skeleton sync (#1175): raw-csv listing parsed to zero date dirs — ' +
@@ -66,7 +51,7 @@ export function planSkeletonDirs(
   }
   return {
     rawCsvDates,
-    snapshotDates: datesFromGcsListing(snapshotListing),
+    snapshotDates: parseGcsDatedDirListing(snapshotListing),
   }
 }
 

--- a/scripts/prune-skeleton-sync.ts
+++ b/scripts/prune-skeleton-sync.ts
@@ -1,0 +1,82 @@
+/**
+ * Prune Skeleton Sync — Runner (#1175)
+ *
+ * Thin glue around the pure functions in ./lib/pruneSkeletonSync.js. The
+ * data-pipeline prune mode calls it twice:
+ *
+ *   1. `--print-exclude-regex` — prints the `gsutil rsync -x` pattern that
+ *      overlays ONLY `<date>/metadata.json` (single source of truth; the
+ *      workflow never hardcodes the regex).
+ *   2. `--raw-listing <file> --snapshot-listing <file> --cache-dir <dir>` —
+ *      reads the two `gsutil ls` outputs and materializes EVERY date dir
+ *      locally. A metadata-less raw-csv dir must exist locally so the
+ *      #1131 protection can SEE it; the rsync overlay alone would skip it.
+ *
+ * All logging goes to stderr (R4); stdout carries only the JSON summary
+ * (or the regex). Any parse/validation failure exits non-zero so the
+ * workflow fails closed instead of classifying an empty cache.
+ *
+ * Usage:
+ *   npx tsx scripts/prune-skeleton-sync.ts --print-exclude-regex
+ *   npx tsx scripts/prune-skeleton-sync.ts \
+ *     --raw-listing /tmp/raw.txt --snapshot-listing /tmp/snap.txt \
+ *     --cache-dir ./cache
+ */
+
+import { mkdirSync, readFileSync } from 'node:fs'
+import * as path from 'node:path'
+import {
+  planSkeletonDirs,
+  RAW_CSV_METADATA_ONLY_EXCLUDE,
+} from './lib/pruneSkeletonSync.js'
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag)
+  return i >= 0 ? process.argv[i + 1] : undefined
+}
+
+if (process.argv.includes('--print-exclude-regex')) {
+  console.log(RAW_CSV_METADATA_ONLY_EXCLUDE)
+  process.exit(0)
+}
+
+const rawListingPath = argValue('--raw-listing')
+const snapshotListingPath = argValue('--snapshot-listing')
+const cacheDir = argValue('--cache-dir')
+
+if (!rawListingPath || !snapshotListingPath || !cacheDir) {
+  console.error(
+    '[ERROR] Usage: prune-skeleton-sync.ts --raw-listing <file> --snapshot-listing <file> --cache-dir <dir> | --print-exclude-regex'
+  )
+  process.exit(1)
+}
+
+try {
+  const readLines = (p: string) => readFileSync(p, 'utf-8').split('\n')
+  const plan = planSkeletonDirs(
+    readLines(rawListingPath),
+    readLines(snapshotListingPath)
+  )
+
+  for (const date of plan.rawCsvDates) {
+    mkdirSync(path.join(cacheDir, 'raw-csv', date), { recursive: true })
+  }
+  for (const date of plan.snapshotDates) {
+    mkdirSync(path.join(cacheDir, 'snapshots', date), { recursive: true })
+  }
+
+  console.error(
+    `[INFO] Skeleton materialized: ${plan.rawCsvDates.length} raw-csv date dirs, ${plan.snapshotDates.length} snapshot date dirs under ${cacheDir}`
+  )
+  console.log(
+    JSON.stringify({
+      rawCsvDates: plan.rawCsvDates.length,
+      snapshotDates: plan.snapshotDates.length,
+    })
+  )
+} catch (error) {
+  console.error(
+    `[ERROR] ${error instanceof Error ? error.message : 'unknown error'}`
+  )
+  process.exit(1)
+}

--- a/scripts/prune-skeleton-sync.ts
+++ b/scripts/prune-skeleton-sync.ts
@@ -52,18 +52,18 @@ if (!rawListingPath || !snapshotListingPath || !cacheDir) {
 }
 
 try {
-  const readLines = (p: string) => readFileSync(p, 'utf-8').split('\n')
   const plan = planSkeletonDirs(
-    readLines(rawListingPath),
-    readLines(snapshotListingPath)
+    readFileSync(rawListingPath, 'utf-8'),
+    readFileSync(snapshotListingPath, 'utf-8')
   )
 
-  for (const date of plan.rawCsvDates) {
-    mkdirSync(path.join(cacheDir, 'raw-csv', date), { recursive: true })
+  const materialize = (layer: 'raw-csv' | 'snapshots', dates: string[]) => {
+    for (const date of dates) {
+      mkdirSync(path.join(cacheDir, layer, date), { recursive: true })
+    }
   }
-  for (const date of plan.snapshotDates) {
-    mkdirSync(path.join(cacheDir, 'snapshots', date), { recursive: true })
-  }
+  materialize('raw-csv', plan.rawCsvDates)
+  materialize('snapshots', plan.snapshotDates)
 
   console.error(
     `[INFO] Skeleton materialized: ${plan.rawCsvDates.length} raw-csv date dirs, ${plan.snapshotDates.length} snapshot date dirs under ${cacheDir}`

--- a/tasks/lessons/162-a-keep-only-rsync-exclude-must-also-keep-the-bare-directory-path.md
+++ b/tasks/lessons/162-a-keep-only-rsync-exclude-must-also-keep-the-bare-directory-path.md
@@ -1,0 +1,65 @@
+---
+id: '162'
+category: lesson
+tags: [gcs, ci, data-pipeline, verification, regex]
+auto_load: true
+date: 2026-06-12
+issues: [1175, 1102]
+---
+
+# Lesson 162 — A "keep only X" rsync exclude must also keep the bare directory path, or traversal prunes the parent before X is ever compared
+
+**Date:** 2026-06-12
+**Issue:** #1175 (epic #1102 Sprint 4 — prune skeleton sync)
+**PR:** _(record on merge)_
+
+## What happened
+
+The prune sync was narrowed from a full-content `gsutil -m rsync -r` (which
+outgrew the runner's disk post-#1147) to a skeleton: materialize every date
+dir from `gsutil ls`, then overlay only `<date>/metadata.json` via
+`rsync -x <exclude>`. The natural exclude — "everything that isn't
+`<date>/metadata.json`" (`^(?!\d{4}-\d{2}-\d{2}/metadata\.json$).*`) — has a
+trap: gsutil matches the pattern against paths relative to the source URL,
+and **a pattern that matches a DIRECTORY path excludes that directory from
+traversal entirely**. The bare path `2026-02-13` doesn't look like
+`<date>/metadata.json`, so the naive exclude matches it, the walker skips the
+dir, and the metadata.json inside is never even compared — the overlay
+silently syncs nothing while exiting 0.
+
+The shipped pattern keeps both the file AND its parent dir:
+`^(?!\d{4}-\d{2}-\d{2}(/metadata\.json)?$).*`. Three layers of proof: unit
+tests on the constant (including the bare-dir case), a python3 `re` canary
+(gsutil's actual engine), and a live staging run that overlaid exactly 79
+metadata.json files with **zero** payload files downloaded (1.5 MB total for
+a bucket that no longer fits a runner disk).
+
+## The transferable principle
+
+**Any allowlist expressed as an exclusion regex over hierarchical paths must
+allowlist every ancestor of the kept leaf, not just the leaf — a tool that
+prunes traversal on directory matches turns "exclude everything but X" into
+"exclude X's parent, therefore X", and the failure is a silent, successful-
+looking no-op.** Test the constant against the bare ancestor paths, in the
+regex dialect the tool actually uses, and verify on the live tree by counting
+what DID transfer (kept-file count > 0, excluded-file count == 0) — exit code
+and "no errors" prove nothing about an overlay that skipped everything.
+
+## How to apply
+
+- Writing an `-x`/`--exclude` for rsync/gsutil/robocopy-style tools: for each
+  kept path `a/b/c`, the pattern must also keep `a` and `a/b`.
+- Pin the pattern as an exported, unit-tested constant; have the
+  runner/workflow print it from the lib (`--print-exclude-regex`) instead of
+  hand-copying it into YAML.
+- Cross-engine regexes (JS test, Python execution) get a one-off canary in
+  the target engine before shipping.
+- Verify the live result by positive AND negative counts: files overlaid ==
+  listing-derived expectation; non-matching files transferred == 0.
+
+## Related
+
+- [[161-scale-fail-closed-thresholds-to-the-actions-reversibility]] — the
+  skeleton-cache dry-run discipline this sprint reused for live verification.
+- `scripts/lib/pruneSkeletonSync.ts` (`RAW_CSV_METADATA_ONLY_EXCLUDE`),
+  `scripts/prune-skeleton-sync.ts`, data-pipeline.yml prune Step 1.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -155,3 +155,4 @@
 - **160** [research, analytics, verification, data-pipeline] — The system's own published per-entity goal numbers are an oracle for recovering historical business rules; back-solve before trusting documents (#1116, #1147)
 - **161** [ci, automation, verification, tests] — A `workflow_dispatch` boolean input compared to a string in `if:` is inert; normalize booleans to step-output strings once (#1133, #1102)
 - **161** [data-pipeline, gcs, collector-cli, verification, process] — The same authority verdict can clear a reversible action but not an irreversible one: scale fail-closed thresholds to reversibility (#1131, #1102)
+- **162** [gcs, ci, data-pipeline, verification, regex] — A "keep only X" rsync exclude must also keep the bare directory path, or traversal prunes the parent before X is ever compared (#1175, #1102)

--- a/tasks/sprint-1175-plan.md
+++ b/tasks/sprint-1175-plan.md
@@ -1,0 +1,65 @@
+# Sprint 4 (#1102) — #1175: prune skeleton sync (listings + metadata.json only)
+
+## Problem
+
+`[prune] Sync all data from GCS` (data-pipeline.yml:998) does a full-content
+`gsutil -m rsync -r` of raw-csv/ + snapshots/. Post-#1147 the bucket no longer
+fits on a GitHub runner (dry-run v2 died at 62 min: `No space left on device`).
+Classification needs only: raw-csv date-dir SET + each date's metadata.json.
+
+## Evidence from code reading
+
+- `PruneService.classifyAll()` reads `cacheDir/raw-csv` dir names only;
+  `classifyDate()` reads only `raw-csv/<date>/metadata.json`. CSV payloads and
+  `cache/snapshots` contents are never read for classification.
+- Destructive-prune local deletions use `fs.rm(..., force: true)` — absent
+  snapshot payloads are harmless.
+- Post-prune manifest steps (latest/dates/rankings/rank-history, snapshot
+  index, club-index, divisions-areas) all read from GCS or fall back to GCS
+  when the local cache is empty (rebuild mode already exercises this path).
+- #1131 constraint: a metadata-less date dir must still be SEEN. GCS prefixes
+  appear in `gsutil ls` iff ≥1 object exists, so materializing dirs from the
+  listing preserves exactly the protection population.
+
+## Design (thin-glue, Lesson 107)
+
+1. **`scripts/lib/pruneSkeletonSync.ts`** (pure, unit-tested):
+   - `datesFromGcsListing(lines)` — parse `gsutil ls gs://…/raw-csv/` output →
+     sorted unique date-dir names; ignore non-date prefixes and bare files.
+   - `planSkeletonDirs(rawListing, snapshotListing)` — fail-closed: throws if
+     the raw-csv listing parses to zero dates (an empty listing on a populated
+     bucket means the ls failed — proceeding would classify nothing and mask).
+   - `RAW_CSV_METADATA_ONLY_EXCLUDE` — `gsutil rsync -x` Python-regex that
+     excludes everything except `<date>` (bare dir path, so local traversal
+     pruning can't skip the dir) and `<date>/metadata.json`.
+2. **`scripts/prune-skeleton-sync.ts`** (runner): reads listing files, mkdirs
+   all date dirs under `--cache-dir`, prints JSON summary to stdout (R4:
+   logs → stderr). `--print-exclude-regex` prints the constant for the
+   workflow's rsync overlay (one source of truth, no drift).
+3. **PruneService contract test**: same fixture in full shape (CSV payloads
+   present) vs skeleton shape (dirs + metadata.json only, incl. one
+   metadata-less dir, empty snapshots dirs) → identical classifications.
+   Pins "classification reads nothing the skeleton omits".
+4. **Workflow**: replace step 1's two rsyncs with: `gsutil ls` raw + snapshots
+   → skeleton script → `gsutil -m rsync -r -x "$(…--print-exclude-regex)"`
+   metadata overlay. Report dir counts + `du -sh ./cache` (the <1GB AC).
+   Revert prune from the 240-min timeout branch (line 99, undoes #1176's
+   mitigation per AC "timeout can return to 30 min").
+
+## Acceptance-criteria mapping
+
+| AC                                 | How                                                                                                                                                                                                                          |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Failing test first                 | new lib's tests red before implementation; PruneService skeleton-shape test is the named fixture test                                                                                                                        |
+| listings+metadata only, <5 min     | 2 `gsutil ls` + 1 rsync over ~190 small objects                                                                                                                                                                              |
+| dry-run report identical           | fixture equivalence test (full vs skeleton shape) + live local skeleton dry-run against staging in evidence; full-sync comparison run is physically impossible on runner (disk) — code-proof per AC wording "where testable" |
+| timeout back to 30 min             | line-99 revert in same PR                                                                                                                                                                                                    |
+| peak disk <1 GB (operator comment) | metadata.json ~1–2 KB × ~190 dirs ≪ 1 GB; du in step summary                                                                                                                                                                 |
+
+## Risks
+
+- `gsutil rsync -x` directory-traversal exclusion: regex must NOT match bare
+  `<date>` dir paths or the dir gets pruned from traversal with metadata.json
+  inside. Covered by unit tests on the constant.
+- Workflow `if:` conditions untouched (Lesson 161 boolean-input trap — not in
+  scope, already normalized via steps.mode outputs).


### PR DESCRIPTION
## Summary

Sprint 4 of epic #1102 — work item #1175 (reference only, do not auto-close).

The prune job's `[prune] Sync all data from GCS` full-content-rsynced raw-csv/ **and** snapshots/ before classifying. Post-#1147 that no longer fits a GitHub runner: dry-run v2 (run 27393189818) died at 62 min with `No space left on device`. Classification (`PruneService`) reads only the raw-csv **date-dir set** and each date's **metadata.json** — so the sync becomes a skeleton:

1. `gsutil ls` the `raw-csv/` and `snapshots/` prefixes
2. materialize **ALL** date dirs locally (`scripts/prune-skeleton-sync.ts`, fail-closed on a zero-date raw-csv listing) — a metadata-less dir must stay **visible**, the #1131 protection works by SEEING a date dir without metadata.json
3. overlay `<date>/metadata.json` only, via `gsutil -m rsync -r -x` with a single-sourced, unit-tested exclude regex (`RAW_CSV_METADATA_ONLY_EXCLUDE`)

Also returns prune to the 30-min timeout class (reverts the #1176 mitigation, AC 4).

## Acceptance criteria → evidence

| AC | Evidence |
|---|---|
| Failing test first | `scripts/lib/__tests__/pruneSkeletonSync.test.ts` red before lib existed (commit order); PruneService skeleton-shape fixture test incl. a metadata-less dir |
| Listings + metadata.json only; wall < 5 min | Live run against real staging: 191 raw-csv dirs + 173 snapshot dirs materialized, **79 metadata.json overlaid, 0 payload files downloaded**, wall ≈ 33 s |
| Dry-run report identical to full-sync | Contract test pins skeleton-shape ≡ full-shape classifications at both `classifyAll()` and the `prune(true)` verdict layer (Lesson 154); live skeleton dry-run on current staging: 191 total / 144 kept / 47 pruned / **112 metadata-less protected — exactly the #1131 live-audit population**. A literal full-sync comparison run is physically impossible on the runner (the disk failure this PR fixes); equivalence is proven structurally: classification inputs = date-dir set + metadata.json bytes, both preserved by construction from the same `gsutil ls` listing rsync itself uses. |
| Timeout returns to 30 min | data-pipeline.yml line 99: prune removed from the 240-min branch |
| Peak local disk < 1 GB (operator comment) | Live skeleton cache: **1.5 MB** (du -sh); step summary now reports cache size + metadata-less count every run |

## Live dry-run on the skeleton cache (staging, 2026-06-12)

```
totalDates: 191, keptDates: 144, prunedDates: 47
closingGuard: allowed (non-closing)
101× Protected: no metadata.json; registry closing window maps to month-end (#1131)
 11× Protected: no metadata.json — mapping unproven; refusing irreversible delete (#1131)
 47× Non-month-end snapshot
 30× Month-end snapshot
  2× Penultimate snapshot
```

## Review notes (fresh-context review: APPROVE-WITH-NITS, 0 High)

- **Medium (documented, deliberate):** the *first* destructive prune post-#1147 deletes ~47×2 prefixes sequentially and may run long inside 30 min; deletions are idempotent and a re-run completes. The destructive flip stays operator-gated (#1037/#1148) — operator can watch the first run and weigh this there.
- **Medium (deliberate):** a failing `gsutil ls` on snapshots/ fails the step under `bash -e` even though the lib tolerates an empty snapshots listing — fail-closed at the workflow level is the intended direction (R14: don't absorb exit codes you care about).
- Low/nits left as-is: `argValue` doesn't reject flag-as-value (workflow-only usage); snapshot skeleton dirs materialized for shape-parity though nothing reads them; cache-size summary is informational, not enforced.

## No PR preview

This PR touches `.github/workflows/`, `scripts/`, and `packages/collector-cli/` only — none of `pr-preview.yml`'s path filters — so there is no live surface to drive. Verification is the full test suite (all workspaces green) + the live staging skeleton sync + dry-run above.

Refs: #1175, #1102, #1131, #1147, #1176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
