### PR TITLE
fix(collector-cli): flush stdout before exit so piped JSON isn't truncated (#1182)

### DIFF
--- a/packages/collector-cli/src/__tests__/cli-stdout-flush.test.ts
+++ b/packages/collector-cli/src/__tests__/cli-stdout-flush.test.ts
@@ -75,6 +75,32 @@ describe('#1182 stdout flush-before-exit', () => {
     expect(exitSpy).toHaveBeenCalledWith(0)
   })
 
+  it('still exits (does not hang) if stdout errors before draining — e.g. a closed `| head` pipe', () => {
+    // Simulate a broken pipe: the drain callback never fires, but stdout
+    // emits 'error'. The exit must still happen.
+    let errorHandler: (() => void) | undefined
+    const onceSpy = vi.spyOn(process.stdout, 'once').mockImplementation(((
+      event: string,
+      cb: () => void
+    ) => {
+      if (event === 'error') errorHandler = cb
+      return process.stdout
+    }) as never)
+    writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((() => false) as never) // backpressure; callback withheld
+
+    emitJsonAndExit({ ok: false }, 1)
+
+    expect(exitSpy).not.toHaveBeenCalled() // nothing drained yet
+    expect(errorHandler).toBeTypeOf('function')
+
+    errorHandler!() // pipe reader went away
+    expect(exitSpy).toHaveBeenCalledWith(1)
+
+    onceSpy.mockRestore()
+  })
+
   it('guard: cli.ts emits no structured JSON via console.log — every terminal summary routes through emitJsonAndExit', () => {
     const here = dirname(fileURLToPath(import.meta.url))
     const cliSrc = readFileSync(join(here, '..', 'cli.ts'), 'utf-8')

--- a/packages/collector-cli/src/__tests__/cli-stdout-flush.test.ts
+++ b/packages/collector-cli/src/__tests__/cli-stdout-flush.test.ts
@@ -4,16 +4,18 @@ import { dirname, join } from 'path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { exitAfterStdoutFlush } from '../cliHelpers.js'
+import { emitJsonAndExit } from '../cliHelpers.js'
 
 /**
  * #1182 — `process.exit()` terminates synchronously and discards any stdout
  * bytes still buffered for an async pipe, truncating a large summary JSON at
  * the ~64KB highWaterMark when piped through `| tee`/`| jq` (the #1070
- * 768-result dry-run died mid-record). The fix: defer the exit until the
- * stdout write has drained. These tests pin that contract at the unit level
- * (acceptance-criterion-approved) plus a source guard so no exit path
- * regresses back to a raw synchronous `process.exit`.
+ * 768-result dry-run died mid-record, while the same data printed intact to a
+ * file). The fix routes every terminal JSON summary through `emitJsonAndExit`,
+ * which defers the exit until the stdout write has drained. These tests pin
+ * that contract at the unit level (acceptance-criterion-approved) plus a
+ * source guard so no command regresses back to the raw
+ * `console.log(JSON.stringify(...))` + `process.exit()` footgun.
  */
 describe('#1182 stdout flush-before-exit', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>
@@ -30,52 +32,55 @@ describe('#1182 stdout flush-before-exit', () => {
     writeSpy?.mockRestore()
   })
 
-  it('does NOT call process.exit synchronously — it waits for the stdout write callback', () => {
-    // Capture the write callback without actually flushing.
-    let flush: (() => void) | undefined
+  it('does NOT call process.exit synchronously — it waits for the stdout write to drain', () => {
+    // Capture the drain callback without firing it.
+    let drain: (() => void) | undefined
     writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((
       _chunk: unknown,
       cb?: () => void
     ) => {
-      flush = cb
+      drain = cb
       return true
     }) as never)
 
-    exitAfterStdoutFlush(3)
+    emitJsonAndExit({ ok: true }, 3)
 
-    // The exit is queued behind the flush, not fired inline.
+    // The exit is queued behind the drain, not fired inline.
     expect(exitSpy).not.toHaveBeenCalled()
-    expect(flush).toBeTypeOf('function')
+    expect(drain).toBeTypeOf('function')
 
     // Once stdout drains, the deferred exit fires with the right code.
-    flush!()
+    drain!()
     expect(exitSpy).toHaveBeenCalledWith(3)
   })
 
-  it('emits the FULL payload before exiting — no 64KB truncation', () => {
-    const big = JSON.stringify({ results: 'x'.repeat(200_000) })
-    const chunks: string[] = []
+  it('writes the FULL payload before exiting — no 64KB truncation — and stays valid JSON', () => {
+    const payload = { results: 'x'.repeat(200_000), totalPairs: 768 }
+    let written = ''
     writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((
       chunk: unknown,
       cb?: () => void
     ) => {
-      chunks.push(String(chunk))
+      written += String(chunk)
       cb?.() // simulate a fully-drained pipe
       return true
     }) as never)
 
-    process.stdout.write(big)
-    exitAfterStdoutFlush(0)
+    emitJsonAndExit(payload, 0)
 
-    expect(chunks.join('')).toContain(big)
-    expect(chunks.join('')).toHaveLength(big.length + 0) // flush write is empty
+    expect(written.length).toBeGreaterThan(200_000)
+    // Byte-identical to the previous console.log(JSON.stringify(p, null, 2)).
+    expect(written).toBe(JSON.stringify(payload, null, 2) + '\n')
+    expect(JSON.parse(written)).toEqual(payload)
     expect(exitSpy).toHaveBeenCalledWith(0)
   })
 
-  it('guard: cli.ts has no raw process.exit() — every exit path drains stdout first', () => {
+  it('guard: cli.ts emits no structured JSON via console.log — every terminal summary routes through emitJsonAndExit', () => {
     const here = dirname(fileURLToPath(import.meta.url))
     const cliSrc = readFileSync(join(here, '..', 'cli.ts'), 'utf-8')
-    const rawExits = cliSrc.match(/process\.exit\(/g) ?? []
-    expect(rawExits).toEqual([])
+    // The exact #1182 footgun: a large stdout write immediately before a
+    // synchronous process.exit. Routing through emitJsonAndExit eliminates it.
+    const footguns = cliSrc.match(/console\.log\(\s*JSON\.stringify/g) ?? []
+    expect(footguns).toEqual([])
   })
 })

--- a/packages/collector-cli/src/__tests__/cli-stdout-flush.test.ts
+++ b/packages/collector-cli/src/__tests__/cli-stdout-flush.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { exitAfterStdoutFlush } from '../cliHelpers.js'
+
+/**
+ * #1182 — `process.exit()` terminates synchronously and discards any stdout
+ * bytes still buffered for an async pipe, truncating a large summary JSON at
+ * the ~64KB highWaterMark when piped through `| tee`/`| jq` (the #1070
+ * 768-result dry-run died mid-record). The fix: defer the exit until the
+ * stdout write has drained. These tests pin that contract at the unit level
+ * (acceptance-criterion-approved) plus a source guard so no exit path
+ * regresses back to a raw synchronous `process.exit`.
+ */
+describe('#1182 stdout flush-before-exit', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>
+  let writeSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never)
+  })
+
+  afterEach(() => {
+    exitSpy.mockRestore()
+    writeSpy?.mockRestore()
+  })
+
+  it('does NOT call process.exit synchronously — it waits for the stdout write callback', () => {
+    // Capture the write callback without actually flushing.
+    let flush: (() => void) | undefined
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((
+      _chunk: unknown,
+      cb?: () => void
+    ) => {
+      flush = cb
+      return true
+    }) as never)
+
+    exitAfterStdoutFlush(3)
+
+    // The exit is queued behind the flush, not fired inline.
+    expect(exitSpy).not.toHaveBeenCalled()
+    expect(flush).toBeTypeOf('function')
+
+    // Once stdout drains, the deferred exit fires with the right code.
+    flush!()
+    expect(exitSpy).toHaveBeenCalledWith(3)
+  })
+
+  it('emits the FULL payload before exiting — no 64KB truncation', () => {
+    const big = JSON.stringify({ results: 'x'.repeat(200_000) })
+    const chunks: string[] = []
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((
+      chunk: unknown,
+      cb?: () => void
+    ) => {
+      chunks.push(String(chunk))
+      cb?.() // simulate a fully-drained pipe
+      return true
+    }) as never)
+
+    process.stdout.write(big)
+    exitAfterStdoutFlush(0)
+
+    expect(chunks.join('')).toContain(big)
+    expect(chunks.join('')).toHaveLength(big.length + 0) // flush write is empty
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
+
+  it('guard: cli.ts has no raw process.exit() — every exit path drains stdout first', () => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const cliSrc = readFileSync(join(here, '..', 'cli.ts'), 'utf-8')
+    const rawExits = cliSrc.match(/process\.exit\(/g) ?? []
+    expect(rawExits).toEqual([])
+  })
+})

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -60,6 +60,7 @@ export {
   validateDateFormat,
   getCurrentDateString,
   parseDistrictList,
+  emitJsonAndExit,
   determineExitCode,
   determineTransformExitCode,
   determineComputeAnalyticsExitCode,
@@ -76,6 +77,7 @@ const {
   validateDateFormat,
   getCurrentDateString,
   parseDistrictList,
+  emitJsonAndExit,
   determineExitCode,
   determineTransformExitCode,
   determineComputeAnalyticsExitCode,
@@ -324,14 +326,12 @@ export function createCLI(): Command {
         }
       }
 
-      // Output JSON summary
-      console.log(JSON.stringify(summary, null, 2))
-
       if (options.verbose) {
         console.error(`[INFO] Scrape completed with exit code: ${exitCode}`)
       }
 
-      process.exit(exitCode)
+      // Output JSON summary, then exit after stdout drains (#1182)
+      emitJsonAndExit(summary, exitCode)
     })
 
   // Add status command for checking cache status
@@ -384,8 +384,8 @@ export function createCLI(): Command {
           missingDistricts: status.missingDistricts,
         }
 
-        console.log(JSON.stringify(output, null, 2))
-        process.exit(ExitCode.SUCCESS)
+        // Output JSON summary, then exit after stdout drains (#1182)
+        emitJsonAndExit(output, ExitCode.SUCCESS)
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : 'Unknown error'
@@ -479,9 +479,8 @@ export function createCLI(): Command {
         duration_ms: transformResult.duration_ms,
       }
 
-      // Format and output JSON summary
+      // Format JSON summary
       const summary = formatTransformSummary(result, snapshotDir)
-      console.log(JSON.stringify(summary, null, 2))
 
       // Determine and use exit code
       const exitCode = determineTransformExitCode(result)
@@ -490,7 +489,8 @@ export function createCLI(): Command {
         console.error(`[INFO] Transform completed with exit code: ${exitCode}`)
       }
 
-      process.exit(exitCode)
+      // Output JSON summary, then exit after stdout drains (#1182)
+      emitJsonAndExit(summary, exitCode)
     })
 
   // Add compute-analytics command for computing analytics from existing snapshots
