### PR TITLE
fix(collector): backfill omits isClosingPeriod + structural registry-injection guard (#1160)

### DIFF
--- a/packages/collector-cli/src/__tests__/BackfillOrchestrator.test.ts
+++ b/packages/collector-cli/src/__tests__/BackfillOrchestrator.test.ts
@@ -290,10 +290,25 @@ describe('buildBackfillMetadata (#125)', () => {
     expect(metadata.programYear).toBe('2024-2025')
     expect(metadata.source).toBe('backfill')
     expect(metadata.cacheVersion).toBe(1)
-    expect(metadata.isClosingPeriod).toBe(false)
+    // Backfill does not parse the CSV footer, so it cannot DECIDE the
+    // closing-period status. It must OMIT the key (undecided) rather than
+    // launder a hardcoded false that the downstream trust branch would honor
+    // — the #1129 twin-writer pattern (Lesson 158, #1160). Downstream
+    // resolution (CSV footer → registry) then decides honestly.
+    expect('isClosingPeriod' in metadata).toBe(false)
     expect((metadata.csvFiles as Record<string, unknown>).allDistricts).toBe(
       true
     )
+  })
+
+  it('omits isClosingPeriod entirely — never a laundered false (#1160)', () => {
+    // A closing-window date (e.g. 2024-07-01 sits in June 2024's window)
+    // must NOT carry an explicit false; the writer did not decide it.
+    const date = new Date(2024, 6, 1) // July 1, 2024
+    const metadata = buildBackfillMetadata(date, ['09'])
+
+    expect(metadata.isClosingPeriod).toBeUndefined()
+    expect(Object.keys(metadata)).not.toContain('isClosingPeriod')
   })
 
   it('should produce correct programYear for January date', () => {

--- a/packages/collector-cli/src/__tests__/transformService.registryInjection.guard.test.ts
+++ b/packages/collector-cli/src/__tests__/transformService.registryInjection.guard.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { findUninjectedTransformServiceConstructions } from '../services/transformServiceRegistryGuard.js'
+
+/**
+ * #1160 — structurally enforce TransformService's closing-date-registry
+ * injection contract (follow-up to the #1129 fail-closed chain).
+ *
+ * The contract: `closingDateRegistry` is optional on the config TYPE (so test
+ * fixtures can opt into legacy fail-open), but every PRODUCTION construction
+ * site MUST inject it. A forgetful site silently reverts to fail-open and can
+ * publish a closing-window date under its raw date. This guard turns the
+ * doc-comment contract into a CI-enforced one.
+ */
+describe('TransformService registry-injection guard (#1160)', () => {
+  describe('detector — must catch a known-bad snippet (Lesson 82)', () => {
+    it('flags a construction that omits closingDateRegistry', () => {
+      const bad = `
+        const svc = new TransformService({
+          cacheDir: '/tmp/x',
+          logger,
+        })
+      `
+      const violations = findUninjectedTransformServiceConstructions(bad)
+      expect(violations).toHaveLength(1)
+      expect(violations[0].snippet).toContain('cacheDir')
+    })
+
+    it('does NOT flag a construction that injects the registry literally', () => {
+      const good = `
+        const svc = new TransformService({
+          cacheDir: '/tmp/x',
+          closingDateRegistry: await loadClosingDateRegistryMonths(),
+        })
+      `
+      expect(findUninjectedTransformServiceConstructions(good)).toHaveLength(0)
+    })
+
+    it('does NOT flag a pass-through construction (option spread by key)', () => {
+      const good = `
+        this.transformService = new TransformService({
+          cacheDir: options.cacheDir,
+          logger: options.logger,
+          closingDateRegistry: options.closingDateRegistry,
+        })
+      `
+      expect(findUninjectedTransformServiceConstructions(good)).toHaveLength(0)
+    })
+
+    it('flags exactly the uninjected site when good and bad are interleaved', () => {
+      const mixed = `
+        new TransformService({ cacheDir: a, closingDateRegistry: r })
+        new TransformService({ cacheDir: b })
+      `
+      const violations = findUninjectedTransformServiceConstructions(mixed)
+      expect(violations).toHaveLength(1)
+      expect(violations[0].snippet).toContain('cacheDir: b')
+    })
+  })
+
+  describe('production source — every site injects the registry', () => {
+    it('has zero uninjected TransformService constructions in src/', async () => {
+      const srcDir = path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '..'
+      )
+
+      async function collectTsFiles(dir: string): Promise<string[]> {
+        const entries = await fs.readdir(dir, { withFileTypes: true })
+        const files: string[] = []
+        for (const entry of entries) {
+          const full = path.join(dir, entry.name)
+          if (entry.isDirectory()) {
+            // Skip test directories — fixtures legitimately omit the registry.
+            if (entry.name === '__tests__' || entry.name === 'tests') continue
+            files.push(...(await collectTsFiles(full)))
+          } else if (
+            entry.name.endsWith('.ts') &&
+            !entry.name.endsWith('.test.ts') &&
+            // The guard module itself names the token in its constant and
+            // doc-comments; it never constructs the service.
+            entry.name !== 'transformServiceRegistryGuard.ts'
+          ) {
+            files.push(full)
+          }
+        }
+        return files
+      }
+
+      const files = await collectTsFiles(srcDir)
+      const offenders: string[] = []
+      for (const file of files) {
+        const source = await fs.readFile(file, 'utf-8')
+        const violations = findUninjectedTransformServiceConstructions(source)
+        if (violations.length > 0) {
+          offenders.push(
+            `${path.relative(srcDir, file)}: ${violations.length} site(s)`
+          )
+        }
+      }
+
+      expect(offenders).toEqual([])
+    })
+  })
+})

--- a/packages/collector-cli/src/__tests__/transformService.registryInjection.guard.test.ts
+++ b/packages/collector-cli/src/__tests__/transformService.registryInjection.guard.test.ts
@@ -49,6 +49,18 @@ describe('TransformService registry-injection guard (#1160)', () => {
       expect(findUninjectedTransformServiceConstructions(good)).toHaveLength(0)
     })
 
+    it('does NOT flag the token when it appears only in a comment (Lesson 84)', () => {
+      const commented = `
+        // A doc-comment may mention new TransformService(...) in prose, e.g.
+        // "any production new TransformService({ cacheDir }) site MUST inject".
+        /* block: new TransformService({ cacheDir: x }) is just an example */
+        const real = new TransformService({ cacheDir, closingDateRegistry })
+      `
+      expect(
+        findUninjectedTransformServiceConstructions(commented)
+      ).toHaveLength(0)
+    })
+
     it('flags exactly the uninjected site when good and bad are interleaved', () => {
       const mixed = `
         new TransformService({ cacheDir: a, closingDateRegistry: r })

--- a/packages/collector-cli/src/__tests__/transformService.registryInjection.guard.test.ts
+++ b/packages/collector-cli/src/__tests__/transformService.registryInjection.guard.test.ts
@@ -25,7 +25,17 @@ describe('TransformService registry-injection guard (#1160)', () => {
       `
       const violations = findUninjectedTransformServiceConstructions(bad)
       expect(violations).toHaveLength(1)
-      expect(violations[0].snippet).toContain('cacheDir')
+      expect(violations[0]).toContain('cacheDir')
+    })
+
+    it('flags an explicit closingDateRegistry: undefined (fail-open in disguise)', () => {
+      const bad = `
+        const svc = new TransformService({
+          cacheDir: '/tmp/x',
+          closingDateRegistry: undefined,
+        })
+      `
+      expect(findUninjectedTransformServiceConstructions(bad)).toHaveLength(1)
     })
 
     it('does NOT flag a construction that injects the registry literally', () => {
@@ -68,7 +78,7 @@ describe('TransformService registry-injection guard (#1160)', () => {
       `
       const violations = findUninjectedTransformServiceConstructions(mixed)
       expect(violations).toHaveLength(1)
-      expect(violations[0].snippet).toContain('cacheDir: b')
+      expect(violations[0]).toContain('cacheDir: b')
     })
   })
 

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -22,7 +22,10 @@
 
 import { Command } from 'commander'
 import { CollectorOrchestrator } from './CollectorOrchestrator.js'
-import { TransformService } from './services/TransformService.js'
+import {
+  createProductionTransformService,
+  loadClosingDateRegistryMonths,
+} from './services/transformServiceFactory.js'
 import { AnalyticsComputeService } from './services/AnalyticsComputeService.js'
 import { UploadService } from './services/UploadService.js'
 import {
@@ -43,30 +46,6 @@ import {
   UploadOptions,
 } from './types/index.js'
 import { resolveConfiguration } from './utils/config.js'
-import {
-  ClosingDateRegistry,
-  type ClosingDateEntry,
-} from './utils/ClosingDateRegistry.js'
-
-/**
- * Load closing-date registry months for the fail-closed closing remap
- * (#1129). Resolves docs/month-end-closing-dates.json relative to cwd — the
- * repo root in CI and local runs. A missing or empty registry yields [], so
- * every metadata-less, footer-less date fails closed (refused) rather than
- * being published under its raw date.
- */
-async function loadClosingDateRegistryMonths(): Promise<ClosingDateEntry[]> {
-  const registry = new ClosingDateRegistry({ projectRoot: process.cwd() })
-  const file = await registry.read()
-  if (file.months.length === 0) {
-    console.error(
-      '[WARN] Closing-date registry is empty or missing ' +
-        '(docs/month-end-closing-dates.json) — dates undecidable from ' +
-        'metadata/CSV footer will FAIL CLOSED (#1129)'
-    )
-  }
-  return file.months
-}
 
 // Re-export configuration utilities for external use
 export {
@@ -257,11 +236,11 @@ export function createCLI(): Command {
             console.error(`[INFO] Running transformation after scrape...`)
           }
 
-          // Create TransformService with optional verbose logger
-          const transformService = new TransformService({
+          // Create TransformService via the production factory, which loads
+          // and injects the closing-date registry (#1160).
+          const transformService = await createProductionTransformService({
             cacheDir,
             logger: createVerboseLogger(options.verbose),
-            closingDateRegistry: await loadClosingDateRegistryMonths(),
           })
 
           // Transform only the successfully scraped districts
@@ -469,12 +448,12 @@ export function createCLI(): Command {
         console.error(`[INFO] Config source: ${resolvedConfig.source}`)
       }
 
-      // Create TransformService with optional verbose logger
+      // Create TransformService via the production factory, which loads and
+      // injects the closing-date registry (#1160).
       // Requirement 2.2: Use the same DataTransformationService logic as the Backend
-      const transformService = new TransformService({
+      const transformService = await createProductionTransformService({
         cacheDir,
         logger: createVerboseLogger(options.verbose),
-        closingDateRegistry: await loadClosingDateRegistryMonths(),
       })
 
       // Execute transformation

--- a/packages/collector-cli/src/services/BackfillOrchestrator.ts
+++ b/packages/collector-cli/src/services/BackfillOrchestrator.ts
@@ -208,11 +208,17 @@ export function buildBackfillMetadata(
     }
   }
 
+  // isClosingPeriod is intentionally OMITTED. Backfill writes raw CSVs
+  // without parsing the "As of" footer, so it cannot decide closing-period
+  // status. Writing a hardcoded `false` would be a laundered default that the
+  // downstream trust branch (TransformService) honors as an explicit scraper
+  // decision — the #1129 twin-writer hole (Lesson 158). Omitting the key
+  // leaves the decision to the resolution chain (CSV footer → registry),
+  // which fails closed when undecided rather than publishing under a raw date.
   return {
     date: dateStr,
     timestamp: Date.now(),
     programYear: calculateProgramYear(date),
-    isClosingPeriod: false,
     csvFiles: {
       allDistricts: true,
       districts,

--- a/packages/collector-cli/src/services/TransformService.ts
+++ b/packages/collector-cli/src/services/TransformService.ts
@@ -127,6 +127,11 @@ export interface TransformServiceConfig {
    * publishing under the raw date. Every production entry point (cli
    * transform, scrape --transform, RebuildService) MUST inject this;
    * omitting it preserves legacy fail-open behavior for test fixtures only.
+   *
+   * This "production sites MUST inject" rule is no longer comment-only: it is
+   * structurally enforced by `transformServiceRegistryGuard` + its guard test
+   * (#1160), which fails CI if any production `new TransformService(...)` site
+   * omits `closingDateRegistry`.
    */
   closingDateRegistry?: ClosingDateEntry[]
 }

--- a/packages/collector-cli/src/services/transformServiceFactory.ts
+++ b/packages/collector-cli/src/services/transformServiceFactory.ts
@@ -1,0 +1,61 @@
+/**
+ * transformServiceFactory — the single blessed production constructor for
+ * TransformService (#1160, follow-up to the #1129 fail-closed chain).
+ *
+ * `TransformService`'s `closingDateRegistry` is optional on the config type so
+ * test fixtures can opt into legacy fail-open behavior. Direct production
+ * construction must always inject a REAL, loaded registry — not just a present
+ * key (a `closingDateRegistry: undefined` would type-check while silently
+ * reverting to fail-open). This factory owns the registry load, so a caller
+ * cannot forget it or pass undefined: it is the ergonomic, correct path.
+ *
+ * The companion guard test (transformServiceRegistryGuard) is the backstop
+ * that catches any future site bypassing this factory with a bare
+ * `new TransformService(...)` that omits the registry.
+ */
+
+import type { Logger } from '@toastmasters/analytics-core'
+import {
+  ClosingDateRegistry,
+  type ClosingDateEntry,
+} from '../utils/ClosingDateRegistry.js'
+import { TransformService } from './TransformService.js'
+
+/**
+ * Load closing-date registry months for the fail-closed closing remap
+ * (#1129). Resolves docs/month-end-closing-dates.json relative to cwd — the
+ * repo root in CI and local runs. A missing or empty registry yields [], so
+ * every metadata-less, footer-less date fails closed (refused) rather than
+ * being published under its raw date.
+ */
+export async function loadClosingDateRegistryMonths(): Promise<
+  ClosingDateEntry[]
+> {
+  const registry = new ClosingDateRegistry({ projectRoot: process.cwd() })
+  const file = await registry.read()
+  if (file.months.length === 0) {
+    console.error(
+      '[WARN] Closing-date registry is empty or missing ' +
+        '(docs/month-end-closing-dates.json) — dates undecidable from ' +
+        'metadata/CSV footer will FAIL CLOSED (#1129)'
+    )
+  }
+  return file.months
+}
+
+/**
+ * Construct a production `TransformService` with the closing-date registry
+ * loaded and injected. Use this — never a bare `new TransformService(...)` —
+ * at every production entry point, so the fail-closed chain can never be
+ * silently disabled by a forgotten registry.
+ */
+export async function createProductionTransformService(config: {
+  cacheDir: string
+  logger?: Logger
+}): Promise<TransformService> {
+  return new TransformService({
+    cacheDir: config.cacheDir,
+    logger: config.logger,
+    closingDateRegistry: await loadClosingDateRegistryMonths(),
+  })
+}

--- a/packages/collector-cli/src/services/transformServiceRegistryGuard.ts
+++ b/packages/collector-cli/src/services/transformServiceRegistryGuard.ts
@@ -23,6 +23,22 @@ export interface RegistryInjectionViolation {
 const CTOR_TOKEN = 'new TransformService('
 
 /**
+ * Strip `//` line comments and block comments from source before scanning.
+ *
+ * A comment (or doc-comment) that mentions the constructor token in prose is
+ * not a real construction site — but a naive substring scan would flag it
+ * (Lesson 84: a documentation example of a parsed format is also valid
+ * input). Removing comments first keeps the guard from tripping on its own
+ * documentation. String literals are left intact; the only production string
+ * carrying the token lives in this module, which the guard test excludes.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    .replace(/\/\/[^\n]*/g, '') // line comments
+}
+
+/**
  * Find every `new TransformService(...)` in `source` whose constructor
  * argument does NOT mention `closingDateRegistry`.
  *
@@ -36,17 +52,18 @@ export function findUninjectedTransformServiceConstructions(
   source: string
 ): RegistryInjectionViolation[] {
   const violations: RegistryInjectionViolation[] = []
+  const scanned = stripComments(source)
   let from = 0
   for (;;) {
-    const start = source.indexOf(CTOR_TOKEN, from)
+    const start = scanned.indexOf(CTOR_TOKEN, from)
     if (start === -1) break
 
     // Walk from the opening paren to its match, tracking nesting depth.
     const openParen = start + CTOR_TOKEN.length - 1
     let depth = 0
     let end = openParen
-    for (let i = openParen; i < source.length; i++) {
-      const ch = source[i]
+    for (let i = openParen; i < scanned.length; i++) {
+      const ch = scanned[i]
       if (ch === '(' || ch === '[' || ch === '{') depth++
       else if (ch === ')' || ch === ']' || ch === '}') {
         depth--
@@ -57,7 +74,7 @@ export function findUninjectedTransformServiceConstructions(
       }
     }
 
-    const snippet = source.slice(openParen, end + 1)
+    const snippet = scanned.slice(openParen, end + 1)
     if (!snippet.includes('closingDateRegistry')) {
       violations.push({ index: start, snippet })
     }

--- a/packages/collector-cli/src/services/transformServiceRegistryGuard.ts
+++ b/packages/collector-cli/src/services/transformServiceRegistryGuard.ts
@@ -1,0 +1,67 @@
+/**
+ * transformServiceRegistryGuard — structural enforcement of TransformService's
+ * closing-date-registry injection contract (#1160, follow-up to #1129).
+ *
+ * `TransformService`'s `closingDateRegistry` is optional on the config type so
+ * test fixtures can opt into legacy fail-open behavior. In production, every
+ * construction site MUST inject it — a site that forgets silently reverts to
+ * fail-open and can publish a closing-window date under its raw date (the
+ * #1129 hole). That contract was previously documented only in a doc-comment.
+ *
+ * This guard converts the comment into a structural, CI-enforced invariant:
+ * scan production source for `new TransformService(...)` and flag any
+ * construction whose argument object does not pass `closingDateRegistry`.
+ * (Lesson 82 — a sentinel must catch a known-bad snippet, not assert config.)
+ */
+
+/** A flagged construction site: its byte offset and the captured argument. */
+export interface RegistryInjectionViolation {
+  index: number
+  snippet: string
+}
+
+const CTOR_TOKEN = 'new TransformService('
+
+/**
+ * Find every `new TransformService(...)` in `source` whose constructor
+ * argument does NOT mention `closingDateRegistry`.
+ *
+ * The scan is brace/paren-depth aware: from each `new TransformService(` it
+ * walks to the matching close paren (respecting nested `(` `[` `{`) and
+ * inspects the captured argument text. A site that passes the registry —
+ * literally or by spread/option pass-through that names the key — is honest;
+ * one that omits the key is a fail-open regression waiting to happen.
+ */
+export function findUninjectedTransformServiceConstructions(
+  source: string
+): RegistryInjectionViolation[] {
+  const violations: RegistryInjectionViolation[] = []
+  let from = 0
+  for (;;) {
+    const start = source.indexOf(CTOR_TOKEN, from)
+    if (start === -1) break
+
+    // Walk from the opening paren to its match, tracking nesting depth.
+    const openParen = start + CTOR_TOKEN.length - 1
+    let depth = 0
+    let end = openParen
+    for (let i = openParen; i < source.length; i++) {
+      const ch = source[i]
+      if (ch === '(' || ch === '[' || ch === '{') depth++
+      else if (ch === ')' || ch === ']' || ch === '}') {
+        depth--
+        if (depth === 0) {
+          end = i
+          break
+        }
+      }
+    }
+
+    const snippet = source.slice(openParen, end + 1)
+    if (!snippet.includes('closingDateRegistry')) {
+      violations.push({ index: start, snippet })
+    }
+    from = end + 1
+  }
+  return violations
+}

--- a/packages/collector-cli/src/services/transformServiceRegistryGuard.ts
+++ b/packages/collector-cli/src/services/transformServiceRegistryGuard.ts
@@ -23,8 +23,18 @@ const CTOR_TOKEN = 'new TransformService('
  * not a real construction site — but a naive substring scan would flag it
  * (Lesson 84: a documentation example of a parsed format is also valid
  * input). Removing comments first keeps the guard from tripping on its own
- * documentation. String literals are left intact; the only production string
- * carrying the token lives in this module, which the guard test excludes.
+ * documentation.
+ *
+ * LIMITATION (intentional, honest about its reach): this is a regex heuristic,
+ * not a lexer. It does NOT understand string literals — a `//` inside a string
+ * is still treated as a comment, and the constructor token hidden inside a
+ * string would evade the scan. Both are acceptable for a guard over our own
+ * prettier-formatted production source: no production site embeds the token in
+ * a string (the only such string is this module's own CTOR_TOKEN, which the
+ * guard test excludes), and constructor calls span multiple lines so a `//`
+ * sequence cannot sit on the same physical line as a `new TransformService(`.
+ * A fully correct stripper would need a TS tokenizer; that is not worth it for
+ * a single-token presence check.
  */
 function stripComments(source: string): string {
   return source

--- a/packages/collector-cli/src/services/transformServiceRegistryGuard.ts
+++ b/packages/collector-cli/src/services/transformServiceRegistryGuard.ts
@@ -14,12 +14,6 @@
  * (Lesson 82 — a sentinel must catch a known-bad snippet, not assert config.)
  */
 
-/** A flagged construction site: its byte offset and the captured argument. */
-export interface RegistryInjectionViolation {
-  index: number
-  snippet: string
-}
-
 const CTOR_TOKEN = 'new TransformService('
 
 /**
@@ -46,12 +40,15 @@ function stripComments(source: string): string {
  * walks to the matching close paren (respecting nested `(` `[` `{`) and
  * inspects the captured argument text. A site that passes the registry —
  * literally or by spread/option pass-through that names the key — is honest;
- * one that omits the key is a fail-open regression waiting to happen.
+ * one that omits the key, or passes it as literal `undefined`, is a fail-open
+ * regression waiting to happen.
+ *
+ * @returns the captured argument text of each offending construction.
  */
 export function findUninjectedTransformServiceConstructions(
   source: string
-): RegistryInjectionViolation[] {
-  const violations: RegistryInjectionViolation[] = []
+): string[] {
+  const violations: string[] = []
   const scanned = stripComments(source)
   let from = 0
   for (;;) {
@@ -75,8 +72,13 @@ export function findUninjectedTransformServiceConstructions(
     }
 
     const snippet = scanned.slice(openParen, end + 1)
-    if (!snippet.includes('closingDateRegistry')) {
-      violations.push({ index: start, snippet })
+    // A present key is necessary but not sufficient: an explicit
+    // `closingDateRegistry: undefined` re-opens the fail-open hole.
+    const injected =
+      snippet.includes('closingDateRegistry') &&
+      !/closingDateRegistry\s*:\s*undefined\b/.test(snippet)
+    if (!injected) {
+      violations.push(snippet)
     }
     from = end + 1
   }

--- a/tasks/lessons/166-a-structural-injection-guard-must-check-value-honesty-not-just-key-presence.md
+++ b/tasks/lessons/166-a-structural-injection-guard-must-check-value-honesty-not-just-key-presence.md
@@ -1,0 +1,82 @@
+---
+id: '166'
+category: lesson
+tags: [collector-cli, monorepo, verification, tdd, data-pipeline, process]
+auto_load: true
+date: 2026-06-13
+issues: [1160, 1129, 1098]
+---
+
+# Lesson 166 — A structural injection guard must check value-honesty, not just key-presence (and a factory beats type-required when fixtures block it)
+
+**Date:** 2026-06-13
+**Issue:** #1160 (epic #1193 Sprint 2 — #1129 review follow-ups)
+**PR:** _(record on merge)_
+
+## What happened
+
+#1129 left two follow-ups: BackfillOrchestrator hardcoded
+`isClosingPeriod: false` (a second laundered-default twin-writer, Lesson 158
+— fixed here by omitting the key), and `TransformService`'s
+`closingDateRegistry` injection was enforced only by a doc-comment ("every
+production site MUST inject this"). The obvious structural fix — make the
+config field `required` — was blocked: ~32 TransformService and 11
+RebuildService **test fixtures** legitimately construct without a registry to
+exercise the legacy fail-open path. Making it required would ripple a 43-site
+edit into test code and destroy the deliberate "fixtures opt into fail-open"
+affordance.
+
+The shipped enforcement was a pair: a **production factory**
+(`createProductionTransformService`, which loads and injects the registry —
+the blessed direct-construction path, zero fixture blast radius) plus a
+**source-scanning guard test** that flags any production `new TransformService(`
+omitting the registry (the backstop covering RebuildService's internal
+construction and any future site).
+
+Two review catches sharpened it:
+
+- The first guard checked only that the **key name** `closingDateRegistry`
+  appeared in the constructor argument — so `closingDateRegistry: undefined`
+  (fail-open in disguise) would have passed. A present key is necessary but
+  not sufficient; the guard now also rejects an explicit `: undefined`.
+- The guard's comment-stripper doc-comment overclaimed "string literals are
+  left intact." It is a regex heuristic, not a lexer (you cannot handle both
+  `//`-inside-a-string and apostrophe-inside-a-comment with naive regex). The
+  honest fix was to state the limitation, not pretend robustness (Lesson 84).
+
+## The transferable principle
+
+**When you turn a "callers must inject X" contract into a structural one,
+enforce the VALUE, not just the syntactic presence of the key — a guard that
+checks `closingDateRegistry` appears will wave through
+`closingDateRegistry: undefined`, which is the exact fail-open it exists to
+catch. And when type-level `required` enforcement is blocked because legacy
+fail-open test fixtures deliberately omit the field, the proportionate
+structural pair is a blessed factory (loads the real value, so the right path
+can't forget it) plus a zero-fixture-cost source-scan guard (the regression
+backstop for bypasses). A source-scan guard is a regex heuristic, not a lexer
+— document precisely what can fool it rather than claiming completeness.**
+
+## How to apply
+
+- Guard a "must be injected" contract on value-honesty: reject key-absent AND
+  `key: undefined` (and `?? undefined`-style launderers if in scope). Presence
+  of the identifier is not proof a real value flows.
+- Type-`required` is the strongest enforcement, but count the fixtures first:
+  if N legitimate fail-open fixtures omit the field, a factory + guard avoids
+  the N-site churn while still closing the "forgot to inject" hole.
+- The factory loads the real dependency so the blessed path is correct by
+  construction; the guard catches bypasses. They reinforce — neither alone is
+  complete (a factory can be bypassed; a key-presence guard passes `undefined`).
+- A regex source-scan stripper cannot be a lexer. State its blind spots in the
+  doc-comment (Lesson 84) instead of overclaiming.
+
+## Related
+
+- [[158-a-fail-closed-chain-is-only-as-honest-as-its-writers-a-persisted-default-reads-as-a-decision]]
+  — the #1129 parent; this is its named #1160 follow-up (the BackfillOrchestrator twin-writer + the injection contract).
+- [[061-fix-the-formula-everywhere-not-just-the-one-in-the-bug-report]] — audit every writer, not just the reported one.
+- Lesson 82 (sentinel catches a known-bad snippet) and Lesson 84 (a doc
+  example of a parsed format is valid input) — both shaped the guard's tests.
+- `packages/collector-cli/src/services/transformServiceFactory.ts`,
+  `transformServiceRegistryGuard.ts`, `BackfillOrchestrator.ts`.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -159,5 +159,6 @@
 - **163** [data-pipeline, collector-cli, verification, tdd, metadata, gcs] — A destructive boundary derived from set-level evidence must filter that evidence by provenance, not by shape (#1178, #1102)
 - **164** [monorepo, build, npm, verification, mcp] — `bundleDependencies` is a no-op for workspace-symlinked deps; a publishable workspace-dependent package must inline at build time (#1163, #1162)
 - **165** [process, ci, automation, release, monorepo] — An attended gate-bypass merge must re-green every artifact the gate pins, or the red lands on the next unrelated session (#1165, #1162, #1186)
+- **166** [collector-cli, monorepo, verification, tdd, data-pipeline, process] — A structural injection guard must check value-honesty, not just key-presence (and a factory beats type-required when fixtures block it) (#1160, #1129, #1098)
 - **166** [frontend, react, tanstack, error-handling, verification] — When a page derives "not found" from query data, check the error branch FIRST or every fetch failure is misreported as a missing entity (#1104, #1191)
 - **167** [accessibility, css, frontend, dark-mode, tests] — A focus ring built from the brand accent needs its own darkened token; the 3:1 non-text floor is a different bar than where the accent is safe as fill (#1106)


### PR DESCRIPTION
Follow-ups from the #1129 fresh-context review (epic #1193 Sprint 2, tracking #1160).

## Part 1 — BackfillOrchestrator omits `isClosingPeriod` (no laundered false)
`buildBackfillMetadata` hardcoded `isClosingPeriod: false`. Backfill writes raw CSVs without parsing the "As of" footer, so it cannot *decide* closing-period status — a hardcoded `false` is a laundered default that TransformService's trust branch honors as an explicit scraper decision (the #1129 twin-writer hole, Lesson 158). The key is now **omitted**; the downstream resolution chain (CSV footer → registry) decides and fails closed when undecided. This mirrors the #1129 CollectorOrchestrator fix.

## Part 2 — registry injection enforced structurally
`TransformService.closingDateRegistry` injection was comment-only ("every production site MUST inject this"). Type-level `required` was blocked by ~43 legitimate fail-open test fixtures. Shipped instead:
- **`createProductionTransformService`** factory — owns `loadClosingDateRegistryMonths` (moved out of cli.ts, dedups two call sites) and is the blessed direct-construction path; it loads a **real** registry, so the right path can't forget it or pass `undefined`. Both direct cli sites now use it.
- **`transformServiceRegistryGuard` + guard test** — scans production `src/` for any bare `new TransformService(` omitting the registry; the zero-fixture-cost backstop covering RebuildService's internal construction and any future site. Checks **value-honesty** (also rejects an explicit `closingDateRegistry: undefined`), not just key presence. Detector proven against known-bad / known-good / commented-token snippets (Lessons 82, 84).

## Acceptance criteria
- [x] BackfillOrchestrator omits `isClosingPeriod` instead of hardcoding false
- [x] Registry injection enforced structurally (factory + guard test)

## Verification
- TDD throughout (Red→Green per part). Full collector-cli suite **989 passing** (53 files).
- /simplify pass (dropped unused field; routed cli through factory per architect review) + fresh-context review (APPROVE-WITH-NITS; the one medium nit — an overclaiming stripper doc-comment — fixed).
- **No PR preview**: this PR touches only `packages/collector-cli/**`, which is outside `pr-preview.yml`'s path filter (frontend / shared-contracts / analytics-core / firebase). There is no live frontend surface to drive — verification is code-proof. The fresh-context reviewer traced the downstream flow: `readCacheMetadata` maps a missing key → `undefined`; `resolveWithoutFooter` requires `=== false` to trust a laundered false, so an omitted key correctly falls through to registry resolution (fail-closed).

Refs #1160. Lesson 166 filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)