### PR TITLE
chore(mcp): sync root lockfile with 0.1.1 (#1164)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8706,7 +8706,7 @@
     },
     "packages/mcp-server": {
       "name": "@taverns-red/toast-stats-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
Follow-up to #1186 — npm version updated the workspace entry in the root lockfile; the bump PR missed it. Ref #1164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)