### PR TITLE
fix(analytics): secondary correctness bundle — YoY same-PY, timezone month, dcpProjections, inline thresholds (#1116)

### DIFF
--- a/frontend/src/hooks/__tests__/deriveProgramYear.test.ts
+++ b/frontend/src/hooks/__tests__/deriveProgramYear.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { deriveProgramYear } from '../useRankHistory'
+
+/**
+ * Timezone-boundary regression (#1116 item 2, live-path twin found in review).
+ *
+ * deriveProgramYear parsed its date via `new Date(str).getMonth()`, which reads
+ * UTC-parsed midnight in local time — so a first-of-July date rolls back to June
+ * in UTC-negative zones and the derived program year is off by one. Run the
+ * suite under TZ=America/New_York to exercise the negative-offset path.
+ */
+describe('deriveProgramYear timezone invariance (#1116 item 2)', () => {
+  it('puts July 1 in the program year that starts that July (from explicit startDate)', () => {
+    expect(deriveProgramYear('2026-07-01').year).toBe('2026-2027')
+    expect(deriveProgramYear('2026-07-01').startDate).toBe('2026-07-01')
+  })
+
+  it('puts June 30 in the prior program year', () => {
+    expect(deriveProgramYear('2026-06-30').year).toBe('2025-2026')
+  })
+
+  it('derives from the latest history point when no startDate is given', () => {
+    const history = [{ date: '2025-12-01' }, { date: '2026-07-01' }]
+    expect(deriveProgramYear(undefined, undefined, history).year).toBe(
+      '2026-2027'
+    )
+  })
+
+  it('returns the empty shape when neither dates nor history are available', () => {
+    expect(deriveProgramYear()).toEqual({
+      startDate: '',
+      endDate: '',
+      year: '',
+    })
+  })
+})

--- a/frontend/src/hooks/useRankHistory.ts
+++ b/frontend/src/hooks/useRankHistory.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchCdnRankHistory } from '../services/cdn'
 import type { RankHistoryResponse } from '../types/districts'
