### PR TITLE
feat(district): at-a-glance club grid (Chiclet / LEO board) — one tile per club (#1230)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,9 @@ const DistrictRankingsPage = React.lazy(
   () => import('./pages/DistrictRankingsPage')
 )
 
+// Code-split: DistrictGridPage — at-a-glance club grid subroute (#1230, epic #1228)
+const DistrictGridPage = React.lazy(() => import('./pages/DistrictGridPage'))
+
 // Code-split: DistrictTrendsPage — trends subroute (#680, epic #674 Sprint 6)
 const DistrictTrendsPage = React.lazy(
   () => import('./pages/DistrictTrendsPage')
@@ -144,6 +147,14 @@ const router = createBrowserRouter(
           element: (
             <Suspense fallback={<PageLoadingFallback />}>
               <DistrictRankingsPage />
+            </Suspense>
+          ),
+        },
+        {
+          path: 'district/:districtId/grid',
+          element: (
+            <Suspense fallback={<PageLoadingFallback />}>
+              <DistrictGridPage />
             </Suspense>
           ),
         },

--- a/frontend/src/components/ClubGridLegend.tsx
+++ b/frontend/src/components/ClubGridLegend.tsx
@@ -1,84 +1,32 @@
 import React from 'react'
-import type { GridColorMode } from '../utils/clubGridColor'
+import { getLegendItems, type GridColorMode } from '../utils/clubGridColor'
 
 /**
  * Legend for the district club grid (#1230). Always visible, and switches with
  * the active colour mode so the tile fills are decodable without relying on
  * colour memory (WCAG 1.4.1 — each swatch also carries its non-colour glyph and
- * a text label). The swatch reuses the same `club-grid-tile--*` modifier classes
- * the tiles use, so legend and grid can never drift apart.
+ * a text label). The rows come from `getLegendItems`, which derives them from
+ * the same `club-grid-tile--*` modifier + glyph maps the tiles use, so legend
+ * and grid can never drift apart (one source of truth — Lesson 052).
  */
 
 export interface ClubGridLegendProps {
   colorMode: GridColorMode
 }
 
-interface LegendItem {
-  modifier: string
-  glyph: string
-  label: string
-}
-
-const HEALTH_ITEMS: LegendItem[] = [
-  { modifier: 'club-grid-tile--thriving', glyph: '✓', label: 'Thriving' },
-  { modifier: 'club-grid-tile--vulnerable', glyph: '⚠', label: 'Vulnerable' },
-  {
-    modifier: 'club-grid-tile--intervention',
-    glyph: '✗',
-    label: 'Intervention Required',
-  },
-]
-
-const TIER_ITEMS: LegendItem[] = [
-  {
-    modifier: 'club-grid-tile--tier-presidents',
-    glyph: 'P',
-    label: "President's Distinguished",
-  },
-  {
-    modifier: 'club-grid-tile--tier-select',
-    glyph: 'S',
-    label: 'Select Distinguished',
-  },
-  {
-    modifier: 'club-grid-tile--tier-distinguished',
-    glyph: 'D',
-    label: 'Distinguished',
-  },
-  {
-    modifier: 'club-grid-tile--tier-smedley',
-    glyph: 'M',
-    label: 'Smedley (10/10)',
-  },
-  {
-    modifier: 'club-grid-tile--tier-none',
-    glyph: '—',
-    label: 'Not yet Distinguished',
-  },
-]
-
-const SUSPENDED_ITEM: LegendItem = {
-  modifier: 'club-grid-tile--suspended',
-  glyph: '⊘',
-  label: 'Suspended',
-}
-
 export const ClubGridLegend: React.FC<ClubGridLegendProps> = ({
   colorMode,
 }) => {
-  const items = [
-    ...(colorMode === 'tier' ? TIER_ITEMS : HEALTH_ITEMS),
-    SUSPENDED_ITEM,
-  ]
+  const items = getLegendItems(colorMode)
   const label =
     colorMode === 'tier' ? 'Distinguished tier legend' : 'Health legend'
 
   return (
     <div className="club-grid-legend" role="group" aria-label={label}>
       {items.map(item => (
-        <span key={item.modifier} className="club-grid-legend__item">
+        <span key={item.modifierClass} className="club-grid-legend__item">
           <span
-            className={`club-grid-legend__swatch ${item.modifier}`}
+            className={`club-grid-legend__swatch ${item.modifierClass}`}
             aria-hidden="true"
           >
             {item.glyph}

--- a/frontend/src/components/ClubGridLegend.tsx
+++ b/frontend/src/components/ClubGridLegend.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import type { GridColorMode } from '../utils/clubGridColor'
+
+/**
+ * Legend for the district club grid (#1230). Always visible, and switches with
+ * the active colour mode so the tile fills are decodable without relying on
+ * colour memory (WCAG 1.4.1 — each swatch also carries its non-colour glyph and
+ * a text label). The swatch reuses the same `club-grid-tile--*` modifier classes
+ * the tiles use, so legend and grid can never drift apart.
+ */
+
+export interface ClubGridLegendProps {
+  colorMode: GridColorMode
+}
+
+interface LegendItem {
+  modifier: string
+  glyph: string
+  label: string
+}
+
+const HEALTH_ITEMS: LegendItem[] = [
+  { modifier: 'club-grid-tile--thriving', glyph: '✓', label: 'Thriving' },
+  { modifier: 'club-grid-tile--vulnerable', glyph: '⚠', label: 'Vulnerable' },
+  {
+    modifier: 'club-grid-tile--intervention',
+    glyph: '✗',
+    label: 'Intervention Required',
+  },
+]
+
+const TIER_ITEMS: LegendItem[] = [
+  {
+    modifier: 'club-grid-tile--tier-presidents',
+    glyph: 'P',
+    label: "President's Distinguished",
+  },
+  {
+    modifier: 'club-grid-tile--tier-select',
+    glyph: 'S',
+    label: 'Select Distinguished',
+  },
+  {
+    modifier: 'club-grid-tile--tier-distinguished',
+    glyph: 'D',
+    label: 'Distinguished',
+  },
+  {
+    modifier: 'club-grid-tile--tier-smedley',
+    glyph: 'M',
+    label: 'Smedley (10/10)',
+  },
+  {
+    modifier: 'club-grid-tile--tier-none',
+    glyph: '—',
+    label: 'Not yet Distinguished',
+  },
+]
+
+const SUSPENDED_ITEM: LegendItem = {
+  modifier: 'club-grid-tile--suspended',
+  glyph: '⊘',
+  label: 'Suspended',
+}
+
+export const ClubGridLegend: React.FC<ClubGridLegendProps> = ({
+  colorMode,
+}) => {
+  const items = [
+    ...(colorMode === 'tier' ? TIER_ITEMS : HEALTH_ITEMS),
+    SUSPENDED_ITEM,
+  ]
+  const label =
+    colorMode === 'tier' ? 'Distinguished tier legend' : 'Health legend'
+
+  return (
+    <div className="club-grid-legend" role="group" aria-label={label}>
+      {items.map(item => (
+        <span key={item.modifier} className="club-grid-legend__item">
+          <span
+            className={`club-grid-legend__swatch ${item.modifier}`}
+            aria-hidden="true"
+          >
+            {item.glyph}
+          </span>
+          <span className="club-grid-legend__label">{item.label}</span>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export default ClubGridLegend

--- a/frontend/src/components/ClubGridTile.tsx
+++ b/frontend/src/components/ClubGridTile.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import type { ClubTrend } from '../hooks/useDistrictAnalytics'
+import { getTileVisual, type GridColorMode } from '../utils/clubGridColor'
+
+/**
+ * A single club tile in the at-a-glance district grid (#1230, epic #1228) — the
+ * "Chiclet / LEO board" cell. The tile fill is keyed on club health or
+ * Distinguished tier (per `colorMode`); the meaning is ALSO carried in text:
+ * the accessible name (status + DCP) and a non-colour glyph, so colour is never
+ * the only signal (WCAG 1.4.1). The whole tile is a real <Link> to club detail,
+ * making it keyboard-operable and screen-reader navigable.
+ */
+
+export interface ClubGridTileProps {
+  club: ClubTrend
+  districtId: string
+  colorMode: GridColorMode
+  /** Optional router location state to carry to the destination. */
+  linkState?: unknown
+}
+
+export const ClubGridTile: React.FC<ClubGridTileProps> = ({
+  club,
+  districtId,
+  colorMode,
+  linkState,
+}) => {
+  const visual = getTileVisual(club, colorMode)
+  const location = [club.divisionName, club.areaName]
+    .filter(Boolean)
+    .join(' · ')
+  const ariaLabel =
+    `${club.clubName}${location ? `, ${location}` : ''}. ` +
+    `${visual.statusLabel}. DCP ${visual.signalText}.`
+
+  return (
+    <Link
+      to={`/district/${districtId}/club/${club.clubId}`}
+      state={linkState}
+      className={`club-grid-tile ${visual.modifierClass}`}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span className="club-grid-tile__name">{club.clubName}</span>
+      <span className="club-grid-tile__signal">
+        <span className="club-grid-tile__glyph" aria-hidden="true">
+          {visual.signalGlyph}
+        </span>
+        <span className="club-grid-tile__dcp tabular-nums">
+          {visual.signalText}
+        </span>
+      </span>
+    </Link>
+  )
+}
+
+export default ClubGridTile

--- a/frontend/src/components/__tests__/ClubGridTile.test.tsx
+++ b/frontend/src/components/__tests__/ClubGridTile.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests for ClubGridTile (#1230, epic #1228) — one colour-coded tile per club
+ * in the at-a-glance district grid. The tile is a real <Link>; colour is never
+ * the only signal (WCAG 1.4.1), so every assertion here also pins the textual
+ * status + DCP carried in the accessible name.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import '@testing-library/jest-dom'
+import { ClubGridTile } from '../ClubGridTile'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import type { GridColorMode } from '../../utils/clubGridColor'
+
+function club(overrides: Partial<ClubTrend> = {}): ClubTrend {
+  return {
+    clubId: '123',
+    clubName: 'Test Speakers',
+    divisionId: 'A',
+    divisionName: 'Division A',
+    areaId: '1',
+    areaName: 'Area 1',
+    membershipTrend: [{ date: '2026-06-01', count: 20 }],
+    dcpGoalsTrend: [{ date: '2026-06-01', goalsAchieved: 7 }],
+    currentStatus: 'thriving',
+    riskFactors: [],
+    distinguishedLevel: 'Distinguished',
+    ...overrides,
+  } as ClubTrend
+}
+
+const renderTile = (
+  props: Partial<{
+    club: ClubTrend
+    districtId: string
+    colorMode: GridColorMode
+  }> = {}
+) =>
+  render(
+    <MemoryRouter>
+      <ClubGridTile
+        club={props.club ?? club()}
+        districtId={props.districtId ?? '61'}
+        colorMode={props.colorMode ?? 'health'}
+      />
+    </MemoryRouter>
+  )
+
+describe('ClubGridTile', () => {
+  it('is a real link to the club detail route', () => {
+    renderTile()
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/district/61/club/123')
+  })
+
+  it('shows the club name', () => {
+    renderTile()
+    expect(screen.getByText('Test Speakers')).toBeInTheDocument()
+  })
+
+  it('exposes an accessible name carrying status + DCP (colour not sole signal)', () => {
+    renderTile({ colorMode: 'health' })
+    const name = screen.getByRole('link').getAttribute('aria-label') ?? ''
+    expect(name).toContain('Test Speakers')
+    expect(name).toContain('Thriving')
+    expect(name).toContain('7/10')
+  })
+
+  it('renders the DCP signal text visibly', () => {
+    renderTile()
+    expect(screen.getByText('7/10')).toBeInTheDocument()
+  })
+
+  it('renders a non-colour status glyph that is aria-hidden (decorative)', () => {
+    const { container } = renderTile({ colorMode: 'health' })
+    const glyph = container.querySelector('.club-grid-tile__glyph')
+    expect(glyph).not.toBeNull()
+    expect(glyph).toHaveTextContent('✓')
+    expect(glyph).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('applies the health modifier class in health mode', () => {
+    renderTile({
+      club: club({ currentStatus: 'intervention-required' }),
+      colorMode: 'health',
+    })
+    expect(screen.getByRole('link').className).toContain(
+      'club-grid-tile--intervention'
+    )
+  })
+
+  it('applies the tier modifier class and tier label in tier mode', () => {
+    renderTile({
+      club: club({ distinguishedLevel: 'Select' }),
+      colorMode: 'tier',
+    })
+    const link = screen.getByRole('link')
+    expect(link.className).toContain('club-grid-tile--tier-select')
+    expect(link.getAttribute('aria-label')).toContain('Select')
+  })
+
+  it('marks a suspended club distinctly in either mode', () => {
+    renderTile({
+      club: club({ clubStatus: 'Suspended' }),
+      colorMode: 'tier',
+    })
+    const link = screen.getByRole('link')
+    expect(link.className).toContain('club-grid-tile--suspended')
+    expect(link.getAttribute('aria-label')).toContain('Suspended')
+  })
+})

--- a/frontend/src/components/__tests__/DistrictSubnav.test.tsx
+++ b/frontend/src/components/__tests__/DistrictSubnav.test.tsx
@@ -55,13 +55,15 @@ describe('DistrictSubnav (#678, ADR-005 §3)', () => {
       'href',
       '/district/61/analytics'
     )
-    // ADR-005 §3 order: lateral views read Overview · Clubs · Divisions ·
-    // Trends · Analytics · Rankings.
+    // ADR-005 §3 order: lateral views read Overview · What Changed · Clubs ·
+    // Divisions · Grid · Trends · Analytics · Rankings. Grid (#1230) sits after
+    // Divisions as the dense whole-district companion to the division breakdown.
     expect(DISTRICT_SECTIONS.map(s => s.label)).toEqual([
       'Overview',
       'What Changed',
       'Clubs',
       'Divisions',
+      'Grid',
       'Trends',
       'Analytics',
       'Rankings',

--- a/frontend/src/config/districtSections.ts
+++ b/frontend/src/config/districtSections.ts
@@ -23,6 +23,10 @@ export const DISTRICT_SECTIONS: readonly DistrictSection[] = [
   { label: 'What Changed', segment: 'changes' },
   { label: 'Clubs', segment: 'clubs' },
   { label: 'Divisions', segment: 'divisions' },
+  // 'Grid' (#1230, epic #1228) — the at-a-glance Chiclet/LEO board, one
+  // colour-coded tile per club. Sits after Divisions as the dense
+  // whole-district companion to the division/area breakdown.
+  { label: 'Grid', segment: 'grid' },
   { label: 'Trends', segment: 'trends' },
   { label: 'Analytics', segment: 'analytics' },
   { label: 'Rankings', segment: 'rankings' },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -47,6 +47,7 @@
 @import './styles/components/district-subnav.css';
 @import './styles/components/district-changes.css';
 @import './styles/components/club-history.css';
+@import './styles/components/club-grid.css';
 @import './styles/responsive.css';
 @import './styles/dark-mode.css';
 @import './styles/print.css';

--- a/frontend/src/pages/DistrictGridPage.tsx
+++ b/frontend/src/pages/DistrictGridPage.tsx
@@ -1,0 +1,323 @@
+import React, { useMemo } from 'react'
+import { useParams, useSearchParams } from 'react-router-dom'
+import { useDistricts } from '../hooks/useDistricts'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useDistrictCachedDates } from '../hooks/useDistrictData'
+import {
+  useDistrictAnalytics,
+  type ClubTrend,
+} from '../hooks/useDistrictAnalytics'
+import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
+import {
+  getAvailableProgramYears,
+  filterDatesByProgramYear,
+  getMostRecentDateInProgramYear,
+  isDateInProgramYear,
+} from '../utils/programYear'
+import { parseColorMode, type GridColorMode } from '../utils/clubGridColor'
+import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
+import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
+import { DistrictSubnav } from '../components/DistrictSubnav'
+import { ClubGridTile } from '../components/ClubGridTile'
+import { ClubGridLegend } from '../components/ClubGridLegend'
+import { LoadingSkeleton } from '../components/LoadingSkeleton'
+import ErrorBoundary from '../components/ErrorBoundary'
+
+/* District Grid Page (#1230, epic #1228 Sprint 2).
+   The at-a-glance "Chiclet / LEO board": one colour-coded tile per club, the
+   whole district on one screen — the view TI's dashboards structurally can't
+   do. Tiles colour by club health (default) or Distinguished tier, toggled via
+   a URL-synced `?color=health|tier` param. Reuses the same program-year/date
+   scaffolding as the other district subpages and the pre-computed
+   `useDistrictAnalytics().allClubs` feed (no new pipeline work — R7). */
+
+interface AreaGroup {
+  areaId: string
+  areaName: string
+  clubs: ClubTrend[]
+}
+
+interface DivisionGroup {
+  divisionId: string
+  divisionName: string
+  areas: AreaGroup[]
+}
+
+/** Natural-ish sort that keeps numeric ids/areas in order ("Area 2" < "Area 10")
+ *  and pushes blank labels (unassigned) to the end. */
+function compareLabel(a: string, b: string): number {
+  if (!a && !b) return 0
+  if (!a) return 1
+  if (!b) return -1
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+}
+
+/** Group clubs Division → Area, each level sorted; clubs sorted by name. The
+ *  grid OWNS this ordering rather than leaning on the hook's incidental order
+ *  (L138 — a view that renders correctly only because an upstream sorts that
+ *  way should pin its own order). */
+function groupByDivisionArea(clubs: ClubTrend[]): DivisionGroup[] {
+  const divisions = new Map<string, DivisionGroup>()
+
+  for (const club of clubs) {
+    const divKey = club.divisionId || club.divisionName || ''
+    let division = divisions.get(divKey)
+    if (!division) {
+      division = {
+        divisionId: divKey,
+        divisionName: club.divisionName || 'Unassigned',
+        areas: [],
+      }
+      divisions.set(divKey, division)
+    }
+    const areaKey = club.areaId || club.areaName || ''
+    let area = division.areas.find(a => a.areaId === areaKey)
+    if (!area) {
+      area = {
+        areaId: areaKey,
+        areaName: club.areaName || 'Unassigned',
+        clubs: [],
+      }
+      division.areas.push(area)
+    }
+    area.clubs.push(club)
+  }
+
+  const result = [...divisions.values()]
+  result.sort((a, b) => compareLabel(a.divisionName, b.divisionName))
+  for (const division of result) {
+    division.areas.sort((a, b) => compareLabel(a.areaName, b.areaName))
+    for (const area of division.areas) {
+      area.clubs.sort((a, b) => compareLabel(a.clubName, b.clubName))
+    }
+  }
+  return result
+}
+
+const DistrictGridPage: React.FC = () => {
+  const { districtId } = useParams<{ districtId: string }>()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // `?color` is URL-seedable, so the whitelist lives at the parse where every
+  // entry path (typed URL, shared link, back button, toggle click) converges —
+  // never on the toggle handler alone (L124/144 / R17).
+  const colorMode = parseColorMode(searchParams.get('color'))
+
+  const setColorMode = (mode: GridColorMode) => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev)
+        // 'health' is the default — keep the URL clean by omitting it.
+        if (mode === 'health') next.delete('color')
+        else next.set('color', mode)
+        return next
+      },
+      { replace: true }
+    )
+  }
+
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+  } = useUrlProgramYear()
+
+  const { data: districtsData } = useDistricts()
+  const selectedDistrict = districtsData?.districts?.find(
+    d => d.id === districtId
+  )
+
+  const { data: cachedDatesData } = useDistrictCachedDates(districtId || '')
+  const allCachedDates = useMemo(
+    () => cachedDatesData?.dates || [],
+    [cachedDatesData?.dates]
+  )
+  const availableProgramYears = useMemo(
+    () => getAvailableProgramYears(allCachedDates),
+    [allCachedDates]
+  )
+
+  React.useEffect(() => {
+    if (availableProgramYears.length > 0) {
+      const has = availableProgramYears.some(
+        py => py.year === selectedProgramYear.year
+      )
+      if (!has) {
+        const mostRecent = availableProgramYears[0]
+        if (mostRecent) setSelectedProgramYear(mostRecent)
+      }
+    }
+  }, [availableProgramYears, selectedProgramYear.year, setSelectedProgramYear])
+
+  const cachedDatesInProgramYear = useMemo(
+    () => filterDatesByProgramYear(allCachedDates, selectedProgramYear),
+    [allCachedDates, selectedProgramYear]
+  )
+
+  const effectiveProgramYear = useMemo(() => {
+    if (availableProgramYears.length === 0) return null
+    const has = availableProgramYears.some(
+      py => py.year === selectedProgramYear.year
+    )
+    if (has) return selectedProgramYear
+    return availableProgramYears[0] ?? null
+  }, [availableProgramYears, selectedProgramYear])
+
+  const effectiveEndDate = useMemo(() => {
+    if (!effectiveProgramYear) return null
+    if (
+      selectedDate &&
+      isDateInProgramYear(selectedDate, effectiveProgramYear)
+    ) {
+      return selectedDate
+    }
+    const mostRecent = getMostRecentDateInProgramYear(
+      allCachedDates,
+      effectiveProgramYear
+    )
+    return mostRecent || effectiveProgramYear.endDate
+  }, [selectedDate, effectiveProgramYear, allCachedDates])
+
+  const hasValidDates =
+    effectiveProgramYear !== null && effectiveEndDate !== null
+
+  const { data: analytics, isLoading } = useDistrictAnalytics(
+    hasValidDates ? districtId || null : null,
+    effectiveProgramYear?.startDate,
+    effectiveEndDate ?? undefined
+  )
+
+  const allClubs = useMemo(() => analytics?.allClubs ?? [], [analytics])
+  const divisions = useMemo(() => groupByDivisionArea(allClubs), [allClubs])
+
+  const rawName = selectedDistrict?.name || districtId || ''
+  const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
+  useDocumentTitle(districtName ? `${districtName} Club Grid` : null)
+
+  const availableDates = cachedDatesInProgramYear.sort((a, b) =>
+    b.localeCompare(a)
+  )
+
+  if (!districtId) {
+    return null
+  }
+
+  return (
+    <ErrorBoundary>
+      <div className="district-detail-page-root">
+        <div className="district-detail-page">
+          <DistrictDetailHeader
+            districtId={districtId}
+            districtName={districtName}
+            selectedProgramYear={selectedProgramYear}
+            setSelectedProgramYear={setSelectedProgramYear}
+            availableProgramYears={availableProgramYears}
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+            availableDates={availableDates}
+            latestSnapshotDate={
+              cachedDatesData?.dateRange?.endDate ?? availableDates[0]
+            }
+          />
+
+          <SubpageBreadcrumb
+            crumbs={[{ label: districtName, to: `/district/${districtId}` }]}
+          />
+
+          <DistrictSubnav districtId={districtId} />
+
+          <div className="club-grid-page">
+            <header className="club-grid-page__intro">
+              <h2 className="club-grid-page__title">Club Grid</h2>
+              <p className="club-grid-page__subtitle">
+                Every club at a glance, grouped by division and area. Each tile
+                links to the club. Colour by{' '}
+                {colorMode === 'tier' ? 'Distinguished tier' : 'club health'}.
+              </p>
+            </header>
+
+            <div className="club-grid-page__controls">
+              <div
+                className="club-grid-toggle"
+                role="group"
+                aria-label="Colour tiles by"
+              >
+                <span
+                  className="club-grid-toggle__label"
+                  id="club-grid-color-label"
+                >
+                  Colour by
+                </span>
+                <button
+                  type="button"
+                  className="club-grid-toggle__btn"
+                  aria-pressed={colorMode === 'health'}
+                  aria-describedby="club-grid-color-label"
+                  onClick={() => setColorMode('health')}
+                >
+                  Health
+                </button>
+                <button
+                  type="button"
+                  className="club-grid-toggle__btn"
+                  aria-pressed={colorMode === 'tier'}
+                  aria-describedby="club-grid-color-label"
+                  onClick={() => setColorMode('tier')}
+                >
+                  Distinguished tier
+                </button>
+              </div>
+
+              <ClubGridLegend colorMode={colorMode} />
+            </div>
+
+            {isLoading && allClubs.length === 0 ? (
+              <LoadingSkeleton variant="card" />
+            ) : divisions.length === 0 ? (
+              <p className="club-grid-page__empty">
+                No clubs to display for this district and date.
+              </p>
+            ) : (
+              <div className="club-grid-divisions">
+                {divisions.map(division => (
+                  <section
+                    key={division.divisionId || division.divisionName}
+                    className="club-grid-division"
+                    aria-label={division.divisionName}
+                  >
+                    <h3 className="club-grid-division__title">
+                      {division.divisionName}
+                    </h3>
+                    {division.areas.map(area => (
+                      <div
+                        key={area.areaId || area.areaName}
+                        className="club-grid-area"
+                      >
+                        <h4 className="club-grid-area__title">
+                          {area.areaName}
+                        </h4>
+                        <div className="club-grid-tiles">
+                          {area.clubs.map(club => (
+                            <ClubGridTile
+                              key={club.clubId}
+                              club={club}
+                              districtId={districtId}
+                              colorMode={colorMode}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </section>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </ErrorBoundary>
+  )
+}
+
+export default DistrictGridPage

--- a/frontend/src/pages/__tests__/DistrictGridPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictGridPage.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * District Grid Page (#1230, epic #1228) — the at-a-glance "Chiclet / LEO board":
+ * one colour-coded tile per club, grouped Division → Area, on `/district/:id/grid`.
+ *
+ * Page-mount test → lives in pages/__tests__ per R22 (must not run in the unit
+ * project). Verifies grouping, the URL-synced health/tier colour toggle (clamped
+ * at parse — L124/144), the aria-pressed toggle model (NOT tabs — L128), and
+ * suspended/empty handling.
+ */
+import React, { Suspense } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import {
+  createMemoryRouter,
+  RouterProvider,
+  type RouteObject,
+} from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '@testing-library/jest-dom'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import { DarkModeProvider } from '../../contexts/DarkModeContext'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: vi.fn(() => ({
+    data: { districts: [{ id: '61', name: 'District 61' }] },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    data: {
+      dates: ['2026-06-01', '2026-05-15'],
+      dateRange: { startDate: '2025-07-01', endDate: '2026-06-01' },
+    },
+    isLoading: false,
+  })),
+}))
+
+// Keep the heavy date/program-year chrome out of the grid-logic assertions.
+vi.mock('../../components/DistrictDetailHeader', () => ({
+  DistrictDetailHeader: () => <div data-testid="district-header" />,
+}))
+
+const club = (overrides: Partial<ClubTrend>): ClubTrend =>
+  ({
+    clubId: '0',
+    clubName: 'Club',
+    divisionId: 'A',
+    divisionName: 'Division A',
+    areaId: '1',
+    areaName: 'Area 1',
+    membershipTrend: [{ date: '2026-06-01', count: 20 }],
+    dcpGoalsTrend: [{ date: '2026-06-01', goalsAchieved: 6 }],
+    currentStatus: 'thriving',
+    riskFactors: [],
+    distinguishedLevel: 'Distinguished',
+    ...overrides,
+  }) as ClubTrend
+
+const CLUBS: ClubTrend[] = [
+  club({
+    clubId: '101',
+    clubName: 'Alpha Speakers',
+    divisionId: 'A',
+    divisionName: 'Division A',
+    areaId: 'A1',
+    areaName: 'Area 1',
+    currentStatus: 'thriving',
+    distinguishedLevel: 'President',
+  }),
+  club({
+    clubId: '102',
+    clubName: 'Beta Orators',
+    divisionId: 'A',
+    divisionName: 'Division A',
+    areaId: 'A2',
+    areaName: 'Area 2',
+    currentStatus: 'vulnerable',
+    distinguishedLevel: 'NotDistinguished',
+  }),
+  club({
+    clubId: '103',
+    clubName: 'Gamma Voices',
+    divisionId: 'B',
+    divisionName: 'Division B',
+    areaId: 'B5',
+    areaName: 'Area 5',
+    currentStatus: 'intervention-required',
+    distinguishedLevel: 'NotDistinguished',
+    clubStatus: 'Suspended',
+  }),
+]
+
+let mockClubs: ClubTrend[] = CLUBS
+
+vi.mock('../../hooks/useDistrictAnalytics', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../hooks/useDistrictAnalytics')>()
+  return {
+    ...actual,
+    useDistrictAnalytics: vi.fn(() => ({
+      data: { allClubs: mockClubs },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })),
+  }
+})
+
+const DistrictGridPage = React.lazy(() => import('../DistrictGridPage'))
+
+const renderAt = (initialUrl: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const routes: RouteObject[] = [
+    {
+      path: '/district/:districtId/grid',
+      element: (
+        <Suspense fallback={<div>Loading…</div>}>
+          <DistrictGridPage />
+        </Suspense>
+      ),
+    },
+    { path: '/district/:districtId/club/:clubId', element: <div>club</div> },
+  ]
+  const router = createMemoryRouter(routes, { initialEntries: [initialUrl] })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DarkModeProvider>
+        <ProgramYearProvider>
+          <RouterProvider router={router} />
+        </ProgramYearProvider>
+      </DarkModeProvider>
+    </QueryClientProvider>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  mockClubs = CLUBS
+})
+
+describe('DistrictGridPage — grouping', () => {
+  it('renders every club as a tile grouped under Division → Area', async () => {
+    renderAt('/district/61/grid')
+    await waitFor(() =>
+      expect(screen.getByText('Alpha Speakers')).toBeInTheDocument()
+    )
+    // Division group headers
+    expect(screen.getByText('Division A')).toBeInTheDocument()
+    expect(screen.getByText('Division B')).toBeInTheDocument()
+    // Area sub-headers
+    expect(screen.getByText(/Area 1/)).toBeInTheDocument()
+    expect(screen.getByText(/Area 2/)).toBeInTheDocument()
+    // Every club is a real link to its detail route
+    expect(
+      screen.getByRole('link', { name: /Alpha Speakers/ })
+    ).toHaveAttribute('href', '/district/61/club/101')
+    expect(screen.getByRole('link', { name: /Beta Orators/ })).toHaveAttribute(
+      'href',
+      '/district/61/club/102'
+    )
+    expect(screen.getByRole('link', { name: /Gamma Voices/ })).toHaveAttribute(
+      'href',
+      '/district/61/club/103'
+    )
+  })
+
+  it('shows an empty state when the district has no clubs', async () => {
+    mockClubs = []
+    renderAt('/district/61/grid')
+    await waitFor(() =>
+      expect(screen.getByText(/no clubs/i)).toBeInTheDocument()
+    )
+  })
+})
+
+describe('DistrictGridPage — colour mode (URL-synced, clamped at parse)', () => {
+  it('defaults to health colouring', async () => {
+    renderAt('/district/61/grid')
+    const tile = await screen.findByRole('link', { name: /Alpha Speakers/ })
+    expect(tile.className).toContain('club-grid-tile--thriving')
+    expect(tile.getAttribute('aria-label')).toContain('Thriving')
+  })
+
+  it('colours by Distinguished tier when ?color=tier', async () => {
+    renderAt('/district/61/grid?color=tier')
+    const tile = await screen.findByRole('link', { name: /Alpha Speakers/ })
+    expect(tile.className).toContain('club-grid-tile--tier-presidents')
+    expect(tile.getAttribute('aria-label')).toContain("President's")
+  })
+
+  it('clamps an unknown ?color value to health (L124/144)', async () => {
+    renderAt('/district/61/grid?color=garbage')
+    const tile = await screen.findByRole('link', { name: /Alpha Speakers/ })
+    expect(tile.className).toContain('club-grid-tile--thriving')
+  })
+})
+
+describe('DistrictGridPage — colour toggle is aria-pressed, not tabs (L128)', () => {
+  it('exposes two toggle buttons, not a tablist', async () => {
+    renderAt('/district/61/grid')
+    await screen.findByRole('link', { name: /Alpha Speakers/ })
+    // No tab semantics — the toggle filters the same view, it does not swap panels
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument()
+    const health = screen.getByRole('button', { name: /health/i })
+    const tier = screen.getByRole('button', { name: /tier/i })
+    expect(health).toHaveAttribute('aria-pressed', 'true')
+    expect(tier).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('reflects the active mode in aria-pressed when ?color=tier', async () => {
+    renderAt('/district/61/grid?color=tier')
+    await screen.findByRole('link', { name: /Alpha Speakers/ })
+    expect(screen.getByRole('button', { name: /tier/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+})
+
+describe('DistrictGridPage — legend + suspended handling', () => {
+  it('renders a legend reflecting the active colour mode', async () => {
+    renderAt('/district/61/grid')
+    await screen.findByRole('link', { name: /Alpha Speakers/ })
+    const legend = screen.getByRole('group', { name: /legend/i })
+    expect(within(legend).getByText(/Thriving/)).toBeInTheDocument()
+    expect(within(legend).getByText(/Vulnerable/)).toBeInTheDocument()
+    expect(within(legend).getByText(/Intervention/)).toBeInTheDocument()
+  })
+
+  it('marks a suspended club distinctly', async () => {
+    renderAt('/district/61/grid')
+    const tile = await screen.findByRole('link', { name: /Gamma Voices/ })
+    expect(tile.className).toContain('club-grid-tile--suspended')
+    expect(tile.getAttribute('aria-label')).toContain('Suspended')
+  })
+})

--- a/frontend/src/styles/components/club-grid.css
+++ b/frontend/src/styles/components/club-grid.css
@@ -1,0 +1,286 @@
+/* District Club Grid (#1230, epic #1228 Sprint 2) — the at-a-glance
+   "Chiclet / LEO board": one colour-coded tile per club. Colour is never the
+   only signal (WCAG 1.4.1): each tile also carries a text status (in its
+   aria-label), a non-colour glyph, and the {n}/10 DCP count.
+
+   Colour values are reused from the shipped clubs-table pills so the two
+   surfaces never drift:
+     • Health tiles use the opaque, THEME-STABLE soft tints (dark text) — the
+       exact same treatment as `.clubs-status-pill--*`, which intentionally
+       carries no dark remap (lesson 062/116: these chips are theme-stable).
+     • Tier tiles use solid dark fills with white text, pinned to literal hex
+       (maroon/loyal/green) that hold white text AA in BOTH themes — so the
+       dark-lightening of `--green-600` can't strand the label (lesson 095).
+     • Neutral (not-yet-Distinguished) and Suspended carry explicit dark
+       overrides (lesson 067/116 — a surface fill must remap with its theme). */
+
+.club-grid-page {
+  margin-top: 1rem;
+}
+
+.club-grid-page__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.club-grid-page__subtitle {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: var(--ink-3);
+}
+
+.club-grid-page__empty {
+  margin-top: 2rem;
+  padding: 2rem;
+  text-align: center;
+  color: var(--ink-3);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md, 8px);
+}
+
+/* ── Controls: colour-by toggle + legend ───────────────────────────────── */
+
+.club-grid-page__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem 1.25rem;
+  margin: 1rem 0 1.25rem;
+}
+
+.club-grid-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.club-grid-toggle__label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--ink-2);
+}
+
+/* Segmented toggle buttons. These FILTER the same view (recolour the tiles),
+   they do not swap panels — so they are aria-pressed toggle buttons, never
+   role="tab" (lesson 128). */
+.club-grid-toggle__btn {
+  min-height: 36px;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--ink-2);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm, 6px);
+  cursor: pointer;
+}
+
+.club-grid-toggle__btn:hover {
+  border-color: var(--ink-3);
+}
+
+.club-grid-toggle__btn[aria-pressed='true'] {
+  color: #fff;
+  background: var(--loyal-500);
+  border-color: var(--loyal-500);
+}
+
+.club-grid-toggle__btn:focus-visible {
+  outline: 2px solid var(--loyal-400);
+  outline-offset: 2px;
+}
+
+.club-grid-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+}
+
+.club-grid-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--ink-2);
+}
+
+.club-grid-legend__swatch {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  border-radius: 4px;
+}
+
+/* ── Grouping: Division → Area ─────────────────────────────────────────── */
+
+.club-grid-division {
+  margin-bottom: 1.5rem;
+}
+
+.club-grid-division__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ink);
+  padding-bottom: 0.25rem;
+  border-bottom: 2px solid var(--line);
+  margin-bottom: 0.75rem;
+}
+
+.club-grid-area {
+  margin-bottom: 1rem;
+}
+
+.club-grid-area__title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--ink-3);
+  margin-bottom: 0.5rem;
+}
+
+.club-grid-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .club-grid-tiles {
+    grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
+  }
+}
+
+/* ── Tile ──────────────────────────────────────────────────────────────── */
+
+.club-grid-tile {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-height: 72px;
+  padding: 0.5rem 0.625rem;
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  text-decoration: none;
+  overflow: hidden;
+}
+
+.club-grid-tile:focus-visible {
+  outline: 3px solid var(--loyal-400);
+  outline-offset: 2px;
+}
+
+.club-grid-tile__name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.25;
+  /* Truncate long club names to keep tiles uniform (the full name is in the
+     aria-label + title). */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.club-grid-tile__signal {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.club-grid-tile__glyph {
+  font-size: 0.875rem;
+  line-height: 1;
+}
+
+.club-grid-tile__dcp {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.85;
+}
+
+/* Health fills (theme-stable soft tints, dark text — mirrors clubs-status-pill) */
+.club-grid-tile--thriving {
+  background-color: #dcfce7;
+  color: #14532d;
+}
+.club-grid-tile--vulnerable {
+  background-color: #fef9c3;
+  color: #713f12;
+}
+.club-grid-tile--intervention {
+  background-color: #fee2e2;
+  color: #7f1d1d;
+}
+
+/* Tier fills (solid, white text — literal hex, theme-stable AA both modes) */
+.club-grid-tile--tier-presidents {
+  background-color: #004165; /* --loyal-500 */
+  color: #fff;
+}
+.club-grid-tile--tier-select {
+  background-color: #2c6e90; /* --loyal-400 */
+  color: #fff;
+}
+.club-grid-tile--tier-distinguished {
+  background-color: #15803d; /* --green-600 (light) pinned for white text */
+  color: #fff;
+}
+.club-grid-tile--tier-smedley {
+  background-color: #7b1828; /* --maroon-500 */
+  color: #fff;
+  box-shadow: inset 0 0 0 2px #d4af37; /* rare-tier gold ring (#546) */
+}
+
+/* Neutral (not yet Distinguished) — light surface, remaps in dark */
+.club-grid-tile--tier-none {
+  background-color: #e2e8f0;
+  color: #334155;
+}
+
+/* Suspended — muted; the operational state overrides health/tier in both modes */
+.club-grid-tile--suspended {
+  background-color: #e5e7eb;
+  color: #6b7280;
+  border-style: dashed;
+}
+.club-grid-tile--suspended .club-grid-tile__name {
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+
+/* ── Dark mode: only the surfaces whose LIGHT value would be wrong on a dark
+   background need a remap. Health tints + solid tier fills are theme-stable by
+   design and are intentionally left as-is. ───────────────────────────────── */
+
+[data-theme='dark'] .club-grid-tile--tier-none {
+  background-color: #2a3340;
+  color: #cbd5e1;
+}
+
+[data-theme='dark'] .club-grid-tile--suspended {
+  background-color: #2a3038;
+  color: #9aa4b2;
+}
+
+[data-theme='dark'] .club-grid-tile {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme='dark'] .club-grid-legend__swatch.club-grid-tile--tier-none {
+  background-color: #2a3340;
+  color: #cbd5e1;
+}

--- a/frontend/src/utils/__tests__/clubGridColor.test.ts
+++ b/frontend/src/utils/__tests__/clubGridColor.test.ts
@@ -168,6 +168,28 @@ describe('getTileVisual — suspended override (handled in BOTH modes)', () => {
     ).toBe('club-grid-tile--suspended')
   })
 
+  it('does not treat a Suspended club promoted by the renewal overlay as suspended', () => {
+    // The read-time Dues-Renewal overlay (#1062) only ever promotes to Active,
+    // so an overlaid club is effectively Active — the grid must match
+    // ClubStatusCell and never render it struck-through Suspended (L052/L154).
+    const overlay = {
+      status: 'Active' as const,
+      source: 'dues-renewal' as const,
+      activeSince: '2026-05-31',
+      asOf: 'June 01, 2026',
+    }
+    const v = getTileVisual(
+      club({
+        clubStatus: 'Suspended',
+        currentStatus: 'vulnerable',
+        statusOverlay: overlay,
+      }),
+      'health'
+    )
+    expect(v.modifierClass).toBe('club-grid-tile--vulnerable')
+    expect(v.statusLabel).toBe('Vulnerable')
+  })
+
   it('does not treat Active/Low/undefined as suspended', () => {
     for (const status of ['Active', 'Low', 'Ineligible', undefined]) {
       const v = getTileVisual(

--- a/frontend/src/utils/__tests__/clubGridColor.test.ts
+++ b/frontend/src/utils/__tests__/clubGridColor.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import {
+  parseColorMode,
+  getTileVisual,
+  GRID_COLOR_MODES,
+} from '../clubGridColor'
+
+/** Minimal ClubTrend factory — only the fields the grid colouring reads. */
+function club(overrides: Partial<ClubTrend> = {}): ClubTrend {
+  return {
+    clubId: '1',
+    clubName: 'Test Club',
+    divisionId: 'A',
+    divisionName: 'Division A',
+    areaId: '1',
+    areaName: 'Area 1',
+    membershipTrend: [{ date: '2026-06-01', count: 20 }],
+    dcpGoalsTrend: [{ date: '2026-06-01', goalsAchieved: 7 }],
+    currentStatus: 'thriving',
+    riskFactors: [],
+    distinguishedLevel: 'Distinguished',
+    ...overrides,
+  } as ClubTrend
+}
+
+describe('parseColorMode (URL-seedable, clamps at parse — L124/144)', () => {
+  it("returns 'tier' only for the exact string 'tier'", () => {
+    expect(parseColorMode('tier')).toBe('tier')
+  })
+
+  it("defaults to 'health' for the explicit health value", () => {
+    expect(parseColorMode('health')).toBe('health')
+  })
+
+  it.each([null, undefined, '', 'TIER', 'garbage', 'health ', '0', 'true'])(
+    'clamps unknown/abusive value %p to health',
+    raw => {
+      expect(parseColorMode(raw)).toBe('health')
+    }
+  )
+
+  it('exposes the canonical mode list', () => {
+    expect([...GRID_COLOR_MODES]).toEqual(['health', 'tier'])
+  })
+})
+
+describe('getTileVisual — health mode', () => {
+  it('maps thriving to the thriving modifier + ✓ glyph + label', () => {
+    const v = getTileVisual(club({ currentStatus: 'thriving' }), 'health')
+    expect(v.modifierClass).toBe('club-grid-tile--thriving')
+    expect(v.signalGlyph).toBe('✓')
+    expect(v.statusLabel).toBe('Thriving')
+  })
+
+  it('maps vulnerable to the vulnerable modifier + ⚠ glyph', () => {
+    const v = getTileVisual(club({ currentStatus: 'vulnerable' }), 'health')
+    expect(v.modifierClass).toBe('club-grid-tile--vulnerable')
+    expect(v.signalGlyph).toBe('⚠')
+    expect(v.statusLabel).toBe('Vulnerable')
+  })
+
+  it('maps intervention-required to the intervention modifier + ✗ glyph', () => {
+    const v = getTileVisual(
+      club({ currentStatus: 'intervention-required' }),
+      'health'
+    )
+    expect(v.modifierClass).toBe('club-grid-tile--intervention')
+    expect(v.signalGlyph).toBe('✗')
+    expect(v.statusLabel).toBe('Intervention Required')
+  })
+
+  it('renders DCP goals as the {n}/10 signal text, clamped to 0..10', () => {
+    expect(
+      getTileVisual(
+        club({ dcpGoalsTrend: [{ date: '2026-06-01', goalsAchieved: 7 }] }),
+        'health'
+      ).signalText
+    ).toBe('7/10')
+    // out-of-range values are clamped (defensive, mirrors clubsColumns)
+    expect(
+      getTileVisual(
+        club({ dcpGoalsTrend: [{ date: '2026-06-01', goalsAchieved: 13 }] }),
+        'health'
+      ).signalText
+    ).toBe('10/10')
+    expect(
+      getTileVisual(club({ dcpGoalsTrend: [] }), 'health').signalText
+    ).toBe('0/10')
+  })
+})
+
+describe('getTileVisual — tier mode (per-club distinguishedLevel, NOT totals.* — L123)', () => {
+  it.each([
+    [
+      'Distinguished',
+      'club-grid-tile--tier-distinguished',
+      'D',
+      'Distinguished',
+    ],
+    ['Select', 'club-grid-tile--tier-select', 'S', 'Select'],
+    ['President', 'club-grid-tile--tier-presidents', 'P', "President's"],
+    ['Smedley', 'club-grid-tile--tier-smedley', 'M', 'Smedley'],
+  ] as const)('%s → %s / %s / %s', (level, modifier, glyph, label) => {
+    const v = getTileVisual(club({ distinguishedLevel: level }), 'tier')
+    expect(v.modifierClass).toBe(modifier)
+    expect(v.signalGlyph).toBe(glyph)
+    expect(v.statusLabel).toBe(label)
+  })
+
+  it('NotDistinguished → neutral tier modifier + em-dash glyph', () => {
+    const v = getTileVisual(
+      club({ distinguishedLevel: 'NotDistinguished' }),
+      'tier'
+    )
+    expect(v.modifierClass).toBe('club-grid-tile--tier-none')
+    expect(v.signalGlyph).toBe('—')
+    expect(v.statusLabel).toBe('Not yet Distinguished')
+  })
+})
+
+describe('getTileVisual — suspended override (handled in BOTH modes)', () => {
+  it.each(['health', 'tier'] as const)(
+    'a suspended club gets the suspended modifier in %s mode',
+    mode => {
+      const v = getTileVisual(
+        club({ clubStatus: 'Suspended', currentStatus: 'thriving' }),
+        mode
+      )
+      expect(v.modifierClass).toBe('club-grid-tile--suspended')
+      expect(v.statusLabel).toBe('Suspended')
+      expect(v.signalGlyph).toBe('⊘')
+    }
+  )
+
+  it('is case-insensitive on clubStatus', () => {
+    expect(
+      getTileVisual(club({ clubStatus: 'suspended' }), 'health').modifierClass
+    ).toBe('club-grid-tile--suspended')
+  })
+
+  it('does not treat Active/Low/undefined as suspended', () => {
+    for (const status of ['Active', 'Low', 'Ineligible', undefined]) {
+      const v = getTileVisual(
+        club({ clubStatus: status, currentStatus: 'thriving' }),
+        'health'
+      )
+      expect(v.modifierClass).toBe('club-grid-tile--thriving')
+    }
+  })
+})

--- a/frontend/src/utils/__tests__/clubGridColor.test.ts
+++ b/frontend/src/utils/__tests__/clubGridColor.test.ts
@@ -3,6 +3,7 @@ import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
 import {
   parseColorMode,
   getTileVisual,
+  getLegendItems,
   GRID_COLOR_MODES,
 } from '../clubGridColor'
 
@@ -116,6 +117,34 @@ describe('getTileVisual — tier mode (per-club distinguishedLevel, NOT totals.*
     expect(v.modifierClass).toBe('club-grid-tile--tier-none')
     expect(v.signalGlyph).toBe('—')
     expect(v.statusLabel).toBe('Not yet Distinguished')
+  })
+})
+
+describe('getLegendItems — single source shared with the tiles', () => {
+  it('health legend lists the three health states + suspended, last', () => {
+    const items = getLegendItems('health')
+    expect(items.map(i => i.label)).toEqual([
+      'Thriving',
+      'Vulnerable',
+      'Intervention Required',
+      'Suspended',
+    ])
+    // swatch modifier matches the tile modifier the mapping produces
+    expect(items[0].modifierClass).toBe('club-grid-tile--thriving')
+  })
+
+  it('tier legend lists tiers + not-yet + suspended, with matching modifiers', () => {
+    const items = getLegendItems('tier')
+    expect(items.map(i => i.modifierClass)).toEqual([
+      'club-grid-tile--tier-presidents',
+      'club-grid-tile--tier-select',
+      'club-grid-tile--tier-distinguished',
+      'club-grid-tile--tier-smedley',
+      'club-grid-tile--tier-none',
+      'club-grid-tile--suspended',
+    ])
+    // glyphs are the same single-letter codes the tiles render
+    expect(items[0].glyph).toBe('P')
   })
 })
 

--- a/frontend/src/utils/clubGridColor.ts
+++ b/frontend/src/utils/clubGridColor.ts
@@ -153,6 +153,11 @@ export function getLegendItems(mode: GridColorMode): LegendItem[] {
 }
 
 function isSuspended(club: ClubTrend): boolean {
+  // The read-time Dues-Renewal overlay (#1062) only ever PROMOTES a frozen club
+  // to Active, so an overlaid club is effectively Active — match ClubStatusCell
+  // and never render it Suspended, or the grid and the Clubs table disagree on
+  // the same club (cross-surface consistency — Lesson 052/154).
+  if (club.statusOverlay) return false
   return club.clubStatus?.toLowerCase() === 'suspended'
 }
 

--- a/frontend/src/utils/clubGridColor.ts
+++ b/frontend/src/utils/clubGridColor.ts
@@ -83,6 +83,75 @@ const HEALTH_MODIFIER: Record<ClubTrend['currentStatus'], string> = {
   'intervention-required': 'club-grid-tile--intervention',
 }
 
+/** Health statuses in the order the legend lists them (best → worst). */
+const HEALTH_LEGEND_ORDER: ClubTrend['currentStatus'][] = [
+  'thriving',
+  'vulnerable',
+  'intervention-required',
+]
+
+/** Confirmed tiers in the order the legend lists them (best → entry). */
+const TIER_LEGEND_ORDER: ConfirmedTier[] = [
+  'President',
+  'Select',
+  'Distinguished',
+  'Smedley',
+]
+
+/** Descriptive legend labels (longer than the per-tile `statusLabel`). */
+const TIER_LEGEND_LABEL: Record<ConfirmedTier, string> = {
+  President: "President's Distinguished",
+  Select: 'Select Distinguished',
+  Distinguished: 'Distinguished',
+  Smedley: 'Smedley (10/10)',
+}
+
+export interface LegendItem {
+  modifierClass: string
+  glyph: string
+  label: string
+}
+
+const NOT_DISTINGUISHED_LEGEND: LegendItem = {
+  modifierClass: 'club-grid-tile--tier-none',
+  glyph: '—',
+  label: 'Not yet Distinguished',
+}
+
+const SUSPENDED_LEGEND: LegendItem = {
+  modifierClass: 'club-grid-tile--suspended',
+  glyph: '⊘',
+  label: 'Suspended',
+}
+
+/**
+ * The legend rows for a colour mode, derived from the SAME modifier/glyph maps
+ * the tiles use — so legend and grid can never drift (adding a tier or status
+ * is a single-file edit here, not parallel edits in the legend component). The
+ * Suspended row is always last because suspended tiles appear in both modes.
+ */
+export function getLegendItems(mode: GridColorMode): LegendItem[] {
+  if (mode === 'tier') {
+    return [
+      ...TIER_LEGEND_ORDER.map(tier => ({
+        modifierClass: TIER_MODIFIER[tier],
+        glyph: TIER_GLYPH[tier],
+        label: TIER_LEGEND_LABEL[tier],
+      })),
+      NOT_DISTINGUISHED_LEGEND,
+      SUSPENDED_LEGEND,
+    ]
+  }
+  return [
+    ...HEALTH_LEGEND_ORDER.map(status => ({
+      modifierClass: HEALTH_MODIFIER[status],
+      glyph: getClubHealthStatusIcon(status),
+      label: getClubHealthStatusLabel(status),
+    })),
+    SUSPENDED_LEGEND,
+  ]
+}
+
 function isSuspended(club: ClubTrend): boolean {
   return club.clubStatus?.toLowerCase() === 'suspended'
 }

--- a/frontend/src/utils/clubGridColor.ts
+++ b/frontend/src/utils/clubGridColor.ts
@@ -1,0 +1,139 @@
+import type { ClubTrend } from '../hooks/useDistrictAnalytics'
+import { getLatestDcpGoals } from './columnFilterUtils'
+import {
+  getClubHealthStatusIcon,
+  getClubHealthStatusLabel,
+} from './clubHealthStatus'
+
+/**
+ * Pure colour/label mapping for the at-a-glance club grid (#1230, epic #1228).
+ *
+ * One tile per club; the tile fill is keyed either on club HEALTH (default) or
+ * on Distinguished TIER. Both signals already live on `ClubTrend` — health via
+ * `currentStatus`, tier via the per-club `distinguishedLevel` (the authoritative
+ * source, NOT the season-gated `totals.distinguished*` aggregate — Lesson 123).
+ *
+ * Colour is never the only signal (WCAG 1.4.1): every tile also carries a
+ * textual `statusLabel` (→ aria-label) and a non-colour `signalGlyph`, plus the
+ * `{n}/10` DCP `signalText`. This module is the unit-testable heart of the
+ * feature — it has no React/DOM dependency.
+ */
+
+export type GridColorMode = 'health' | 'tier'
+
+/** The canonical, ordered list of colour modes (drives the toggle + legend). */
+export const GRID_COLOR_MODES: readonly GridColorMode[] = ['health', 'tier']
+
+/**
+ * Clamp an arbitrary URL value to a valid colour mode. The `?color` param is
+ * URL-seedable, so a shared/hand-edited link is an unguarded write path — the
+ * whitelist must live at the parse where every entry path converges (a typed
+ * URL, the back button, and the toggle click are all judged here), not on the
+ * toggle handler alone (Lessons 124, 144 / R17). Unknown ⇒ the 'health' default.
+ */
+export function parseColorMode(raw: string | null | undefined): GridColorMode {
+  return raw === 'tier' ? 'tier' : 'health'
+}
+
+export interface TileVisual {
+  /** CSS modifier class controlling the tile's fill + text colour. */
+  modifierClass: string
+  /** The non-colour DCP signal shown on the tile, e.g. '7/10'. */
+  signalText: string
+  /** Short non-colour glyph reinforcing the status (✓/⚠/✗, D/S/P/M/—, ⊘). */
+  signalGlyph: string
+  /** Human-readable status for the tile's aria-label / tooltip. */
+  statusLabel: string
+}
+
+/** Confirmed Distinguished tiers (everything except NotDistinguished). */
+type ConfirmedTier = Exclude<
+  ClubTrend['distinguishedLevel'],
+  'NotDistinguished'
+>
+
+/** Tier → tile modifier. Mirrors `clubsColumns` TIER_MODIFIER (same colours,
+ *  tile-scoped class names) so the two surfaces read identically (Lesson 052). */
+const TIER_MODIFIER: Record<ConfirmedTier, string> = {
+  Distinguished: 'club-grid-tile--tier-distinguished',
+  Select: 'club-grid-tile--tier-select',
+  President: 'club-grid-tile--tier-presidents',
+  Smedley: 'club-grid-tile--tier-smedley',
+}
+
+/** Tier → single-letter glyph (the raw TI "Club Distinguished Status" codes). */
+const TIER_GLYPH: Record<ConfirmedTier, string> = {
+  Distinguished: 'D',
+  Select: 'S',
+  President: 'P',
+  Smedley: 'M',
+}
+
+/** Tier → display label. Mirrors `clubsColumns` TIER_DISPLAY. */
+const TIER_LABEL: Record<ConfirmedTier, string> = {
+  Distinguished: 'Distinguished',
+  Select: 'Select',
+  President: "President's",
+  Smedley: 'Smedley',
+}
+
+const HEALTH_MODIFIER: Record<ClubTrend['currentStatus'], string> = {
+  thriving: 'club-grid-tile--thriving',
+  vulnerable: 'club-grid-tile--vulnerable',
+  'intervention-required': 'club-grid-tile--intervention',
+}
+
+function isSuspended(club: ClubTrend): boolean {
+  return club.clubStatus?.toLowerCase() === 'suspended'
+}
+
+function dcpSignalText(club: ClubTrend): string {
+  const goals = Math.max(0, Math.min(10, getLatestDcpGoals(club)))
+  return `${goals}/10`
+}
+
+/**
+ * Resolve the tile's colour modifier, glyph, status label and DCP signal for a
+ * club under the active colour mode. A suspended club is an operational override
+ * that wins over both health and tier in either mode (its health/tier is moot).
+ */
+export function getTileVisual(
+  club: ClubTrend,
+  mode: GridColorMode
+): TileVisual {
+  const signalText = dcpSignalText(club)
+
+  if (isSuspended(club)) {
+    return {
+      modifierClass: 'club-grid-tile--suspended',
+      signalGlyph: '⊘',
+      statusLabel: 'Suspended',
+      signalText,
+    }
+  }
+
+  if (mode === 'tier') {
+    const level = club.distinguishedLevel
+    if (level === 'NotDistinguished') {
+      return {
+        modifierClass: 'club-grid-tile--tier-none',
+        signalGlyph: '—',
+        statusLabel: 'Not yet Distinguished',
+        signalText,
+      }
+    }
+    return {
+      modifierClass: TIER_MODIFIER[level],
+      signalGlyph: TIER_GLYPH[level],
+      statusLabel: TIER_LABEL[level],
+      signalText,
+    }
+  }
+
+  return {
+    modifierClass: HEALTH_MODIFIER[club.currentStatus],
+    signalGlyph: getClubHealthStatusIcon(club.currentStatus),
+    statusLabel: getClubHealthStatusLabel(club.currentStatus),
+    signalText,
+  }
+}

--- a/tasks/plan-1230-club-grid.md
+++ b/tasks/plan-1230-club-grid.md
@@ -1,0 +1,47 @@
+# Sprint #1230 — At-a-glance club grid (Chiclet / LEO board)
+
+Epic #1228 Sprint 2. New deep-linkable `/district/:id/grid`: one color-coded tile per
+club, grouped Division→Area. Default color = club health; URL-synced toggle to color by
+Distinguished tier (`?color=health|tier`).
+
+## Reuse (no new deps, no new computation — R7)
+
+- Data: `useDistrictAnalytics(id, start, end).allClubs: ClubTrend[]` (same scaffold as
+  DistrictDivisionsPage — program year/date via `useUrlProgramYear`).
+- Health: `currentStatus: ClubHealthStatus` + `utils/clubHealthStatus.ts`
+  (`getClubHealthStatusLabel/PillModifier/Icon`).
+- Tier: `distinguishedLevel` on ClubTrend (already the per-club source — L123, NOT
+  `totals.distinguished*`). Mirror `clubsColumns` TIER_DISPLAY/TIER_MODIFIER.
+- DCP: `getLatestDcpGoals(club)` from `columnFilterUtils.ts` → `{n}/10`.
+- Suspended: `clubStatus` ('Suspended'/'Low'/...).
+- Link: `/district/${id}/club/${clubId}`. Legend: mirror existing chip patterns.
+
+## Files (additive)
+
+1. `utils/clubGridColor.ts` — PURE `getTileVisual(club, mode)` → `{ modifierClass,
+signalText, signalGlyph, statusLabel }`. The unit-testable core (both modes,
+   suspended, NotDistinguished). Also `parseColorMode(raw)` clamping unknown→'health'.
+2. `components/ClubGridTile.tsx` — `<Link>` tile, color modifier, club name (truncated),
+   secondary signal line (`{n}/10` + glyph/letter), full `aria-label` (color never sole
+   signal — text+glyph+aria).
+3. `pages/DistrictGridPage.tsx` — scaffold + group Division→Area, legend, `aria-pressed`
+   color-mode toggle (NOT tabs — L128), URL `?color`, loading/empty.
+4. `styles/components/club-grid.css` — tile + responsive grid, dark-mode; wired into
+   `index.css` (L142 — no orphan stylesheet).
+5. `config/districtSections.ts` — add `{ label: 'Grid', segment: 'grid' }`.
+6. `App.tsx` — lazy route `district/:districtId/grid`.
+
+## Tests (TDD, Red first)
+
+- `utils/__tests__/clubGridColor.test.ts` — both modes × all health/tier states +
+  suspended + NotDistinguished + `parseColorMode` clamps garbage→health (L124/144).
+- `components/__tests__/ClubGridTile.test.tsx` — href, accessible label, non-color
+  signal present, modifier class.
+- `pages/__tests__/DistrictGridPage.test.tsx` (page mount → pages/**tests**, R22) —
+  grouping Division→Area, `?color=tier` toggles, `?color=garbage` clamps to health,
+  suspended handled.
+
+## Verify
+
+Dual-engine Playwright smoke on PR preview (chromium+webkit), `:visible` + route-keyed
+locators (L149/152); 375/768/1280 + dark mode screenshots.


### PR DESCRIPTION
## Summary

Adds a new deep-linkable view **`/district/:id/grid`** — the at-a-glance "Chiclet / LEO board": one colour-coded tile per club, the whole district on one screen (the view TI's dashboards structurally can't do). Sprint 2 of epic #1228 (#1230).

- New **Grid** subnav item, after Divisions.
- Tiles grouped **Division → Area** (each level natural-sorted; unassigned pushed last; the view owns its own order — L138).
- Default tile colour = **club health** (Thriving / Vulnerable / Intervention); URL-synced toggle to colour by **Distinguished tier** (`?color=health|tier`).
- Tier colour comes from the per-club `distinguishedLevel`, **not** `totals.distinguished*` (L123).
- The `?color` whitelist is clamped at the **parse**, so a typed/shared/back-button URL is judged the same as a toggle click (L124/144). Unknown → `health`.
- Colour is **never the sole signal**: every tile is a real keyboard-operable `<Link>` with a full aria-label (name · division·area · status · DCP), a non-colour glyph, and the `{n}/10` DCP count.
- Colour toggle is **`aria-pressed` buttons in a `role="group"`**, not tabs — it recolours one view, it doesn't swap panels (L128).
- **Suspended/empty handled**: suspended tiles are distinctly muted+struck in both modes — but a club promoted Active by the read-time Dues-Renewal overlay is **not** shown Suspended, matching `ClubStatusCell` (L052/L154).
- Legend always visible, derived from the **same** colour-map source the tiles use (one source of truth — L052).
- New stylesheet wired into the import graph (L142); health soft-tints are theme-stable, tier fills pinned to AA-safe literals, neutral/suspended remapped for dark mode.

## Testing

- `clubGridColor.test.ts` — colour/label mapping both modes, suspended override (incl. renewal-overlay promotion), `parseColorMode` clamps abusive values, single-source legend.
- `ClubGridTile.test.tsx` — link href, accessible label carries status+DCP, glyph aria-hidden, modifier classes.
- `DistrictGridPage.test.tsx` (page-mount → `pages/__tests__`, R22) — grouping Division→Area, URL-synced toggle, `?color=garbage` clamps to health, aria-pressed (not tabs), legend, suspended.
- Full frontend unit suite green (2781 tests); production build green.
- `/simplify` pass (legend dedup) + fresh-context `/review` (one Medium fix applied: renewal-overlay consistency).

Live verification on the PR preview channel (dual-engine Playwright + 375/768/1280 + dark mode) to follow on this PR.

Refs #1228, #1230.