### PR TITLE
chore(mcp): bump to 0.1.1 — 0.1.0 burned by npm new-account hold (#1164)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taverns-red/toast-stats-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "type": "module",
   "description": "Thin, local, read-only MCP server over the public Toast Stats snapshot CDN (ADR-008). Exposes the pre-computed snapshot fields as MCP tools over stdio — no computation, no analytics-core.",


### PR DESCRIPTION
Ref #1164. One-line version bump; 0.1.0 was accepted then held invisible by npm (new-account quarantine) and the version number is tombstoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)