### PR TITLE
fix(pipeline): rescrape clobbers district-awards-history.json (R2) + validateDistrictId gaps (#1111)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -747,6 +747,15 @@ jobs:
           mkdir -p ./cache/time-series ./cache/club-trends
           gsutil -m rsync -r "gs://${GCS_BUCKET}/time-series/" "./cache/time-series/" 2>&1 || true
           gsutil -m rsync -r "gs://${GCS_BUCKET}/club-trends/" "./cache/club-trends/" 2>&1 || true
+
+          # District awards history store (~5 KB) (#1111): pull before push, or
+          # the end-of-run push back (DistrictAwardsHistoryStore starts empty
+          # when absent) clobbers the accumulated multi-PY GCS store with a
+          # single-PY partial. Mirrors the daily/rebuild sync steps.
+          echo "Syncing district-awards-history..."
+          gsutil cp "gs://${GCS_BUCKET}/district-awards-history.json" \
+            "./cache/district-awards-history.json" 2>/dev/null || true
+
           echo "## ⏬ Store Sync (rescrape)" >> "$GITHUB_STEP_SUMMARY"
 
       # ── Rescrape Step 2: Scrape → transform → compute → upload ──

--- a/packages/collector-cli/src/__tests__/districtId-path-traversal.guard.test.ts
+++ b/packages/collector-cli/src/__tests__/districtId-path-traversal.guard.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Path-traversal guard for district-id inputs (#1111).
+ *
+ * A district id is interpolated into file/GCS paths (`district_{id}.json`,
+ * `district-{id}/...`). The active tripwire requires `validateDistrictId`
+ * before any path is constructed from request/operator input. This guard
+ * pins two surfaces the 2026-06-09 audit (§9b) found unprotected:
+ *
+ *  1. `parseDistrictList` — the CLI `--districts` chokepoint, which only
+ *     split/trimmed (`--districts '../x'` flowed straight through).
+ *  2. The `getDistrictSnapshotPath` builders in TransformService and
+ *     AnalyticsComputeService, which `path.join`-ed raw districtId.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parseDistrictList } from '../cliHelpers.js'
+import { TransformService } from '../services/TransformService.js'
+import { AnalyticsComputeService } from '../services/AnalyticsComputeService.js'
+
+const TRAVERSAL_IDS = [
+  '../x',
+  '..',
+  'a/b',
+  '../../etc/passwd',
+  'foo.bar',
+  '6 1',
+]
+
+describe('parseDistrictList — alphanumeric chokepoint (#1111)', () => {
+  it('accepts valid alphanumeric district ids', () => {
+    expect(parseDistrictList('01,61,F,U,130')).toEqual([
+      '01',
+      '61',
+      'F',
+      'U',
+      '130',
+    ])
+  })
+
+  it.each(TRAVERSAL_IDS)('rejects non-alphanumeric id %j', id => {
+    expect(() => parseDistrictList(`61,${id}`)).toThrow(/district id/i)
+  })
+})
+
+describe('path builders reject traversal district ids (#1111)', () => {
+  const transform = new TransformService({ cacheDir: '/tmp/ts-guard-1111' })
+  const analytics = new AnalyticsComputeService({
+    cacheDir: '/tmp/ac-guard-1111',
+  })
+
+  it.each(TRAVERSAL_IDS)(
+    'TransformService.snapshotExists rejects %j',
+    async id => {
+      await expect(transform.snapshotExists('2026-01-01', id)).rejects.toThrow(
+        /district id/i
+      )
+    }
+  )
+
+  it.each(TRAVERSAL_IDS)(
+    'AnalyticsComputeService.analyticsExist rejects %j',
+    async id => {
+      await expect(analytics.analyticsExist('2026-01-01', id)).rejects.toThrow(
+        /district id/i
+      )
+    }
+  )
+})

--- a/packages/collector-cli/src/cliHelpers.ts
+++ b/packages/collector-cli/src/cliHelpers.ts
@@ -17,6 +17,7 @@ import {
   UploadResult,
   UploadSummary,
 } from './types/index.js'
+import { validateDistrictId } from './utils/validateDistrictId.js'
 
 // ============================================================================
 // Date Utilities
@@ -78,12 +79,18 @@ export function getCurrentDateString(): string {
 /**
  * Parse comma-separated district list
  * Requirement 1.5: Comma-separated district parsing
+ *
+ * Each id is validated as the single CLI chokepoint (#1111): a district id is
+ * interpolated into file/GCS paths downstream, so a non-alphanumeric value
+ * (e.g. `--districts '../x'`) must be rejected here before any path is built.
  */
 export function parseDistrictList(value: string): string[] {
-  return value
+  const ids = value
     .split(',')
     .map(d => d.trim())
     .filter(d => d.length > 0)
+  ids.forEach(validateDistrictId)
+  return ids
 }
 
 // ============================================================================

--- a/packages/collector-cli/src/services/AnalyticsComputeService.ts
+++ b/packages/collector-cli/src/services/AnalyticsComputeService.ts
@@ -33,6 +33,7 @@ import type {
 import type { AllDistrictsRankingsData } from '@toastmasters/shared-contracts'
 import { AnalyticsWriter } from './AnalyticsWriter.js'
 import { TimeSeriesIndexWriter } from './TimeSeriesIndexWriter.js'
+import { validateDistrictId } from '../utils/validateDistrictId.js'
 import type { CacheMetadata } from '../types/collector.js'
 import {
   ClosingPeriodDetector,
@@ -204,7 +205,20 @@ export class AnalyticsComputeService {
    * Get the district snapshot file path
    */
   private getDistrictSnapshotPath(date: string, districtId: string): string {
+    validateDistrictId(districtId)
     return path.join(this.getSnapshotDir(date), `district_${districtId}.json`)
+  }
+
+  /**
+   * Get the per-district analytics file path. Validates districtId (#1111)
+   * before interpolating it into the path (active path-traversal tripwire).
+   */
+  private getDistrictAnalyticsPath(date: string, districtId: string): string {
+    validateDistrictId(districtId)
+    return path.join(
+      this.getAnalyticsDir(date),
+      `district_${districtId}_analytics.json`
+    )
   }
 
   /**
@@ -385,11 +399,7 @@ export class AnalyticsComputeService {
    * Check if analytics already exist for a district
    */
   async analyticsExist(date: string, districtId: string): Promise<boolean> {
-    const analyticsDir = this.getAnalyticsDir(date)
-    const analyticsPath = path.join(
-      analyticsDir,
-      `district_${districtId}_analytics.json`
-    )
+    const analyticsPath = this.getDistrictAnalyticsPath(date, districtId)
     try {
       await fs.access(analyticsPath)
       return true
@@ -435,11 +445,7 @@ export class AnalyticsComputeService {
     date: string,
     districtId: string
   ): Promise<string | null> {
-    const analyticsDir = this.getAnalyticsDir(date)
-    const analyticsPath = path.join(
-      analyticsDir,
-      `district_${districtId}_analytics.json`
-    )
+    const analyticsPath = this.getDistrictAnalyticsPath(date, districtId)
 
     try {
       const content = await fs.readFile(analyticsPath, 'utf-8')
@@ -1419,6 +1425,7 @@ export class AnalyticsComputeService {
     currentDate: string,
     districtId: string
   ): Promise<string[]> {
+    validateDistrictId(districtId) // #1111: guards the path.join below
     // Calculate program year boundaries
     const d = new Date(currentDate + 'T00:00:00Z')
     const year = d.getUTCFullYear()

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -17,6 +17,7 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { parse } from 'csv-parse/sync'
 import { parseClosingPeriodFromCsv } from '../utils/csvFooterParser.js'
+import { validateDistrictId } from '../utils/validateDistrictId.js'
 import type { ClosingDateEntry } from '../utils/ClosingDateRegistry.js'
 import {
   resolveClosingWindow,
@@ -228,6 +229,7 @@ export class TransformService {
    * Get the district snapshot file path
    */
   private getDistrictSnapshotPath(date: string, districtId: string): string {
+    validateDistrictId(districtId)
     return path.join(this.getSnapshotDir(date), `district_${districtId}.json`)
   }
 

--- a/scripts/lib/__tests__/dataPipelineStoreSync.test.ts
+++ b/scripts/lib/__tests__/dataPipelineStoreSync.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Store-sync symmetry guard for data-pipeline.yml (#1111).
+ *
+ * The pipeline runs in three modes (daily / rebuild / rescrape). Each mode
+ * that pushes a GCS-backed store FILE back at the end of its run must first
+ * pull that same file at the start — otherwise the store loads empty and the
+ * push CLOBBERS the accumulated GCS copy (R2 / R9).
+ *
+ * The 2026-06-09 audit (§9b) found rescrape pushing district-awards-history.json
+ * back without ever syncing it down (daily and rebuild both sync it). This
+ * guard parses the workflow and asserts: for every mode, the set of stores it
+ * UPLOADS is a subset of the set it DOWNLOADS. Sourced from the workflow YAML
+ * itself, so it can't drift from the real steps.
+ */
+
+import { describe, it, expect } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { parse } from 'yaml'
+
+const WORKFLOW_PATH = path.resolve(
+  process.cwd(),
+  '.github/workflows/data-pipeline.yml'
+)
+
+// GCS-backed store files that persist across runs and must survive a clobber.
+const STORE_FILES = ['district-awards-history.json']
+
+interface Step {
+  name?: string
+  run?: string
+}
+
+function loadSteps(): Step[] {
+  const doc = parse(fs.readFileSync(WORKFLOW_PATH, 'utf-8')) as {
+    jobs: Record<string, { steps?: Step[] }>
+  }
+  return Object.values(doc.jobs).flatMap(job => job.steps ?? [])
+}
+
+function modeOf(step: Step): string | null {
+  const m = step.name?.match(/^\[(\w+)\]/)
+  return m ? m[1]! : null
+}
+
+// download: GCS path is the FIRST cp arg (gs:// → ./cache)
+function downloadsStore(run: string, file: string): boolean {
+  return new RegExp(
+    `cp\\s+"gs://\\$\\{GCS_BUCKET\\}/${file.replace(/\./g, '\\.')}"`
+  ).test(run)
+}
+
+// upload: local cache path is the FIRST cp arg (./cache → gs://)
+function uploadsStore(run: string, file: string): boolean {
+  return new RegExp(`cp\\s+"\\./cache/${file.replace(/\./g, '\\.')}"`).test(run)
+}
+
+describe('data-pipeline.yml store-sync symmetry (#1111)', () => {
+  const steps = loadSteps()
+
+  for (const file of STORE_FILES) {
+    const downloaders = new Set<string>()
+    const uploaders = new Set<string>()
+    for (const step of steps) {
+      const mode = modeOf(step)
+      if (!mode || !step.run) continue
+      if (downloadsStore(step.run, file)) downloaders.add(mode)
+      if (uploadsStore(step.run, file)) uploaders.add(mode)
+    }
+
+    it(`every mode that uploads ${file} also downloads it first`, () => {
+      const clobberers = [...uploaders].filter(m => !downloaders.has(m))
+      expect(clobberers).toEqual([])
+    })
+
+    it(`rescrape syncs ${file} down (regression: #1111)`, () => {
+      expect(uploaders.has('rescrape')).toBe(true)
+      expect(downloaders.has('rescrape')).toBe(true)
+    })
+  }
+})


### PR DESCRIPTION
## Summary
Sprint 1 of epic #1193 — two pipeline-discipline fixes from the 2026-06-09 audit (§9b). Refs #1111.

### 1. R2 clobber — rescrape now syncs district-awards-history.json before push
The `[rescrape]` store-sync step pulled only time-series + club-trends, yet the end-of-run step pushed `district-awards-history.json` back to GCS. `DistrictAwardsHistoryStore.load` starts empty when the file is absent, so a single-PY rescrape overwrote the accumulated multi-PY GCS store with a partial. Added the download to the rescrape sync step, mirroring daily/rebuild (R9 sync-from-GCS-first).

### 2. validateDistrictId tripwire gaps
`parseDistrictList` only split/trimmed (`--districts '../x'` flowed through), and the `getDistrictSnapshotPath` builders in `TransformService`/`AnalyticsComputeService` `path.join`-ed raw districtId. Now:
- `parseDistrictList` validates each id as the single CLI chokepoint (rejects non-alphanumeric early).
- Both services validate at the path-construction boundary (defense-in-depth, matching the `TimeSeriesIndexWriter`/`DistrictReportsWriter` posture).

## Tests (TDD)
- `districtId-path-traversal.guard.test.ts` — traversal ids rejected at `parseDistrictList`, `snapshotExists`, `analyticsExist`; valid alphanumeric ids pass.
- `dataPipelineStoreSync.test.ts` — parses the workflow YAML and asserts every mode that *uploads* a GCS-backed store also *downloads* it first (sourced from the workflow itself, can't drift).

Both failed before the fix, pass after. Full suite green (collector-cli 981, scripts 338, frontend 2738, mcp-server 63); typecheck/lint/yaml/format clean.

## Verification
Backend/pipeline-only change. Fix #1 lands via the scheduled pipeline (workflow YAML); fix #2 is CLI/library. Code-proof via the two guards above (preview-channel verification N/A — no frontend surface; `pr-preview.yml` path filter not matched by workflow/CLI-only files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)