### PR TITLE
chore(mcp): normalize bin path per npm pkg fix (#1164)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Thin, local, read-only MCP server over the public Toast Stats snapshot CDN (ADR-008). Exposes the pre-computed snapshot fields as MCP tools over stdio — no computation, no analytics-core.",
   "bin": {
-    "toast-stats-mcp": "./dist/bin.js"
+    "toast-stats-mcp": "dist/bin.js"
   },
   "files": [
     "dist/bin.js",


### PR DESCRIPTION
One-char manifest normalization so the first npm publish carries zero auto-corrections. Ref #1164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)