### PR TITLE
fix(district-hub): reserve DistinguishedDistrictTrophyCase slot while awards query loads (#1105)

### DIFF
--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -224,8 +224,12 @@ const TrophyCaseSkeleton: React.FC = () => (
             key={i}
             className="rounded-md border border-gray-200 theme-dark:border-gray-700 px-3 py-2"
           >
+            {/* label · value · "+x%" sub-item — the three rows a populated
+                GapTile renders in the common (count present, gate open)
+                case, so the tile height matches the loaded one. */}
             <SkeletonBar className="h-3 w-20" />
             <SkeletonBar className="mt-1.5 h-5 w-16" />
+            <SkeletonBar className="mt-1.5 h-3 w-10" />
           </div>
         ))}
       </div>

--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -49,6 +49,16 @@ export interface DistinguishedDistrictStatus {
 
 interface DistinguishedDistrictTrophyCaseProps {
   status: DistinguishedDistrictStatus | null
+  /**
+   * True while the competitive-awards query is still in flight (#1105).
+   * That query resolves *separately from and later than* the page-analytics
+   * query that paints DistrictDetailPage, so without a reserved slot the
+   * panel pops in from 0px when the query lands and shoves everything below
+   * it down — the AwardsRaceSection (#750) / Lesson 107 failure class. While
+   * loading we render a height-matched skeleton so the real panel fills the
+   * slot in place.
+   */
+  isLoading?: boolean
   /** Optional rankings row used to derive the absolute remaining counts
       when the canonical fields are absent or the next tier is above
       Distinguished. Matches the region page's data source. */
@@ -156,10 +166,72 @@ const GapTile: React.FC<GapTileSpec> = ({
   )
 }
 
+/* Height-matched loading placeholder (#1105 / Lesson 107, 158). Reuses the
+   real panel's chrome — the `redesign-panel` wrapper, the static title +
+   "Program Item 1490" caption, the section borders, and the gap-tiles grid
+   container — so the reserved height emerges from the SAME CSS that sizes the
+   loaded panel (across breakpoints + dark mode) rather than a pinned `Npx`
+   that drifts the day a label changes. Only the data rows (pill, summary,
+   per-tile label/value) become skeleton bars. `aria-hidden` keeps it out of
+   the AT tree and the gap-tile test queries. */
+const SkeletonBar: React.FC<{ className: string }> = ({ className }) => (
+  <span
+    className={`block animate-pulse rounded bg-gray-200 theme-dark:bg-gray-700 ${className}`}
+  />
+)
+
+const TrophyCaseSkeleton: React.FC = () => (
+  <div
+    className="redesign-panel"
+    aria-hidden="true"
+    data-testid="distinguished-trophy-skeleton"
+  >
+    <div className="flex flex-wrap items-start justify-between gap-3 mb-4">
+      <div>
+        <h2 className="text-lg font-bold text-gray-900 font-tm-headline">
+          Distinguished District Status
+        </h2>
+        <p className="mt-0.5 text-xs uppercase tracking-wide text-gray-500 font-tm-body">
+          Program Item 1490
+        </p>
+      </div>
+      {/* Status pill placeholder — matches the px-4 py-2 text-base pill box. */}
+      <SkeletonBar className="h-10 w-48 rounded-full" />
+    </div>
+
+    {/* Prerequisite summary line — 44px touch-target floor like the real
+        toggle/status row, so the reserved height tracks it. */}
+    <div className="mb-4 flex items-center min-h-11">
+      <SkeletonBar className="h-4 w-44" />
+    </div>
+
+    {/* Gap-to-next-tier: the dominant slot. Reuse the real section border +
+        3-up grid so the tiles land in place. */}
+    <div className="border-t border-gray-200 pt-4">
+      <SkeletonBar className="h-4 w-40 mb-2" />
+      <div
+        data-testid="distinguished-trophy-skeleton-tiles"
+        className="grid grid-cols-1 md:grid-cols-3 gap-2"
+      >
+        {[0, 1, 2].map(i => (
+          <div
+            key={i}
+            className="rounded-md border border-gray-200 theme-dark:border-gray-700 px-3 py-2"
+          >
+            <SkeletonBar className="h-3 w-20" />
+            <SkeletonBar className="mt-1.5 h-5 w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+)
+
 export const DistinguishedDistrictTrophyCase: React.FC<
   DistinguishedDistrictTrophyCaseProps
 > = ({
   status,
+  isLoading = false,
   ranking,
   clubStrengthQualifies,
   clubStrengthGrowth,
@@ -170,7 +242,10 @@ export const DistinguishedDistrictTrophyCase: React.FC<
 }) => {
   const [userExpanded, setUserExpanded] = useState(false)
 
-  if (!status) return null
+  // Reserve the slot while the (separate, slower) competitive-awards query is
+  // in flight so its late arrival doesn't shift the page below it (#1105 /
+  // Lesson 107). Once it settles with genuinely no status, collapse to null.
+  if (!status) return isLoading ? <TrophyCaseSkeleton /> : null
 
   const { currentTier, allPrerequisitesMet, prerequisites, nextTierGap } =
     status

--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -206,7 +206,13 @@ const TrophyCaseSkeleton: React.FC = () => (
     </div>
 
     {/* Gap-to-next-tier: the dominant slot. Reuse the real section border +
-        3-up grid so the tiles land in place. */}
+        3-up grid so the tiles land in place. We always reserve this block
+        because it's the common loaded shape (any district below its top tier
+        shows a gap). Districts that resolve with `nextTierGap == null` (already
+        Smedley, or Unknown) omit it and settle slightly UPWARD — a bounded,
+        rare residual, far smaller than the original 0→full downward pop, and
+        unknowable before the query lands. Same accepted-collapse tradeoff as
+        AwardsRaceSection (#750). */}
     <div className="border-t border-gray-200 pt-4">
       <SkeletonBar className="h-4 w-40 mb-2" />
       <div

--- a/frontend/src/components/__tests__/DistinguishedDistrictTrophyCase.test.tsx
+++ b/frontend/src/components/__tests__/DistinguishedDistrictTrophyCase.test.tsx
@@ -279,4 +279,45 @@ describe('DistinguishedDistrictTrophyCase', () => {
     )
     expect(container).toBeEmptyDOMElement()
   })
+
+  describe('loading slot reservation (#1105 — Lesson 107 CLS pattern)', () => {
+    /* The competitive-awards query resolves separately from and later than
+       the page analytics query that paints DistrictDetailPage. Without a
+       reserved slot the trophy case pops in from 0px when that query lands
+       and shoves everything below it down — the AwardsRaceSection (#750)
+       failure class. While the awards query is in flight we render a
+       height-matched skeleton so the real panel fills the slot in place. */
+
+    it('renders a height-matched skeleton while the awards query is loading', () => {
+      render(<DistinguishedDistrictTrophyCase status={null} isLoading />)
+      const skeleton = screen.getByTestId('distinguished-trophy-skeleton')
+      expect(skeleton).toBeInTheDocument()
+      // Reuses the real panel chrome so the loaded content lands in place.
+      expect(skeleton).toHaveClass('redesign-panel')
+      // Decorative — read by neither AT nor the gap-tile queries.
+      expect(skeleton).toHaveAttribute('aria-hidden', 'true')
+      // Reserves the dominant gap-tiles slot (3-up grid) that the loaded
+      // panel renders, so the slot height is present before data arrives.
+      expect(
+        within(skeleton).getByTestId('distinguished-trophy-skeleton-tiles')
+      ).toBeInTheDocument()
+    })
+
+    it('still renders nothing when not loading and status is null', () => {
+      const { container } = render(
+        <DistinguishedDistrictTrophyCase status={null} isLoading={false} />
+      )
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it('renders the real panel, not the skeleton, once status resolves even if isLoading is stale', () => {
+      render(<DistinguishedDistrictTrophyCase status={baseStatus} isLoading />)
+      expect(
+        screen.queryByTestId('distinguished-trophy-skeleton')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('heading', { name: /Distinguished District Status/i })
+      ).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -243,10 +243,12 @@ const DistrictDetailPageInner: React.FC = () => {
     }
   }, [aggregatedAnalytics])
 
-  // Fetch competitive awards / Distinguished District status (#332)
-  const { data: competitiveAwards } = useCompetitiveAwards(
-    effectiveEndDate ?? undefined
-  )
+  // Fetch competitive awards / Distinguished District status (#332). This
+  // query resolves separately from (and later than) the page-analytics query;
+  // its loading flag reserves the trophy-case slot to avoid the late-insert
+  // CLS shift (#1105 / Lesson 107).
+  const { data: competitiveAwards, isLoading: isLoadingCompetitiveAwards } =
+    useCompetitiveAwards(effectiveEndDate ?? undefined)
   const distinguishedDistrictStatus = React.useMemo(() => {
     if (!districtId || !competitiveAwards?.distinguishedDistrict) return null
     return competitiveAwards.distinguishedDistrict[districtId] ?? null
@@ -514,6 +516,7 @@ const DistrictDetailPageInner: React.FC = () => {
                 {/* Distinguished District Trophy Case (#332) */}
                 <DistinguishedDistrictTrophyCase
                   status={distinguishedDistrictStatus}
+                  isLoading={isLoadingCompetitiveAwards}
                   ranking={distinguishedRankingInputs}
                   clubStrengthQualifies={clubStrengthResult?.qualifies}
                   clubStrengthGrowth={clubStrengthResult?.growthPercent}


### PR DESCRIPTION
## What & why

`DistinguishedDistrictTrophyCase` returned `null` until its data (from `useCompetitiveAwards`) arrived, then expanded and shoved everything below it down — the Lesson-107 null-until-data CLS pattern, same class as the fixed `AwardsRaceSection` (#750). `useCompetitiveAwards` resolves *separately from and later than* the page-analytics query that paints `DistrictDetailPage`, so on the district hub the panel popped in late.

Fixes #1105 (referenced, not auto-closed — closed explicitly after preview verification per the sprint flow).

## Change

- New `isLoading` prop on `DistinguishedDistrictTrophyCase`; when `!status && isLoading` it renders a **height-matched skeleton** (`TrophyCaseSkeleton`) instead of `null`.
- The skeleton reuses the real panel chrome (`redesign-panel`, the static title + "Program Item 1490" caption, section borders, the 3-up gap-tiles grid, the 44px summary-row floor) and skeleton-bars only the data rows — height **emerges** from the same CSS that sizes the loaded panel (Lesson 158), no pinned `Npx`.
- `DistrictDetailPage` threads `isLoading={isLoadingCompetitiveAwards}` down; primary page content is **not** gated on the secondary query (Lesson 107).
- Skeleton is `aria-hidden` (out of the AT tree and the gap-tile queries).

## Acceptance criteria
- [x] Height-matched skeleton reserves the slot while the awards query loads (Lesson 107 pattern)
- [x] Test asserting the slot renders during `isLoading`

## Tests
- TDD: Red (skeleton test fails on `null`-return baseline) → Green → Refactor.
- 16/16 in `DistinguishedDistrictTrophyCase.test.tsx`; full unit suite green (2718 tests) via pre-push hook.
- Live CLS verification on the PR preview (both engines) to follow in an evidence comment.

## Reviewer notes (Low)
- For districts that resolve with `nextTierGap == null` (already Smedley, or Unknown) the loaded panel omits the gap-tiles block, so the skeleton over-reserves and settles slightly *upward* — a bounded, rare residual (unknowable before the query lands), far smaller than the original 0→full downward pop. Same accepted-collapse tradeoff as `AwardsRaceSection`. Documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)