### PR TITLE
docs: PM competitor-gap memo (epics #1225, #1228)

### DIFF
--- a/tasks/pm-memo-2026-06-21.md
+++ b/tasks/pm-memo-2026-06-21.md
@@ -1,0 +1,127 @@
+# PM Memo — Competitor Gap, Historical View, Two Fixes (2026-06-21)
+
+Covers four asks: (1) competitor gap analysis, (2) "Smedley" bug, (3) per-club
+historical view brainstorm, (4) restore the DCP per-goal "what's missing" breakdown.
+
+---
+
+## 1. Competitor landscape & feature gaps
+
+| Competitor | What it is | Strength | Weakness vs. Toast Stats |
+| --- | --- | --- | --- |
+| **TI official Dashboards** (`dashboards.toastmasters.org`) | Canonical daily source | Authoritative, free, every district | Raw tables, no trends, no projections, no health flags, dated UX, no dark mode |
+| **TmTools / Marshall reports** (`marshalls.org/tmtools`) | Long-standing report generator | **Multi-year DCP history per club**, charter dates, begin/end membership | Utilitarian 2000s UI, no visual analytics, member-PII oriented |
+| **RAFFETY Reports** | District action reports | **"Almost Distinguished Clubs"**, **"Area-To-Do's"**, District Summary | Static, district-specific, no self-serve trends |
+| **Pacho Grande / Chiclet / "LEO board"** | At-a-glance color grid of every club | One-screen district health scan | Single view only; no drill-down, no history |
+| **Reports2/Reports3** | District Analysis Reports | DCP history, club education history | Bureaucratic, export-only feel |
+| **District-built dashboards** (D100/D108/Houston) | Embedded Power BI / static pages | Tailored to one district | Not reusable; maintenance burden; no cross-district |
+
+### Where Toast Stats already wins
+Trends over time, Distinguished projections, club-health classification (Thriving/
+Vulnerable/IR), regions view, deep links, dark mode, MCP/AI access. No competitor
+combines visual trend analytics + projections + health flags in one self-serve SPA.
+
+### Gap-closing features (ranked by value/effort)
+
+1. **At-a-glance club grid ("Chiclet / LEO board" equivalent)** — single screen,
+   one color-coded tile per club (health or DCP tier), filterable by division/area.
+   This is the one thing the official dashboards *can't* do and every DD asks for.
+   **High value, medium effort.** Reuses existing health + DCP data. New page
+   `/district/:id/grid` or an Overview-hub toggle.
+2. **Per-club historical view (multi-year)** — see §3. Directly matches TmTools'
+   one durable advantage (DCP history) but visualized. **High value, medium effort.**
+3. **"Almost Distinguished" / action lists surfaced as a destination** — we already
+   have the `isCloseToDistinguished` predicate and a clubs-table preset; promote it
+   into a shareable **Action List** view per Area Director (mirrors RAFFETY's
+   "Area-To-Do's"). **Medium value, low effort** — mostly a routed view over
+   existing predicates + the visit-report data we already ingest.
+4. **DCP per-goal "what's missing" breakdown** — see §4. Was shipped, regressed.
+   **High value, low effort** — data already computed.
+
+### Deliberately NOT chasing
+Per-member education tracking and member PII reports (TmTools/Marshall territory) —
+violates our de-identification stance and adds no district-leader value.
+
+---
+
+## 2. Bug — "Smedley" dropped from "What Changed"
+
+**Confirmed, root-caused.** Not a regex/truncation issue — two tier-code→name maps
+mislabel the `M` (Smedley) code as plain `'Distinguished'`:
+
+- `packages/analytics-core/src/analytics/diffSnapshots.ts:61` → `M: 'Distinguished'`
+  (feeds the change-event label string).
+- `frontend/src/utils/distinguishedTier.ts:14` → same defect (drives the on-screen
+  table + CSV export). The two maps are intentionally mirrored (Lesson 117).
+
+`M` = Smedley is authoritative: `DataTransformer.ts:561` counts `M` into
+`smedleyDistinguishedClubs`; `types/distinguished.ts:64` lists `'Smedley'` as the top tier.
+
+**Fix (TDD):** change both maps to `'Smedley Distinguished'`. A test currently pins the
+bug — `frontend/src/utils/__tests__/distinguishedTier.test.ts:14` expects
+`'Distinguished'` for `'M'`; correct it to `'Smedley Distinguished'` (this is fixing an
+assertion that encodes the bug, *not* assertion-pinning). Check
+`diffSnapshots.test.ts` for an `M`-tier assertion too. ~3 files, trivial.
+
+---
+
+## 3. Brainstorm — per-club historical view
+
+**Problem:** A club president / area director can see *this* year's trend, but not the
+multi-year story ("are we declining, recovering, or stable?"). TmTools shows raw DCP
+history; nobody visualizes it. The data exists (daily snapshots back through prior PYs).
+
+**Proposed: a "History" subpage on club detail (`/club/:id/history`).**
+
+Per-program-year rows (a timeline / small-multiples), each showing:
+
+| Dimension | Source (already in pipeline) |
+| --- | --- |
+| **DCP points earned** (0–10) + goals-met sparkline | `dcpGoalDefinitions.ts` / Goal Achievement Timeline |
+| **Distinguished status achieved** (—/D/S/P/Smedley) tier badge | `clubPerformance` letter code, per-tier counts (#1124) |
+| **Membership strength** (base → end-of-year, net growth) | time-series, `useTimeSeries` base rule |
+| **Charter status / suspended periods** | club status overlay |
+| **Payments** (renewals on time Oct/Apr) | `clubPerformance` raw fields |
+
+**Visual options (pick one to start):**
+- **A — Year-over-year table** (rows = PYs, cols = the dimensions above, tier badges +
+  ✓/✗). Simplest, ships fast, sortable, exportable. *Recommended MVP.*
+- **B — Multi-line trend** (one line per dimension across PYs). Prettier, but mixed
+  units (points vs members) fight on one axis.
+- **C — Tier "lifeline"** (a horizontal band per PY colored by Distinguished tier, with
+  membership as bar height). Most evocative; more design effort.
+
+**Recommendation:** Ship **A** first (low risk, reuses Goal Achievement Timeline data
+plumbing), then layer **C** as a hero strip above it once we see real multi-year data
+density. Single responsibility, deep-linkable, no pipeline work.
+
+**Open question for you:** how many program years of history do we reliably have per
+club in the snapshot archive? That bounds whether this is 2-year or 6-year storytelling.
+
+---
+
+## 4. Restore — DCP per-goal "what's missing" breakdown
+
+**Confirmed regression, trivially restorable.** The breakdown lived in
+`ClubDCPGoalsCard.tsx`, deleted in commit `2f834b08` (PR #642, #620, 2026-05-23) when
+the redesign panel replaced it. The replacement `ClubDCPGoalsPanel.tsx` kept the goal
+grid but **renders only goal number + name + ✓**, throwing away the gap text.
+
+**The gap data is still computed live.** `extractDcpGoalProgress()` in
+`frontend/src/utils/dcpGoals.ts` (used by the current panel) still produces per goal:
+`statusText` (e.g. *"2 Level 1 awards needed"*), `subItems[]` (label/required/achieved),
+and the `achieved` boolean. The panel just discards `statusText`.
+
+**Fix:** render `goal.statusText` (and optionally the `subItems` required-vs-achieved
+counts) for each unmet goal inside the existing grid. Frontend-only, no pipeline /
+contract / analytics change. Reference layout: the deleted `ClubDCPGoalsCard.tsx` diff.
+
+---
+
+## Recommended execution order
+1. **#2 Smedley bug** — trivial, user-reported, clear DoD. Do first.
+2. **#4 DCP breakdown restore** — low effort, high value, data ready.
+3. **#3 Historical view (option A MVP)** — needs the history-depth answer first.
+4. **#1 Gap features** — sequence the club grid + action-list views into a sprint.
+</content>
+</invoke>


### PR DESCRIPTION
Adds `tasks/pm-memo-2026-06-21.md` — the competitor/gap analysis, per-club historical-view brainstorm, and root-cause notes referenced by the two newly-queued epics so runner-launched sessions can read the rationale behind their sprints.

- Epic #1225 — Club detail accuracy (Smedley change-label fix #1226, DCP per-goal breakdown restore #1227)
- Epic #1228 — Historical & competitive depth (history view #1229, club grid #1230, action list #1231)

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)