### PR TITLE
fix(pages): district subpages surface retryable fetch errors (#1104)

### DIFF
--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -28,7 +28,7 @@ import {
 } from '../utils/dcpProjections'
 import { isCloseToDistinguished } from '../utils/closeToDistinguished'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
-import { EmptyState } from '../components/ErrorDisplay'
+import { EmptyState, ErrorDisplay } from '../components/ErrorDisplay'
 import ErrorBoundary from '../components/ErrorBoundary'
 import { ChartSparklineExpand } from '../components/ChartSparklineExpand'
 import { useDistrictStatistics } from '../hooks/useMembershipData'
@@ -233,7 +233,13 @@ const ClubDetailPage: React.FC = () => {
     effectiveProgramYear !== null && effectiveEndDate !== null
 
   // Fetch district analytics to get this club's data
-  const { data: analytics, isLoading } = useDistrictAnalytics(
+  const {
+    data: analytics,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useDistrictAnalytics(
     hasValidDates ? districtId || null : null,
     effectiveProgramYear?.startDate,
     effectiveEndDate ?? undefined
@@ -405,6 +411,32 @@ const ClubDetailPage: React.FC = () => {
           <div className="mt-6">
             <LoadingSkeleton variant="chart" height="400px" />
           </div>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Fetch error ──────────────────────────────────────────────────────────
+  // #1104 — a transient CDN/analytics fetch reject must surface a distinct,
+  // retryable error state. Checked BEFORE the not-found branch below, because
+  // on error `analytics` is undefined and `club` is null too — without this
+  // gate the page would falsely claim "Club Not Found" (that the club was
+  // removed) for what is really a network failure. Same outer wrapper geometry
+  // as the loading / not-found states so the error path adds no layout shift
+  // (L125).
+
+  if (isError) {
+    return (
+      <div className="min-h-screen">
+        <div className="container mx-auto px-4 py-8">
+          <ErrorDisplay
+            error={error ?? 'Failed to load club data'}
+            title="Failed to Load Club"
+            onRetry={() => {
+              refetch()
+            }}
+            showDetails={true}
+          />
         </div>
       </div>
     )

--- a/frontend/src/pages/DistrictAnalyticsPage.tsx
+++ b/frontend/src/pages/DistrictAnalyticsPage.tsx
@@ -19,6 +19,7 @@ import { DistrictSubnav } from '../components/DistrictSubnav'
 import { TopGrowthClubs } from '../components/TopGrowthClubs'
 import { EducationLevelsCard } from '../components/EducationLevelsCard'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
+import { ErrorDisplay } from '../components/ErrorDisplay'
 import ErrorBoundary from '../components/ErrorBoundary'
 
 /* District Analytics Page (#680, epic #674 Sprint 6, ADR-005 §1/§2).
@@ -98,12 +99,17 @@ const DistrictAnalyticsPage: React.FC = () => {
   const hasValidDates =
     effectiveProgramYear !== null && effectiveEndDate !== null
 
-  const { data: analytics, isLoading: isLoadingAnalytics } =
-    useDistrictAnalytics(
-      hasValidDates ? districtId || null : null,
-      effectiveProgramYear?.startDate,
-      effectiveEndDate ?? undefined
-    )
+  const {
+    data: analytics,
+    isLoading: isLoadingAnalytics,
+    isError: isAnalyticsError,
+    error: analyticsError,
+    refetch: refetchAnalytics,
+  } = useDistrictAnalytics(
+    hasValidDates ? districtId || null : null,
+    effectiveProgramYear?.startDate,
+    effectiveEndDate ?? undefined
+  )
 
   const { data: districtStatistics } = useDistrictStatistics(
     hasValidDates ? districtId || null : null,
@@ -184,6 +190,18 @@ const DistrictAnalyticsPage: React.FC = () => {
                 topGrowthClubs={analytics.topGrowthClubs}
                 topDCPClubs={topDCPClubs}
                 isLoading={isLoadingAnalytics}
+              />
+            ) : isAnalyticsError ? (
+              // #1104 — a fetch reject must surface a retryable error state,
+              // not silently render nothing (the old `: isLoading && …` arm
+              // collapsed to empty on error).
+              <ErrorDisplay
+                error={analyticsError ?? 'Failed to load analytics data'}
+                title="Failed to Load Analytics"
+                onRetry={() => {
+                  refetchAnalytics()
+                }}
+                showDetails={true}
               />
             ) : (
               isLoadingAnalytics && <LoadingSkeleton variant="card" />

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -23,6 +23,7 @@ import { DistrictSubnav } from '../components/DistrictSubnav'
 import { ClubsTable } from '../components/ClubsTable'
 import { ProspectiveClubsPanel } from '../components/ProspectiveClubsPanel'
 import ErrorBoundary from '../components/ErrorBoundary'
+import { ErrorDisplay } from '../components/ErrorDisplay'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import type { SortDirection, SortField } from '../components/filters/types'
 import type { FilterState } from '../components/filters/types'
@@ -210,7 +211,13 @@ const DistrictClubsPage: React.FC = () => {
   const hasValidDates =
     effectiveProgramYear !== null && effectiveEndDate !== null
 
-  const { data: analytics, isLoading } = useDistrictAnalytics(
+  const {
+    data: analytics,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useDistrictAnalytics(
     hasValidDates ? districtId || null : null,
     effectiveProgramYear?.startDate,
     effectiveEndDate ?? undefined
@@ -289,7 +296,20 @@ const DistrictClubsPage: React.FC = () => {
           <DistrictSubnav districtId={districtId} />
 
           <div className="space-y-4 sm:space-y-6">
-            {isLoading && allClubs.length === 0 ? (
+            {isError && allClubs.length === 0 ? (
+              // #1104 — a fetch reject must surface a retryable error state,
+              // not silently render an empty ClubsTable (`allClubs` falls back
+              // to `[]` on error). Gated on emptiness so a background refetch
+              // error never wipes already-rendered rows.
+              <ErrorDisplay
+                error={error ?? 'Failed to load clubs data'}
+                title="Failed to Load Clubs"
+                onRetry={() => {
+                  refetch()
+                }}
+                showDetails={true}
+              />
+            ) : isLoading && allClubs.length === 0 ? (
               <LoadingSkeleton variant="table" count={6} />
             ) : (
               <>

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -284,6 +284,28 @@ describe('ClubDetailPage (#208)', () => {
     expect(screen.getByText('Club Not Found')).toBeInTheDocument()
   })
 
+  // #1104 — a transient CDN fetch reject must surface a distinct, retryable
+  // error state, NOT the false "Club Not Found" empty state (which claims the
+  // club was removed). Error is checked before the loaded-but-absent branch.
+  it('renders a retryable error state — not "Club Not Found" — when the analytics fetch rejects', () => {
+    const refetch = vi.fn()
+    vi.mocked(useDistrictAnalytics).mockReturnValueOnce({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Failed to fetch'),
+      refetch,
+    } as unknown as ReturnType<typeof useDistrictAnalytics>)
+
+    renderWithRoute()
+
+    expect(screen.queryByText('Club Not Found')).not.toBeInTheDocument()
+    const retry = screen.getByRole('button', { name: /retry loading data/i })
+    expect(retry).toBeInTheDocument()
+    fireEvent.click(retry)
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
   it('renders DCP status section', () => {
     renderWithRoute()
 

--- a/frontend/src/pages/__tests__/DistrictAnalyticsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictAnalyticsPage.test.tsx
@@ -8,7 +8,13 @@
 
 import React, { Suspense } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import {
   createMemoryRouter,
   RouterProvider,
@@ -19,6 +25,7 @@ import '@testing-library/jest-dom'
 import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import { DarkModeProvider } from '../../contexts/DarkModeContext'
 import DistrictDetailPage from '../DistrictDetailPage'
+import { useDistrictAnalytics } from '../../hooks/useDistrictAnalytics'
 
 vi.mock('../../hooks/useDistricts', () => ({
   useDistricts: vi.fn(() => ({
@@ -207,5 +214,28 @@ describe('DistrictAnalyticsPage (#680 — ADR-005)', () => {
     await waitFor(() => {
       expect(router.state.location.pathname).toBe('/district/61/analytics')
     })
+  })
+
+  // #1104 — a fetch reject must surface a retryable error state, not silently
+  // render an empty page (the old `{analytics ? … : isLoading && <Skeleton/>}`
+  // collapsed to nothing on error).
+  it('surfaces a retryable error state when the analytics fetch rejects', async () => {
+    const refetch = vi.fn()
+    vi.mocked(useDistrictAnalytics).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Failed to fetch'),
+      refetch,
+    } as unknown as ReturnType<typeof useDistrictAnalytics>)
+
+    renderAt('/district/61/analytics')
+
+    const retry = await screen.findByRole('button', {
+      name: /retry loading data/i,
+    })
+    expect(screen.queryByTestId('top-growth-clubs')).not.toBeInTheDocument()
+    fireEvent.click(retry)
+    expect(refetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
@@ -16,6 +16,7 @@ import React, { Suspense } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   cleanup,
+  fireEvent,
   render,
   screen,
   waitFor,
@@ -29,7 +30,10 @@ import {
 } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import '@testing-library/jest-dom'
-import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import {
+  useDistrictAnalytics,
+  type ClubTrend,
+} from '../../hooks/useDistrictAnalytics'
 import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import { DarkModeProvider } from '../../contexts/DarkModeContext'
 import DistrictDetailPage from '../DistrictDetailPage'
@@ -473,5 +477,28 @@ describe('DistrictClubsPage (#570 — Phase 2)', () => {
       expect(params.get('dir')).toBe('desc')
       expect(params.get('page')).toBeNull()
     })
+  })
+
+  // #1104 — a fetch reject must surface a retryable error state, not silently
+  // render an empty ClubsTable (the old `allClubs = analytics?.allClubs || []`
+  // collapsed to `[]` on error).
+  it('surfaces a retryable error state when the analytics fetch rejects', async () => {
+    const refetch = vi.fn()
+    vi.mocked(useDistrictAnalytics).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Failed to fetch'),
+      refetch,
+    } as unknown as ReturnType<typeof useDistrictAnalytics>)
+
+    renderAt('/district/61/clubs')
+
+    const retry = await screen.findByRole('button', {
+      name: /retry loading data/i,
+    })
+    expect(screen.queryByText(/alpha toastmasters/i)).not.toBeInTheDocument()
+    fireEvent.click(retry)
+    expect(refetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/tasks/lessons/166-check-the-query-error-branch-before-the-derived-not-found-branch.md
+++ b/tasks/lessons/166-check-the-query-error-branch-before-the-derived-not-found-branch.md
@@ -1,0 +1,79 @@
+---
+id: '166'
+category: lesson
+tags: [frontend, react, tanstack, error-handling, verification]
+auto_load: true
+date: 2026-06-13
+issues: [1104, 1191]
+---
+
+# Lesson 166 — When a page derives "not found" from query data, check the error branch FIRST or every fetch failure is misreported as a missing entity
+
+**Date:** 2026-06-13
+**Issue:** #1104 (epic #1191 Sprint 2 — frontend defects)
+**PR:** #1201
+
+## What happened
+
+Three district subpages (`ClubDetailPage`, `DistrictAnalyticsPage`,
+`DistrictClubsPage`) destructured only `{ data, isLoading }` from
+`useDistrictAnalytics` (a raw `useQuery`), discarding `isError`/`error`/
+`refetch`. They then derived presence from the data:
+
+```ts
+const club = analytics?.allClubs.find(c => c.clubId === clubId) ?? null
+// …
+if (!club) return <EmptyState title="Club Not Found" message="…may have been removed" />
+```
+
+On a transient CDN reject, `analytics` is `undefined` → `club` is `null` →
+the page rendered a confident **"Club Not Found … may have been removed"** — a
+false data claim about a network blip, with no retry. The sibling pages
+silently rendered an empty table / blank section. The hub (`DistrictDetailPage`)
+did it right, capturing `error` + `refetch` and rendering `<ErrorDisplay
+onRetry={refetch} />`.
+
+## The transferable principle
+
+**A "not found" / "empty" state derived from query data is indistinguishable
+from a fetch error at the data layer — on error the derived entity is `null`
+and the derived list is `[]`, exactly as if the entity genuinely didn't exist.
+So the `isError` branch must be checked BEFORE the derived not-found/empty
+branch.** If the not-found branch comes first (or the error state is never read
+at all), every network failure is laundered into a confident, wrong "this was
+removed" claim. Order the terminal states `isLoading → isError → notFound/empty
+→ loaded`, and wire the error state's retry to the query's `refetch`.
+
+This is the component-level sibling of [[148-a-render-thrown-response-is-not-wrapped-by-isrouteerrorresponse]]'s
+"gate not-found on data _loaded_, not emptiness": there the gate was for a
+route-throwing 404; here it is for an in-page query whose error and emptiness
+collapse to the same derived value.
+
+## How to apply
+
+- Destructuring a `useQuery` for a page that derives presence from `data`? Take
+  `isError`, `error`, **and** `refetch`, not just `{ data, isLoading }`. The
+  hub component in the same area is usually the reference pattern — copy it.
+- Put the `isError` return/branch physically before the `!entity` branch.
+  A trailing error check after a not-found early-return is dead code (on error
+  the entity is null, so not-found already returned).
+- Reuse the shared error component (`ErrorDisplay` here) with `onRetry={() =>
+refetch()}`; don't hand-roll a one-off.
+- Give the error branch the **same outer wrapper geometry** as the loading /
+  not-found states so it adds no layout shift ([[125-a-cls-fix-for-the-loading-state-must-cover-the-error-and-empty-states-too]]).
+- Verify by **driving the real error path**: intercept the data fetch
+  (Playwright `route.fulfill({ status: 503 })`) on the live preview and assert
+  the retry affordance renders and the not-found copy is absent — in both
+  engines.
+
+## Related
+
+- [[148-a-render-thrown-response-is-not-wrapped-by-isrouteerrorresponse]] — the
+  route-level form of "don't infer not-found from emptiness."
+- [[125-a-cls-fix-for-the-loading-state-must-cover-the-error-and-empty-states-too]]
+  — keep the error state's geometry aligned with loading/not-found.
+- [[146-a-root-errorelement-renders-outside-the-app-context-providers]] — the
+  branded root boundary handles uncaught throws; this lesson is about the
+  handled, in-page query-error state that should never reach that boundary.
+- `frontend/src/pages/{ClubDetailPage,DistrictAnalyticsPage,DistrictClubsPage}.tsx`,
+  `frontend/src/components/ErrorDisplay.tsx`.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -159,3 +159,4 @@
 - **163** [data-pipeline, collector-cli, verification, tdd, metadata, gcs] — A destructive boundary derived from set-level evidence must filter that evidence by provenance, not by shape (#1178, #1102)
 - **164** [monorepo, build, npm, verification, mcp] — `bundleDependencies` is a no-op for workspace-symlinked deps; a publishable workspace-dependent package must inline at build time (#1163, #1162)
 - **165** [process, ci, automation, release, monorepo] — An attended gate-bypass merge must re-green every artifact the gate pins, or the red lands on the next unrelated session (#1165, #1162, #1186)
+- **166** [frontend, react, tanstack, error-handling, verification] — When a page derives "not found" from query data, check the error branch FIRST or every fetch failure is misreported as a missing entity (#1104, #1191)


### PR DESCRIPTION
## Problem (#1104)

District subpages + `ClubDetailPage` discarded the analytics query's error
state. On a transient CDN fetch reject:

- **ClubDetailPage** rendered the **false** "Club Not Found … may have been
  removed" empty state — a data claim for what is really a network failure, with
  no retry.
- **DistrictAnalyticsPage** silently rendered nothing.
- **DistrictClubsPage** silently rendered an empty `ClubsTable`.

The hub (`DistrictDetailPage`) already handles this correctly — the subpages
didn't.

## Fix

Capture `isError` / `error` / `refetch` from `useDistrictAnalytics` and render
the shared `ErrorDisplay` (retry affordance), mirroring the hub's pattern.

- The **error branch is checked before** the not-found / empty branch, because
  on error `analytics` is undefined and `club`/`allClubs` are empty too — without
  this gate a network failure is misreported as a removed club ([L148] — gate
  not-found on data *loaded*, not emptiness).
- The error path reuses the **same outer wrapper geometry** as the loading /
  not-found states, so it adds no layout shift ([L125]).
- `DistrictClubsPage` gates its error on `allClubs.length === 0`, so a
  background refetch error never wipes already-rendered rows.

## Acceptance criteria

- [x] `isError` surfaced distinctly from not-found on ClubDetailPage + district
      subpages, with a retry affordance
- [x] Tests: fetch-reject fixture renders the error state (not "Club Not
      Found" / empty) on all three pages; retry click calls `refetch`

## Testing

- TDD: RED commit (`6d07cc4c`) adds 3 fetch-reject tests that fail for the right
  reason (no retry button); GREEN commit (`60f940e9`) makes them pass.
- Full frontend suite: **3447 passed**, zero regressions. Lint + typecheck clean.
- Fresh-context review: APPROVE, no high/medium findings.

Refs #1104. Live verification on the PR preview channel to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)