### PR TITLE
fix: CSP-gate frontend distinguished projections (#1139)

### DIFF
--- a/frontend/src/utils/__tests__/dcpProjections.test.ts
+++ b/frontend/src/utils/__tests__/dcpProjections.test.ts
@@ -350,4 +350,45 @@ describe('DCP Projections Utility (#6)', () => {
       expect(projections).toEqual([])
     })
   })
+
+  // #1139 — frontend distinguished projections must not be CSP-blind.
+  // A club without a submitted Club Success Plan cannot be Distinguished
+  // (2025-2026+ rule), even when it meets goal/membership thresholds.
+  describe('CSP gate (#1139)', () => {
+    const distinguishedShape = {
+      dcpGoalsTrend: [{ date: '2025-01-01', goalsAchieved: 5 }],
+      membershipTrend: [{ date: '2025-01-01', count: 20 }],
+    }
+
+    it('does NOT project Distinguished when cspSubmitted is false', () => {
+      const club = makeClub({
+        clubId: 'csp-no',
+        ...distinguishedShape,
+        cspSubmitted: false,
+      })
+      const projection = calculateClubProjection(club)
+      expect(projection.currentLevel).toBe('NotDistinguished')
+      expect(projection.projectedLevel).toBe('NotDistinguished')
+    })
+
+    it('projects Distinguished when cspSubmitted is true', () => {
+      const club = makeClub({
+        clubId: 'csp-yes',
+        ...distinguishedShape,
+        cspSubmitted: true,
+      })
+      const projection = calculateClubProjection(club)
+      expect(projection.currentLevel).toBe('Distinguished')
+    })
+
+    it('treats undefined cspSubmitted as submitted (pre-2025-26 historical data)', () => {
+      const club = makeClub({
+        clubId: 'csp-historical',
+        ...distinguishedShape,
+        // cspSubmitted intentionally omitted → undefined
+      })
+      const projection = calculateClubProjection(club)
+      expect(projection.currentLevel).toBe('Distinguished')
+    })
+  })
 })

--- a/frontend/src/utils/__tests__/provisionalDistinguished.test.ts
+++ b/frontend/src/utils/__tests__/provisionalDistinguished.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { isProvisionallyDistinguished } from '../provisionalDistinguished'
+import {
+  isProvisionallyDistinguished,
+  getConfirmedLevel,
+} from '../provisionalDistinguished'
 import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
 
 function makeClub(overrides: Partial<ClubTrend> = {}): ClubTrend {
@@ -89,5 +92,41 @@ describe('isProvisionallyDistinguished', () => {
     const club = makeClub({ membershipBase: 15 })
     // No aprilRenewals → defaults to 0 → provisional
     expect(isProvisionallyDistinguished(club, '2026-02-15')).toBe(true)
+  })
+})
+
+// #1139 — getConfirmedLevel mirrored the distinguished thresholds without
+// the CSP gate, so a CSP-less club meeting goals/renewals was still
+// returned as Distinguished. CSP is required for distinguished recognition
+// from 2025-2026 onward.
+describe('getConfirmedLevel CSP gate (#1139)', () => {
+  const confirmedDistinguishedShape = {
+    dcpGoalsTrend: [{ date: '2026-02-15', goalsAchieved: 5 }],
+    aprilRenewals: 20,
+    membershipBase: 20,
+  }
+
+  it('returns NotDistinguished when cspSubmitted is false', () => {
+    const club = makeClub({
+      ...confirmedDistinguishedShape,
+      cspSubmitted: false,
+    })
+    expect(getConfirmedLevel(club)).toBe('NotDistinguished')
+  })
+
+  it('returns Distinguished when cspSubmitted is true', () => {
+    const club = makeClub({
+      ...confirmedDistinguishedShape,
+      cspSubmitted: true,
+    })
+    expect(getConfirmedLevel(club)).toBe('Distinguished')
+  })
+
+  it('treats undefined cspSubmitted as submitted (pre-2025-26 historical data)', () => {
+    const club = makeClub({
+      ...confirmedDistinguishedShape,
+      // cspSubmitted omitted → undefined
+    })
+    expect(getConfirmedLevel(club)).toBe('Distinguished')
   })
 })