+import { getProgramYearForDate } from '../utils/programYear'
 
 interface UseRankHistoryParams {
   districtIds: string[]
@@ -75,28 +76,17 @@ export function deriveProgramYear(
   _endDate?: string,
   history?: Array<{ date: string }>
 ) {
-  // If explicit dates provided, derive from them
-  if (startDate) {
-    const start = new Date(startDate)
-    const startYear =
-      start.getMonth() >= 6 ? start.getFullYear() : start.getFullYear() - 1
+  // Resolve from the explicit start date, else the most recent history point.
+  // Route through getProgramYearForDate so the July-1 boundary is derived
+  // timezone-invariantly (a `new Date(str).getMonth()` deriver rolls a
+  // first-of-July date back to June in UTC-negative zones — #1116 item 2).
+  const anchorDate = startDate ?? history?.[history.length - 1]?.date
+  if (anchorDate) {
+    const py = getProgramYearForDate(anchorDate)
     return {
-      startDate: `${startYear}-07-01`,
-      endDate: `${startYear + 1}-06-30`,
-      year: `${startYear}-${startYear + 1}`,
-    }
-  }
-
-  // Fall back to the most recent history point
-  if (history?.length) {
-    const latestDate = history[history.length - 1]!.date
-    const latest = new Date(latestDate)
-    const startYear =
-      latest.getMonth() >= 6 ? latest.getFullYear() : latest.getFullYear() - 1
-    return {
-      startDate: `${startYear}-07-01`,
-      endDate: `${startYear + 1}-06-30`,
-      year: `${startYear}-${startYear + 1}`,
+      startDate: py.startDate,
+      endDate: py.endDate,
+      year: py.label,
     }
   }
 

--- a/frontend/src/hooks/useRankHistory.ts
+++ b/frontend/src/hooks/useRankHistory.ts
@@ -67,8 +67,10 @@ export const useRankHistory = ({
 
 /**
  * Derive a ProgramYearInfo from the start/end date range or history data.
+ *
+ * Exported for unit testing of the timezone-boundary behaviour (#1116 item 2).
  */
-function deriveProgramYear(
+export function deriveProgramYear(
   startDate?: string,
   _endDate?: string,
   history?: Array<{ date: string }>

--- a/frontend/src/utils/__tests__/dcpProjections.test.ts
+++ b/frontend/src/utils/__tests__/dcpProjections.test.ts
@@ -97,7 +97,7 @@ describe('DCP Projections Utility (#6)', () => {
       expect(projection.gapToSelect.members).toBe(0) // 22 >= 20
     })
 
-    it('should project membership using aprilRenewals when available', () => {
+    it('does not inflate projected membership with April renewals (#1116 item 3)', () => {
       const club = makeClub({
         clubId: '4',
         membershipTrend: [{ date: '2025-01-01', count: 15 }],
@@ -107,11 +107,11 @@ describe('DCP Projections Utility (#6)', () => {
 
       const projection = calculateClubProjection(club)
 
-      // projectedMembers should factor in April renewals
+      // April renewals are renewal PAYMENTS by members already counted in
+      // currentMembers; adding them double-counts (§4.1). The renewal count is
+      // still surfaced informationally, but it must not inflate the projection.
       expect(projection.aprilRenewals).toBe(8)
-      expect(projection.projectedMembers).toBeGreaterThan(
-        projection.currentMembers
-      )
+      expect(projection.projectedMembers).toBe(projection.currentMembers)
     })
 
     it('should use current members as projected when aprilRenewals is missing', () => {

--- a/frontend/src/utils/__tests__/programYear.timezone.test.ts
+++ b/frontend/src/utils/__tests__/programYear.timezone.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getProgramYearForDate,
+  getAvailableProgramYears,
+  calculateProgramYearDay,
+} from '../programYear'
+
+/**
+ * Timezone-boundary regression (#1116 item 2).
+ *
+ * `new Date("YYYY-MM-DD")` parses as UTC midnight, but `.getMonth()` /
+ * `.getFullYear()` read LOCAL time. In a UTC-negative zone a first-of-July
+ * date rolls back to June 30 of the prior calendar year, flipping the
+ * derived program year (and the program-year-day) by a full year/day.
+ *
+ * The program-year boundary is a calendar-date fact, not a wall-clock fact,
+ * so these must be TZ-invariant. Run the suite under TZ=America/New_York to
+ * exercise the negative-offset path.
+ */
+describe('programYear timezone invariance (#1116 item 2)', () => {
+  it('getProgramYearForDate puts July 1 in the program year that starts that July', () => {
+    expect(getProgramYearForDate('2026-07-01').year).toBe(2026)
+    // June 30 belongs to the prior program year.
+    expect(getProgramYearForDate('2026-06-30').year).toBe(2025)
+  })
+
+  it('getAvailableProgramYears assigns a July-1 date to the year starting that July', () => {
+    expect(getAvailableProgramYears(['2026-07-01']).map(p => p.year)).toEqual([
+      2026,
+    ])
+    expect(getAvailableProgramYears(['2026-06-30']).map(p => p.year)).toEqual([
+      2025,
+    ])
+  })
+
+  it('calculateProgramYearDay treats July 1 as day 0', () => {
+    expect(calculateProgramYearDay('2026-07-01')).toBe(0)
+  })
+})

--- a/frontend/src/utils/dcpProjections.ts
+++ b/frontend/src/utils/dcpProjections.ts
@@ -168,13 +168,9 @@ export function calculateClubProjection(club: ClubTrend): ClubDCPProjection {
     netGrowth,
     cspSubmitted
   )
-  const projectedNetGrowth = projectedMembers - membershipBase
-  const projectedLevel = determineLevel(
-    currentGoals,
-    projectedMembers,
-    projectedNetGrowth,
-    cspSubmitted
-  )
+  // projectedMembers === currentMembers (no April-renewal inflation, #1116
+  // item 3), so the projected level is identical to the current level.
+  const projectedLevel = currentLevel
 
   const gapToDistinguished = computeGap(
     currentGoals,

--- a/frontend/src/utils/dcpProjections.ts
+++ b/frontend/src/utils/dcpProjections.ts
@@ -149,12 +149,12 @@ export function calculateClubProjection(club: ClubTrend): ClubDCPProjection {
       ? club.membershipTrend[0]!.count
       : currentMembers)
 
-  // Project year-end membership:
-  // If April renewals available, assume renewals represent re-committed members
-  // projected = currentMembers + aprilRenewals (additive signal)
-  // If not available, use current members as projection
-  const projectedMembers =
-    aprilRenewals !== null ? currentMembers + aprilRenewals : currentMembers
+  // Project year-end membership. April renewals are renewal PAYMENTS made by
+  // members who are already counted in currentMembers, so adding them
+  // double-counts membership (#1116 item 3 / §4.1). Without a forward
+  // retention model the honest year-end estimate is the current membership;
+  // aprilRenewals is surfaced separately as an informational signal.
+  const projectedMembers = currentMembers
 
   const netGrowth = currentMembers - membershipBase
 

--- a/frontend/src/utils/programYear.ts
+++ b/frontend/src/utils/programYear.ts
@@ -11,6 +11,26 @@ export interface ProgramYear {
 }
 
 /**
+ * Extract calendar year + month from a `YYYY-MM-DD` string WITHOUT going
+ * through `new Date()`. `new Date("YYYY-MM-DD")` parses as UTC midnight, but
+ * `.getFullYear()` / `.getMonth()` read LOCAL time — so in a UTC-negative
+ * zone a first-of-month date rolls back to the prior month (and, at Jan 1 /
+ * Jul 1, the prior year), flipping the derived program year. Reading the
+ * components from the string keeps program-year derivation TZ-invariant.
+ *
+ * Falls back to `new Date()` for non-ISO inputs (e.g. a Date coerced to a
+ * locale string), preserving prior behaviour for those callers.
+ */
+function calendarParts(dateStr: string): { year: number; month: number } {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateStr)
+  if (match) {
+    return { year: parseInt(match[1]!, 10), month: parseInt(match[2]!, 10) }
+  }
+  const date = new Date(dateStr)
+  return { year: date.getFullYear(), month: date.getMonth() + 1 }
+}
+
+/**
  * Get the current program year
  */
 export function getCurrentProgramYear(): ProgramYear {
@@ -51,9 +71,7 @@ export function getAvailableProgramYears(dates: string[]): ProgramYear[] {
   const programYears = new Set<number>()
 
   dates.forEach(dateStr => {
-    const date = new Date(dateStr)
-    const year = date.getFullYear()
-    const month = date.getMonth() + 1
+    const { year, month } = calendarParts(dateStr)
 
     // Determine which program year this date belongs to
     const programYearStart = month >= 7 ? year : year - 1
@@ -82,9 +100,7 @@ export function filterDatesByProgramYear(
  * Get the program year that a specific date belongs to
  */
 export function getProgramYearForDate(dateStr: string): ProgramYear {
-  const date = new Date(dateStr)
-  const year = date.getFullYear()
-  const month = date.getMonth() + 1
+  const { year, month } = calendarParts(dateStr)
 
   const programYearStart = month >= 7 ? year : year - 1
   return getProgramYear(programYearStart)
@@ -157,20 +173,36 @@ export function getProgramYearProgress(programYear: ProgramYear): number {
  * Requirements: 2.2 - Align data by relative position within the program year
  */
 export function calculateProgramYearDay(dateStr: string | Date): number {
-  const date = typeof dateStr === 'string' ? new Date(dateStr) : dateStr
+  // Resolve the calendar day (year, 0-indexed month, day-of-month). For a
+  // YYYY-MM-DD string read the components directly — `new Date(str)` is UTC
+  // midnight but local getters shift it (see calendarParts). For a Date,
+  // honour the local calendar day the caller intended.
+  let year: number
+  let month: number // 0-indexed (0 = January, 6 = July)
+  let day: number
+  const isoMatch =
+    typeof dateStr === 'string'
+      ? /^(\d{4})-(\d{2})-(\d{2})/.exec(dateStr)
+      : null
+  if (isoMatch) {
+    year = parseInt(isoMatch[1]!, 10)
+    month = parseInt(isoMatch[2]!, 10) - 1
+    day = parseInt(isoMatch[3]!, 10)
+  } else {
+    const date = typeof dateStr === 'string' ? new Date(dateStr) : dateStr
+    year = date.getFullYear()
+    month = date.getMonth()
+    day = date.getDate()
+  }
 
-  // Get the program year start date for this date
-  const year = date.getFullYear()
-  const month = date.getMonth() // 0-indexed (0 = January, 6 = July)
-
-  // Program year starts July 1
-  // If month >= 6 (July or later), program year started this calendar year
-  // If month < 6 (before July), program year started previous calendar year
+  // Program year starts July 1. month >= 6 (July+) → started this calendar
+  // year; earlier → started last calendar year.
   const programYearStartYear = month >= 6 ? year : year - 1
-  const programYearStart = new Date(programYearStartYear, 6, 1) // July 1
 
-  // Calculate days since program year start
-  const diffTime = date.getTime() - programYearStart.getTime()
+  // Anchor both endpoints in UTC so the day count is timezone- and
+  // DST-invariant (a local-July-1 anchor drifts across the spring DST jump).
+  const diffTime =
+    Date.UTC(year, month, day) - Date.UTC(programYearStartYear, 6, 1)
   const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
 
   // Clamp to valid range [0, 365]

--- a/packages/analytics-core/src/analytics/AnalyticsUtils.test.ts
+++ b/packages/analytics-core/src/analytics/AnalyticsUtils.test.ts
@@ -15,6 +15,8 @@ import {
   getCurrentProgramMonth,
   getMonthName,
   findPreviousProgramYearDate,
+  getProgramYearStartYear,
+  selectPreviousProgramYearSnapshot,
   calculatePercentageChange,
   determineTrend,
 } from './AnalyticsUtils.js'
@@ -164,6 +166,56 @@ describe('AnalyticsUtils', () => {
       expect(findPreviousProgramYearDate('2024-01-15')).toBe('2023-01-15')
       expect(findPreviousProgramYearDate('2024-07-01')).toBe('2023-07-01')
       expect(findPreviousProgramYearDate('2025-12-31')).toBe('2024-12-31')
+    })
+  })
+
+  describe('getProgramYearStartYear', () => {
+    it('maps Jul–Dec dates to their own calendar year', () => {
+      expect(getProgramYearStartYear('2025-07-01')).toBe(2025)
+      expect(getProgramYearStartYear('2025-08-15')).toBe(2025)
+      expect(getProgramYearStartYear('2025-12-31')).toBe(2025)
+    })
+
+    it('maps Jan–Jun dates to the prior calendar year (program year start)', () => {
+      expect(getProgramYearStartYear('2026-01-01')).toBe(2025)
+      expect(getProgramYearStartYear('2026-06-30')).toBe(2025)
+    })
+  })
+
+  describe('selectPreviousProgramYearSnapshot (#1116 item 1)', () => {
+    it('picks the previous PROGRAM year, not a same-PY snapshot in the prior calendar year', () => {
+      // currentDate 2026-06-15 is in program year 2025-26 (Jul 2025 – Jun 2026).
+      // The matching predicate `snapshotYear === currentYear-1` (calendar 2025)
+      // wrongly matched the 2025-08-15 snapshot, which is the SAME program year.
+      // The correct comparison anchor is the previous program year (2024-25),
+      // e.g. 2025-06-15.
+      const snapshots = [
+        { snapshotDate: '2026-06-15', tag: 'current' },
+        { snapshotDate: '2025-08-15', tag: 'same-py' },
+        { snapshotDate: '2025-06-15', tag: 'prev-py' },
+      ]
+      const prev = selectPreviousProgramYearSnapshot(snapshots, '2026-06-15')
+      expect(prev?.tag).toBe('prev-py')
+    })
+
+    it('picks the candidate closest to the same calendar day one year earlier', () => {
+      const snapshots = [
+        { snapshotDate: '2024-09-01', tag: 'far' },
+        { snapshotDate: '2025-05-20', tag: 'near' }, // prev PY (2024-25), near anchor
+        { snapshotDate: '2026-05-20', tag: 'current' },
+      ]
+      const prev = selectPreviousProgramYearSnapshot(snapshots, '2026-05-20')
+      expect(prev?.tag).toBe('near')
+    })
+
+    it('returns undefined when no snapshot falls in the previous program year', () => {
+      const snapshots = [
+        { snapshotDate: '2026-01-15' },
+        { snapshotDate: '2026-03-15' },
+      ]
+      expect(
+        selectPreviousProgramYearSnapshot(snapshots, '2026-03-15')
+      ).toBeUndefined()
     })
   })
 

--- a/packages/analytics-core/src/analytics/AnalyticsUtils.test.ts
+++ b/packages/analytics-core/src/analytics/AnalyticsUtils.test.ts
@@ -119,10 +119,19 @@ describe('AnalyticsUtils', () => {
 
   describe('getCurrentProgramMonth', () => {
     it('should parse valid date strings', () => {
-      // Note: Date parsing can be affected by timezone, so we test with mid-month dates
       expect(getCurrentProgramMonth('2024-01-15')).toBe(1)
       expect(getCurrentProgramMonth('2024-07-15')).toBe(7)
       expect(getCurrentProgramMonth('2024-12-15')).toBe(12)
+    })
+
+    it('should derive the month from the string, not a timezone-shifted Date (#1116 item 2)', () => {
+      // `new Date("YYYY-MM-DD")` parses as UTC midnight; `.getMonth()` reads
+      // LOCAL time, so in a UTC-negative zone a first-of-month date rolls back
+      // to the prior month (a 2026-07-01 snapshot read as June → wrong DCP
+      // checkpoint). The month must come from the string itself, TZ-invariant.
+      expect(getCurrentProgramMonth('2026-07-01')).toBe(7)
+      expect(getCurrentProgramMonth('2026-01-01')).toBe(1)
+      expect(getCurrentProgramMonth('2026-12-01')).toBe(12)
     })
 
     it('should throw for invalid date strings', () => {

--- a/packages/analytics-core/src/analytics/AnalyticsUtils.ts
+++ b/packages/analytics-core/src/analytics/AnalyticsUtils.ts
@@ -205,6 +205,62 @@ export function findPreviousProgramYearDate(currentDate: string): string {
 }
 
 /**
+ * Resolve the program-year START year for a YYYY-MM-DD date.
+ *
+ * The Toastmasters program year runs July 1 – June 30, so a Jul–Dec date
+ * belongs to the program year named by its own calendar year, while a Jan–Jun
+ * date belongs to the prior calendar year's program year. Uses
+ * `getCurrentProgramMonth` (string-based, timezone-invariant) so a
+ * first-of-month boundary date is classified correctly in every timezone.
+ *
+ * @param dateString - Date in YYYY-MM-DD format
+ * @returns The starting calendar year of the program year (e.g. 2025 for 2025-26)
+ */
+export function getProgramYearStartYear(dateString: string): number {
+  const year = parseInt(dateString.substring(0, 4), 10)
+  return getCurrentProgramMonth(dateString) >= 7 ? year : year - 1
+}
+
+/**
+ * Select the snapshot that best represents the same point in the PREVIOUS
+ * program year.
+ *
+ * Callers historically matched `parseInt(snapshotDate) === currentYear - 1`
+ * (calendar year). Because a single calendar year straddles two program years
+ * (Jan–Jun = prior PY, Jul–Dec = current PY), that predicate matched a Jul–Dec
+ * snapshot of the SAME program year as a June `currentDate` — a within-year
+ * comparison masquerading as year-over-year (#1116 item 1). This anchors on the
+ * previous program year and, among its snapshots, returns the one closest to
+ * the same calendar day one year earlier.
+ *
+ * @param snapshots - Snapshots carrying a `snapshotDate` (YYYY-MM-DD)
+ * @param currentDate - The current snapshot's date
+ * @returns The previous-program-year snapshot, or undefined if none exists
+ */
+export function selectPreviousProgramYearSnapshot<
+  T extends { snapshotDate: string },
+>(snapshots: T[], currentDate: string): T | undefined {
+  const targetStartYear = getProgramYearStartYear(currentDate) - 1
+  // Date.parse on a YYYY-MM-DD string is UTC for both anchor and candidates,
+  // so the proximity delta is timezone-consistent.
+  const anchorTime = Date.parse(findPreviousProgramYearDate(currentDate))
+
+  let best: T | undefined
+  let bestDelta = Infinity
+  for (const snapshot of snapshots) {
+    if (getProgramYearStartYear(snapshot.snapshotDate) !== targetStartYear) {
+      continue
+    }
+    const delta = Math.abs(Date.parse(snapshot.snapshotDate) - anchorTime)
+    if (delta < bestDelta) {
+      best = snapshot
+      bestDelta = delta
+    }
+  }
+  return best
+}
+
+/**
  * Calculate percentage change between two values
  *
  * Returns 100 if previous value is 0 and current is positive,

--- a/packages/analytics-core/src/analytics/AnalyticsUtils.ts
+++ b/packages/analytics-core/src/analytics/AnalyticsUtils.ts
@@ -138,25 +138,31 @@ export function getDCPCheckpoint(month: number): number {
  * @throws Error if date string is invalid
  */
 export function getCurrentProgramMonth(dateString?: string): number {
-  let date: Date
-
   if (dateString) {
-    // Parse the date string (expected format: YYYY-MM-DD)
-    date = new Date(dateString)
-
-    // Validate the parsed date
-    if (isNaN(date.getTime())) {
+    // Read the month directly from the YYYY-MM-DD string. Going through
+    // `new Date(dateString)` parses it as UTC midnight, but `getMonth()`
+    // reads LOCAL time — so in a UTC-negative zone a first-of-month date
+    // rolls back to the prior month (a 2026-07-01 snapshot evaluated as
+    // June → wrong DCP checkpoint). Validate the date is real, then take
+    // the month from the string itself so the result is TZ-invariant.
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString)
+    const parsed = new Date(dateString)
+    if (!match || isNaN(parsed.getTime())) {
       throw new Error(
         `Invalid date string: ${dateString}. Expected format: YYYY-MM-DD`
       )
     }
-  } else {
-    // Use current date
-    date = new Date()
+    const month = parseInt(match[2]!, 10)
+    if (month < 1 || month > 12) {
+      throw new Error(
+        `Invalid date string: ${dateString}. Expected format: YYYY-MM-DD`
+      )
+    }
+    return month
   }
 
-  // getMonth() returns 0-11, so add 1 to get 1-12
-  return date.getMonth() + 1
+  // No date provided: use the current local month (getMonth() returns 0-11).
+  return new Date().getMonth() + 1
 }
 
 /**

--- a/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.test.ts
+++ b/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.test.ts
@@ -102,3 +102,47 @@ describe('DistinguishedClubAnalyticsModule.calculateDistinguishedYearOverYear (#
     expect(result?.change).toBe(1)
   })
 })
+
+describe('DistinguishedClubAnalyticsModule achievement tracking (#1116 item 4)', () => {
+  it('tracks a club that reaches Select via the net-growth alternative (members < 20)', () => {
+    const module = new DistinguishedClubAnalyticsModule()
+    // 7 goals + 18 members but +6 net growth (base 12) qualifies as Select via
+    // the net-growth path. The inlined ladder (members >= 20 only) missed it.
+    const snapshot = createMockSnapshot('2025-08-15', [
+      createMockClub({
+        clubId: 'growth1',
+        clubName: 'Growth Club',
+        dcpGoals: 7,
+        membershipCount: 18,
+        membershipBase: 12,
+      }),
+    ])
+
+    const result = module.generateDistinguishedClubAnalytics('D101', [snapshot])
+
+    const achievement = result.achievements.find(a => a.clubId === 'growth1')
+    expect(achievement).toBeDefined()
+    expect(achievement?.level).toBe('Select')
+  })
+
+  it('does not track a CSP-less club as a distinguished achievement', () => {
+    const module = new DistinguishedClubAnalyticsModule()
+    // 5 goals + 25 members would be Distinguished, but no submitted CSP (a
+    // 2025-26 requirement) makes the club ineligible. The inlined ladder had
+    // no CSP gate and tracked it anyway.
+    const snapshot = createMockSnapshot('2025-08-15', [
+      createMockClub({
+        clubId: 'nocsp1',
+        clubName: 'No CSP Club',
+        dcpGoals: 5,
+        membershipCount: 25,
+        membershipBase: 20,
+        cspSubmitted: false,
+      }),
+    ])
+
+    const result = module.generateDistinguishedClubAnalytics('D101', [snapshot])
+
+    expect(result.achievements.find(a => a.clubId === 'nocsp1')).toBeUndefined()
+  })
+})

--- a/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.test.ts
+++ b/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.test.ts
@@ -1,0 +1,104 @@
+/**
+ * DistinguishedClubAnalyticsModule Unit Tests
+ *
+ * Focused coverage for the secondary-correctness fixes in epic #1192 Sprint 1
+ * (#1116): the year-over-year previous-snapshot selection (item 1) and the
+ * achievement-tracking distinguished-level determination (item 4).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { DistinguishedClubAnalyticsModule } from './DistinguishedClubAnalyticsModule.js'
+import type { DistrictStatistics, ClubStatistics } from '../interfaces.js'
+
+function createMockClub(
+  overrides: Partial<ClubStatistics> = {}
+): ClubStatistics {
+  return {
+    clubId: '1234',
+    clubName: 'Test Club',
+    divisionId: 'A',
+    areaId: 'A1',
+    divisionName: 'Division A',
+    areaName: 'Area A1',
+    membershipCount: 25,
+    paymentsCount: 20,
+    dcpGoals: 5,
+    status: 'Active',
+    octoberRenewals: 10,
+    aprilRenewals: 5,
+    newMembers: 5,
+    membershipBase: 20,
+    clubStatus: 'Active',
+    ...overrides,
+  }
+}
+
+function createMockSnapshot(
+  snapshotDate: string,
+  clubs: ClubStatistics[]
+): DistrictStatistics {
+  return {
+    districtId: 'D101',
+    snapshotDate,
+    clubs,
+    divisions: [],
+    areas: [],
+    totals: {
+      totalClubs: clubs.length,
+      totalMembership: clubs.reduce((s, c) => s + c.membershipCount, 0),
+      totalPayments: clubs.reduce((s, c) => s + c.paymentsCount, 0),
+      distinguishedClubs: clubs.filter(c => c.dcpGoals >= 5).length,
+      selectDistinguishedClubs: clubs.filter(c => c.dcpGoals >= 7).length,
+      presidentDistinguishedClubs: clubs.filter(c => c.dcpGoals >= 9).length,
+    },
+  }
+}
+
+/** N default (Distinguished-qualifying) clubs with distinct ids. */
+function distinguishedClubs(n: number): ClubStatistics[] {
+  return Array.from({ length: n }, (_, i) =>
+    createMockClub({ clubId: `c${i}`, clubName: `Club ${i}` })
+  )
+}
+
+describe('DistinguishedClubAnalyticsModule.calculateDistinguishedYearOverYear (#1116 item 1)', () => {
+  it('does not fabricate a comparison from a same-program-year snapshot when no previous-PY data exists', () => {
+    const module = new DistinguishedClubAnalyticsModule()
+    // current 2026-06-15 is program year 2025-26. The only other snapshot,
+    // 2025-08-15, is also program year 2025-26 (Jul 2025+) — it shares the
+    // calendar year (2025) the buggy `snapshotYear === currentYear-1`
+    // predicate matched, so the old code reported a bogus same-PY YoY delta.
+    // There is no 2024-25 data, so the honest answer is "no comparison".
+    const snapshots = [
+      createMockSnapshot('2025-08-15', distinguishedClubs(1)), // same PY (2025-26)
+      createMockSnapshot('2026-06-15', distinguishedClubs(3)), // current
+    ]
+
+    const result = module.calculateDistinguishedYearOverYear(
+      snapshots,
+      '2026-06-15'
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it('compares against a real previous-program-year snapshot when one exists', () => {
+    const module = new DistinguishedClubAnalyticsModule()
+    const snapshots = [
+      createMockSnapshot('2025-06-15', distinguishedClubs(2)), // prev PY (2024-25)
+      createMockSnapshot('2025-08-15', distinguishedClubs(1)), // same PY (2025-26)
+      createMockSnapshot('2026-06-15', distinguishedClubs(3)), // current
+    ]
+
+    const result = module.calculateDistinguishedYearOverYear(
+      snapshots,
+      '2026-06-15'
+    )
+
+    expect(result).toBeDefined()
+    expect(result?.currentTotal).toBe(3)
+    // The previous-program-year snapshot (2 distinguished), not the same-PY one.
+    expect(result?.previousTotal).toBe(2)
+    expect(result?.change).toBe(1)
+  })
+})

--- a/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.ts
@@ -35,7 +35,11 @@ import {
   hasDcpGoalColumns,
   isDcpGoalAchieved,
 } from './dcpGoalDefinitions.js'
-import { ensureString } from './AnalyticsUtils.js'
+import {
+  ensureString,
+  findPreviousProgramYearDate,
+  selectPreviousProgramYearSnapshot,
+} from './AnalyticsUtils.js'
 import {
   calculateNetGrowth,
   determineDistinguishedLevel,
@@ -363,23 +367,22 @@ export class DistinguishedClubAnalyticsModule {
       return undefined
     }
 
-    // Calculate previous year date (subtract 1 year)
-    const currentYear = parseInt(currentDate.substring(0, 4))
-    const previousYearDate = `${currentYear - 1}${currentDate.substring(4)}`
-
-    // Find current and previous year snapshots
+    // Find current and the previous-PROGRAM-year snapshots. Matching the
+    // previous snapshot by calendar year alone (snapshotYear === currentYear-1)
+    // matched a Jul-Dec snapshot of the SAME program year as a June currentDate
+    // (#1116 item 1); anchor on the previous program year instead.
     const currentSnapshot = snapshots.find(s => s.snapshotDate === currentDate)
-    const previousSnapshot = snapshots.find(s => {
-      const snapshotYear = parseInt(s.snapshotDate.substring(0, 4))
-      return snapshotYear === currentYear - 1
-    })
+    const previousSnapshot = selectPreviousProgramYearSnapshot(
+      snapshots,
+      currentDate
+    )
 
     if (!currentSnapshot || !previousSnapshot) {
       logger.info(
         'Insufficient data for year-over-year distinguished comparison',
         {
           currentDate,
-          previousYearDate,
+          previousYearDate: findPreviousProgramYearDate(currentDate),
           hasCurrentSnapshot: !!currentSnapshot,
           hasPreviousSnapshot: !!previousSnapshot,
         }

--- a/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/DistinguishedClubAnalyticsModule.ts
@@ -650,21 +650,24 @@ export class DistinguishedClubAnalyticsModule {
         const clubId = ensureString(club.clubId)
         const clubName = ensureString(club.clubName)
         const dcpGoals = club.dcpGoals
-        const membership = club.membershipCount
 
         if (!clubId) continue
 
-        let currentLevel: string | undefined
-        // Check levels from highest to lowest
-        if (dcpGoals >= 10 && membership >= 25) {
-          currentLevel = 'Smedley'
-        } else if (dcpGoals >= 9 && membership >= 20) {
-          currentLevel = 'President'
-        } else if (dcpGoals >= 7 && membership >= 20) {
-          currentLevel = 'Select'
-        } else if (dcpGoals >= 5 && membership >= 20) {
-          currentLevel = 'Distinguished'
-        }
+        // Use the shared distinguished-level logic (net-growth alternative for
+        // Select/Distinguished) and the CSP gate, matching the other
+        // distinguished paths in this module (#1116 item 4). The inlined ladder
+        // here had neither, so it missed net-growth qualifiers and tracked
+        // CSP-less clubs. 'NotDistinguished' is normalised to undefined so the
+        // achievement-history checks below stay unchanged.
+        const level = getCSPStatus(club)
+          ? determineDistinguishedLevel(
+              dcpGoals,
+              club.membershipCount,
+              calculateNetGrowth(club)
+            )
+          : 'NotDistinguished'
+        const currentLevel: string | undefined =
+          level === 'NotDistinguished' ? undefined : level
 
         const previousRecord = clubLevelHistory.get(clubId)
 

--- a/packages/analytics-core/src/analytics/MembershipAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/MembershipAnalyticsModule.ts
@@ -18,6 +18,7 @@
  */
 
 import type { DistrictStatistics } from '../interfaces.js'
+import { selectPreviousProgramYearSnapshot } from './AnalyticsUtils.js'
 import type {
   MembershipTrendPoint,
   PaymentsTrendPoint,
@@ -567,13 +568,14 @@ export class MembershipAnalyticsModule {
     }
 
     const currentDate = latestSnapshot.snapshotDate
-    const currentYear = parseInt(currentDate.substring(0, 4))
 
-    // Find snapshot closest to previous year date
-    const previousSnapshot = snapshots.find(s => {
-      const snapshotYear = parseInt(s.snapshotDate.substring(0, 4))
-      return snapshotYear === currentYear - 1
-    })
+    // Compare against the previous PROGRAM year, not the prior calendar year —
+    // a calendar-year match picks a Jul-Dec snapshot of the SAME program year
+    // for a Jan-Jun currentDate (#1116 item 1).
+    const previousSnapshot = selectPreviousProgramYearSnapshot(
+      snapshots,
+      currentDate
+    )
 
     if (!previousSnapshot) {
       return undefined
@@ -690,11 +692,13 @@ export class MembershipAnalyticsModule {
     const currentDate = latestSnapshot.snapshotDate
     const currentYear = parseInt(currentDate.substring(0, 4))
 
-    // Find snapshot closest to previous year date
-    const previousSnapshot = snapshots.find(s => {
-      const snapshotYear = parseInt(s.snapshotDate.substring(0, 4))
-      return snapshotYear === currentYear - 1
-    })
+    // Compare against the previous PROGRAM year, not the prior calendar year —
+    // a calendar-year match picks a Jul-Dec snapshot of the SAME program year
+    // for a Jan-Jun currentDate (#1116 item 1).
+    const previousSnapshot = selectPreviousProgramYearSnapshot(
+      snapshots,
+      currentDate
+    )
 
     if (!previousSnapshot) {
       return undefined

--- a/packages/analytics-core/src/analytics/MembershipAnalyticsModule.ts
+++ b/packages/analytics-core/src/analytics/MembershipAnalyticsModule.ts
@@ -721,6 +721,9 @@ export class MembershipAnalyticsModule {
         : 0
 
     return {
+      // currentYear/previousYear are calendar-year labels; they stay aligned
+      // with the program-year-selected previousSnapshot because the selector's
+      // anchor is currentDate minus one calendar year (findPreviousProgramYearDate).
       currentYear,
       previousYear: currentYear - 1,
       membershipChange,


### PR DESCRIPTION
## Sprint 1 of epic #1192 — secondary analytics correctness bundle (#1116)

Four verified-on-paper analytics correctness defects from the 2026-06-09 audit (§8). Item 5 shipped separately in PR #1166; this covers items 1–4 plus a live-path twin surfaced in review. Each fix is TDD'd (failing test → fix), every commit references #1116.

### Item 1 — Year-over-year picked a same-program-year snapshot
`calculateDistinguishedYearOverYear` (and two `MembershipAnalyticsModule` twins) selected the previous snapshot by **calendar year** (`snapshotYear === currentYear - 1`). Because a calendar year straddles two program years, a June snapshot (PY N) matched a Jul–Dec snapshot of the **same** PY N — a within-year delta masquerading as YoY. Extracted one shared `selectPreviousProgramYearSnapshot` (program-year-anchored, picks the candidate closest to the same day a year earlier) and wired all three sites to it (R61 / Lesson 117).

### Item 2 — Timezone-sensitive program-month / program-year derivation
`new Date("YYYY-MM-DD")` parses as **UTC midnight**, but `.getMonth()`/`.getFullYear()` read **local** time, so a first-of-month date rolls back a month (and at Jan 1 / Jul 1, a year) in UTC-negative zones — mis-assigning the DCP checkpoint and the program year. Fixed by reading the components from the string directly:
- analytics-core `getCurrentProgramMonth`
- frontend `programYear.ts` — `getProgramYearForDate`, `getAvailableProgramYears`, `calculateProgramYearDay` (UTC-anchored, DST-safe)
- frontend `useRankHistory.deriveProgramYear` (live-path twin found in fresh-context review; now delegates to the TZ-safe `getProgramYearForDate`)

### Item 3 — dcpProjections double-counted April renewals
`projectedMembers = currentMembers + aprilRenewals` added renewal **payments** to a member count that already includes those members (§4.1). Now `projectedMembers = currentMembers` (no forward-retention model to justify inflation); `aprilRenewals` stays as an informational field. The only consumer of `projectedMembers`/`projectedLevel` is the unmounted `DCPProjectionsTable` (dead code, deletion tracked in #1114) — this keeps the live `calculateClubProjection` honest meanwhile.

### Item 4 — trackDistinguishedAchievements inlined the tier ladder
Replaced the inlined thresholds (no net-growth alternative, no CSP gate) with the shared `determineDistinguishedLevel` behind the `getCSPStatus` gate, matching the other distinguished paths in the module. Now tracks net-growth qualifiers and excludes CSP-less clubs.

## Tests
- New: shared selector + program-year helpers, Distinguished YoY + achievement integration cases, TZ-boundary suites for `getCurrentProgramMonth`, `programYear.ts`, and `deriveProgramYear` (verified RED under `TZ=America/New_York`).
- Full suites green: analytics-core 878, frontend 3476, all workspaces. Typecheck + format + R22 page-mount guard clean. /simplify + fresh-context review passes applied.

## Verification
Logic-only changes; no UI render change. Per-PR preview job triggers on `frontend/**` + `packages/{shared-contracts,analytics-core}/**` (this diff touches both) — evidence is code-proof via the unit/integration suites (the analytics values land via the scheduled pipeline, not a live UI surface).

## Known low-priority follow-up
- `MembershipTrendChart.tsx:205` uses `new Date(point.date).getMonth()` for seasonal-average month bucketing — same primitive, but a fuzzy display heuristic (not a program-year boundary). Left out of scope; safe to fold into a charting cleanup.

Sprint 1 of epic #1192. References #1116 (not "Closes", per L106 tick-before-close ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
