### PR TITLE
fix(trends): program-year selector now drives useTimeSeries (#1184)

### DIFF
--- a/frontend/src/hooks/__tests__/useTimeSeries.test.tsx
+++ b/frontend/src/hooks/__tests__/useTimeSeries.test.tsx
@@ -23,10 +23,13 @@ vi.mock('../../services/cdnTimeSeries', () => ({
   fetchTimeSeriesMetadata: vi.fn(),
   fetchTimeSeriesProgramYear: vi.fn(),
   getCurrentProgramYear: vi.fn(() => '2025-2026'),
-  getPreviousProgramYears: vi.fn((_current: string, count: number) => {
+  getPreviousProgramYears: vi.fn((current: string, count: number) => {
+    // Honour the passed anchor year (mirrors the real implementation) so that
+    // a SELECTED program year anchors its own priors, not the calendar-current.
+    const start = parseInt(current.split('-')[0] ?? '0', 10)
     const years = []
     for (let i = 1; i <= count; i++) {
-      years.push(`${2025 - i}-${2026 - i}`)
+      years.push(`${start - i}-${start - i + 1}`)
     }
     return years
   }),
@@ -175,6 +178,98 @@ describe('useTimeSeries', () => {
     expect(result.current.data!.currentMembership).toBe(2810)
     expect(result.current.data!.memberChange).toBe(-90)
     expect(result.current.data!.availableYears).toEqual(['2025-2026'])
+  })
+
+  it('should anchor on the SELECTED program year when one is provided (#1184)', async () => {
+    // Backfill (#1147) made historical PYs selectable. The selector must drive
+    // which series is fetched — not the calendar-current year (R3 violation).
+    mockFetchMetadata.mockResolvedValue({
+      districtId: '61',
+      lastUpdated: '2026-03-20T00:00:00.000Z',
+      availableProgramYears: [
+        '2020-2021',
+        '2021-2022',
+        '2024-2025',
+        '2025-2026',
+      ],
+      totalDataPoints: 40,
+    })
+
+    const priorYear = makeProgramYearIndex('61', '2020-2021', [
+      { date: '2020-07-31', membership: 2600, payments: 5200 },
+      { date: '2021-06-30', membership: 2700, payments: 5400 },
+    ])
+    const selectedYear = makeProgramYearIndex('61', '2021-2022', [
+      { date: '2021-07-31', membership: 2710, payments: 5420 },
+      { date: '2022-06-30', membership: 2790, payments: 5580 },
+    ])
+
+    mockFetchProgramYear.mockImplementation(async (_id, year) => {
+      if (year === '2020-2021') return priorYear
+      if (year === '2021-2022') return selectedYear
+      throw new Error(`Unexpected fetch for ${year}`)
+    })
+
+    const { result } = renderHook(() => useTimeSeries('61', '2021-2022'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.data).not.toBeNull())
+
+    // Anchor is the selected PY, not the calendar-current 2025-2026.
+    expect(result.current.data!.currentProgramYear).toBe('2021-2022')
+    // Current = last point of the SELECTED year.
+    expect(result.current.data!.currentMembership).toBe(2790)
+    // Base = last point of the prior PY (2020-2021), the selected year's prior.
+    expect(result.current.data!.baseMembership).toBe(2700)
+    expect(result.current.data!.memberChange).toBe(90)
+    // Only the selected year + its prior are fetched — never the current PY.
+    expect(result.current.data!.availableYears).toEqual([
+      '2021-2022',
+      '2020-2021',
+    ])
+    expect(mockFetchProgramYear).not.toHaveBeenCalledWith('61', '2025-2026')
+  })
+
+  it('should isolate the query cache per program year (#1184)', async () => {
+    // A shared QueryClient must not serve one PY's series for another — the
+    // query key has to include the selected PY.
+    mockFetchMetadata.mockResolvedValue({
+      districtId: '61',
+      lastUpdated: '2026-03-20T00:00:00.000Z',
+      availableProgramYears: ['2020-2021', '2021-2022'],
+      totalDataPoints: 20,
+    })
+    const y2021 = makeProgramYearIndex('61', '2021-2022', [
+      { date: '2022-06-30', membership: 2790, payments: 5580 },
+    ])
+    const y2020 = makeProgramYearIndex('61', '2020-2021', [
+      { date: '2021-06-30', membership: 2700, payments: 5400 },
+    ])
+    mockFetchProgramYear.mockImplementation(async (_id, year) => {
+      if (year === '2021-2022') return y2021
+      if (year === '2020-2021') return y2020
+      throw new Error(`Unexpected fetch for ${year}`)
+    })
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        children
+      )
+
+    const a = renderHook(() => useTimeSeries('61', '2021-2022'), { wrapper })
+    await waitFor(() => expect(a.result.current.data).not.toBeNull())
+    expect(a.result.current.data!.currentProgramYear).toBe('2021-2022')
+
+    const b = renderHook(() => useTimeSeries('61', '2020-2021'), { wrapper })
+    await waitFor(() => expect(b.result.current.data).not.toBeNull())
+    // Distinct key → 2020-2021 anchor, NOT the cached 2021-2022 entry.
+    expect(b.result.current.data!.currentProgramYear).toBe('2020-2021')
   })
 
   it('should handle metadata fetch failure', async () => {

--- a/frontend/src/hooks/useTimeSeries.ts
+++ b/frontend/src/hooks/useTimeSeries.ts
@@ -80,10 +80,20 @@ function computeBaseMembership(
  * Computes base membership and member change for the "+N members" badge.
  *
  * @param districtId - District ID to fetch data for (null to skip)
+ * @param selectedProgramYear - Program year to anchor on (e.g. "2021-2022").
+ *   When provided, this drives which series is fetched and which prior years
+ *   are compared against. Omitting it falls back to the calendar-current PY.
+ *   #1184: the parent (DistrictTrendsPage) holds the selected PY; the hook must
+ *   not self-select the latest year and ignore the selector (R3 violation).
  */
-export function useTimeSeries(districtId: string | null) {
+export function useTimeSeries(
+  districtId: string | null,
+  selectedProgramYear?: string
+) {
   const query = useQuery({
-    queryKey: ['timeSeries', districtId],
+    // #1184: the selected PY is part of the cache identity — without it, two
+    // different PYs share one cache entry and crosstalk (stale-cache bug).
+    queryKey: ['timeSeries', districtId, selectedProgramYear ?? null],
     queryFn: async (): Promise<TimeSeriesData> => {
       if (!districtId) {
         throw new Error('District ID is required')
@@ -92,7 +102,8 @@ export function useTimeSeries(districtId: string | null) {
       // Step 1: Fetch metadata to discover available program years
       const metadata = await fetchTimeSeriesMetadata(districtId)
 
-      const currentProgramYear = getCurrentProgramYear()
+      // Anchor on the selected PY when provided; otherwise the calendar-current.
+      const currentProgramYear = selectedProgramYear ?? getCurrentProgramYear()
       const desiredPriorYears = getPreviousProgramYears(currentProgramYear, 2)
 
       // Step 2: Determine which years to fetch (current + available priors)

--- a/frontend/src/pages/DistrictTrendsPage.tsx
+++ b/frontend/src/pages/DistrictTrendsPage.tsx
@@ -117,7 +117,11 @@ const DistrictTrendsPage: React.FC = () => {
     )
 
   const { data: timeSeries } = useTimeSeries(
-    hasValidDates ? districtId || null : null
+    hasValidDates ? districtId || null : null,
+    // #1184: thread the selected program year so the series, base membership,
+    // and YoY comparison follow the selector instead of the calendar-current PY
+    // (R3 — the parent holds the PY; don't let the child self-select).
+    effectiveProgramYear?.label
   )
 
   const { data: performanceTargets } = usePerformanceTargets(


### PR DESCRIPTION
## Problem
The Trends page's program-year selector had no effect — `useTimeSeries(districtId)` self-selected the calendar-current PY and ignored the selection. Surfaced by the #1147 backfill making PY 2021-22 selectable with real data. R3 violation: the child re-derived context (which program year) the parent already holds.

## Fix
- `useTimeSeries` takes an optional `selectedProgramYear` anchor (e.g. `"2021-2022"`). When provided it drives the fetched series, the prior-year comparison, and base membership; omitting it falls back to the calendar-current PY (other callers unchanged).
- The selected PY is part of the query key (`['timeSeries', districtId, selectedProgramYear ?? null]`) so distinct PYs don't share a cache entry (no stale-cache crosstalk).
- `DistrictTrendsPage` threads `effectiveProgramYear?.label`.
- **YoY follows automatically** — `computeYearOverYear` / `computePaymentYoYFromTimeSeries` derive from `timeSeries.currentProgramYear` (now the anchored PY) and `availableYears` (now `[selected, selected-1]`). For 2021-22 → compares vs 2020-21, not hardcoded recent years.

## R3 sweep of the page
`useTimeSeries` was the only unparameterized hook. `usePaymentsTrend` already receives `effectiveProgramYear`; `useAggregatedAnalytics` / `usePerformanceTargets` are date-anchored via `effectiveEndDate`.

## Tests (TDD)
Red: two new tests in `useTimeSeries.test.tsx` failed against `origin/main` (anchor ignored → returned `2025-2026`). Green after the fix. Full frontend suite: 3444 passing, zero regressions. Fresh-context review: APPROVE.

Ref #1184 (epic #1191).