### PR TITLE
docs: retire stale SnapshotBuilder.build() tripwire (#1113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Read `tasks/rules.md` completely before every task. Key rules:
 
 ## Active Tripwires
 
-- `SnapshotBuilder.build()` has two district-tracking code paths (success + validation-failure) — must update both.
+- District success/failure tracking lives in **one place** — `TransformService.transform()` (`packages/collector-cli`) loops over per-district `transformDistrictToDate` results and derives `districtsSucceeded`/`districtsFailed`/`districtsSkipped` by filtering that single `results[]` array. There is no second validation-failure path: the old `SnapshotBuilder.build()` two-path hazard died with the now-deleted backend (the name survives only in `DataTransformer.ts` comments). Changing district discovery touches only that one loop — don't reintroduce a parallel path.
 - DCP goals are **independent**, not sequential. Use `clubPerformance` raw fields, never infer count as Goals 1-N.
 - Chart `|| 1` range fallback causes y-axis inversion. Pad symmetrically when `range === 0`.
 - `Path.join()` with raw user input = path traversal. Always call `validateDistrictId()` first.

--- a/tasks/rules.md
+++ b/tasks/rules.md
@@ -103,7 +103,7 @@ _Trigger:_ writing a test that imports a `pages/*Page` component or `<App/>`.
 
 ## ⚠️ Active Tripwires
 
-- `SnapshotBuilder.build()` has **two** district-tracking code paths (success + validation-failure). Changing district discovery must update both.
+- District success/failure tracking lives in **one place** — `TransformService.transform()` (`packages/collector-cli`) loops over per-district `transformDistrictToDate` results and derives `districtsSucceeded`/`districtsFailed`/`districtsSkipped` by filtering that single `results[]` array. No second validation-failure path exists: the `SnapshotBuilder.build()` two-path hazard is gone with the now-deleted backend (the name survives only in `DataTransformer.ts` comments). Changing district discovery touches only that one loop.
 - DCP goals are **independent** (not sequential). Never approximate `dcpGoals` count as Goals 1-N achieved in order. Use `clubPerformance` raw fields.
 - Any chart with `|| 1` range fallback is a y-axis inversion bug waiting to happen. Pad symmetrically when `range === 0`.
 - Tailwind opacity variants (`text-tm-*-80`) don't inherit CSS variable overrides. Audit on every new brand token.


### PR DESCRIPTION
## What

Sprint 2 of epic #1194. Retires the stale **Active Tripwire** in both `CLAUDE.md` and `tasks/rules.md`:

> ~~`SnapshotBuilder.build()` has two district-tracking code paths (success + validation-failure) — must update both.~~

`SnapshotBuilder` no longer exists in tracked source — it died with the deleted backend. The name now survives only in two `DataTransformer.ts` doc comments. The "two code paths" warning misled sessions auditing the current pipeline (2026-06-09 audit §9b, #1113).

## Current reality (verified)

District success/failure tracking lives in a **single path** — `TransformService.transform()` (`packages/collector-cli`) loops over per-district `transformDistrictToDate` results and derives `districtsSucceeded`/`districtsFailed`/`districtsSkipped` by filtering one `results[]` array (`TransformService.ts:2236-2247`). There is no second validation-failure path.

The rewritten tripwire points at that single loop and warns against re-splitting it, in both files together (the AC).

## Scope note

Left `R6`'s `SnapshotBuilder`/`DataTransformer` mention untouched — it's a historical *example* in "trace the call graph before refactoring," not the active tripwire this issue targets. Dropped the issue's "(Lesson 33)" provenance citation: Lesson 33 is about property-based tests, not the backend deletion, so it doesn't support the claim.

## Verification

- Docs-only change (2 lines). `pr-preview.yml` path filter excludes root docs → no live preview surface; code-proof below.
- **Code-proof of the new claim:** `grep -rn SnapshotBuilder packages frontend` (tracked `.ts`, excluding `dist/`) → only `DataTransformer.ts:5,72` comments; zero live code. `TransformService.transform()` single-loop tracking confirmed at lines 2236-2247.
- Prettier clean; pre-push full unit suite green (2738 tests).

Refs #1113