### PR TITLE
fix(a11y): darken amber focus rings to clear WCAG 1.4.11 3:1 on light surfaces (#1106)

### DIFF
--- a/frontend/src/__tests__/accessibility/AmberFocusRingContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/AmberFocusRingContrast.test.ts
@@ -38,6 +38,13 @@ const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '')
 const tokensCss = stripComments(
   readFileSync(resolve(stylesDir, 'tokens/redesign.css'), 'utf8')
 )
+// The brand tokens (--rt-stats etc.) live in their own file; the dark focus
+// ring remaps to --rt-stats, so we must resolve it from there — NOT lean on the
+// inline `var(--rt-stats, #d4873f)` fallback, which would be undefined-token
+// theatre (lesson 132). --rt-* are theme-independent (`:root` only).
+const brandCss = stripComments(
+  readFileSync(resolve(stylesDir, 'tokens/rt-brand-v1.css'), 'utf8')
+)
 const appShellRaw = readFileSync(
   resolve(stylesDir, 'components/app-shell.css'),
   'utf8'
@@ -69,7 +76,12 @@ function parseTokenBlock(
   return map
 }
 
-const lightTokens = parseTokenBlock(tokensCss, ':root')
+const brandTokens = parseTokenBlock(brandCss, ':root')
+// Brand `:root` is the theme-independent base under both light and dark.
+const lightTokens = new Map([
+  ...brandTokens,
+  ...parseTokenBlock(tokensCss, ':root'),
+])
 const darkTokens = parseTokenBlock(tokensCss, "[data-theme='dark']")
 
 /** Resolve a token / var() chain to a hex string in the requested theme. */

--- a/frontend/src/__tests__/accessibility/AmberFocusRingContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/AmberFocusRingContrast.test.ts
@@ -101,19 +101,15 @@ function resolve_(value: string, dark: boolean, depth = 0): string {
   return v
 }
 
-// Surfaces a focus ring actually lands on, per theme (lesson 112 — audit
-// EVERY surface a token lands on, not just the canonical one).
-const LIGHT_SURFACES = [
-  'var(--surface)',
-  'var(--surface-2)',
-  'var(--surface-3)',
-]
-const DARK_SURFACES = ['var(--surface)', 'var(--surface-2)', 'var(--surface-3)']
+// Surfaces a focus ring actually lands on (lesson 112 — audit EVERY surface a
+// token lands on, not just the canonical one). The same surface tokens carry
+// both themes; resolve_(…, dark) maps each to the right per-theme value.
+const SURFACES = ['var(--surface)', 'var(--surface-2)', 'var(--surface-3)']
 
 describe('Amber focus-ring contrast (#1106)', () => {
   it('--rt-stats-focus clears WCAG 1.4.11 (3:1) on every LIGHT surface', () => {
     const ring = resolve_('var(--rt-stats-focus)', false)
-    for (const s of LIGHT_SURFACES) {
+    for (const s of SURFACES) {
       const surface = resolve_(s, false)
       const ratio = calculateContrastRatio(ring, surface)
       expect(
@@ -125,7 +121,7 @@ describe('Amber focus-ring contrast (#1106)', () => {
 
   it('--rt-stats-focus clears WCAG 1.4.11 (3:1) on every DARK surface', () => {
     const ring = resolve_('var(--rt-stats-focus)', true)
-    for (const s of DARK_SURFACES) {
+    for (const s of SURFACES) {
       const surface = resolve_(s, true)
       const ratio = calculateContrastRatio(ring, surface)
       expect(

--- a/frontend/src/__tests__/accessibility/AmberFocusRingContrast.test.ts
+++ b/frontend/src/__tests__/accessibility/AmberFocusRingContrast.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Amber focus-ring contrast audit (#1106).
+ *
+ * The product accent `--rt-stats` (#D4873F, amber) was the sole focus
+ * affordance at ~10 sites via the pattern
+ * `outline: none; box-shadow: 0 0 0 2px var(--rt-stats)`
+ * (chart-sparkline-expand.css + app-shell.css). On the LIGHT surfaces these
+ * controls sit on, that amber measures only 2.86:1 against white — below
+ * WCAG 1.4.11's 3:1 non-text-contrast minimum for a focus indicator. Dark
+ * mode already passes (amber on the dark surfaces is 5.5–6.2:1).
+ *
+ * The fix introduces a focus-specific, theme-aware token `--rt-stats-focus`
+ * (local — redesign.css, NOT the brand tokens file rt-brand-v1.css): a
+ * darkened amber `#b5651d` in light mode that clears 3:1 on every light
+ * surface the ring lands on, remapped back to the bright brand amber in dark
+ * mode where it already passes (lesson 093/094 — the token must remap with
+ * the surface). All focus-ring sites switch from `var(--rt-stats)` to
+ * `var(--rt-stats-focus)`; the brand accent's non-focus uses (404 numerals,
+ * checkbox accent-color, hover borders) are untouched.
+ *
+ * Like the other Track-D audits (ThemeToggleContrast etc.) this reads the
+ * *actual* CSS source, resolves the token through both `:root` (light) and
+ * `[data-theme='dark']` maps, and checks the ratio against each surface. It
+ * is falsifiable: revert `--rt-stats-focus` to the bright amber and the light
+ * cases drop below 3:1 (asserted explicitly below).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { calculateContrastRatio } from '../../utils/contrastCalculator'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const stylesDir = resolve(here, '../../styles')
+
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '')
+
+const tokensCss = stripComments(
+  readFileSync(resolve(stylesDir, 'tokens/redesign.css'), 'utf8')
+)
+const appShellRaw = readFileSync(
+  resolve(stylesDir, 'components/app-shell.css'),
+  'utf8'
+)
+const sparklineRaw = readFileSync(
+  resolve(stylesDir, 'components/chart-sparkline-expand.css'),
+  'utf8'
+)
+
+/** Declarations from the first block whose selector matches exactly. */
+function parseTokenBlock(
+  css: string,
+  selectorLiteral: string
+): Map<string, string> {
+  const re = new RegExp(
+    '(?:^|\\n)\\s*' +
+      selectorLiteral.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\s*\\{'
+  )
+  const m = re.exec(css)
+  if (!m) throw new Error(`block ${selectorLiteral} not found`)
+  const open = css.indexOf('{', m.index)
+  const close = css.indexOf('}', open)
+  const body = css.slice(open + 1, close)
+  const map = new Map<string, string>()
+  for (const d of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    map.set(d[1].trim(), d[2].trim())
+  }
+  return map
+}
+
+const lightTokens = parseTokenBlock(tokensCss, ':root')
+const darkTokens = parseTokenBlock(tokensCss, "[data-theme='dark']")
+
+/** Resolve a token / var() chain to a hex string in the requested theme. */
+function resolve_(value: string, dark: boolean, depth = 0): string {
+  if (depth > 8) throw new Error(`var() resolution too deep: ${value}`)
+  const v = value.trim()
+  // Strip an optional fallback: var(--x, #hex) → resolve --x, ignore fallback.
+  const varMatch = v.match(/^var\((--[\w-]+)(?:\s*,[^)]*)?\)$/)
+  if (varMatch) {
+    const name = varMatch[1]
+    const next = dark
+      ? (darkTokens.get(name) ?? lightTokens.get(name))
+      : lightTokens.get(name)
+    if (!next) throw new Error(`token ${name} undefined`)
+    return resolve_(next, dark, depth + 1)
+  }
+  return v
+}
+
+// Surfaces a focus ring actually lands on, per theme (lesson 112 — audit
+// EVERY surface a token lands on, not just the canonical one).
+const LIGHT_SURFACES = [
+  'var(--surface)',
+  'var(--surface-2)',
+  'var(--surface-3)',
+]
+const DARK_SURFACES = ['var(--surface)', 'var(--surface-2)', 'var(--surface-3)']
+
+describe('Amber focus-ring contrast (#1106)', () => {
+  it('--rt-stats-focus clears WCAG 1.4.11 (3:1) on every LIGHT surface', () => {
+    const ring = resolve_('var(--rt-stats-focus)', false)
+    for (const s of LIGHT_SURFACES) {
+      const surface = resolve_(s, false)
+      const ratio = calculateContrastRatio(ring, surface)
+      expect(
+        ratio,
+        `ring ${ring} on ${s} (${surface}) = ${ratio.toFixed(2)}:1 (need 3:1)`
+      ).toBeGreaterThanOrEqual(3)
+    }
+  })
+
+  it('--rt-stats-focus clears WCAG 1.4.11 (3:1) on every DARK surface', () => {
+    const ring = resolve_('var(--rt-stats-focus)', true)
+    for (const s of DARK_SURFACES) {
+      const surface = resolve_(s, true)
+      const ratio = calculateContrastRatio(ring, surface)
+      expect(
+        ratio,
+        `ring ${ring} on ${s} (${surface}) = ${ratio.toFixed(2)}:1 (need 3:1)`
+      ).toBeGreaterThanOrEqual(3)
+    }
+  })
+
+  it('falsifiability: the bright brand amber #d4873f would FAIL on white', () => {
+    // Documents the bug the fix cures — proves the 3:1 bar is meaningful.
+    const ratio = calculateContrastRatio('#d4873f', '#ffffff')
+    expect(ratio).toBeLessThan(3)
+    // ...and the light focus token must NOT be that failing value.
+    const lightRing = resolve_('var(--rt-stats-focus)', false).toLowerCase()
+    expect(['#d4873f', '#d4873e']).not.toContain(lightRing)
+  })
+
+  it('every amber focus-ring site uses --rt-stats-focus, not bare --rt-stats', () => {
+    // The focus affordance is `box-shadow: 0 0 0 2px var(--…)`; a focus
+    // border-color paired with it counts too. None may still resolve to the
+    // bare brand accent (which fails 3:1 in light mode).
+    const ringDecl = /box-shadow:\s*0 0 0 2px var\(--rt-stats(?!-focus)[,)]/g
+    const offenders: string[] = []
+    for (const [name, css] of [
+      ['app-shell.css', appShellRaw],
+      ['chart-sparkline-expand.css', sparklineRaw],
+    ] as const) {
+      const matches = css.match(ringDecl)
+      if (matches) offenders.push(`${name}: ${matches.length} site(s)`)
+    }
+    expect(
+      offenders,
+      `focus rings still on the bare brand amber: ${offenders.join('; ')}`
+    ).toEqual([])
+
+    // And the focused-input border-color must also use the focus token.
+    expect(appShellRaw).not.toMatch(
+      /:focus\s*\{[^}]*border-color:\s*var\(--rt-stats(?!-focus)[,)]/
+    )
+  })
+})

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -3606,8 +3606,8 @@
 
   .clubs-search__input:focus {
     outline: none;
-    border-color: var(--rt-stats, #d4873f);
-    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+    border-color: var(--rt-stats-focus, #b5651d);
+    box-shadow: 0 0 0 2px var(--rt-stats-focus, #b5651d);
   }
 
   .clubs-search__input::-webkit-search-decoration,
@@ -3638,7 +3638,7 @@
   .clubs-search__clear:focus-visible {
     outline: none;
     border-radius: 0.375rem;
-    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+    box-shadow: 0 0 0 2px var(--rt-stats-focus, #b5651d);
   }
 
   /* ── Filters drawer (#816, epic #818 Sprint 3) ───────────────────────────
@@ -3690,7 +3690,7 @@
 
   .clubs-filters-trigger:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+    box-shadow: 0 0 0 2px var(--rt-stats-focus, #b5651d);
   }
 
   /* Active-filter count badge on the trigger. */
@@ -3843,7 +3843,7 @@
 
   .clubs-filters-panel__clear-all:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+    box-shadow: 0 0 0 2px var(--rt-stats-focus, #b5651d);
   }
 
   /* 44px touch target (WCAG 2.5.5). */
@@ -3865,7 +3865,7 @@
 
   .clubs-filters-panel__close:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+    box-shadow: 0 0 0 2px var(--rt-stats-focus, #b5651d);
   }
 
   .clubs-filters-panel__body {
@@ -4737,7 +4737,7 @@
 
   .jump-to-chip:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+    box-shadow: 0 0 0 2px var(--rt-stats-focus, #b5651d);
   }
 
   .jump-to-chip__caret {
@@ -4827,7 +4827,7 @@
 
   .jump-to-sheet__close:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+    box-shadow: 0 0 0 2px var(--rt-stats-focus, #b5651d);
   }
 
   .jump-to-sheet__nav {

--- a/frontend/src/styles/components/chart-sparkline-expand.css
+++ b/frontend/src/styles/components/chart-sparkline-expand.css
@@ -32,7 +32,7 @@
 
   .chart-spark__trigger:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+    box-shadow: 0 0 0 2px var(--rt-stats-focus, #b5651d);
   }
 
   .chart-spark__headline {
@@ -134,7 +134,7 @@
 
   .chart-expand-sheet__close:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px var(--rt-stats, #d4873f);
+    box-shadow: 0 0 0 2px var(--rt-stats-focus, #b5651d);
   }
 
   .chart-expand-sheet__body {

--- a/frontend/src/styles/tokens/redesign.css
+++ b/frontend/src/styles/tokens/redesign.css
@@ -45,6 +45,17 @@
   --ink-4: #828b9a;
   --link: var(--loyal-500);
 
+  /* #1106: focus-ring amber. The brand product accent --rt-stats (#d4873f) is
+     the sole focus affordance at ~10 sites (box-shadow: 0 0 0 2px), but on
+     light surfaces it measures only 2.86:1 against white — below WCAG 1.4.11's
+     3:1 non-text floor for a focus indicator. This darkened amber clears 3:1 on
+     every light surface a ring lands on (#fff 4.34, --surface-2 4.15,
+     --surface-3 3.90) while reading as the same amber. Dark mode remaps back to
+     the bright brand accent below, where it already passes (5.5–6.2:1) — the
+     token must remap with the surface (lesson 093/094). Local override, NOT a
+     brand-token edit (rt-brand-v1.css stays untouched). */
+  --rt-stats-focus: #b5651d;
+
   --serif: 'Montserrat', system-ui, sans-serif;
   --sans: 'Source Sans 3', system-ui, sans-serif;
   --mono: 'JetBrains Mono', ui-monospace, monospace;
@@ -73,6 +84,9 @@
 
 [data-theme='dark'] {
   --bg: #0a0f15;
+  /* #1106: on the dark surfaces the bright brand amber already clears 3:1
+     (5.5–6.2:1), so the focus ring stays on the accent in dark mode. */
+  --rt-stats-focus: var(--rt-stats, #d4873f);
   --surface: #111922;
   --surface-2: #161f2a;
   --surface-3: #1a2330;

--- a/tasks/lessons/167-a-focus-ring-built-from-the-brand-accent-needs-its-own-darkened-token-3-1-not-the-text-bar.md
+++ b/tasks/lessons/167-a-focus-ring-built-from-the-brand-accent-needs-its-own-darkened-token-3-1-not-the-text-bar.md
@@ -1,0 +1,70 @@
+---
+id: '167'
+category: lesson
+tags: [accessibility, css, frontend, dark-mode, tests]
+auto_load: true
+date: 2026-06-13
+issues: [1106]
+---
+
+# Lesson 167 — A focus ring built from the brand accent needs its own darkened token; the 3:1 non-text floor is a different bar than where the accent is safe as fill
+
+**Date:** 2026-06-13
+**Issue:** #1106 (epic #1191 Sprint 7 — amber `--rt-stats` focus rings fail 3:1 on light surfaces)
+**PR:** _(record on merge)_
+
+## What happened
+
+The product accent `--rt-stats` (#d4873f, amber) was the sole focus affordance
+at ~10 sites via `outline: none; box-shadow: 0 0 0 2px var(--rt-stats)`. The
+accent is fine as a _fill_ (white text on the amber pill clears AA) and fine as
+the _404 numerals_, so it had been reached for as the focus ring too. But a
+focus indicator is **non-text graphic** — WCAG 1.4.11 holds it to **3:1 against
+the adjacent surface**, and amber-on-white is only **2.86:1**. The accent passed
+every bar it was originally chosen for and still failed the one the focus ring
+lives under.
+
+The fix is a focus-specific token, not a brand edit: `--rt-stats-focus`
+(`redesign.css`, the local token file — `rt-brand-v1.css` is copy-on-release and
+must stay untouched). Light mode = a darkened amber `#b5651d` (4.34 / 4.15 /
+3.90:1 on `--surface` / `--surface-2` / `--surface-3`); dark mode **remaps back
+to the bright accent** `var(--rt-stats)` (5.5–6.2:1 on the dark surfaces, where
+it already passed). A darker ring on a dark surface would _lose_ contrast — the
+token must move with the surface (lesson 093/094), so the remap is load-bearing,
+not cosmetic.
+
+## The transferable principle
+
+**A brand accent that clears its text/fill contrast can still fail the 3:1
+non-text floor when reused as a focus indicator — they are different WCAG bars
+on different surfaces. Don't darken the accent globally (it would dim every
+fill/numeral consumer); mint a sibling `--accent-focus` token, darken it for the
+light surfaces the ring lands on, and remap it back to the bright accent in dark
+mode where dark-on-dark would otherwise regress.** The non-focus uses of the
+accent stay on the original token, untouched.
+
+## How to apply
+
+- Auditing a focus ring? Check 3:1 against **every** surface it lands on
+  (`--surface`, off-white `--surface-2`, `--surface-3`), not just white — the
+  off-white surface is the tightest margin (lesson 112).
+- The audit reuses the established CSS-parsing harness (resolve the token
+  through the `:root` / `[data-theme='dark']` maps, assert the ratio). Resolve
+  the dark remap through the **brand file**, not the inline `var(--x, #hex)`
+  fallback — leaning on the fallback is undefined-token theatre (lesson 132).
+  Prove it falsifiable: set the token back to the bright accent and confirm the
+  light cases drop below 3:1 (lesson 107).
+- Pair the contrast assertion with a **site-guard** regex: every
+  `box-shadow: 0 0 0 2px var(--…)` focus ring (and any paired `:focus`
+  `border-color`) must use the focus token, so a future site can't quietly
+  re-introduce the bare accent.
+
+## Related
+
+- [[112-the-verification-sprint-contrast-guard-earns-its-keep-on-the-marginals]]
+  — audit every surface; off-white is the tight one. The light-side mirror idea.
+- [[058-invisible-select-overlay-needs-focus-within-ring]] — focus-ring
+  _presence_ (2.4.7); this is focus-ring _contrast_ (1.4.11).
+- [[093-a-token-that-doesnt-remap-in-dark-is-a-trap-for-any-non-link-consumer]],
+  [[107-css-audit-matcher-must-exclude-pseudo-class-rules-or-hover-shadows-the-resting-state]],
+  [[132-a-var-fallback-on-an-undefined-token-is-a-permanent-literal-not-a-theme]].

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -160,3 +160,4 @@
 - **164** [monorepo, build, npm, verification, mcp] — `bundleDependencies` is a no-op for workspace-symlinked deps; a publishable workspace-dependent package must inline at build time (#1163, #1162)
 - **165** [process, ci, automation, release, monorepo] — An attended gate-bypass merge must re-green every artifact the gate pins, or the red lands on the next unrelated session (#1165, #1162, #1186)
 - **166** [frontend, react, tanstack, error-handling, verification] — When a page derives "not found" from query data, check the error branch FIRST or every fetch failure is misreported as a missing entity (#1104, #1191)
+- **167** [accessibility, css, frontend, dark-mode, tests] — A focus ring built from the brand accent needs its own darkened token; the 3:1 non-text floor is a different bar than where the accent is safe as fill (#1106)


### PR DESCRIPTION
## What & why (#1106)

The product accent `--rt-stats` (#d4873f, amber) was the **sole focus affordance** at ~10 sites via `outline: none; box-shadow: 0 0 0 2px var(--rt-stats)`. On the light surfaces these controls sit on, amber-on-white measures only **2.86:1** — below **WCAG 1.4.11**'s 3:1 non-text-contrast minimum for a focus indicator. Dark mode already passed (5.5–6.2:1 on the dark surfaces).

## Fix

A focus-specific, theme-aware token **`--rt-stats-focus`** in `redesign.css` (the local token file — `rt-brand-v1.css` is **not** touched, per the acceptance criterion):

- **Light:** `#b5651d` (darkened amber) — **4.34 / 4.15 / 3.90:1** on `--surface` / `--surface-2` / `--surface-3`, all ≥3:1.
- **Dark:** remaps to `var(--rt-stats)` — the bright accent, already 5.5–6.2:1 (a darker ring on a dark surface would *lose* contrast — the token must move with the surface, lesson 093/094).

The 9 `box-shadow` focus rings + the `.clubs-search__input:focus` border-color switch to the focus token. The accent's **non-focus** uses (404 numerals, checkbox `accent-color`, hover borders) are untouched.

## Tests / evidence

- `AmberFocusRingContrast.test.ts` — CSS-parsing audit resolving `--rt-stats-focus` through the `:root` / `[data-theme='dark']` maps (and `--rt-stats` from the brand file, not the inline fallback — lesson 132), asserting ≥3:1 on every surface in both themes. **Falsifiable**: setting the token back to `#d4873f` drops the light cases below 3:1 (verified) — plus a site-guard regex so no future ring can re-introduce the bare accent.
- TDD: RED (2.86:1 fail) → GREEN → /simplify → fresh-context review (APPROVE, contrast numbers independently re-derived).
- Full frontend suite: **3469 passed, 0 regressions**. Typecheck + format + no-page-mounts clean.

Sprint 7 of epic #1191.