@@ -591,7 +591,6 @@ export function createCLI(): Command {
       // Format and output JSON summary
       // Requirement 8.4: THE `compute-analytics` command SHALL output a JSON summary
       const summary = formatComputeAnalyticsSummary(result, analyticsDir)
-      console.log(JSON.stringify(summary, null, 2))
 
       // Determine and use exit code
       const exitCode = determineComputeAnalyticsExitCode(result)
@@ -602,7 +601,8 @@ export function createCLI(): Command {
         )
       }
 
-      process.exit(exitCode)
+      // Output JSON summary, then exit after stdout drains (#1182)
+      emitJsonAndExit(summary, exitCode)
     })
 
   // Add upload command for syncing local snapshots and analytics to Google Cloud Storage
@@ -842,7 +842,6 @@ export function createCLI(): Command {
         prefix,
         options.dryRun
       )
-      console.log(JSON.stringify(summary, null, 2))
 
       // Determine and use exit code
       const exitCode = determineUploadExitCode(result)
@@ -851,7 +850,8 @@ export function createCLI(): Command {
         console.error(`[INFO] Upload completed with exit code: ${exitCode}`)
       }
 
-      process.exit(exitCode)
+      // Output JSON summary, then exit after stdout drains (#1182)
+      emitJsonAndExit(summary, exitCode)
     })
 
   // Add backfill command for historical data collection (#123)
