### PR TITLE
fix(contracts): add dcpGoalsAchieved to ClubStatisticsFileSchema (#1143)

### DIFF
--- a/packages/shared-contracts/src/__tests__/district-statistics-file.schema.test.ts
+++ b/packages/shared-contracts/src/__tests__/district-statistics-file.schema.test.ts
@@ -41,6 +41,28 @@ function createValidDistrictTotals() {
 }
 
 /**
+ * Creates a valid ClubStatisticsFile object (required fields only).
+ */
+function createValidClub() {
+  return {
+    clubId: '00012345',
+    clubName: 'Test Club',
+    divisionId: 'A',
+    areaId: '1',
+    membershipCount: 25,
+    paymentsCount: 30,
+    dcpGoals: 7,
+    status: 'Active',
+    divisionName: 'Division A',
+    areaName: 'Area 1',
+    octoberRenewals: 20,
+    aprilRenewals: 5,
+    newMembers: 3,
+    membershipBase: 20,
+  }
+}
+
+/**
  * Creates a valid DistrictStatisticsFile object for testing.
  */
 function createValidDistrictStatisticsFile() {
@@ -527,6 +549,60 @@ describe('DistrictStatisticsFileSchema validation', () => {
       }
       const result = DistrictStatisticsFileSchema.safeParse(data)
       expect(result.success).toBe(false)
+    })
+  })
+
+  // ============================================================================
+  // ClubStatisticsFile dcpGoalsAchieved field tests (#1143)
+  // ============================================================================
+
+  describe('ClubStatisticsFileSchema — dcpGoalsAchieved (#1143)', () => {
+    // Silent-strip class (ADR-010, audit §9a): dcpGoalsAchieved is declared on
+    // the ClubStatisticsFile interface and written by DataTransformer
+    // (computeDcpGoalsAchieved, #1118) but was absent from the schema, so a
+    // validating parse silently STRIPPED it from every .clubs[] row.
+    it('preserves dcpGoalsAchieved on a parsed club (no silent strip)', () => {
+      const club = {
+        ...createValidClub(),
+        dcpGoalsAchieved: [
+          true,
+          false,
+          true,
+          false,
+          true,
+          false,
+          true,
+          false,
+          false,
+          false,
+        ],
+      }
+      const res = ClubStatisticsFileSchema.safeParse(club)
+      expect(res.success).toBe(true)
+      if (res.success) {
+        // Keyed access (not dotted) so this test type-checks at the Red step,
+        // before the schema's inferred type carries the new field.
+        const parsed = res.data as Record<string, unknown>
+        expect(parsed['dcpGoalsAchieved']).toEqual(club.dcpGoalsAchieved)
+      }
+    })
+
+    it('accepts a club that omits dcpGoalsAchieved (dormant snapshots)', () => {
+      const res = ClubStatisticsFileSchema.safeParse(createValidClub())
+      expect(res.success).toBe(true)
+      if (res.success) {
+        const parsed = res.data as Record<string, unknown>
+        expect(parsed['dcpGoalsAchieved']).toBeUndefined()
+      }
+    })
+
+    it('rejects a non-boolean-array dcpGoalsAchieved (keeps the contract falsifiable)', () => {
+      const club = {
+        ...createValidClub(),
+        dcpGoalsAchieved: [1, 0, 1],
+      }
+      const res = ClubStatisticsFileSchema.safeParse(club)
+      expect(res.success).toBe(false)
     })
   })
 

--- a/packages/shared-contracts/src/schemas/district-statistics-file.schema.ts
+++ b/packages/shared-contracts/src/schemas/district-statistics-file.schema.ts
@@ -124,7 +124,9 @@ export const ClubStatisticsFileSchema = z.object({
    * (computeDcpGoalsAchieved, #1118) when the per-goal CSV columns are
    * present; omitted otherwise. Was absent from this schema, so a
    * validating parse silently stripped it from .clubs[] — the ADR-010
-   * silent-strip class (#1143).
+   * silent-strip class (#1143). Length is intentionally unbounded (not
+   * pinned to 10) so historical/variant snapshots stay valid; the
+   * consumer (membersToDistinguished) length-guards before indexing.
    */
   dcpGoalsAchieved: z.array(z.boolean()).optional(),
 

--- a/packages/shared-contracts/src/schemas/district-statistics-file.schema.ts
+++ b/packages/shared-contracts/src/schemas/district-statistics-file.schema.ts
@@ -118,6 +118,16 @@ export const ClubStatisticsFileSchema = z.object({
   /** Membership base for net growth calculation */
   membershipBase: z.number(),
 
+  /**
+   * Exact list of 10 boolean flags representing which DCP goals were
+   * achieved (0-indexed; index 0 is Goal 1). Written by DataTransformer
+   * (computeDcpGoalsAchieved, #1118) when the per-goal CSV columns are
+   * present; omitted otherwise. Was absent from this schema, so a
+   * validating parse silently stripped it from .clubs[] — the ADR-010
+   * silent-strip class (#1143).
+   */
+  dcpGoalsAchieved: z.array(z.boolean()).optional(),
+
   /** Club operational status (Active, Suspended, Low, Ineligible) */
   clubStatus: z.string().optional(),
 


### PR DESCRIPTION
## What
Adds `dcpGoalsAchieved: z.array(z.boolean()).optional()` to `ClubStatisticsFileSchema`, closing an ADR-010 silent-strip gap found during the #1123 fresh-context review (epic #1096 / tracked in #1192 Sprint 2).

## Why
`dcpGoalsAchieved?: boolean[]` is declared on the `ClubStatisticsFile` interface and **is** written by `DataTransformer` (`computeDcpGoalsAchieved`, #1118) when the per-goal CSV columns are present — yet it was absent from the schema. Under `z.object` strip mode every validating parse silently **dropped** the field from `.clubs[]`, contradicting the schema header's "match the interfaces exactly" claim and degrading consumers (`membersToDistinguished`) to the sequential approximation.

## Acceptance criteria
- [x] Determined a writer populates it — `DataTransformer.ts:295` via `computeDcpGoalsAchieved` when `hasDcpGoalColumns(record)`; consumed by `frontend/src/utils/membersToDistinguished.ts`. **Add to schema** (not dead).
- [x] Field added to the schema. Recorded fixtures are dormant (captured CSV predated the per-goal columns), so a synthetic round-trip test is used in place of a recorded-fixture assertion.
- [x] Schema/interface exact-match claim holds — audited all 31 interface fields; `dcpGoalsAchieved` was the only gap.

## Design notes
- Length intentionally **unbounded** (not `.length(10)`): keeps historical/variant snapshots valid; the consumer length-guards before indexing.
- Mirrors the FAC-field silent-strip fix (audit §9a, recorded-snapshot-contract.test.ts:88).

## Tests (TDD)
- Red: round-trip preservation + falsifiability (`[1,0,1]` rejected) — both failed pre-fix (stripped → `undefined`; arbitrary array accepted).
- Green: schema field added.
- shared-contracts 162/162; analytics-core parity + frontend consumer suites green; full pre-push suite 2738/2738.

Refs #1143, #1123, ADR-010, epic #1096.

🤖 Generated with [Claude Code](https://claude.com/claude-code)