### PR TITLE
fix(changes): label tier M as 'Smedley Distinguished' in change feed + CSV export (#1226)

### DIFF
--- a/frontend/src/utils/__tests__/distinguishedTier.test.ts
+++ b/frontend/src/utils/__tests__/distinguishedTier.test.ts
@@ -11,7 +11,9 @@ describe('distinguishedTierName (#795)', () => {
     expect(distinguishedTierName('D')).toBe('Distinguished')
     expect(distinguishedTierName('S')).toBe('Select Distinguished')
     expect(distinguishedTierName('P')).toBe("President's Distinguished")
-    expect(distinguishedTierName('M')).toBe('Distinguished')
+    // M = Smedley Distinguished, the top DCP tier — NOT plain "Distinguished"
+    // (#1226). The prior assertion here pinned the mislabeling bug.
+    expect(distinguishedTierName('M')).toBe('Smedley Distinguished')
   })
 
   it('maps the empty code to "None"', () => {

--- a/frontend/src/utils/distinguishedTier.ts
+++ b/frontend/src/utils/distinguishedTier.ts
@@ -11,7 +11,7 @@ const TIER_NAMES: Record<string, string> = {
   D: 'Distinguished',
   S: 'Select Distinguished',
   P: "President's Distinguished",
-  M: 'Distinguished',
+  M: 'Smedley Distinguished',
 }
 
 export function distinguishedTierName(code: string): string {

--- a/packages/analytics-core/src/analytics/diffSnapshots.test.ts
+++ b/packages/analytics-core/src/analytics/diffSnapshots.test.ts
@@ -181,6 +181,26 @@ describe('diffSnapshots', () => {
     )
   })
 
+  it('labels a P→M promotion as "Smedley Distinguished" (#1226)', () => {
+    // Tier code M = Smedley Distinguished (top DCP tier), NOT plain
+    // "Distinguished". DataTransformer counts M into smedleyDistinguishedClubs.
+    const from = snapshot({
+      date: '2026-05-25',
+      clubs: [club({ clubId: '001' })],
+      perf: [perf('001', 'P')],
+    })
+    const to = snapshot({
+      date: '2026-05-26',
+      clubs: [club({ clubId: '001' })],
+      perf: [perf('001', 'M')],
+    })
+    const event = diffSnapshots(from, to).events.find(
+      e => e.category === 'distinguished'
+    )
+    expect(event?.label).toContain('Smedley Distinguished')
+    expect(event?.label).toBe('Club 001 moved to Smedley Distinguished')
+  })
+
   it('returns no events when nothing changed (valid outcome)', () => {
     const a = snapshot({
       date: '2026-05-25',

--- a/packages/analytics-core/src/analytics/diffSnapshots.ts
+++ b/packages/analytics-core/src/analytics/diffSnapshots.ts
@@ -58,7 +58,7 @@ const TIER_NAMES: Record<string, string> = {
   D: 'Distinguished',
   S: 'Select Distinguished',
   P: "President's Distinguished",
-  M: 'Distinguished',
+  M: 'Smedley Distinguished',
 }
 
 function tierName(code: string): string {

--- a/tasks/pm-memo-2026-06-21.md
+++ b/tasks/pm-memo-2026-06-21.md
@@ -7,16 +7,17 @@ historical view brainstorm, (4) restore the DCP per-goal "what's missing" breakd
 
 ## 1. Competitor landscape & feature gaps
 
-| Competitor | What it is | Strength | Weakness vs. Toast Stats |
-| --- | --- | --- | --- |
-| **TI official Dashboards** (`dashboards.toastmasters.org`) | Canonical daily source | Authoritative, free, every district | Raw tables, no trends, no projections, no health flags, dated UX, no dark mode |
-| **TmTools / Marshall reports** (`marshalls.org/tmtools`) | Long-standing report generator | **Multi-year DCP history per club**, charter dates, begin/end membership | Utilitarian 2000s UI, no visual analytics, member-PII oriented |
-| **RAFFETY Reports** | District action reports | **"Almost Distinguished Clubs"**, **"Area-To-Do's"**, District Summary | Static, district-specific, no self-serve trends |
-| **Pacho Grande / Chiclet / "LEO board"** | At-a-glance color grid of every club | One-screen district health scan | Single view only; no drill-down, no history |
-| **Reports2/Reports3** | District Analysis Reports | DCP history, club education history | Bureaucratic, export-only feel |
-| **District-built dashboards** (D100/D108/Houston) | Embedded Power BI / static pages | Tailored to one district | Not reusable; maintenance burden; no cross-district |
+| Competitor                                                 | What it is                           | Strength                                                                 | Weakness vs. Toast Stats                                                       |
+| ---------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| **TI official Dashboards** (`dashboards.toastmasters.org`) | Canonical daily source               | Authoritative, free, every district                                      | Raw tables, no trends, no projections, no health flags, dated UX, no dark mode |
+| **TmTools / Marshall reports** (`marshalls.org/tmtools`)   | Long-standing report generator       | **Multi-year DCP history per club**, charter dates, begin/end membership | Utilitarian 2000s UI, no visual analytics, member-PII oriented                 |
+| **RAFFETY Reports**                                        | District action reports              | **"Almost Distinguished Clubs"**, **"Area-To-Do's"**, District Summary   | Static, district-specific, no self-serve trends                                |
+| **Pacho Grande / Chiclet / "LEO board"**                   | At-a-glance color grid of every club | One-screen district health scan                                          | Single view only; no drill-down, no history                                    |
+| **Reports2/Reports3**                                      | District Analysis Reports            | DCP history, club education history                                      | Bureaucratic, export-only feel                                                 |
+| **District-built dashboards** (D100/D108/Houston)          | Embedded Power BI / static pages     | Tailored to one district                                                 | Not reusable; maintenance burden; no cross-district                            |
 
 ### Where Toast Stats already wins
+
 Trends over time, Distinguished projections, club-health classification (Thriving/
 Vulnerable/IR), regions view, deep links, dark mode, MCP/AI access. No competitor
 combines visual trend analytics + projections + health flags in one self-serve SPA.
@@ -25,7 +26,7 @@ combines visual trend analytics + projections + health flags in one self-serve S
 
 1. **At-a-glance club grid ("Chiclet / LEO board" equivalent)** — single screen,
    one color-coded tile per club (health or DCP tier), filterable by division/area.
-   This is the one thing the official dashboards *can't* do and every DD asks for.
+   This is the one thing the official dashboards _can't_ do and every DD asks for.
    **High value, medium effort.** Reuses existing health + DCP data. New page
    `/district/:id/grid` or an Overview-hub toggle.
 2. **Per-club historical view (multi-year)** — see §3. Directly matches TmTools'
@@ -39,6 +40,7 @@ combines visual trend analytics + projections + health flags in one self-serve S
    **High value, low effort** — data already computed.
 
 ### Deliberately NOT chasing
+
 Per-member education tracking and member PII reports (TmTools/Marshall territory) —
 violates our de-identification stance and adds no district-leader value.
 
@@ -60,14 +62,14 @@ mislabel the `M` (Smedley) code as plain `'Distinguished'`:
 **Fix (TDD):** change both maps to `'Smedley Distinguished'`. A test currently pins the
 bug — `frontend/src/utils/__tests__/distinguishedTier.test.ts:14` expects
 `'Distinguished'` for `'M'`; correct it to `'Smedley Distinguished'` (this is fixing an
-assertion that encodes the bug, *not* assertion-pinning). Check
+assertion that encodes the bug, _not_ assertion-pinning). Check
 `diffSnapshots.test.ts` for an `M`-tier assertion too. ~3 files, trivial.
 
 ---
 
 ## 3. Brainstorm — per-club historical view
 
-**Problem:** A club president / area director can see *this* year's trend, but not the
+**Problem:** A club president / area director can see _this_ year's trend, but not the
 multi-year story ("are we declining, recovering, or stable?"). TmTools shows raw DCP
 history; nobody visualizes it. The data exists (daily snapshots back through prior PYs).
 
@@ -75,17 +77,18 @@ history; nobody visualizes it. The data exists (daily snapshots back through pri
 
 Per-program-year rows (a timeline / small-multiples), each showing:
 
-| Dimension | Source (already in pipeline) |
-| --- | --- |
-| **DCP points earned** (0–10) + goals-met sparkline | `dcpGoalDefinitions.ts` / Goal Achievement Timeline |
+| Dimension                                                      | Source (already in pipeline)                           |
+| -------------------------------------------------------------- | ------------------------------------------------------ |
+| **DCP points earned** (0–10) + goals-met sparkline             | `dcpGoalDefinitions.ts` / Goal Achievement Timeline    |
 | **Distinguished status achieved** (—/D/S/P/Smedley) tier badge | `clubPerformance` letter code, per-tier counts (#1124) |
-| **Membership strength** (base → end-of-year, net growth) | time-series, `useTimeSeries` base rule |
-| **Charter status / suspended periods** | club status overlay |
-| **Payments** (renewals on time Oct/Apr) | `clubPerformance` raw fields |
+| **Membership strength** (base → end-of-year, net growth)       | time-series, `useTimeSeries` base rule                 |
+| **Charter status / suspended periods**                         | club status overlay                                    |
+| **Payments** (renewals on time Oct/Apr)                        | `clubPerformance` raw fields                           |
 
 **Visual options (pick one to start):**
+
 - **A — Year-over-year table** (rows = PYs, cols = the dimensions above, tier badges +
-  ✓/✗). Simplest, ships fast, sortable, exportable. *Recommended MVP.*
+  ✓/✗). Simplest, ships fast, sortable, exportable. _Recommended MVP._
 - **B — Multi-line trend** (one line per dimension across PYs). Prettier, but mixed
   units (points vs members) fight on one axis.
 - **C — Tier "lifeline"** (a horizontal band per PY colored by Distinguished tier, with
@@ -109,7 +112,7 @@ grid but **renders only goal number + name + ✓**, throwing away the gap text.
 
 **The gap data is still computed live.** `extractDcpGoalProgress()` in
 `frontend/src/utils/dcpGoals.ts` (used by the current panel) still produces per goal:
-`statusText` (e.g. *"2 Level 1 awards needed"*), `subItems[]` (label/required/achieved),
+`statusText` (e.g. _"2 Level 1 awards needed"_), `subItems[]` (label/required/achieved),
 and the `achieved` boolean. The panel just discards `statusText`.
 
 **Fix:** render `goal.statusText` (and optionally the `subItems` required-vs-achieved
@@ -119,9 +122,10 @@ contract / analytics change. Reference layout: the deleted `ClubDCPGoalsCard.tsx
 ---
 
 ## Recommended execution order
+
 1. **#2 Smedley bug** — trivial, user-reported, clear DoD. Do first.
 2. **#4 DCP breakdown restore** — low effort, high value, data ready.
 3. **#3 Historical view (option A MVP)** — needs the history-depth answer first.
 4. **#1 Gap features** — sequence the club grid + action-list views into a sprint.
-</content>
-</invoke>
+   </content>
+   </invoke>


### PR DESCRIPTION
## What

Tier code **`M` = Smedley Distinguished** (the top DCP tier) was mislabeled as plain **"Distinguished"** on the Changes view and CSV export. Both intentionally-mirrored tier-code→name maps dropped the word "Smedley":

- `packages/analytics-core/src/analytics/diffSnapshots.ts` — feeds the change-event label (`tierName()` → `distinguishedLabel()`).
- `frontend/src/utils/distinguishedTier.ts` — drives the on-screen table cell + CSV export (`csvExport.ts`).

`M` is authoritatively Smedley: `DataTransformer.ts` counts it into `smedleyDistinguishedClubs`; `types/distinguished.ts` lists `'Smedley'` as the top tier.

## TDD

- **Red:** corrected the prior `distinguishedTierName('M') === 'Distinguished'` assertion that *encoded* the bug (R1 — fixing a bug-pinning test, not assertion-pinning), and added an analytics-core test that a `P→M` transition emits `"... moved to Smedley Distinguished"`.
- **Green:** mapped `M → 'Smedley Distinguished'` in both maps, kept in sync (Lesson 117).

## Verification

- analytics-core 879/879, frontend utils 894/894, full pre-push suite 2714/2714 — all green.
- Live verification on the PR preview channel (per sprint protocol).

Part of epic #1225 (Club detail accuracy), Sprint 1 #1226. No \`Closes\` keyword — the sub-issue closes after live verification (R15/L106 ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)