@@ -1081,16 +1081,15 @@ export function createCLI(): Command {
           cleanSnapshots: options.cleanSnapshots,
         })
 
-        // Output JSON summary
-        console.log(JSON.stringify(result, null, 2))
-
         if (options.verbose) {
           console.error(
             `[INFO] Rebuild complete: ${result.datesSucceeded}/${result.datesProcessed} succeeded in ${result.duration_ms}ms`
           )
         }
 
-        process.exit(
+        // Output JSON summary, then exit after stdout drains (#1182)
+        emitJsonAndExit(
+          result,
           result.success ? ExitCode.SUCCESS : ExitCode.PARTIAL_FAILURE
         )
       }
@@ -1135,32 +1134,25 @@ export function createCLI(): Command {
 
         const result = await service.prune(options.dryRun)
 
-        // Output JSON summary
-        console.log(
-          JSON.stringify(
-            {
-              dryRun: options.dryRun,
-              closingGuard: result.closingGuard,
-              blocked: result.blocked,
-              layerScope: result.layerScope,
-              totalDates: result.totalDates,
-              keptDates: result.keptDates,
-              prunedDates: result.prunedDates,
-              deletedRawCsv: result.deletedRawCsv,
-              deletedSnapshots: result.deletedSnapshots,
-              errors: result.errors,
-              classifications: result.classifications.map(c => ({
-                rawCsvDate: c.rawCsvDate,
-                snapshotDate: c.snapshotDate,
-                keep: c.keep,
-                reason: c.reason,
-              })),
-              duration_ms: result.duration_ms,
-            },
-            null,
-            2
-          )
-        )
+        const summary = {
+          dryRun: options.dryRun,
+          closingGuard: result.closingGuard,
+          blocked: result.blocked,
+          layerScope: result.layerScope,
+          totalDates: result.totalDates,
+          keptDates: result.keptDates,
+          prunedDates: result.prunedDates,
+          deletedRawCsv: result.deletedRawCsv,
+          deletedSnapshots: result.deletedSnapshots,
+          errors: result.errors,
+          classifications: result.classifications.map(c => ({
+            rawCsvDate: c.rawCsvDate,
+            snapshotDate: c.snapshotDate,
+            keep: c.keep,
+            reason: c.reason,
+          })),
+          duration_ms: result.duration_ms,
+        }
 
         if (options.verbose) {
           console.error(
@@ -1168,7 +1160,9 @@ export function createCLI(): Command {
           )
         }
 
-        process.exit(
+        // Output JSON summary, then exit after stdout drains (#1182)
+        emitJsonAndExit(
+          summary,
           result.success ? ExitCode.SUCCESS : ExitCode.PARTIAL_FAILURE
         )
       }
@@ -1373,9 +1367,9 @@ export function createCLI(): Command {
               : undefined,
           results,
         }
-        console.log(JSON.stringify(summary, null, 2))
-
-        process.exit(
+        // Output JSON summary, then exit after stdout drains (#1182)
+        emitJsonAndExit(
+          summary,
           summary.failed === 0 ? ExitCode.SUCCESS : ExitCode.PARTIAL_FAILURE
         )
       }
@@ -1490,9 +1484,9 @@ export function createCLI(): Command {
           totalFacOnly: results.reduce((s, r) => s + (r.facOnly ?? 0), 0),
           results,
         }
-        console.log(JSON.stringify(summary, null, 2))
-
-        process.exit(
+        // Output JSON summary, then exit after stdout drains (#1182)
+        emitJsonAndExit(
+          summary,
           summary.failed === 0 ? ExitCode.SUCCESS : ExitCode.PARTIAL_FAILURE
         )
       }
@@ -1542,18 +1536,17 @@ export function createCLI(): Command {
           // Fail-closed: if we cannot read/compare the snapshots, do NOT promote.
           const message = err instanceof Error ? err.message : String(err)
           console.error(`[ERROR] value-diff failed: ${message}`)
-          console.log(
-            JSON.stringify(
-              {
-                promote: false,
-                requiresReview: true,
-                reasons: [`value-diff failed: ${message}`],
-              },
-              null,
-              2
-            )
+          // Namespace call (not the destructured alias) so TS sees the `never`
+          // return and narrows `result` to defined below; flush-before-exit
+          // (#1182).
+          helpers.emitJsonAndExit(
+            {
+              promote: false,
+              requiresReview: true,
+              reasons: [`value-diff failed: ${message}`],
+            },
+            ExitCode.PARTIAL_FAILURE
           )
-          process.exit(ExitCode.PARTIAL_FAILURE)
         }
 
         const { report, decision } = result
@@ -1567,10 +1560,9 @@ export function createCLI(): Command {
         }
 
         // Structured JSON to stdout (R4: logs to stderr only).
-        console.log(JSON.stringify({ ...decision, report }, null, 2))
-
         // result.exitCode is the single source of truth (0 promote / 1 blocked).
-        process.exit(result.exitCode)
+        // Flush-before-exit so the full diff isn't truncated through a pipe (#1182).
+        emitJsonAndExit({ ...decision, report }, result.exitCode)
       }
     )
 
@@ -1693,9 +1685,6 @@ export function createCLI(): Command {
           failed: results.filter(r => !r.ok).length,
           results,
         }
-        // Structured JSON to stdout (R4: logs to stderr only).
-        console.log(JSON.stringify(summary, null, 2))
-
         // Distinguish total outage (every district failed) from partial — a
         // monitoring caller reads 2 vs 1 differently (matches the enum).
         const exitCode =
@@ -1704,7 +1693,8 @@ export function createCLI(): Command {
             : summary.succeeded === 0 && summary.totalDistricts > 0
               ? ExitCode.COMPLETE_FAILURE
               : ExitCode.PARTIAL_FAILURE
-        process.exit(exitCode)
+        // Structured JSON to stdout (R4), then exit after stdout drains (#1182).
+        emitJsonAndExit(summary, exitCode)
       }
     )
 
