### PR TITLE
Sprint 3 (#1162) — public /mcp page with install instructions (#1165)

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,5 @@
   "packages/shared-contracts": "1.6.0",
   "packages/collector-cli": "1.5.0",
   "packages/analytics-core": "1.9.0",
-  "packages/mcp-server": "0.1.0"
+  "packages/mcp-server": "0.1.1"
 }

--- a/frontend/e2e/touch-targets.smoke.ts
+++ b/frontend/e2e/touch-targets.smoke.ts
@@ -66,6 +66,7 @@ const ROUTES: { path: string; mustRender?: string }[] = [
   { path: '/club/01479548' },
   { path: '/history' },
   { path: '/methodology' },
+  { path: '/mcp' },
   { path: '/awards' },
   { path: '/regions', mustRender: '.region-finder__chip' }, // family C
   { path: '/region/1' },

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -15,4 +15,7 @@
   <url>
     <loc>https://ts.taverns.red/awards</loc>
   </url>
+  <url>
+    <loc>https://ts.taverns.red/mcp</loc>
+  </url>
 </urlset>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,6 +55,9 @@ const MethodologyPage = React.lazy(() => import('./pages/MethodologyPage'))
 // Code-split: AwardsPage — top-10 leaderboards per district award (#370-#373)
 const AwardsPage = React.lazy(() => import('./pages/AwardsPage'))
 
+// Code-split: McpPage — public MCP-server install page (#1165, epic #1162)
+const McpPage = React.lazy(() => import('./pages/McpPage'))
+
 // Code-split: RegionPage — /region/:n landing (#423)
 const RegionPage = React.lazy(() => import('./pages/RegionPage'))
 
@@ -194,6 +197,14 @@ const router = createBrowserRouter(
           element: (
             <Suspense fallback={<PageLoadingFallback />}>
               <AwardsPage />
+            </Suspense>
+          ),
+        },
+        {
+          path: 'mcp',
+          element: (
+            <Suspense fallback={<PageLoadingFallback />}>
+              <McpPage />
             </Suspense>
           ),
         },

--- a/frontend/src/__tests__/components/AppShell.test.tsx
+++ b/frontend/src/__tests__/components/AppShell.test.tsx
@@ -210,6 +210,16 @@ describe('AppShell (#354)', () => {
       expect(footer).toHaveTextContent(/mit license/i)
     })
 
+    it('links "MCP server" to the /mcp page (#1165)', () => {
+      // AppMeta is the single chrome source rendered in BOTH the desktop
+      // footer and the mobile "About ▾" disclosure (#889), so this one link
+      // makes /mcp reachable from every page at every breakpoint.
+      renderShell()
+      const footer = screen.getByRole('contentinfo')
+      const link = within(footer).getByRole('link', { name: /mcp server/i })
+      expect(link).toHaveAttribute('href', '/mcp')
+    })
+
     it('renders a non-empty version (no double-v, no bare-v)', () => {
       // Three regression guards:
       //   1. No 'vv' — VITE_APP_VERSION ships pre-prefixed with 'v', so

--- a/frontend/src/__tests__/integration/routing.test.tsx
+++ b/frontend/src/__tests__/integration/routing.test.tsx
@@ -18,6 +18,7 @@ import { render, screen } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import HistoryPage from '../../pages/HistoryPage'
 import MethodologyPage from '../../pages/MethodologyPage'
+import McpPage from '../../pages/McpPage'
 
 // HistoryPage now fetches per-year summary cards (#892). This routing test
 // only asserts the synchronous scaffold (heading, year strip, TI link), so
@@ -106,6 +107,22 @@ describe('Routing scaffolding (#355)', () => {
           })
         ).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('/mcp page (#1165)', () => {
+    it('renders the page heading', () => {
+      renderRoute(McpPage, '/mcp')
+      expect(
+        screen.getByRole('heading', { level: 1, name: /mcp server/i })
+      ).toBeInTheDocument()
+    })
+
+    it('renders the install snippet with the published package name', () => {
+      renderRoute(McpPage, '/mcp')
+      expect(document.body.textContent).toContain(
+        '@taverns-red/toast-stats-mcp'
+      )
     })
   })
 })

--- a/frontend/src/components/AppShell/AppMeta.tsx
+++ b/frontend/src/components/AppShell/AppMeta.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 declare const __APP_VERSION__: string
 