--- a/frontend/src/utils/dcpProjections.ts
+++ b/frontend/src/utils/dcpProjections.ts
@@ -15,6 +15,7 @@
  * It provides additive projections for district leaders (issue #6 constraint).
  */
 
+import { getCSPStatus } from '@toastmasters/analytics-core'
 import type { ClubTrend } from '../hooks/useDistrictAnalytics'
 
 // --- Types ---
@@ -56,12 +57,20 @@ export interface ClubDCPProjection {
  * Determine distinguished level from goals + membership.
  * Mirrors ClubEligibilityUtils.determineDistinguishedLevel but operates
  * on raw numbers without needing ClubStatistics.
+ *
+ * CSP gate (#1139): from 2025-2026 a club without a submitted Club Success
+ * Plan cannot reach any distinguished level. `cspSubmitted` is the value the
+ * shared `getCSPStatus` rule has already normalized (undefined → true for
+ * pre-2025-26 historical data), so this gate stays in lockstep with
+ * analytics-core's distinguished paths.
  */
 function determineLevel(
   goals: number,
   members: number,
-  netGrowth: number
+  netGrowth: number,
+  cspSubmitted: boolean
 ): DistinguishedLevel {
+  if (!cspSubmitted) return 'NotDistinguished'
   if (goals >= 10 && members >= 25) return 'Smedley'
   if (goals >= 9 && members >= 20) return 'President'
   if (goals >= 7 && (members >= 20 || netGrowth >= 5)) return 'Select'
@@ -149,12 +158,22 @@ export function calculateClubProjection(club: ClubTrend): ClubDCPProjection {
 
   const netGrowth = currentMembers - membershipBase
 
-  const currentLevel = determineLevel(currentGoals, currentMembers, netGrowth)
+  // CSP gate (#1139): source the rule from analytics-core so a CSP-less club
+  // is never projected Distinguished (undefined → submitted for historical).
+  const cspSubmitted = getCSPStatus(club)
+
+  const currentLevel = determineLevel(
+    currentGoals,
+    currentMembers,
+    netGrowth,
+    cspSubmitted
+  )
   const projectedNetGrowth = projectedMembers - membershipBase
   const projectedLevel = determineLevel(
     currentGoals,
     projectedMembers,
-    projectedNetGrowth
+    projectedNetGrowth,
+    cspSubmitted
   )
 
   const gapToDistinguished = computeGap(

--- a/frontend/src/utils/provisionalDistinguished.ts
+++ b/frontend/src/utils/provisionalDistinguished.ts
@@ -16,6 +16,7 @@
  *   All Distinguished = confirmed.
  */
 
+import { getCSPStatus } from '@toastmasters/analytics-core'
 import type { ClubTrend } from '../hooks/useDistrictAnalytics'
 import type { DistinguishedLevel } from '@toastmasters/analytics-core'
 
@@ -96,6 +97,11 @@ const LEVEL_THRESHOLDS: Record<string, { members: number; growth?: number }> = {
  * with confirmed renewals.
  */
 export function getConfirmedLevel(club: ClubTrend): DistinguishedLevel {
+  // CSP gate (#1139): a club without a submitted Club Success Plan cannot be
+  // confirmed Distinguished (2025-2026+). Source the rule from analytics-core
+  // (undefined → submitted for pre-2025-26 historical data).
+  if (!getCSPStatus(club)) return 'NotDistinguished'
+
   const renewals = club.aprilRenewals ?? 0
   const base = club.membershipBase ?? 0
   const trend = club.dcpGoalsTrend

--- a/packages/analytics-core/src/analytics/ClubEligibilityUtils.ts
+++ b/packages/analytics-core/src/analytics/ClubEligibilityUtils.ts
@@ -249,10 +249,19 @@ export function determineDistinguishedLevel(
  * When cspSubmitted is undefined (pre-2025 data), we assume CSP was submitted
  * for backward compatibility — CSP was not a requirement before 2025-2026.
  *
- * @param club - Club statistics data
+ * The parameter is widened to the structural `{ cspSubmitted?: boolean }`
+ * (the only field this rule reads) so frontend models that carry the same
+ * normalized boolean — e.g. `ClubTrend` (#1139) — can source the gate from
+ * this single shared rule instead of forking a local copy (lessons 61/76).
+ * Every `ClubStatistics` still satisfies it, so existing callers are
+ * unaffected.
+ *
+ * @param club - Any object carrying the normalized `cspSubmitted` boolean
  * @returns true if CSP is submitted or field is absent (historical data), false otherwise
  */
-export function getCSPStatus(club: ClubStatistics): boolean {
+export function getCSPStatus(
+  club: Pick<ClubStatistics, 'cspSubmitted'>
+): boolean {
   // If cspSubmitted is undefined, this is pre-2025 data — assume submitted
   return club.cspSubmitted ?? true
 }


### PR DESCRIPTION
## Summary

Sprint 6 of epic #1191. Closes the frontend half of the CSP-blind distinguished defect class (analytics-core half was #1121).

`frontend/src/utils/dcpProjections.ts` (`determineLevel`) and `frontend/src/utils/provisionalDistinguished.ts` (`getConfirmedLevel`) both mirrored the distinguished goal/membership thresholds **without** the Club Success Plan gate. A club with `cspSubmitted=false` that met the thresholds was still projected/confirmed Distinguished on frontend-derived surfaces (`ClubsTable`, `ClubDetailPage`) — even though analytics-core's distinguished paths (`DistinguishedClubAnalyticsModule`, `ClubHealthAnalyticsModule`) are already CSP-gated.

## Fix

Both utils now source the gate from the **shared** `getCSPStatus` rule in analytics-core (lessons 61/76 — one implementation, never a local copy):

- `getCSPStatus`'s parameter is widened from `ClubStatistics` → `Pick<ClubStatistics, 'cspSubmitted'>` so a frontend `ClubTrend` (which carries the same normalized `cspSubmitted` boolean) can use it. Every existing `ClubStatistics` caller still satisfies the structural type — no behavior change for them.
- `determineLevel` gains a `cspSubmitted` param and short-circuits to `NotDistinguished` when false; both call sites in `calculateClubProjection` (current + projected level) pass `getCSPStatus(club)`.
- `getConfirmedLevel` short-circuits to `NotDistinguished` when `!getCSPStatus(club)`.

## Acceptance criteria

- [x] Failing test first: a `cspSubmitted=false` club meeting thresholds is NOT projected/confirmed Distinguished (RED committed in 326ffd97)
- [x] CSP gate sourced from the shared rule (`getCSPStatus` / analytics-core), not a local copy
- [x] Historical pre-2025-26 data unaffected — `undefined → submitted` (asserted explicitly in both test files)

## Verification

- New tests: 6 added (3 per util — false / true / undefined cases). RED proven before fix.
- `npm run test:analytics-core` — 868 pass (param widening safe).
- `npm run test:frontend` — 3465 pass, 0 regressions.
- `analytics-core` rebuilt before tests (R16, touched `packages/*/src`).

Refs #1139, epic #1191.