### PR TITLE
feat(club): restore DCP per-goal 'what's missing' breakdown on club detail (#1227)

### DIFF
--- a/frontend/src/components/ClubDCPGoalsPanel.tsx
+++ b/frontend/src/components/ClubDCPGoalsPanel.tsx
@@ -116,7 +116,17 @@ export const ClubDCPGoalsPanel: React.FC<ClubDCPGoalsPanelProps> = ({
                     {goal.achieved ? '✓' : ''}
                   </span>
                   <span className="goal-num">{goal.goalNumber}</span>
-                  <span className="goal-name">{goal.name}</span>
+                  <span className="goal-body">
+                    <span className="goal-name">{goal.name}</span>
+                    {/* "What's missing" gap text for unmet goals (#1227,
+                        restoring the breakdown #642 dropped). `statusText` is
+                        '' for met goals, so this only renders when there's a
+                        real gap. It's visible text, so it conveys the gap to
+                        assistive tech without colour reliance. */}
+                    {!goal.achieved && goal.statusText ? (
+                      <span className="goal-gap">{goal.statusText}</span>
+                    ) : null}
+                  </span>
                   {/* Met state is also carried by bg + the check glyph, but
                       colour/glyph alone is not accessible — expose the status
                       as screen-reader-only text. */}

--- a/frontend/src/components/__tests__/ClubDCPGoalsPanel.test.tsx
+++ b/frontend/src/components/__tests__/ClubDCPGoalsPanel.test.tsx
@@ -10,6 +10,7 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, cleanup, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { ClubDCPGoalsPanel } from '../ClubDCPGoalsPanel'
+import { extractDcpGoalProgress } from '../../utils/dcpGoals'
 
 // A record where goals 1–5, 7, 9 are met (7 of 10). Keys mirror dcpGoals.ts.
 const record = {
@@ -102,6 +103,34 @@ describe('ClubDCPGoalsPanel (#620)', () => {
     ) as HTMLElement
     // Goal 1 is met → row carries a screen-reader-only "Achieved" label.
     expect(within(firstRow).getByText(/achieved/i)).toBeInTheDocument()
+  })
+
+  it("renders the 'what's missing' gap text for unmet goals only (#1227)", () => {
+    const { container } = render(
+      <ClubDCPGoalsPanel
+        goalsAchieved={7}
+        clubRecord={record}
+        isLoading={false}
+      />
+    )
+    // Drive the assertion from the live util, not hand-typed strings — the gap
+    // text is the same `statusText` the panel must surface (R3: single source).
+    const progress = extractDcpGoalProgress(record)
+    const rows = container.querySelectorAll('.goals-table .goal-row')
+    expect(rows).toHaveLength(progress.length)
+
+    progress.forEach((goal, i) => {
+      const gap = rows[i]!.querySelector('.goal-gap')
+      if (goal.achieved) {
+        // Met goals keep the ✓ and carry NO gap text.
+        expect(gap).toBeNull()
+      } else {
+        // Sanity: the fixture's unmet goals do produce a non-empty gap string.
+        expect(goal.statusText).not.toBe('')
+        expect(gap).not.toBeNull()
+        expect(gap!.textContent).toBe(goal.statusText)
+      }
+    })
   })
 
   it('still renders the progress bar when no raw record is available', () => {

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -2251,7 +2251,9 @@
 
   .goal-row {
     display: flex;
-    align-items: center;
+    /* Top-align so the check + number sit beside the goal name's first line
+       when an unmet goal wraps its gap text onto a second line (#1227). */
+    align-items: flex-start;
     gap: 10px;
     padding: 10px 12px;
     background: var(--surface-2);
@@ -2293,8 +2295,17 @@
     min-width: 16px;
   }
 
-  .goal-row .goal-name {
+  /* Name + gap-text column. flex:1 lives here (moved off .goal-name) so the
+     unmet "what's missing" line stacks under the name (#1227). */
+  .goal-row .goal-body {
     flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .goal-row .goal-name {
     color: var(--ink-2);
     min-width: 0;
   }
@@ -2302,6 +2313,15 @@
   .goal-row.met .goal-name {
     color: var(--ink);
     font-weight: 500;
+  }
+
+  /* "What's missing" gap text for unmet goals (#1227). --red-500 clears AA on
+     --surface-2 in BOTH themes (it remaps lighter to #f87171 in dark, per the
+     #670 filter-error precedent); --red-600 was 4.42:1, just under (L116/L112). */
+  .goal-row .goal-gap {
+    color: var(--red-500);
+    font-size: 11px;
+    line-height: 1.35;
   }
 
   [data-theme='dark'] .goal-row.met {


### PR DESCRIPTION
## What & why
Restores the per-goal **"what's missing"** breakdown on the Club Detail DCP panel (#1227). The gap text was dropped in PR #642 (#620) when `ClubDCPGoalsCard` was replaced by `ClubDCPGoalsPanel` — but the data (`statusText`) is **still computed live** by `extractDcpGoalProgress()`; the panel just discarded it. This is a frontend-only re-render: no pipeline / contract / analytics change.

## Changes
- `ClubDCPGoalsPanel.tsx` — each **unmet** goal now renders `goal.statusText` (e.g. "2 Level 1 awards needed") under its name; met goals keep the ✓. Name + gap wrap in a `.goal-body` column.
- `app-shell.css` — `.goal-body` (column, holds the moved `flex:1`), `.goal-gap` (red gap text), row top-aligned so check/number sit beside the name's first line.

## Dark mode / a11y
- `.goal-gap` uses `--red-500`, which remaps lighter (#f87171) in dark and clears AA on `.goal-row`'s `--surface-2` in **both** themes — same vetted pairing as the `.clubs-filter-error` band (#670). `--red-600` was 4.42:1, just under (L116/L112).
- Gap text is real visible text → conveys "what's missing" without colour reliance; the existing `sr-only` Achieved/Not-yet label is untouched.

## Acceptance criteria
- [x] Each unmet goal renders its `statusText`; met goals keep ✓.
- [ ] (Optional) per-goal `subItems` counts — **skipped** (optional; `statusText` already conveys the gap).
- [x] Styling matches the redesign panel + dark-mode contrast (AA verified, both themes).
- [x] Test asserts an unmet goal renders its `statusText`; met goal does not — driven from the live util, no hand-typed strings.
- [x] Zero regressions — full frontend suite 3447 passed.

## Testing
- TDD: failing test (gap absent) → implement → green.
- Full suite: 278 files / 3447 tests pass. `test:no-page-mounts:check` OK.
- Fresh-context `/review`: APPROVE, no High/Medium findings.

Live verification on the PR preview channel to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)