@@ -36,6 +37,15 @@ const AppMeta: React.FC = () => {
           >
             dashboards.toastmasters.org
           </a>
+          {' · '}
+          {/* /mcp entry point (#1165): AppMeta renders in both the desktop
+              footer and the mobile "About ▾" disclosure (#889), so this one
+              link covers every page at every breakpoint. Placed before the
+              license so the "MIT License · <version>" slot pairing the
+              version guard asserts on stays adjacent. */}
+          <Link to="/mcp" className="app-shell-footer__link">
+            MCP server
+          </Link>
           {' · '}
           <a
             href="https://github.com/taverns-red/toast-stats/blob/main/LICENSE"

--- a/frontend/src/pages/McpPage.tsx
+++ b/frontend/src/pages/McpPage.tsx
@@ -69,14 +69,6 @@ const JSON_CONFIG_SNIPPET = `{
   }
 }`
 
-const SECTIONS: ReadonlyArray<{ id: string; num: string; title: string }> = [
-  { id: 'what-it-is', num: '01', title: 'What it is' },
-  { id: 'install', num: '02', title: 'Install' },
-  { id: 'tools', num: '03', title: 'The eight tools' },
-  { id: 'freshness', num: '04', title: 'Data freshness & provenance' },
-  { id: 'developers', num: '05', title: 'For developers' },
-]
-
 const McpPage: React.FC = () => {
   useDocumentTitle('MCP Server')
 
@@ -84,7 +76,7 @@ const McpPage: React.FC = () => {
   // a disclosure on <768px; desktop renders the full static page. This page is
   // short enough that open-state is plain local state — no URL round-trip.
   const isMobile = useIsMobile()
-  const [openIds, setOpenIds] = useState<ReadonlySet<string>>(new Set())
+  const [openIds, setOpenIds] = useState<ReadonlySet<string>>(() => new Set())
   const toggle = useCallback((id: string) => {
     setOpenIds(prev => {
       const next = new Set(prev)
@@ -96,8 +88,6 @@ const McpPage: React.FC = () => {
 
   const sectionProps = (id: string) => ({
     id,
-    num: SECTIONS.find(s => s.id === id)?.num ?? '',
-    title: SECTIONS.find(s => s.id === id)?.title ?? '',
     collapsible: isMobile,
     open: openIds.has(id),
     onToggle: toggle,
@@ -115,7 +105,11 @@ const McpPage: React.FC = () => {
         </p>
       </header>
 
-      <CollapsibleSection {...sectionProps('what-it-is')}>
+      <CollapsibleSection
+        num="01"
+        title="What it is"
+        {...sectionProps('what-it-is')}
+      >
         <p>
           <code>{PACKAGE_NAME}</code> is a thin, local, read-only{' '}
           <a
@@ -154,7 +148,7 @@ const McpPage: React.FC = () => {
         </ul>
       </CollapsibleSection>
 
-      <CollapsibleSection {...sectionProps('install')}>
+      <CollapsibleSection num="02" title="Install" {...sectionProps('install')}>
         <p>
           Requires <strong>Node.js 22+</strong>. For{' '}
           <strong>Claude Code</strong>, one command:
@@ -185,7 +179,11 @@ const McpPage: React.FC = () => {
         </p>
       </CollapsibleSection>
 
-      <CollapsibleSection {...sectionProps('tools')}>
+      <CollapsibleSection
+        num="03"
+        title="The eight tools"
+        {...sectionProps('tools')}
+      >
         <p>
           All eight tools are read-only and return a JSON envelope citing the
           CDN URL and snapshot date they read.
@@ -202,7 +200,11 @@ const McpPage: React.FC = () => {
         </dl>
       </CollapsibleSection>
 
-      <CollapsibleSection {...sectionProps('freshness')}>
+      <CollapsibleSection
+        num="04"
+        title="Data freshness & provenance"
+        {...sectionProps('freshness')}
+      >
         <ul>
           <li>
             <strong>Refresh cadence.</strong> The data pipeline runs once daily
@@ -233,7 +235,11 @@ const McpPage: React.FC = () => {
         </p>
       </CollapsibleSection>
 
-      <CollapsibleSection {...sectionProps('developers')}>
+      <CollapsibleSection
+        num="05"
+        title="For developers"
+        {...sectionProps('developers')}
+      >
         <p>
           The server is MIT-licensed and lives in the{' '}
           <a

--- a/frontend/src/pages/McpPage.tsx
+++ b/frontend/src/pages/McpPage.tsx
@@ -153,7 +153,7 @@ const McpPage: React.FC = () => {
           Requires <strong>Node.js 22+</strong>. For{' '}
           <strong>Claude Code</strong>, one command:
         </p>
-        <pre className="mcp-page__snippet">
+        <pre className="mcp-page__snippet" tabIndex={0}>
           <code>{CLAUDE_CODE_SNIPPET}</code>
         </pre>
         <p>
@@ -161,7 +161,7 @@ const McpPage: React.FC = () => {
           <code>claude_desktop_config.json</code>) or any other MCP-capable
           client, add an <code>mcpServers</code> entry:
         </p>
-        <pre className="mcp-page__snippet">
+        <pre className="mcp-page__snippet" tabIndex={0}>
           <code>{JSON_CONFIG_SNIPPET}</code>
         </pre>
         <p>

--- a/frontend/src/pages/McpPage.tsx
+++ b/frontend/src/pages/McpPage.tsx
@@ -208,7 +208,7 @@ const McpPage: React.FC = () => {
         <ul>
           <li>
             <strong>Refresh cadence.</strong> The data pipeline runs once daily
-            (~09:15 UTC); the server reads whatever snapshot is currently
+            (08:00 UTC); the server reads whatever snapshot is currently
             published. Answers are as-of the snapshot <code>date</code> they
             cite — not real time.
           </li>

--- a/frontend/src/pages/McpPage.tsx
+++ b/frontend/src/pages/McpPage.tsx
@@ -1,0 +1,266 @@
+import React, { useCallback, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useIsMobile } from '../hooks/useIsMobile'
+import CollapsibleSection from '../components/CollapsibleSection'
+
+/* MCP Server page (#1165, epic #1162). The public announcement surface for
+   the published @taverns-red/toast-stats-mcp package: what it is, how to
+   install it, the eight read-only tools, and the freshness/provenance
+   caveats. Authored against the package README (packages/mcp-server) and
+   ADR-008 as the sources of truth — keep the install snippets in sync with
+   the README's Install section (one story, per the #1165 operator ruling).
+
+   Doc-style route in the Methodology family: same section chrome
+   (CollapsibleSection — collapses per-section on mobile, static on desktop),
+   same lede pattern. Fully static content — no data fetch, so there are no
+   null-until-data sections and the page is CLS-safe by construction. */
+
+const PACKAGE_NAME = '@taverns-red/toast-stats-mcp'
+
+const TOOLS: ReadonlyArray<{ name: string; purpose: string }> = [
+  {
+    name: 'get-latest-date',
+    purpose: 'Most recent published snapshot date.',
+  },
+  {
+    name: 'list-dates',
+    purpose: 'Every available snapshot date.',
+  },
+  {
+    name: 'list-districts',
+    purpose: 'District ids with snapshots, and the dates each has.',
+  },
+  {
+    name: 'resolve-club',
+    purpose:
+      'Which district a club id belongs to. Unknown club → not available, never guessed.',
+  },
+  {
+    name: 'get-district-snapshot',
+    purpose:
+      'Full per-district snapshot (roster, division/area aggregates, totals) for a date.',
+  },
+  {
+    name: 'query-rankings',
+    purpose:
+      'All-districts rankings — ranks, paid clubs, payments, distinguished tiers.',
+  },
+  {
+    name: 'get-club-health',
+    purpose:
+      'Raw per-club health-signal fields (membership, base, renewals, DCP goals, status), optionally filtered to one division.',
+  },
+  {
+    name: 'get-time-series',
+    purpose:
+      'Pre-computed program-year time series for a district — membership, payments, DCP, distinguished, club-health counts.',
+  },
+]
+
+const CLAUDE_CODE_SNIPPET = `claude mcp add toast-stats -- npx -y ${PACKAGE_NAME}`
+
+const JSON_CONFIG_SNIPPET = `{
+  "mcpServers": {
+    "toast-stats": {
+      "command": "npx",
+      "args": ["-y", "${PACKAGE_NAME}"]
+    }
+  }
+}`
+
+const SECTIONS: ReadonlyArray<{ id: string; num: string; title: string }> = [
+  { id: 'what-it-is', num: '01', title: 'What it is' },
+  { id: 'install', num: '02', title: 'Install' },
+  { id: 'tools', num: '03', title: 'The eight tools' },
+  { id: 'freshness', num: '04', title: 'Data freshness & provenance' },
+  { id: 'developers', num: '05', title: 'For developers' },
+]
+
+const McpPage: React.FC = () => {
+  useDocumentTitle('MCP Server')
+
+  // Same mobile pattern as /methodology (#877): each section collapses behind
+  // a disclosure on <768px; desktop renders the full static page. This page is
+  // short enough that open-state is plain local state — no URL round-trip.
+  const isMobile = useIsMobile()
+  const [openIds, setOpenIds] = useState<ReadonlySet<string>>(new Set())
+  const toggle = useCallback((id: string) => {
+    setOpenIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const sectionProps = (id: string) => ({
+    id,
+    num: SECTIONS.find(s => s.id === id)?.num ?? '',
+    title: SECTIONS.find(s => s.id === id)?.title ?? '',
+    collapsible: isMobile,
+    open: openIds.has(id),
+    onToggle: toggle,
+  })
+
+  return (
+    <div className="methodology-page mcp-page">
+      <header className="methodology-page__header">
+        <p className="placeholder-page__eyebrow">AI access · MCP</p>
+        <h1 className="placeholder-page__title">MCP Server</h1>
+        <p className="long-text-lede" data-testid="mcp-lede">
+          Ask Claude (or any MCP-capable client) about district performance,
+          grounded in the same public data this site renders — a local,
+          read-only server you install with one command.
+        </p>
+      </header>
+
+      <CollapsibleSection {...sectionProps('what-it-is')}>
+        <p>
+          <code>{PACKAGE_NAME}</code> is a thin, local, read-only{' '}
+          <a
+            href="https://modelcontextprotocol.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="methodology-link"
+          >
+            Model Context Protocol
+          </a>{' '}
+          server over the public Toast Stats snapshot CDN. It gives an AI client
+          eight read-only tools over the <em>pre-computed</em> snapshots this
+          site renders — so its answers cite the same numbers you see here.
+        </p>
+        <p>It is deliberately thin:</p>
+        <ul>
+          <li>
+            <strong>Read-only, no computation.</strong> Tools fetch CDN JSON,
+            validate it, and return fields. They never derive a tier, threshold,
+            or recognition state.
+          </li>
+          <li>
+            <strong>Not available, never guess.</strong> If a question needs
+            something a snapshot doesn&apos;t already contain, the tool returns
+            a structured <em>not available</em> — it never fabricates.
+          </li>
+          <li>
+            <strong>Local only.</strong> Runs on your machine over stdio. No
+            hosting, no account, no auth — the data is public.
+          </li>
+          <li>
+            <strong>Cites its source.</strong> Every response carries the exact
+            CDN <code>sourceUrl</code> it read and the snapshot{' '}
+            <code>date</code>, so any answer is verifiable against this site.
+          </li>
+        </ul>
+      </CollapsibleSection>
+
+      <CollapsibleSection {...sectionProps('install')}>
+        <p>
+          Requires <strong>Node.js 22+</strong>. For{' '}
+          <strong>Claude Code</strong>, one command:
+        </p>
+        <pre className="mcp-page__snippet">
+          <code>{CLAUDE_CODE_SNIPPET}</code>
+        </pre>
+        <p>
+          For <strong>Claude Desktop</strong> (
+          <code>claude_desktop_config.json</code>) or any other MCP-capable
+          client, add an <code>mcpServers</code> entry:
+        </p>
+        <pre className="mcp-page__snippet">
+          <code>{JSON_CONFIG_SNIPPET}</code>
+        </pre>
+        <p>
+          Restart the client and the <code>toast-stats</code> tools below become
+          available. The package is published on{' '}
+          <a
+            href={`https://www.npmjs.com/package/${PACKAGE_NAME}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="methodology-link"
+          >
+            npm
+          </a>
+          .
+        </p>
+      </CollapsibleSection>
+
+      <CollapsibleSection {...sectionProps('tools')}>
+        <p>
+          All eight tools are read-only and return a JSON envelope citing the
+          CDN URL and snapshot date they read.
+        </p>
+        <dl className="methodology-glossary">
+          {TOOLS.map(t => (
+            <React.Fragment key={t.name}>
+              <dt>
+                <code>{t.name}</code>
+              </dt>
+              <dd>{t.purpose}</dd>
+            </React.Fragment>
+          ))}
+        </dl>
+      </CollapsibleSection>
+
+      <CollapsibleSection {...sectionProps('freshness')}>
+        <ul>
+          <li>
+            <strong>Refresh cadence.</strong> The data pipeline runs once daily
+            (~09:15 UTC); the server reads whatever snapshot is currently
+            published. Answers are as-of the snapshot <code>date</code> they
+            cite — not real time.
+          </li>
+          <li>
+            <strong>Closing periods & restatements.</strong> Toastmasters
+            occasionally republishes corrected files, and month-end results
+            settle over a few days. Recent values can restate; the cited
+            snapshot date tells you exactly which day&apos;s data an answer
+            used.
+          </li>
+          <li>
+            <strong>Provenance.</strong> Every response carries the exact CDN{' '}
+            <code>sourceUrl</code> it read, so you can verify any number against
+            the live site or the raw JSON.
+          </li>
+        </ul>
+        <p className="methodology-source">
+          How the numbers themselves are computed — rankings, DCP tiers, club
+          health — is documented on{' '}
+          <Link to="/methodology" className="methodology-link">
+            How it works
+          </Link>
+          .
+        </p>
+      </CollapsibleSection>
+
+      <CollapsibleSection {...sectionProps('developers')}>
+        <p>
+          The server is MIT-licensed and lives in the{' '}
+          <a
+            href="https://github.com/taverns-red/toast-stats/tree/main/packages/mcp-server"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="methodology-link"
+          >
+            Toast Stats GitHub repo
+          </a>{' '}
+          (<code>packages/mcp-server</code>) — the README covers the
+          clone-and-build development path, the offline smoke tests, and the
+          response envelope. The design rationale (why a thin read-only server,
+          why no computation) is{' '}
+          <a
+            href="https://github.com/taverns-red/toast-stats/blob/main/docs/architecture-decisions/008-ai-enable-toast-stats.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="methodology-link"
+          >
+            ADR-008
+          </a>
+          .
+        </p>
+      </CollapsibleSection>
+    </div>
+  )
+}
+
+export default McpPage

--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -176,6 +176,14 @@ const MethodologyPage: React.FC = () => {
           stops publishing a file, the pipeline fails loudly rather than
           silently inferring values.
         </p>
+        <p className="methodology-source">
+          Prefer asking an AI? The same public snapshots are exposed through a
+          local read-only MCP server — see{' '}
+          <Link to="/mcp" className="methodology-link">
+            MCP Server
+          </Link>{' '}
+          for the one-command install.
+        </p>
       </CollapsibleSection>
 
       <CollapsibleSection

--- a/frontend/src/pages/MethodologyPage.tsx
+++ b/frontend/src/pages/MethodologyPage.tsx
@@ -195,8 +195,8 @@ const MethodologyPage: React.FC = () => {
         onToggle={toggle}
       >
         <p>
-          The data pipeline runs once daily at 09:15 UTC (≈04:15 ET / 02:15 PT)
-          — the schedule lives in{' '}
+          The data pipeline runs once daily at 08:00 UTC (4 AM EST / 5 AM EDT),
+          with an 11:00 UTC backup run — the schedule lives in{' '}
           <code>.github/workflows/data-pipeline.yml</code>. Each run pulls the
           latest TI CSVs, transforms them, computes rankings + analytics, and
           writes a dated snapshot to GCS. Frontend serves the most recent

--- a/frontend/src/pages/__tests__/McpPage.test.tsx
+++ b/frontend/src/pages/__tests__/McpPage.test.tsx
@@ -1,0 +1,125 @@
+/* /mcp page (#1165, epic #1162) — the public announcement surface for the
+   published MCP server. Content correctness against the package README and
+   ADR-008: the real published package name in the install snippets, all 8
+   tool names, the freshness/provenance caveats, and the GitHub + ADR links. */
+
+import React from 'react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import McpPage from '../McpPage'
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <McpPage />
+    </MemoryRouter>
+  )
+
+afterEach(() => cleanup())
+
+describe('McpPage — scaffold (#1165)', () => {
+  it('renders a level-1 heading naming the MCP server', () => {
+    renderPage()
+    expect(
+      screen.getByRole('heading', { level: 1, name: /mcp server/i })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the lede explaining what the page answers', () => {
+    renderPage()
+    expect(screen.getByTestId('mcp-lede')).toBeInTheDocument()
+  })
+
+  it('sets the document title', async () => {
+    renderPage()
+    await waitFor(() => expect(document.title).toBe('MCP Server — Toast Stats'))
+  })
+})
+
+describe('McpPage — install snippets (#1165)', () => {
+  it('shows the real published package name in an npx one-liner', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toContain('npx -y @taverns-red/toast-stats-mcp')
+  })
+
+  it('shows the claude mcp add one-liner for Claude Code', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toMatch(/claude mcp add toast-stats/)
+  })
+
+  it('shows the JSON client config using npx (no absolute paths)', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toContain('"command": "npx"')
+    expect(txt).not.toMatch(/\/absolute\/path/)
+  })
+
+  it('never shows the stale pre-publish framing', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).not.toMatch(/not yet published/i)
+  })
+})
+
+describe('McpPage — tools inventory (#1165)', () => {
+  it('lists all 8 read-only tools by their real names', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    for (const tool of [
+      'get-latest-date',
+      'list-dates',
+      'list-districts',
+      'resolve-club',
+      'get-district-snapshot',
+      'query-rankings',
+      'get-club-health',
+      'get-time-series',
+    ]) {
+      expect(txt).toContain(tool)
+    }
+  })
+
+  it('states the read-only / no-computation contract', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toMatch(/read-only/i)
+  })
+})
+
+describe('McpPage — freshness, provenance, and links (#1165)', () => {
+  it('explains data freshness (daily pipeline) and source citation', () => {
+    renderPage()
+    const txt = document.body.textContent || ''
+    expect(txt).toMatch(/once daily/i)
+    expect(txt).toMatch(/sourceUrl/)
+  })
+
+  it('links to the GitHub repo', () => {
+    renderPage()
+    const gh = screen.getByRole('link', { name: /github/i })
+    expect(gh).toHaveAttribute(
+      'href',
+      expect.stringContaining('github.com/taverns-red/toast-stats')
+    )
+  })
+
+  it('links to ADR-008', () => {
+    renderPage()
+    const adr = screen.getByRole('link', { name: /adr[- ]?008/i })
+    expect(adr).toHaveAttribute(
+      'href',
+      expect.stringContaining('008-ai-enable-toast-stats.md')
+    )
+  })
+
+  it('links back to How it works for the methodology', () => {
+    renderPage()
+    const link = screen
+      .getAllByRole('link')
+      .find(a => a.getAttribute('href') === '/methodology')
+    expect(link).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/__tests__/MethodologyPage.test.tsx
+++ b/frontend/src/pages/__tests__/MethodologyPage.test.tsx
@@ -78,8 +78,9 @@ describe('MethodologyPage — Club health classifications (#440)', () => {
 describe('MethodologyPage — pointer to the MCP server page (#1165)', () => {
   it('links to /mcp from the data source section', () => {
     renderPage()
-    const links = screen.getAllByRole('link')
-    const mcpLink = links.find(a => a.getAttribute('href') === '/mcp')
-    expect(mcpLink).toBeTruthy()
+    expect(screen.getByRole('link', { name: /mcp server/i })).toHaveAttribute(
+      'href',
+      '/mcp'
+    )
   })
 })

--- a/frontend/src/pages/__tests__/MethodologyPage.test.tsx
+++ b/frontend/src/pages/__tests__/MethodologyPage.test.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react'
 import { describe, it, expect } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import MethodologyPage from '../MethodologyPage'
 
@@ -72,5 +72,14 @@ describe('MethodologyPage — Club health classifications (#440)', () => {
     const txt = document.body.textContent || ''
     expect(txt).toMatch(/paid members\s*&?lt;?\s*12|paid members\s*<\s*12/i)
     expect(txt).toMatch(/net growth\s*&?lt;?\s*3|net growth\s*<\s*3/i)
+  })
+})
+
+describe('MethodologyPage — pointer to the MCP server page (#1165)', () => {
+  it('links to /mcp from the data source section', () => {
+    renderPage()
+    const links = screen.getAllByRole('link')
+    const mcpLink = links.find(a => a.getAttribute('href') === '/mcp')
+    expect(mcpLink).toBeTruthy()
   })
 })

--- a/frontend/src/pages/__tests__/staticPageTitles.test.tsx
+++ b/frontend/src/pages/__tests__/staticPageTitles.test.tsx
@@ -7,6 +7,7 @@ import { render, cleanup, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import MethodologyPage from '../MethodologyPage'
 import HistoryPage from '../HistoryPage'
+import McpPage from '../McpPage'
 
 // HistoryPage fetches per-year cards (#892); the title is still synchronous on
 // mount, so stub the data hook to keep this title test network-free.
@@ -42,5 +43,14 @@ describe('static page document titles (#780)', () => {
     await waitFor(() =>
       expect(document.title).toBe('Program Year History — Toast Stats')
     )
+  })
+
+  it('titles the MCP Server page (#1165)', async () => {
+    render(
+      <MemoryRouter>
+        <McpPage />
+      </MemoryRouter>
+    )
+    await waitFor(() => expect(document.title).toBe('MCP Server — Toast Stats'))
   })
 })

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -4881,6 +4881,28 @@
     color: var(--ink-2);
   }
 
+  /* MCP Server page (#1165) — block install snippets. Inline `code` inherits
+     the .methodology-section treatment; the block form needs its own box and
+     horizontal scroll so a one-liner never wraps mid-command on mobile. */
+  .mcp-page__snippet {
+    font-family: var(--mono);
+    font-size: 13px;
+    line-height: 1.55;
+    background-color: var(--surface-3);
+    color: var(--ink-2);
+    padding: 12px 14px;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin: 8px 0 14px;
+  }
+
+  .mcp-page__snippet code {
+    /* Reset the inline-code chip styling inside the block. */
+    background-color: transparent;
+    padding: 0;
+    font-size: inherit;
+  }
+
   /* Awards page (#371-#373). Top-10 leaderboards per district award. */
   .awards-page {
     max-width: 1280px;

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -169,8 +169,10 @@ Releases are deliberately **not** automated: no `NPM_TOKEN` lives in CI, and
 every publish requires the operator's 2FA. Flow:
 
 1. Bump the version via PR (`npm version patch --no-git-tag-version` in
-   `packages/mcp-server`, commit **both** `package.json` and the root
-   `package-lock.json`), merge.
+   `packages/mcp-server`, commit `package.json`, the root
+   `package-lock.json`, **and** the root `.release-please-manifest.json` —
+   the packaging test pins manifest == package.json, so skipping the
+   manifest sync ships a red Test Suite, as the 0.1.1 bump did), merge.
 2. `git pull && cd packages/mcp-server && npm publish` — the `prepack` hook
    rebuilds from source; enter your OTP at the prompt.
 3. Verify from the outside: `npm view @taverns-red/toast-stats-mcp version`

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -20,11 +20,37 @@ It is deliberately **thin**:
 
 ## Install
 
-This package is **publishable but not yet published** (`@taverns-red/toast-stats-mcp`
-— npm distribution ships with the `/mcp` page, epic #1162). Until then it is
-distributed **locally / self-installed** from the
-[Toast Stats monorepo](../../). Build it once, then point your MCP client at
-the built binary.
+Published on npm as
+[`@taverns-red/toast-stats-mcp`](https://www.npmjs.com/package/@taverns-red/toast-stats-mcp).
+Requires **Node.js 22+**. No clone, no build — `npx` fetches and runs the
+published bin.
+
+**Claude Code** — one command:
+
+```bash
+claude mcp add toast-stats -- npx -y @taverns-red/toast-stats-mcp
+```
+
+**Claude Desktop** (`claude_desktop_config.json`) or any other MCP-capable
+client — add an `mcpServers` entry:
+
+```json
+{
+  "mcpServers": {
+    "toast-stats": {
+      "command": "npx",
+      "args": ["-y", "@taverns-red/toast-stats-mcp"]
+    }
+  }
+}
+```
+
+Restart the client; the `toast-stats` tools below become available.
+
+### Development install (from the monorepo)
+
+Working on the server itself? Build the workspace and point your client at the
+local bin (use an **absolute** path) instead of the published package:
 
 ```bash
 # from the monorepo root
@@ -32,14 +58,6 @@ npm install
 npm run build:shared-contracts   # mcp-server depends on the built contracts
 npm run build:mcp-server         # emits packages/mcp-server/dist/bin.js
 ```
-
-This produces the executable `dist/bin.js` (bin name: `toast-stats-mcp`).
-
-## Configure your MCP client
-
-Add a `mcpServers` entry pointing at the built bin. Use an **absolute** path.
-
-**Claude Desktop** (`claude_desktop_config.json`) / **Claude Code** (`.mcp.json`):
 
 ```json
 {
@@ -52,8 +70,6 @@ Add a `mcpServers` entry pointing at the built bin. Use an **absolute** path.
 }
 ```
 
-Restart the client; the `toast-stats` tools below become available.
-
 ### Pointing at a different CDN (optional)
 
 The server reads `https://cdn.taverns.red` by default. Set `CDN_BASE_URL` to read a
@@ -63,8 +79,8 @@ staging origin or a local fixture server instead:
 {
   "mcpServers": {
     "toast-stats": {
-      "command": "node",
-      "args": ["/absolute/path/to/.../dist/bin.js"],
+      "command": "npx",
+      "args": ["-y", "@taverns-red/toast-stats-mcp"],
       "env": { "CDN_BASE_URL": "https://staging.example" }
     }
   }

--- a/packages/mcp-server/src/__tests__/packaging-manifest.test.ts
+++ b/packages/mcp-server/src/__tests__/packaging-manifest.test.ts
@@ -58,7 +58,10 @@ describe('publishable manifest (@taverns-red/toast-stats-mcp)', () => {
   })
 
   it('exposes the toast-stats-mcp bin at the bundled entry', () => {
-    expect(pkg.bin).toEqual({ 'toast-stats-mcp': './dist/bin.js' })
+    // No `./` prefix: npm normalizes bin paths on publish, and the manifest
+    // was deliberately aligned with the normalized form so `npm publish`
+    // ships without auto-corrections (#1185).
+    expect(pkg.bin).toEqual({ 'toast-stats-mcp': 'dist/bin.js' })
   })
 
   it('carries repository/homepage/license metadata', () => {

--- a/scripts/lib/__tests__/seoAssets.test.ts
+++ b/scripts/lib/__tests__/seoAssets.test.ts
@@ -18,7 +18,14 @@ const REPO_ROOT = join(
 )
 const PUBLIC_DIR = join(REPO_ROOT, 'frontend', 'public')
 
-const EXPECTED_PATHS = ['/', '/methodology', '/history', '/regions', '/awards']
+const EXPECTED_PATHS = [
+  '/',
+  '/methodology',
+  '/history',
+  '/regions',
+  '/awards',
+  '/mcp', // #1165 — public MCP-server install page
+]
 
 function locs(xml: string): string[] {
   return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1])

--- a/scripts/lib/seoAssets.ts
+++ b/scripts/lib/seoAssets.ts
@@ -34,6 +34,7 @@ export const PUBLIC_ROUTES: readonly PublicRoute[] = [
   { path: '/history' },
   { path: '/regions' },
   { path: '/awards' },
+  { path: '/mcp' }, // MCP-server install page (#1165)
 ]
 
 /** Absolute URL for a route path (`/` → `${ORIGIN}/`). */

--- a/tasks/lessons/165-an-attended-gate-bypass-must-re-green-every-artifact-the-gate-pins.md
+++ b/tasks/lessons/165-an-attended-gate-bypass-must-re-green-every-artifact-the-gate-pins.md
@@ -1,0 +1,69 @@
+---
+id: '165'
+category: lesson
+tags: [process, ci, automation, release, monorepo]
+auto_load: true
+date: 2026-06-12
+issues: [1165, 1162, 1186]
+---
+
+# Lesson 165 — An attended gate-bypass merge must re-green every artifact the gate pins, or the red lands on the next unrelated session
+
+**Date:** 2026-06-12
+**Issue:** #1165 (epic #1162 Sprint 3 — public /mcp page)
+**PR:** #1190
+
+## What happened
+
+Sprint 3's baseline run found main's mcp-server Test Suite **red**: PR #1186
+(the operator-attended 0.1.1 version bump, part of the manual npm release
+flow) had been merged with a failing Test Suite to unblock the publish. Two
+guards were tripped:
+
+- the packaging test still pinned `bin: './dist/bin.js'` after #1185
+  deliberately normalized it to `dist/bin.js` (so `npm publish` ships
+  without auto-corrections);
+- `.release-please-manifest.json` still said `0.1.0` while `package.json`
+  said `0.1.1` — the manual bump flow's documented checklist named
+  `package.json` and the lockfile, but not the manifest the test pins.
+
+Neither red was related to this sprint's scope (a frontend page), but R1
+("if pre-existing tests are red, fix them before adding new code") made the
+reconciliation this session's job: align the test with the deliberate spec
+change, sync the manifest, and extend the documented release-flow checklist
+so the gap can't recur.
+
+## The transferable principle
+
+**When an operator knowingly merges past a red gate (attended override,
+release pressure, burned-version recovery), the override is only complete
+when every artifact the gate pins is re-greened in the same change — an
+intentionally-eaten red doesn't disappear, it becomes a surprise baseline
+failure for the next session, which must first archaeology whether the red
+is a real regression, an intended spec change, or forgotten bookkeeping.**
+The cost asymmetry is stark: the merging operator has full context ("I
+normalized the bin path on purpose") and could fix the guard in seconds;
+the inheriting session must re-derive that intent from commit history
+before it dares touch the assertion (R1 — is fixing the test pinning a
+bug, or aligning with a deliberate decision?).
+
+## How to apply
+
+- Before merging any red-gate override, diff the failing assertions against
+  the intended end state and include the test/manifest updates in the same
+  PR — or file a same-day follow-up issue naming each tripped guard.
+- A manual flow document (here: the README release flow) must enumerate
+  every version-tracking artifact a test pins: `package.json`, lockfile,
+  **and** `.release-please-manifest.json`.
+- Inheriting a pre-existing red: `git log` the asserted-on values first.
+  "Test expects old value, code has new value via a deliberate commit" →
+  update the test (spec changed). No such commit → treat as a regression.
+
+## Related
+
+- [[158-a-fail-closed-chain-is-only-as-honest-as-its-writers-a-persisted-default-reads-as-a-decision]]
+  — same laundering shape: state that looks decided but was merely left behind.
+- [[164-bundledependencies-is-a-no-op-for-workspace-symlinked-deps-inline-at-build-time]]
+  — the same package's publish pipeline, one sprint earlier.
+- `packages/mcp-server/README.md` (release flow checklist),
+  `packages/mcp-server/src/__tests__/packaging-manifest.test.ts`.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -158,3 +158,4 @@
 - **162** [gcs, ci, data-pipeline, verification, regex] — A "keep only X" rsync exclude must also keep the bare directory path, or traversal prunes the parent before X is ever compared (#1175, #1102)
 - **163** [data-pipeline, collector-cli, verification, tdd, metadata, gcs] — A destructive boundary derived from set-level evidence must filter that evidence by provenance, not by shape (#1178, #1102)
 - **164** [monorepo, build, npm, verification, mcp] — `bundleDependencies` is a no-op for workspace-symlinked deps; a publishable workspace-dependent package must inline at build time (#1163, #1162)
+- **165** [process, ci, automation, release, monorepo] — An attended gate-bypass merge must re-green every artifact the gate pins, or the red lands on the next unrelated session (#1165, #1162, #1186)


### PR DESCRIPTION
Sprint 3 of epic #1162 — sub-issue #1165 (referenced plain, no auto-close keyword per R15/L106).

## What

- **New public `/mcp` page** (`McpPage.tsx`): lazy-loaded doc-style route in the Methodology family announcing the published `@taverns-red/toast-stats-mcp` package — what it is, `claude mcp add` / `npx` install snippets (real published name), the eight read-only tools, data freshness + provenance caveats, GitHub + ADR-008 links. Fully static (CLS-safe by construction); sections collapse on mobile like `/methodology` (#877 pattern).
- **Pointers**: How-it-works §01 links to `/mcp`; the footer meta strip (AppMeta — desktop footer **and** mobile "About ▾", #889) gains an "MCP server" link. Top nav deliberately untouched (5 items + hamburger constraint; developer-audience page belongs in secondary chrome).
- **Route inventories (R20 spirit)**: SEO manifest (`scripts/lib/seoAssets.ts`) + regenerated `sitemap.xml`, touch-targets e2e ROUTES sweep, routing integration test, static-title test.
- **README rewrite (binding operator comment on #1165)**: Install section now leads with the published npm package / npx one-liners; clone-and-build demoted to a "Development install" subsection; stale "publishable but not yet published" framing removed; CDN override example uses the npx form. Release-flow step 1 now names `.release-please-manifest.json` as a required sync.
- **Fix pre-existing red on main (R1)**: PR #1186 (operator-attended 0.1.1 bump) merged with a red Test Suite — the bin-path guard still expected `./dist/bin.js` after the deliberate npm normalization (#1185), and `.release-please-manifest.json` was never synced to 0.1.1. Both aligned with the intended state.
- **Review fix**: corrected the stale "09:15 UTC" pipeline-refresh claim to the real 08:00 UTC cron on both `/methodology` and `/mcp`; install snippet scroll regions are keyboard-focusable.

## Acceptance criteria (#1165)

- [x] `/mcp` renders with working install snippet (real published package name)
- [x] How-it-works links to it; route added to page inventories/tests
- [x] Lazy-loaded, CLS-safe (static content, no null-until-data sections)
- [ ] Preview-channel verification (Playwright smoke keyed on the stable route, Lesson 152) — pending preview deploy; evidence to follow on #1165

## Verification

- TDD throughout: every feature commit is preceded by a failing-spec commit.
- `npm run quality:check` exit 0 (typecheck, lint, YAML lint, format, all 5 workspace suites — 5,494 tests).
- `npm run test:no-page-mounts:check` green (R22).
- Fresh-context review verdict: APPROVE-WITH-NITS; the one Medium (08:00 UTC) and the a11y nit are fixed in-branch. Remaining Low (not-available envelope carries no `date`) matches the package README/source-of-truth — defer upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