@@ -1879,16 +1869,15 @@ export function createCLI(): Command {
           failed: results.filter(r => !r.ok).length,
           results,
         }
-        // Structured JSON to stdout (R4: logs to stderr only).
-        console.log(JSON.stringify(summary, null, 2))
-
         const exitCode =
           summary.failed === 0
             ? ExitCode.SUCCESS
             : summary.succeeded === 0 && summary.totalPairs > 0
               ? ExitCode.COMPLETE_FAILURE
               : ExitCode.PARTIAL_FAILURE
-        process.exit(exitCode)
+        // Structured JSON to stdout (R4), then exit after stdout drains (#1182).
+        // This is the command the #1070 768-result dry-run truncated.
+        emitJsonAndExit(summary, exitCode)
       }
     )
 

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -1536,10 +1536,11 @@ export function createCLI(): Command {
           // Fail-closed: if we cannot read/compare the snapshots, do NOT promote.
           const message = err instanceof Error ? err.message : String(err)
           console.error(`[ERROR] value-diff failed: ${message}`)
-          // Namespace call (not the destructured alias) so TS sees the `never`
-          // return and narrows `result` to defined below; flush-before-exit
-          // (#1182).
-          helpers.emitJsonAndExit(
+          // `return` so the catch actually terminates the handler — the exit
+          // is deferred (#1182), so without it control would fall through to
+          // the destructure below with `result` still undefined. The return
+          // also narrows `result` to defined past the try/catch.
+          return emitJsonAndExit(
             {
               promote: false,
               requiresReview: true,

--- a/packages/collector-cli/src/cliHelpers.ts
+++ b/packages/collector-cli/src/cliHelpers.ts
@@ -42,8 +42,17 @@ import { validateDistrictId } from './utils/validateDistrictId.js'
  * R4 is unaffected: structured JSON goes to stdout, logs to stderr. Output is
  * byte-identical to the previous `console.log(JSON.stringify(payload, null,
  * 2))` (trailing newline included).
+ *
+ * Because the exit is deferred, this function returns control synchronously —
+ * so it must be the last thing a code path does. Inside a `catch` (or any
+ * block with code after it), call it as `return emitJsonAndExit(...)`, or the
+ * handler keeps running past the "exit" on the same tick.
  */
 export function emitJsonAndExit(payload: unknown, exitCode: number): never {
+  // A closed reader (e.g. `| head`) makes stdout emit 'error'; the drain
+  // callback isn't guaranteed to fire then, so exit on error too rather than
+  // hang. (The pre-fix synchronous process.exit could never hang.)
+  process.stdout.once('error', () => process.exit(exitCode))
   process.stdout.write(JSON.stringify(payload, null, 2) + '\n', () =>
     process.exit(exitCode)
   )

--- a/packages/collector-cli/src/cliHelpers.ts
+++ b/packages/collector-cli/src/cliHelpers.ts
@@ -20,6 +20,39 @@ import {
 import { validateDistrictId } from './utils/validateDistrictId.js'
 
 // ============================================================================
+// Structured-output Termination
+// ============================================================================
+
+/**
+ * Print a structured JSON summary to stdout and exit — but only after that
+ * write has fully drained.
+ *
+ * `process.exit()` terminates synchronously and discards any stdout bytes
+ * still buffered for an async pipe, so a large summary gets cut at the ~64KB
+ * highWaterMark when the command runs through `| tee`/`| jq` (the #1070
+ * 768-result dry-run died mid-record), while the same data prints intact to a
+ * file or TTY (#1182). Deferring the exit to the write's drain callback
+ * guarantees every byte reaches the OS first.
+ *
+ * Use this for the *terminal* JSON-summary emit at the end of a command — it
+ * both emits and exits, so nothing should run after it. (Fail-fast option
+ * validators stay on `process.exit()`: they write only small stderr and must
+ * stop the world immediately, which a deferred exit would not do.)
+ *
+ * R4 is unaffected: structured JSON goes to stdout, logs to stderr. Output is
+ * byte-identical to the previous `console.log(JSON.stringify(payload, null,
+ * 2))` (trailing newline included).
+ */
+export function emitJsonAndExit(payload: unknown, exitCode: number): never {
+  process.stdout.write(JSON.stringify(payload, null, 2) + '\n', () =>
+    process.exit(exitCode)
+  )
+  // The drain callback owns termination; `never` lets callers treat this as
+  // the end of the command.
+  return undefined as never
+}
+
+// ============================================================================
 // Date Utilities
 // ============================================================================
 

--- a/tasks/lessons/168-a-never-typed-deferred-exit-narrows-types-but-doesnt-halt-runtime.md
+++ b/tasks/lessons/168-a-never-typed-deferred-exit-narrows-types-but-doesnt-halt-runtime.md
@@ -1,0 +1,90 @@
+---
+id: '168'
+category: lesson
+tags: [collector-cli, typescript, tdd, verification, node]
+auto_load: true
+date: 2026-06-13
+issues: [1182, 1193]
+---
+
+# Lesson 168 — A `: never`-typed _deferred_ exit narrows types but does NOT halt runtime; inside a `catch` you must `return` it
+
+**Date:** 2026-06-13
+**Issue:** #1182 (epic #1193 Sprint 3 — stdout flush-before-exit)
+**PR:** _(record on merge)_
+
+## What happened
+
+`process.exit()` truncates a large stdout summary at the ~64KB highWaterMark
+when stdout is a pipe (it discards bytes still buffered for the async pipe;
+file/TTY are unaffected). The fix replaced the terminal
+`console.log(JSON.stringify(...)); process.exit(code)` pattern with a helper
+that writes then exits from the write's **drain callback**:
+
+```ts
+export function emitJsonAndExit(payload: unknown, exitCode: number): never {
+  process.stdout.once('error', () => process.exit(exitCode)) // EPIPE: don't hang
+  process.stdout.write(JSON.stringify(payload, null, 2) + '\n', () =>
+    process.exit(exitCode)
+  )
+  return undefined as never
+}
+```
+
+The helper is typed `: never`, so TypeScript treats every call as terminating
+control flow — code after it is "unreachable", and a variable assigned in a
+`try` narrows to defined past the `catch`. That made the build pass. But the
+helper **returns synchronously** (the real exit is deferred to the next tick).
+At a `catch` that had live code after the `try/catch`, control fell straight
+through to `const { report, decision } = result` with `result` still
+`undefined` (the `try` had thrown) — a `TypeError` on the same tick, _before_
+the deferred exit fired, surfacing the wrong exit code. The original
+synchronous `process.exit()` could never do this. A fresh-context review
+caught it; the unit tests and typecheck did not (the type says `never`, so
+nothing flagged the fall-through).
+
+The fix at that one site: `return emitJsonAndExit(...)`. The `return` both
+terminates the handler at runtime AND gives the same CFA narrowing — so the
+`never` type isn't even load-bearing there.
+
+Two more traps from the same change:
+
+- **`never`-narrowing doesn't survive a destructured alias.** `const { fn } =
+helpers` loses the "this call is unreachable-after" assertion that
+  `helpers.fn()` (namespace access) or a `return` keeps. (Empirically
+  confirmed with a canary; modern TS, this repo's config.)
+- **A deferred exit can hang on EPIPE.** A closed reader (`| head`) makes
+  stdout emit `'error'`; the drain callback isn't guaranteed to fire, so the
+  process hangs instead of exiting. Guard with `stdout.once('error', exit)`.
+
+## The transferable principle
+
+**Replacing a synchronous, OS-level terminator (`process.exit`) with a helper
+that _defers_ termination is a control-flow change, not just a refactor — even
+when the helper is typed `: never`. The type only governs the compiler's
+reachability analysis; at runtime the function returns and the next statement
+runs on the same tick. Make it the genuine last action of every code path that
+calls it: trivially at the end of a block, explicitly with `return` inside a
+`catch` or any block with code after it. And only defer where deferral is safe
+— fail-fast paths that must stop the world (option validators, fail-closed
+guards) stay on synchronous `process.exit()`.**
+
+## How to apply
+
+- Auditing a sync→deferred exit swap: for each call site ask "is there code
+  after this on the same tick?" If yes, it must be `return`ed (or the exit
+  kept synchronous). The typechecker will not ask this for you.
+- Keep the sync/deferred split principled and documented: defer only the
+  large-stdout terminal emits; keep small-stderr fail-fast exits synchronous.
+- A deferred exit needs an `'error'`/EPIPE escape hatch so a closed pipe can't
+  hang it — the synchronous version it replaced never could.
+- This is exactly the class of bug fresh-context review exists to catch:
+  "obvious to the author, invisible to the type system." Don't skip it because
+  the diff looks mechanical.
+
+## Related
+
+- [[158-a-fail-closed-chain-is-only-as-honest-as-its-writers-a-persisted-default-reads-as-a-decision]]
+  — same package's fail-closed exit discipline (R4 stdout/stderr split).
+- `tasks/rules.md` R4 (stdout = structured JSON only; logs to stderr) — the
+  invariant the flush helper preserves byte-for-byte.

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -162,3 +162,4 @@
 - **166** [collector-cli, monorepo, verification, tdd, data-pipeline, process] — A structural injection guard must check value-honesty, not just key-presence (and a factory beats type-required when fixtures block it) (#1160, #1129, #1098)
 - **166** [frontend, react, tanstack, error-handling, verification] — When a page derives "not found" from query data, check the error branch FIRST or every fetch failure is misreported as a missing entity (#1104, #1191)
 - **167** [accessibility, css, frontend, dark-mode, tests] — A focus ring built from the brand accent needs its own darkened token; the 3:1 non-text floor is a different bar than where the accent is safe as fill (#1106)
+- **168** [collector-cli, typescript, tdd, verification, node] — A `: never`-typed _deferred_ exit narrows types but does NOT halt runtime; inside a `catch` you must `return` it (#1182, #1193)


### PR DESCRIPTION
## What & why

`backfill-education-archive` (and every sibling command that emits a large stdout JSON summary) truncated its output at exactly **65,536 bytes** when stdout was a pipe. `process.exit()` terminates synchronously and discards bytes still buffered for an async pipe — the #1070 768-result dry-run (~100KB) died mid-record through `| tee`, while the same data printed intact to a file/TTY. Refs #1182 (epic #1193, Sprint 3).

## The fix

A new helper `emitJsonAndExit(payload, exitCode)` in `cliHelpers.ts` writes the JSON, then calls `process.exit` from the write's **drain callback** — so every byte reaches the OS first. The 13 terminal JSON-summary emit sites in `cli.ts` now route through it.

- **Fail-fast guards stay synchronous.** The ~20 option-validator / fail-closed `process.exit()` calls write only small stderr and must stop the world immediately; deferring them would let code keep running on the same tick (and broke `cli-upload-validation.test.ts`, which is the canary). The split is principled and documented in the helper's JSDoc.
- **Broken-pipe guard.** A closed reader (`| head`) makes stdout emit `'error'` where the drain callback isn't guaranteed to fire; `emitJsonAndExit` exits on that too rather than hang.
- **R4 intact.** stdout = structured JSON only; output is byte-identical to the old `console.log(JSON.stringify(p, null, 2))` (trailing newline included).

## Verification (no preview surface — CLI-only diff)

`pr-preview.yml` is path-filtered to `frontend/**` + `packages/{shared-contracts,analytics-core}/**`; this PR touches only `packages/collector-cli/**`, so there is no live web surface. Verified instead by end-to-end pipe reproduction with the **real compiled helper** + the full suite:

| Check | Result |
|---|---|
| OLD pattern (`console.log` + `process.exit`) through `\| cat` | **65,536 bytes — truncated** (bug reproduced) |
| NEW `emitJsonAndExit` (compiled `dist/`) through `\| cat` | **200,076 bytes — full, parses as valid JSON** |
| Exit code through a pipe | preserved (emit code 1 → exit 1; code 0 → exit 0) |
| `cli-stdout-flush.test.ts` | 4/4 (deferred-exit, full-payload, EPIPE guard, source guard) |
| collector-cli / analytics-core / shared-contracts / mcp-server / frontend | 966 / 868 / 159 / 63 / 3442 — all green |

## Review

Fresh-context `/review` caught a real bug pre-push: the value-diff fail-closed `catch` deferred its exit but had live code after it, so control fell through to a destructure of an `undefined` `result`. Fixed with `return emitJsonAndExit(...)`. Captured as Lesson 166.

**Low (deferred, not in scope):** an altitude reviewer suggested a unified `CLIOutput` abstraction funnelling *all* exits. Skipped — it would expand blast radius well beyond this bug, and a naïve "all exits flush" would re-introduce the fail-fast regression above. Worth a follow-up if the CLI's exit surface grows.

## TDD / DoD

- ✅ Failing test committed first (`d36ba6cb`), then the fix — Red proven (helper absent → import failure + source guard red).
- ✅ No assertion pinning; zero regressions repo-wide.
- ✅ Every commit references #1182. Lesson 166 filed + index regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
