### PR TITLE
Sprint 5 (#1102) — prune keep rule exempts the in-progress month (#1178)

### DIFF
--- a/packages/collector-cli/src/__tests__/PruneService.test.ts
+++ b/packages/collector-cli/src/__tests__/PruneService.test.ts
@@ -580,9 +580,10 @@ describe('PruneService', () => {
 
       // Every June daily is kept, with an explicit in-progress-month reason.
       for (const date of juneDailies) {
-        expect(byDate.get(date)?.keep).toBe(true)
-        expect(byDate.get(date)?.reason).toMatch(/in-progress month/i)
-        expect(byDate.get(date)?.reason).toContain('2026-05-31')
+        const c = byDate.get(date)
+        expect(c?.keep).toBe(true)
+        expect(c?.reason).toMatch(/in-progress month/i)
+        expect(c?.reason).toContain('2026-05-31')
       }
 
       // Completed-month behavior unchanged: April/May dailies still thinned,

--- a/packages/collector-cli/src/__tests__/PruneService.test.ts
+++ b/packages/collector-cli/src/__tests__/PruneService.test.ts
@@ -326,7 +326,9 @@ describe('PruneService', () => {
     })
 
     it('never deletes under time-series/, club-trends/, or v1/rank-history/ (#1132 guard)', async () => {
-      // A prunable mid-month date
+      // A prunable mid-month date — January must be closed (#1178), so its
+      // month-end is present too.
+      await createRawCsvDate('2026-01-31')
       await createRawCsvDate('2026-01-15')
       await createSnapshotDate('2026-01-15')
 
@@ -360,6 +362,8 @@ describe('PruneService', () => {
     })
 
     it('dry-run mode does not delete anything', async () => {
+      // Month-end present so January is closed and 01-15 is thinnable (#1178)
+      await createRawCsvDate('2026-01-31')
       await createRawCsvDate('2026-01-15')
       await createSnapshotDate('2026-01-15')
 
@@ -385,11 +389,14 @@ describe('PruneService', () => {
       // Also a mid-month: raw-csv/2026-02-05 → snapshots/2026-02-05 (non-keeper)
       await createRawCsvDate('2026-02-05')
       await createSnapshotDate('2026-02-05')
+      // February's own month-end, so the month is closed and thinnable (#1178)
+      await createRawCsvDate('2026-02-28')
+      await createSnapshotDate('2026-02-28')
 
       const service = new PruneService({ cacheDir: testDir, ...NON_CLOSING })
       const result = await service.prune(false)
 
-      expect(result.keptDates).toBe(1)
+      expect(result.keptDates).toBe(2) // 2026-01-31 (via remap) + 2026-02-28
       expect(result.prunedDates).toBe(1)
       expect(result.deletedRawCsv).toContain('2026-02-05')
       expect(result.deletedSnapshots).toContain('2026-02-05')
@@ -399,9 +406,12 @@ describe('PruneService', () => {
       // Metadata-less: classification is unprovable → protected
       await createRawCsvDateWithoutMetadata('2026-02-13')
       await createSnapshotDate('2026-02-13')
-      // Metadata-full mid-month: still prunes (keep rules unchanged)
+      // Metadata-full mid-month: still prunes (keep rules unchanged).
+      // March's month-end closes the month so 03-15 is thinnable (#1178).
       await createRawCsvDate('2026-03-15')
       await createSnapshotDate('2026-03-15')
+      await createRawCsvDate('2026-03-31')
+      await createSnapshotDate('2026-03-31')
 
       const service = new PruneService({
         cacheDir: testDir,
@@ -413,7 +423,7 @@ describe('PruneService', () => {
       })
       const result = await service.prune(false)
 
-      expect(result.keptDates).toBe(1)
+      expect(result.keptDates).toBe(2) // protected 2026-02-13 + 2026-03-31
       expect(result.prunedDates).toBe(1)
       expect(result.deletedRawCsv).toEqual(['2026-03-15'])
 
@@ -469,6 +479,7 @@ describe('PruneService', () => {
       })
 
       it('lets a dry-run proceed during a closing window but surfaces the refused verdict', async () => {
+        await createRawCsvDate('2026-01-31') // closes January (#1178)
         await createRawCsvDate('2026-01-15')
         await createSnapshotDate('2026-01-15')
 
@@ -486,6 +497,7 @@ describe('PruneService', () => {
       })
 
       it('allows a destructive prune once today is past the closing window', async () => {
+        await createRawCsvDate('2026-01-31') // closes January (#1178)
         await createRawCsvDate('2026-01-15')
         await createSnapshotDate('2026-01-15')
 
@@ -690,10 +702,12 @@ describe('PruneService', () => {
         }
       }
 
-      // Month-end keeper, mid-month non-keeper, closing-period remap,
+      // Month-end keeper, mid-month non-keeper (with its own month-end so
+      // March is closed and thinnable, #1178), closing-period remap,
       // and the live #1131 case: a metadata-less date dir.
       await writeDate('2026-01-31', { isClosingPeriod: false })
       await writeDate('2026-03-15', { isClosingPeriod: false })
+      await writeDate('2026-03-31', { isClosingPeriod: false })
       await writeDate('2026-02-03', {
         isClosingPeriod: true,
         dataMonth: '2026-01',
@@ -726,7 +740,7 @@ describe('PruneService', () => {
 
       // Spot-pin the decisions themselves so the equivalence can't be
       // vacuously satisfied by two empty/broken caches.
-      expect(skeleton).toHaveLength(4)
+      expect(skeleton).toHaveLength(5)
       const byDate = new Map(skeleton.map(c => [c.rawCsvDate, c]))
       expect(byDate.get('2026-01-31')?.keep).toBe(true)
       expect(byDate.get('2026-03-15')?.keep).toBe(false)

--- a/packages/collector-cli/src/__tests__/PruneService.test.ts
+++ b/packages/collector-cli/src/__tests__/PruneService.test.ts
@@ -647,6 +647,45 @@ describe('PruneService', () => {
       expect(byDate.get('2026-07-01')?.reason).toMatch(/in-progress month/i)
     })
 
+    it('an UNPROVEN metadata-less month-end dir does not set the boundary (review M1)', async () => {
+      // A scrape that crashed before writing metadata.json on the last day
+      // of the in-progress month: the dir exists, its raw date LOOKS like a
+      // month-end, but the raw→snapshot mapping is unproven (#1131). It must
+      // not count as "the month closed" evidence, or it would un-protect
+      // every daily of the month it sits in.
+      await createCompletedAprilMay()
+      await createRawCsvDate('2026-06-06')
+      await createRawCsvDateWithoutMetadata('2026-06-30')
+
+      const service = new PruneService({ cacheDir: testDir, ...ctx })
+      const classifications = await service.classifyAll()
+      const byDate = new Map(classifications.map(c => [c.rawCsvDate, c]))
+
+      // The bare dir stays protected (#1131)…
+      expect(byDate.get('2026-06-30')?.keep).toBe(true)
+      // …and June dailies stay in-progress-protected: the proven boundary
+      // is still May 31.
+      expect(byDate.get('2026-06-06')?.keep).toBe(true)
+      expect(byDate.get('2026-06-06')?.reason).toMatch(/in-progress month/i)
+      expect(byDate.get('2026-06-06')?.reason).toContain('2026-05-31')
+    })
+
+    it('a registry-remapped metadata-less month-end DOES set the boundary', async () => {
+      // Registry-proven closing remap: raw 2026-06-03 (no metadata) sits in
+      // May's closing window → snapshot 2026-05-31. That month-end is
+      // registry-proven, so May's dailies are thinnable.
+      await createRawCsvDateWithoutMetadata('2026-06-03')
+      await createRawCsvDate('2026-05-15')
+
+      const service = new PruneService({ cacheDir: testDir, ...ctx })
+      const classifications = await service.classifyAll()
+      const byDate = new Map(classifications.map(c => [c.rawCsvDate, c]))
+
+      expect(byDate.get('2026-06-03')?.snapshotDate).toBe('2026-05-31')
+      expect(byDate.get('2026-06-03')?.keep).toBe(true)
+      expect(byDate.get('2026-05-15')?.keep).toBe(false)
+    })
+
     it('a destructive prune never deletes in-progress month dates', async () => {
       await createCompletedAprilMay()
       await createRawCsvDate('2026-06-10')

--- a/packages/collector-cli/src/__tests__/PruneService.test.ts
+++ b/packages/collector-cli/src/__tests__/PruneService.test.ts
@@ -527,6 +527,132 @@ describe('PruneService', () => {
     })
   })
 
+  describe('in-progress month exemption (#1178)', () => {
+    // The dry-run v3 failure class: June dailies with no June month-end yet
+    // were classified deletable, which would regress staging's latest
+    // snapshot to 2026-05-31 and propagate to prod. The keep rule must
+    // exempt every date after the most recent completed month-end.
+    const ctx = {
+      today: '2026-06-12',
+      closingDateRegistry: [
+        { dataMonth: '2026-05', closingDate: '2026-06-05' },
+      ] as ClosingDateEntry[],
+    }
+
+    /** April + May fully closed (month-end + penultimate + a daily each). */
+    async function createCompletedAprilMay(): Promise<void> {
+      for (const date of [
+        '2026-04-15',
+        '2026-04-29',
+        '2026-04-30',
+        '2026-05-15',
+        '2026-05-30',
+        '2026-05-31',
+      ]) {
+        await createRawCsvDate(date)
+        await createSnapshotDate(date)
+      }
+    }
+
+    it('keeps every current-month daily when the month has no month-end snapshot yet', async () => {
+      await createCompletedAprilMay()
+      const juneDailies = ['2026-06-06', '2026-06-08', '2026-06-10']
+      for (const date of juneDailies) {
+        await createRawCsvDate(date)
+        await createSnapshotDate(date)
+      }
+
+      const service = new PruneService({ cacheDir: testDir, ...ctx })
+      const classifications = await service.classifyAll()
+      const byDate = new Map(classifications.map(c => [c.rawCsvDate, c]))
+
+      // Every June daily is kept, with an explicit in-progress-month reason.
+      for (const date of juneDailies) {
+        expect(byDate.get(date)?.keep).toBe(true)
+        expect(byDate.get(date)?.reason).toMatch(/in-progress month/i)
+        expect(byDate.get(date)?.reason).toContain('2026-05-31')
+      }
+
+      // Completed-month behavior unchanged: April/May dailies still thinned,
+      // month-end and penultimate keeps keep their original reasons.
+      expect(byDate.get('2026-04-15')?.keep).toBe(false)
+      expect(byDate.get('2026-05-15')?.keep).toBe(false)
+      expect(byDate.get('2026-05-31')?.reason).toContain('Month-end')
+      expect(byDate.get('2026-05-30')?.reason).toContain('Penultimate')
+
+      // No silent keeps: every classification carries a non-empty reason.
+      for (const c of classifications) {
+        expect(c.reason.length).toBeGreaterThan(0)
+      }
+    })
+
+    it('keeps everything when no month-end snapshot exists anywhere (fail closed)', async () => {
+      for (const date of ['2026-06-06', '2026-06-08', '2026-06-10']) {
+        await createRawCsvDate(date)
+      }
+
+      const service = new PruneService({ cacheDir: testDir, ...ctx })
+      const classifications = await service.classifyAll()
+
+      expect(classifications).toHaveLength(3)
+      for (const c of classifications) {
+        expect(c.keep).toBe(true)
+        expect(c.reason).toMatch(/in-progress month/i)
+      }
+    })
+
+    it('treats a closing-remapped month-end as the completed-month boundary', async () => {
+      // raw 2026-06-03 → snapshot 2026-05-31 (May closing): May is closed,
+      // so its daily is thinned, while June dailies stay protected.
+      await createRawCsvDate('2026-06-03', {
+        isClosingPeriod: true,
+        dataMonth: '2026-05',
+      })
+      await createRawCsvDate('2026-05-15')
+      await createRawCsvDate('2026-06-08')
+
+      const service = new PruneService({ cacheDir: testDir, ...ctx })
+      const classifications = await service.classifyAll()
+      const byDate = new Map(classifications.map(c => [c.rawCsvDate, c]))
+
+      expect(byDate.get('2026-06-03')?.snapshotDate).toBe('2026-05-31')
+      expect(byDate.get('2026-06-03')?.keep).toBe(true)
+      expect(byDate.get('2026-05-15')?.keep).toBe(false)
+      expect(byDate.get('2026-06-08')?.keep).toBe(true)
+      expect(byDate.get('2026-06-08')?.reason).toMatch(/in-progress month/i)
+    })
+
+    it('keeps a new-month daily that lands right after a completed month-end', async () => {
+      await createRawCsvDate('2026-06-30')
+      await createRawCsvDate('2026-07-01')
+
+      const service = new PruneService({ cacheDir: testDir })
+      const classifications = await service.classifyAll()
+      const byDate = new Map(classifications.map(c => [c.rawCsvDate, c]))
+
+      expect(byDate.get('2026-07-01')?.keep).toBe(true)
+      expect(byDate.get('2026-07-01')?.reason).toMatch(/in-progress month/i)
+    })
+
+    it('a destructive prune never deletes in-progress month dates', async () => {
+      await createCompletedAprilMay()
+      await createRawCsvDate('2026-06-10')
+      await createSnapshotDate('2026-06-10')
+
+      const service = new PruneService({ cacheDir: testDir, ...ctx })
+      const result = await service.prune(false)
+
+      expect(result.deletedRawCsv).toEqual(['2026-04-15', '2026-05-15'])
+      expect(result.deletedRawCsv).not.toContain('2026-06-10')
+      expect(result.deletedSnapshots).not.toContain('2026-06-10')
+
+      const rawCsvEntries = await fs.readdir(path.join(testDir, 'raw-csv'))
+      expect(rawCsvEntries).toContain('2026-06-10')
+      const snapshotEntries = await fs.readdir(path.join(testDir, 'snapshots'))
+      expect(snapshotEntries).toContain('2026-06-10')
+    })
+  })
+
   describe('skeleton-shape cache contract (#1175)', () => {
     // The prune sync no longer downloads CSV payloads or snapshot contents
     // (post-#1147 the full bucket exceeds the runner's disk). The skeleton

--- a/packages/collector-cli/src/services/PruneService.ts
+++ b/packages/collector-cli/src/services/PruneService.ts
@@ -173,11 +173,12 @@ export function applyInProgressMonthExemption(
   for (const c of classifications) {
     if (c.keep) continue
     if (latestMonthEnd === undefined || c.snapshotDate > latestMonthEnd) {
-      c.keep = true
-      c.reason =
+      const boundary =
         latestMonthEnd === undefined
-          ? `In-progress month (${c.snapshotDate.slice(0, 7)}): no completed month-end snapshot exists yet — thinning deferred until the month closes (#1178)`
-          : `In-progress month (${c.snapshotDate.slice(0, 7)}): after the latest completed month-end (${latestMonthEnd}) — thinning deferred until the month closes (#1178)`
+          ? 'no completed month-end snapshot exists yet'
+          : `after the latest completed month-end (${latestMonthEnd})`
+      c.keep = true
+      c.reason = `In-progress month (${c.snapshotDate.slice(0, 7)}): ${boundary} — thinning deferred until the month closes (#1178)`
     }
   }
 

--- a/packages/collector-cli/src/services/PruneService.ts
+++ b/packages/collector-cli/src/services/PruneService.ts
@@ -54,6 +54,14 @@ export interface DateClassification {
   keep: boolean
   /** Reason for keep/prune decision */
   reason: string
+  /**
+   * Whether the raw→snapshot mapping is proven by an authority — a
+   * metadata.json or a registry closing window (#1178). A metadata-less
+   * date outside any known window reports its raw date as snapshotDate,
+   * but that mapping is a guess and must never count as completed-month
+   * evidence for the thinning boundary.
+   */
+  mappingProven: boolean
 }
 
 /**
@@ -152,11 +160,14 @@ export function isPenultimateDayOfMonth(dateStr: string): boolean {
 /**
  * In-progress-month exemption (#1178), applied over a full classification set.
  *
- * A month's dailies may be thinned only once that month has closed AND its
- * month-end snapshot exists. Set-level evidence: the most recent month-end
- * snapshot present in the classifications. Every non-kept date whose
- * snapshot falls AFTER that boundary (or every date, when no month-end
- * exists at all) is re-marked keep with an explicit reason — never silently.
+ * Set-level boundary: the most recent PROVEN month-end snapshot in the
+ * classifications (metadata-backed or registry-remapped — an unproven
+ * metadata-less dir that merely LOOKS month-end-dated must not count, or a
+ * crashed scrape on the 30th/31st would un-protect its whole month). Every
+ * non-kept date whose snapshot falls AFTER that boundary (or every date,
+ * when no proven month-end exists at all) is re-marked keep with an
+ * explicit reason — never silently. Dates at or before the boundary keep
+ * the per-date rules unchanged.
  *
  * Mutates and returns the same array (classifyAll's single consumer).
  */
@@ -165,7 +176,11 @@ export function applyInProgressMonthExemption(
 ): DateClassification[] {
   let latestMonthEnd: string | undefined
   for (const c of classifications) {
-    if (c.isMonthEnd && (!latestMonthEnd || c.snapshotDate > latestMonthEnd)) {
+    if (
+      c.isMonthEnd &&
+      c.mappingProven &&
+      (!latestMonthEnd || c.snapshotDate > latestMonthEnd)
+    ) {
       latestMonthEnd = c.snapshotDate
     }
   }
@@ -274,6 +289,7 @@ export class PruneService {
       isClosingPeriod: closingInfo.isClosingPeriod,
       isMonthEnd,
       keep,
+      mappingProven: true,
       reason: isMonthEnd
         ? `Month-end snapshot (${snapshotDate})`
         : isPenultimate
@@ -307,6 +323,7 @@ export class PruneService {
         isClosingPeriod: true,
         isMonthEnd: isLastDayOfMonth(closingInfo.snapshotDate),
         keep: true,
+        mappingProven: true,
         reason: `Protected: no metadata.json; registry closing window for ${verdict.dataMonth} maps to ${closingInfo.snapshotDate} (#1131)`,
       }
     }
@@ -322,6 +339,7 @@ export class PruneService {
       isClosingPeriod: false,
       isMonthEnd: isLastDayOfMonth(rawCsvDate),
       keep: true,
+      mappingProven: false,
       reason: `Protected: no metadata.json — ${detail}; refusing irreversible delete (#1131)`,
     }
   }
@@ -330,11 +348,11 @@ export class PruneService {
    * Classify all raw-csv dates for pruning.
    *
    * Applies the in-progress-month exemption (#1178) on top of the per-date
-   * rules: a month's dailies are thinnable only once that month has closed
-   * and its month-end snapshot exists in the set. Anything after the most
-   * recent completed month-end (or everything, when no month-end exists at
-   * all) is always kept — otherwise a prune run mid-month deletes the live
-   * latest snapshot and regresses staging/prod to the previous month-end.
+   * rules: anything after the most recent PROVEN completed month-end in the
+   * set (or everything, when none exists) is always kept — otherwise a
+   * prune run mid-month deletes the live latest snapshot and regresses
+   * staging/prod to the previous month-end. Note the boundary is global,
+   * not per-month: dates at or before it follow the per-date rules alone.
    */
   async classifyAll(): Promise<DateClassification[]> {
     const rawCsvDir = path.join(this.cacheDir, 'raw-csv')

--- a/packages/collector-cli/src/services/PruneService.ts
+++ b/packages/collector-cli/src/services/PruneService.ts
@@ -149,6 +149,41 @@ export function isPenultimateDayOfMonth(dateStr: string): boolean {
   return day === lastDay - 1
 }
 
+/**
+ * In-progress-month exemption (#1178), applied over a full classification set.
+ *
+ * A month's dailies may be thinned only once that month has closed AND its
+ * month-end snapshot exists. Set-level evidence: the most recent month-end
+ * snapshot present in the classifications. Every non-kept date whose
+ * snapshot falls AFTER that boundary (or every date, when no month-end
+ * exists at all) is re-marked keep with an explicit reason — never silently.
+ *
+ * Mutates and returns the same array (classifyAll's single consumer).
+ */
+export function applyInProgressMonthExemption(
+  classifications: DateClassification[]
+): DateClassification[] {
+  let latestMonthEnd: string | undefined
+  for (const c of classifications) {
+    if (c.isMonthEnd && (!latestMonthEnd || c.snapshotDate > latestMonthEnd)) {
+      latestMonthEnd = c.snapshotDate
+    }
+  }
+
+  for (const c of classifications) {
+    if (c.keep) continue
+    if (latestMonthEnd === undefined || c.snapshotDate > latestMonthEnd) {
+      c.keep = true
+      c.reason =
+        latestMonthEnd === undefined
+          ? `In-progress month (${c.snapshotDate.slice(0, 7)}): no completed month-end snapshot exists yet — thinning deferred until the month closes (#1178)`
+          : `In-progress month (${c.snapshotDate.slice(0, 7)}): after the latest completed month-end (${latestMonthEnd}) — thinning deferred until the month closes (#1178)`
+    }
+  }
+
+  return classifications
+}
+
 export class PruneService {
   private readonly cacheDir: string
   private readonly logger: Logger
@@ -292,6 +327,13 @@ export class PruneService {
 
   /**
    * Classify all raw-csv dates for pruning.
+   *
+   * Applies the in-progress-month exemption (#1178) on top of the per-date
+   * rules: a month's dailies are thinnable only once that month has closed
+   * and its month-end snapshot exists in the set. Anything after the most
+   * recent completed month-end (or everything, when no month-end exists at
+   * all) is always kept — otherwise a prune run mid-month deletes the live
+   * latest snapshot and regresses staging/prod to the previous month-end.
    */
   async classifyAll(): Promise<DateClassification[]> {
     const rawCsvDir = path.join(this.cacheDir, 'raw-csv')
@@ -314,7 +356,7 @@ export class PruneService {
       classifications.push(await this.classifyDate(date))
     }
 
-    return classifications
+    return applyInProgressMonthExemption(classifications)
   }
 
   /**

--- a/tasks/lessons/163-a-destructive-boundary-derived-from-set-evidence-must-filter-by-provenance.md
+++ b/tasks/lessons/163-a-destructive-boundary-derived-from-set-evidence-must-filter-by-provenance.md
@@ -1,0 +1,70 @@
+---
+id: '163'
+category: lesson
+tags: [data-pipeline, collector-cli, verification, tdd, metadata, gcs]
+auto_load: true
+date: 2026-06-12
+issues: [1178, 1102]
+---
+
+# Lesson 163 — A destructive boundary derived from set-level evidence must filter that evidence by provenance, not by shape
+
+**Date:** 2026-06-12
+**Issue:** #1178 (epic #1102 Sprint 5 — prune exempts the in-progress month)
+**PR:** _(record on merge)_
+
+## What happened
+
+The sprint added the in-progress-month exemption to prune: every date after
+the most recent completed month-end in the classification set is always
+kept, so a mid-month prune can no longer delete the live latest snapshot.
+The boundary was computed as "max snapshotDate where `isMonthEnd`".
+
+The fresh-context review caught the hole: `isMonthEnd` is a statement about
+the date string's SHAPE, not about evidence. A metadata-less raw-csv dir
+whose name happens to be the 30th/31st (a scrape that crashed before
+writing metadata.json — exactly the #1131 population) reports
+`isMonthEnd: true` over an unproven raw→snapshot mapping. One such dir
+dated inside the in-progress month would have silently advanced the
+boundary and un-protected every daily of the month the exemption exists to
+protect — the protected classification itself becoming the key that
+unlocks deletion of its neighbours.
+
+The fix: classifications carry `mappingProven` (true when metadata.json or
+a registry closing window decided the mapping; false when the snapshot
+date is just the raw date echoed back), and the boundary scan requires
+`isMonthEnd && mappingProven`.
+
+## The transferable principle
+
+**When a rule derives a boundary (latest, max, newest, threshold) from a
+set of records and then acts destructively relative to that boundary, each
+record must qualify as evidence by its PROVENANCE, not by its shape — a
+value that merely looks like the evidence class (right format, right
+position, right date pattern) but was defaulted, echoed, or guessed will
+silently move the boundary, and the failure lands on the records the
+boundary was supposed to protect.** This is the set-level sibling of
+Lesson 158's laundered default: there a persisted `false` read as a
+decision; here an echoed raw date read as a completed month-end.
+
+## How to apply
+
+- Deriving a max/latest/newest over records that feed a destructive or
+  gating decision? Ask of each record: "who decided this value?" If any
+  branch produces the field by echo or default, add a provenance flag at
+  the writer and filter on it in the scan.
+- The hazardous records are usually the PROTECTED ones (fail-closed keeps,
+  unknowns) — they survive into the set precisely because they're unproven,
+  so they're always available to poison set-level aggregates.
+- Test it with the adversarial fixture: the unproven record placed exactly
+  where it would move the boundary (here: a bare dir named like the
+  in-progress month's month-end).
+
+## Related
+
+- [[158-a-fail-closed-chain-is-only-as-honest-as-its-writers-a-persisted-default-reads-as-a-decision]]
+  — the per-record version of the same laundering failure.
+- [[161-scale-fail-closed-thresholds-to-the-actions-reversibility]] — why
+  the unproven population exists in the set at all.
+- `packages/collector-cli/src/services/PruneService.ts`
+  (`applyInProgressMonthExemption`, `mappingProven`).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -156,3 +156,4 @@
 - **161** [ci, automation, verification, tests] — A `workflow_dispatch` boolean input compared to a string in `if:` is inert; normalize booleans to step-output strings once (#1133, #1102)
 - **161** [data-pipeline, gcs, collector-cli, verification, process] — The same authority verdict can clear a reversible action but not an irreversible one: scale fail-closed thresholds to reversibility (#1131, #1102)
 - **162** [gcs, ci, data-pipeline, verification, regex] — A "keep only X" rsync exclude must also keep the bare directory path, or traversal prunes the parent before X is ever compared (#1175, #1102)
+- **163** [data-pipeline, collector-cli, verification, tdd, metadata, gcs] — A destructive boundary derived from set-level evidence must filter that evidence by provenance, not by shape (#1178, #1102)


### PR DESCRIPTION
## Sprint 5 of epic #1102 — prune keep rule exempts the in-progress month

Sub-issue: #1178 (do not auto-close; epic tick ordering per R15)

### Problem

Dry-run v3 (run 27410414082) classified **all** of June's dates — including the live latest snapshot — as deletable, because June has no month-end yet. A real run would regress staging's latest to 2026-05-31, propagate to prod via reconciliation, and self-inflict the #1072 stale-prod failure class.

### Fix

`applyInProgressMonthExemption` in `PruneService.classifyAll()` (#1178):

- Boundary = the most recent **proven** month-end snapshot in the classification set (metadata-backed or registry-remapped).
- Every non-kept date after the boundary — or every date, when no proven month-end exists — is re-marked `keep: true` with an explicit reason (no silent keeps).
- `DateClassification` gains `mappingProven`: an unproven metadata-less dir that merely *looks* month-end-dated (crashed scrape on the 30th/31st) cannot advance the boundary and un-protect its month (fresh-context review finding M1).

Pre-existing fixtures that modelled a lone daily with no month-end now describe an in-progress month under the new semantics, so they gained the closing month-end to preserve their original intent (not assertion pinning — verified by the fresh-context review).

### Acceptance criteria

- [x] Failing test first: current-month dailies + no month-end → all kept with explicit "in-progress month" reason (commit f5bd1703 predates the impl)
- [x] Completed-month behavior unchanged — full collector-cli suite green (939/939)
- [x] Dry-run against **live staging** (skeleton cache, 191 dates): all June dates kept (06-06→06-10 with the in-progress reason, 06-01→06-05 via May closing remap); 42 deletable, all April/May dailies
- [x] Reason strings explicit — no silent keeps (asserted in tests)

### Live-staging dry-run evidence (2026-06-12)

```
totalDates: 191, keptDates: 149, prunedDates: 42
deletable by month: 20 × 2026-04, 22 × 2026-05 (dailies only)
2026-06-06 → keep=true :: In-progress month (2026-06): after the latest
  completed month-end (2026-05-31) — thinning deferred until the month closes (#1178)
… (same through 2026-06-10, the live latest snapshot)
```

### Notes

- No frontend/preview surface (collector-cli only — `pr-preview.yml` path filter doesn't trigger); verification = unit suite + the live-staging dry-run above.
- Reviewer nit (documented, not fixed): when no month-end exists anywhere, very old dailies get the "In-progress month" label; keep is correct (fail-closed), label could mislead in dry-run output.
- Lesson 163 filed: a destructive boundary derived from set evidence must filter by provenance.

Refs: #1102, #1148 (Sprint 6 re-runs the evidence dry-run), #1036, #1131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
