### PR TITLE
feat(area): Area Director action list — shareable 'what to do next' (#1231)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,11 @@ const DistrictRankingsPage = React.lazy(
 // Code-split: DistrictGridPage — at-a-glance club grid subroute (#1230, epic #1228)
 const DistrictGridPage = React.lazy(() => import('./pages/DistrictGridPage'))
 
+// Code-split: DistrictActionListPage — area-director action list (#1231, epic #1228)
+const DistrictActionListPage = React.lazy(
+  () => import('./pages/DistrictActionListPage')
+)
+
 // Code-split: DistrictTrendsPage — trends subroute (#680, epic #674 Sprint 6)
 const DistrictTrendsPage = React.lazy(
   () => import('./pages/DistrictTrendsPage')
@@ -155,6 +160,14 @@ const router = createBrowserRouter(
           element: (
             <Suspense fallback={<PageLoadingFallback />}>
               <DistrictGridPage />
+            </Suspense>
+          ),
+        },
+        {
+          path: 'district/:districtId/action-list',
+          element: (
+            <Suspense fallback={<PageLoadingFallback />}>
+              <DistrictActionListPage />
             </Suspense>
           ),
         },

--- a/frontend/src/components/__tests__/DistrictSubnav.test.tsx
+++ b/frontend/src/components/__tests__/DistrictSubnav.test.tsx
@@ -36,6 +36,7 @@ describe('DistrictSubnav (#678, ADR-005 §3)', () => {
       Trends: '/district/61/trends',
       Analytics: '/district/61/analytics',
       Rankings: '/district/61/rankings',
+      'Action List': '/district/61/action-list',
     }
     for (const [label, href] of Object.entries(expected)) {
       expect(screen.getByRole('link', { name: label })).toHaveAttribute(
@@ -58,6 +59,8 @@ describe('DistrictSubnav (#678, ADR-005 §3)', () => {
     // ADR-005 §3 order: lateral views read Overview · What Changed · Clubs ·
     // Divisions · Grid · Trends · Analytics · Rankings. Grid (#1230) sits after
     // Divisions as the dense whole-district companion to the division breakdown.
+    // Action List (#1231) closes the epic as the area-director "what to do
+    // next" destination — last, since it's a task view, not a lateral data view.
     expect(DISTRICT_SECTIONS.map(s => s.label)).toEqual([
       'Overview',
       'What Changed',
@@ -67,6 +70,7 @@ describe('DistrictSubnav (#678, ADR-005 §3)', () => {
       'Trends',
       'Analytics',
       'Rankings',
+      'Action List',
     ])
   })
 

--- a/frontend/src/config/districtSections.ts
+++ b/frontend/src/config/districtSections.ts
@@ -30,6 +30,10 @@ export const DISTRICT_SECTIONS: readonly DistrictSection[] = [
   { label: 'Trends', segment: 'trends' },
   { label: 'Analytics', segment: 'analytics' },
   { label: 'Rankings', segment: 'rankings' },
+  // 'Action List' (#1231, epic #1228) — the area-director "what to do next"
+  // destination (close-to-Distinguished gaps, missing club visits, clubs needing
+  // intervention). Last in the strip: a task view, not a lateral data view.
+  { label: 'Action List', segment: 'action-list' },
 ]
 
 /** Build the URL for a district section. Empty segment = the Overview hub. */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -48,6 +48,7 @@
 @import './styles/components/district-changes.css';
 @import './styles/components/club-history.css';
 @import './styles/components/club-grid.css';
+@import './styles/components/action-list.css';
 @import './styles/responsive.css';
 @import './styles/dark-mode.css';
 @import './styles/print.css';

--- a/frontend/src/pages/DistrictActionListPage.tsx
+++ b/frontend/src/pages/DistrictActionListPage.tsx
@@ -15,6 +15,8 @@ import {
 import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
 import {
   buildActionList,
+  formatCloseGap,
+  formatVisitGap,
   type ActionListSections,
 } from '../utils/actionListData'
 import { arrayToCSV, downloadCSV, generateFilename } from '../utils/csvExport'
@@ -48,11 +50,33 @@ function compareId(a: string, b: string): number {
   return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
 }
 
-const EMPTY_SECTIONS: ActionListSections = {
-  closeToDistinguished: [],
-  visitGaps: [],
-  interventionRequired: [],
-}
+/** One action section: heading + count badge, then either the empty state or
+ *  the caller-supplied list rows. The section/heading/count/empty scaffold is
+ *  shared; the divergent `<li>` bodies are passed as children. */
+const ActionListSection: React.FC<{
+  id: string
+  testId: string
+  heading: string
+  count: number
+  emptyText: string
+  children: React.ReactNode
+}> = ({ id, testId, heading, count, emptyText, children }) => (
+  <section
+    className="action-list-section"
+    aria-labelledby={id}
+    data-testid={testId}
+  >
+    <h3 id={id} className="action-list-section__heading">
+      {heading}
+      <span className="action-list-section__count">{count}</span>
+    </h3>
+    {count === 0 ? (
+      <p className="action-list-section__empty">{emptyText}</p>
+    ) : (
+      <ul className="action-list-items">{children}</ul>
+    )}
+  </section>
+)
 
 const DistrictActionListPage: React.FC = () => {
   const { districtId } = useParams<{ districtId: string }>()
@@ -172,7 +196,8 @@ const DistrictActionListPage: React.FC = () => {
   )
 
   const sections = useMemo<ActionListSections>(() => {
-    if (!analytics && divisionPerformance.length === 0) return EMPTY_SECTIONS
+    // buildActionList already returns empty sections for empty input, so no
+    // separate no-data guard is needed — the `?? []` fallbacks make it safe.
     return buildActionList(
       {
         clubs: analytics?.allClubs ?? [],
@@ -228,7 +253,7 @@ const DistrictActionListPage: React.FC = () => {
         c.divisionId,
         c.areaId,
         c.clubName,
-        `needs ${c.membersNeeded} member${c.membersNeeded === 1 ? '' : 's'} + ${c.goalsNeeded} DCP goal${c.goalsNeeded === 1 ? '' : 's'}`,
+        formatCloseGap(c),
       ])
     }
     for (const g of sections.visitGaps) {
@@ -237,7 +262,7 @@ const DistrictActionListPage: React.FC = () => {
         g.divisionId,
         g.areaId,
         `Area ${g.areaId}`,
-        `${g.missingClubs.length} club(s) unvisited (Round ${g.currentRound}, due ${g.deadline})`,
+        formatVisitGap(g),
       ])
     }
     for (const i of sections.interventionRequired) {
@@ -362,125 +387,74 @@ const DistrictActionListPage: React.FC = () => {
               <LoadingSkeleton variant="table" count={3} />
             ) : (
               <div className="action-list-sections">
-                <section
-                  className="action-list-section"
-                  aria-labelledby="action-close"
-                  data-testid="section-close"
+                <ActionListSection
+                  id="action-close"
+                  testId="section-close"
+                  heading="Clubs close to Distinguished"
+                  count={sections.closeToDistinguished.length}
+                  emptyText="No clubs are within reach of Distinguished for this scope."
                 >
-                  <h3
-                    id="action-close"
-                    className="action-list-section__heading"
-                  >
-                    Clubs close to Distinguished
-                    <span className="action-list-section__count">
-                      {sections.closeToDistinguished.length}
-                    </span>
-                  </h3>
-                  {sections.closeToDistinguished.length === 0 ? (
-                    <p className="action-list-section__empty">
-                      No clubs are within reach of Distinguished for this scope.
-                    </p>
-                  ) : (
-                    <ul className="action-list-items">
-                      {sections.closeToDistinguished.map(c => (
-                        <li key={c.clubId} className="action-list-item">
-                          <Link
-                            className="action-list-item__link"
-                            to={`/district/${districtId}/club/${c.clubId}`}
-                          >
-                            {c.clubName}
-                          </Link>
-                          <span className="action-list-item__meta">
-                            {c.divisionId}/{c.areaId} · needs {c.membersNeeded}{' '}
-                            member{c.membersNeeded === 1 ? '' : 's'} +{' '}
-                            {c.goalsNeeded} DCP goal
-                            {c.goalsNeeded === 1 ? '' : 's'}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </section>
+                  {sections.closeToDistinguished.map(c => (
+                    <li key={c.clubId} className="action-list-item">
+                      <Link
+                        className="action-list-item__link"
+                        to={`/district/${districtId}/club/${c.clubId}`}
+                      >
+                        {c.clubName}
+                      </Link>
+                      <span className="action-list-item__meta">
+                        {c.divisionId}/{c.areaId} · {formatCloseGap(c)}
+                      </span>
+                    </li>
+                  ))}
+                </ActionListSection>
 
-                <section
-                  className="action-list-section"
-                  aria-labelledby="action-visits"
-                  data-testid="section-visits"
+                <ActionListSection
+                  id="action-visits"
+                  testId="section-visits"
+                  heading="Areas missing club visits"
+                  count={sections.visitGaps.length}
+                  emptyText="Every area has completed the current round's club visits for this scope."
                 >
-                  <h3
-                    id="action-visits"
-                    className="action-list-section__heading"
-                  >
-                    Areas missing club visits
-                    <span className="action-list-section__count">
-                      {sections.visitGaps.length}
-                    </span>
-                  </h3>
-                  {sections.visitGaps.length === 0 ? (
-                    <p className="action-list-section__empty">
-                      Every area has completed the current round&rsquo;s club
-                      visits for this scope.
-                    </p>
-                  ) : (
-                    <ul className="action-list-items">
-                      {sections.visitGaps.map(g => (
-                        <li
-                          key={`${g.divisionId}-${g.areaId}`}
-                          className="action-list-item"
-                        >
-                          <Link
-                            className="action-list-item__link"
-                            to={`/district/${districtId}/division/${g.divisionId}/area/${g.areaId}`}
-                          >
-                            Area {g.areaId}
-                          </Link>
-                          <span className="action-list-item__meta">
-                            {g.missingClubs.length} club
-                            {g.missingClubs.length === 1 ? '' : 's'} unvisited ·
-                            Round {g.currentRound}, due {g.deadline}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </section>
+                  {sections.visitGaps.map(g => (
+                    <li
+                      key={`${g.divisionId}-${g.areaId}`}
+                      className="action-list-item"
+                    >
+                      <Link
+                        className="action-list-item__link"
+                        to={`/district/${districtId}/division/${g.divisionId}/area/${g.areaId}`}
+                      >
+                        Area {g.areaId}
+                      </Link>
+                      <span className="action-list-item__meta">
+                        {formatVisitGap(g)}
+                      </span>
+                    </li>
+                  ))}
+                </ActionListSection>
 
-                <section
-                  className="action-list-section"
-                  aria-labelledby="action-intervention"
-                  data-testid="section-intervention"
+                <ActionListSection
+                  id="action-intervention"
+                  testId="section-intervention"
+                  heading="Clubs needing intervention"
+                  count={sections.interventionRequired.length}
+                  emptyText="No clubs are flagged intervention-required for this scope."
                 >
-                  <h3
-                    id="action-intervention"
-                    className="action-list-section__heading"
-                  >
-                    Clubs needing intervention
-                    <span className="action-list-section__count">
-                      {sections.interventionRequired.length}
-                    </span>
-                  </h3>
-                  {sections.interventionRequired.length === 0 ? (
-                    <p className="action-list-section__empty">
-                      No clubs are flagged intervention-required for this scope.
-                    </p>
-                  ) : (
-                    <ul className="action-list-items">
-                      {sections.interventionRequired.map(i => (
-                        <li key={i.clubId} className="action-list-item">
-                          <Link
-                            className="action-list-item__link"
-                            to={`/district/${districtId}/club/${i.clubId}`}
-                          >
-                            {i.clubName}
-                          </Link>
-                          <span className="action-list-item__meta">
-                            {i.divisionId}/{i.areaId} · intervention required
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </section>
+                  {sections.interventionRequired.map(i => (
+                    <li key={i.clubId} className="action-list-item">
+                      <Link
+                        className="action-list-item__link"
+                        to={`/district/${districtId}/club/${i.clubId}`}
+                      >
+                        {i.clubName}
+                      </Link>
+                      <span className="action-list-item__meta">
+                        {i.divisionId}/{i.areaId} · intervention required
+                      </span>
+                    </li>
+                  ))}
+                </ActionListSection>
               </div>
             )}
           </div>

--- a/frontend/src/pages/DistrictActionListPage.tsx
+++ b/frontend/src/pages/DistrictActionListPage.tsx
@@ -1,0 +1,493 @@
+import React, { useMemo } from 'react'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
+import { useDistricts } from '../hooks/useDistricts'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useDistrictCachedDates } from '../hooks/useDistrictData'
+import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
+import { useDistrictStatistics } from '../hooks/useMembershipData'
+import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
+import {
+  getAvailableProgramYears,
+  filterDatesByProgramYear,
+  getMostRecentDateInProgramYear,
+  isDateInProgramYear,
+} from '../utils/programYear'
+import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
+import {
+  buildActionList,
+  type ActionListSections,
+} from '../utils/actionListData'
+import { arrayToCSV, downloadCSV, generateFilename } from '../utils/csvExport'
+import { DistrictDetailHeader } from '../components/DistrictDetailHeader'
+import { SubpageBreadcrumb } from '../components/SubpageBreadcrumb'
+import { DistrictSubnav } from '../components/DistrictSubnav'
+import { LoadingSkeleton } from '../components/LoadingSkeleton'
+import ErrorBoundary from '../components/ErrorBoundary'
+
+/* District Action List Page (#1231, epic #1228 Sprint 3 — the epic's close).
+   RAFFETY's "Almost Distinguished" / "Area To-Do" reports made action-oriented
+   and shareable: a deep-linkable destination scoped to a district (and
+   filterable to a division/area via URL-synced `?division=`/`?area=`).
+
+   Reuse-only (R7): every row comes from existing predicates via `buildActionList`
+   — `isCloseToDistinguished` + `calculateClubProjection` for the gap, the
+   deadline-aware `AreaPerformance.clubsMissingCurrentRoundVisit`/`currentRound`
+   for visit gaps, and the club-health `currentStatus` for intervention. The page
+   OWNS the scope state and passes it to the pure derivation (R3 / Lesson 124);
+   the scope whitelist is irrelevant because an out-of-range slice simply yields
+   empty sections (Lesson 144). */
+
+interface ScopeOption {
+  /** Division ids present in the snapshot, sorted. */
+  divisions: string[]
+  /** Area ids for the active division (or all areas when unscoped), sorted. */
+  areas: string[]
+}
+
+function compareId(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+}
+
+const EMPTY_SECTIONS: ActionListSections = {
+  closeToDistinguished: [],
+  visitGaps: [],
+  interventionRequired: [],
+}
+
+const DistrictActionListPage: React.FC = () => {
+  const { districtId } = useParams<{ districtId: string }>()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // Scope is URL-seedable (typed URL, shared link, back button, select change),
+  // so it is read at the single parse point every entry path converges on
+  // (L124/144 / R17). An empty string is treated as "no filter".
+  const division = searchParams.get('division') || undefined
+  const area = searchParams.get('area') || undefined
+
+  const setScope = (next: {
+    division?: string | undefined
+    area?: string | undefined
+  }) => {
+    setSearchParams(
+      prev => {
+        const params = new URLSearchParams(prev)
+        if (next.division) params.set('division', next.division)
+        else params.delete('division')
+        if (next.area) params.set('area', next.area)
+        else params.delete('area')
+        return params
+      },
+      { replace: true }
+    )
+  }
+
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+  } = useUrlProgramYear()
+
+  const { data: districtsData } = useDistricts()
+  const selectedDistrict = districtsData?.districts?.find(
+    d => d.id === districtId
+  )
+
+  const { data: cachedDatesData } = useDistrictCachedDates(districtId || '')
+  const allCachedDates = useMemo(
+    () => cachedDatesData?.dates || [],
+    [cachedDatesData?.dates]
+  )
+  const availableProgramYears = useMemo(
+    () => getAvailableProgramYears(allCachedDates),
+    [allCachedDates]
+  )
+
+  React.useEffect(() => {
+    if (availableProgramYears.length > 0) {
+      const has = availableProgramYears.some(
+        py => py.year === selectedProgramYear.year
+      )
+      if (!has) {
+        const mostRecent = availableProgramYears[0]
+        if (mostRecent) setSelectedProgramYear(mostRecent)
+      }
+    }
+  }, [availableProgramYears, selectedProgramYear.year, setSelectedProgramYear])
+
+  const cachedDatesInProgramYear = useMemo(
+    () => filterDatesByProgramYear(allCachedDates, selectedProgramYear),
+    [allCachedDates, selectedProgramYear]
+  )
+
+  const effectiveProgramYear = useMemo(() => {
+    if (availableProgramYears.length === 0) return null
+    const has = availableProgramYears.some(
+      py => py.year === selectedProgramYear.year
+    )
+    if (has) return selectedProgramYear
+    return availableProgramYears[0] ?? null
+  }, [availableProgramYears, selectedProgramYear])
+
+  const effectiveEndDate = useMemo(() => {
+    if (!effectiveProgramYear) return null
+    if (
+      selectedDate &&
+      isDateInProgramYear(selectedDate, effectiveProgramYear)
+    ) {
+      return selectedDate
+    }
+    const mostRecent = getMostRecentDateInProgramYear(
+      allCachedDates,
+      effectiveProgramYear
+    )
+    return mostRecent || effectiveProgramYear.endDate
+  }, [selectedDate, effectiveProgramYear, allCachedDates])
+
+  const hasValidDates =
+    effectiveProgramYear !== null && effectiveEndDate !== null
+
+  const { data: analytics, isLoading: analyticsLoading } = useDistrictAnalytics(
+    hasValidDates ? districtId || null : null,
+    effectiveProgramYear?.startDate,
+    effectiveEndDate ?? undefined
+  )
+
+  const { data: districtStatistics, isLoading: statsLoading } =
+    useDistrictStatistics(
+      hasValidDates ? districtId || null : null,
+      effectiveEndDate ?? undefined,
+      'divisions'
+    )
+
+  const divisionPerformance = useMemo(
+    () =>
+      districtStatistics
+        ? extractDivisionPerformance(
+            districtStatistics,
+            districtStatistics.asOfDate
+          )
+        : [],
+    [districtStatistics]
+  )
+
+  const sections = useMemo<ActionListSections>(() => {
+    if (!analytics && divisionPerformance.length === 0) return EMPTY_SECTIONS
+    return buildActionList(
+      {
+        clubs: analytics?.allClubs ?? [],
+        interventionClubs: analytics?.interventionRequiredClubs ?? [],
+        divisions: divisionPerformance,
+        snapshotDate: districtStatistics?.asOfDate ?? effectiveEndDate ?? '',
+      },
+      { division, area }
+    )
+  }, [
+    analytics,
+    divisionPerformance,
+    districtStatistics?.asOfDate,
+    effectiveEndDate,
+    division,
+    area,
+  ])
+
+  // Scope-select options come from the authoritative division/area structure.
+  const scopeOptions = useMemo<ScopeOption>(() => {
+    const divisions = [
+      ...new Set(divisionPerformance.map(d => d.divisionId)),
+    ].sort(compareId)
+    const areaSource = division
+      ? (divisionPerformance.find(d => d.divisionId === division)?.areas ?? [])
+      : divisionPerformance.flatMap(d => d.areas)
+    const areas = [...new Set(areaSource.map(a => a.areaId))].sort(compareId)
+    return { divisions, areas }
+  }, [divisionPerformance, division])
+
+  const rawName = selectedDistrict?.name || districtId || ''
+  const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
+  useDocumentTitle(districtName ? `${districtName} Action List` : null)
+
+  const availableDates = cachedDatesInProgramYear.sort((a, b) =>
+    b.localeCompare(a)
+  )
+
+  const isLoading = analyticsLoading || statsLoading
+  const totalItems =
+    sections.closeToDistinguished.length +
+    sections.visitGaps.length +
+    sections.interventionRequired.length
+
+  const handleExport = () => {
+    if (!districtId) return
+    const rows: (string | number)[][] = [
+      ['Section', 'Division', 'Area', 'Item', 'Detail'],
+    ]
+    for (const c of sections.closeToDistinguished) {
+      rows.push([
+        'Close to Distinguished',
+        c.divisionId,
+        c.areaId,
+        c.clubName,
+        `needs ${c.membersNeeded} member${c.membersNeeded === 1 ? '' : 's'} + ${c.goalsNeeded} DCP goal${c.goalsNeeded === 1 ? '' : 's'}`,
+      ])
+    }
+    for (const g of sections.visitGaps) {
+      rows.push([
+        'Missing club visits',
+        g.divisionId,
+        g.areaId,
+        `Area ${g.areaId}`,
+        `${g.missingClubs.length} club(s) unvisited (Round ${g.currentRound}, due ${g.deadline})`,
+      ])
+    }
+    for (const i of sections.interventionRequired) {
+      rows.push([
+        'Intervention required',
+        i.divisionId,
+        i.areaId,
+        i.clubName,
+        'Club health: intervention required',
+      ])
+    }
+    downloadCSV(arrayToCSV(rows), generateFilename('action-list', districtId))
+  }
+
+  if (!districtId) {
+    return null
+  }
+
+  return (
+    <ErrorBoundary>
+      <div className="district-detail-page-root">
+        <div className="district-detail-page">
+          <DistrictDetailHeader
+            districtId={districtId}
+            districtName={districtName}
+            selectedProgramYear={selectedProgramYear}
+            setSelectedProgramYear={setSelectedProgramYear}
+            availableProgramYears={availableProgramYears}
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+            availableDates={availableDates}
+            latestSnapshotDate={
+              cachedDatesData?.dateRange?.endDate ?? availableDates[0]
+            }
+          />
+
+          <SubpageBreadcrumb
+            crumbs={[{ label: districtName, to: `/district/${districtId}` }]}
+          />
+
+          <DistrictSubnav districtId={districtId} />
+
+          <div className="action-list-page" data-testid="action-list-page">
+            <header className="action-list-page__intro">
+              <h2 className="action-list-page__title">Area Director Actions</h2>
+              <p className="action-list-page__subtitle">
+                Prioritized to-dos for this district: clubs within reach of
+                Distinguished, areas with outstanding club visits, and clubs
+                that need intervention. Filter to your division or area and
+                share the link.
+              </p>
+            </header>
+
+            <div className="action-list-page__controls">
+              <div
+                className="action-list-scope"
+                role="group"
+                aria-label="Scope"
+              >
+                <label className="action-list-scope__field">
+                  <span className="action-list-scope__label">Division</span>
+                  <select
+                    className="action-list-scope__select"
+                    value={division ?? ''}
+                    onChange={e =>
+                      // Changing division clears any area from a prior division.
+                      setScope({ division: e.target.value || undefined })
+                    }
+                  >
+                    <option value="">All divisions</option>
+                    {scopeOptions.divisions.map(d => (
+                      <option key={d} value={d}>
+                        Division {d}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="action-list-scope__field">
+                  <span className="action-list-scope__label">Area</span>
+                  <select
+                    className="action-list-scope__select"
+                    value={area ?? ''}
+                    onChange={e =>
+                      setScope({
+                        division,
+                        area: e.target.value || undefined,
+                      })
+                    }
+                  >
+                    <option value="">All areas</option>
+                    {scopeOptions.areas.map(a => (
+                      <option key={a} value={a}>
+                        Area {a}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                {(division || area) && (
+                  <button
+                    type="button"
+                    className="action-list-scope__clear"
+                    onClick={() => setScope({})}
+                  >
+                    Clear filter
+                  </button>
+                )}
+              </div>
+
+              <button
+                type="button"
+                className="action-list-page__export"
+                onClick={handleExport}
+                disabled={totalItems === 0}
+              >
+                Export CSV
+              </button>
+            </div>
+
+            {isLoading && totalItems === 0 ? (
+              <LoadingSkeleton variant="table" count={3} />
+            ) : (
+              <div className="action-list-sections">
+                <section
+                  className="action-list-section"
+                  aria-labelledby="action-close"
+                  data-testid="section-close"
+                >
+                  <h3
+                    id="action-close"
+                    className="action-list-section__heading"
+                  >
+                    Clubs close to Distinguished
+                    <span className="action-list-section__count">
+                      {sections.closeToDistinguished.length}
+                    </span>
+                  </h3>
+                  {sections.closeToDistinguished.length === 0 ? (
+                    <p className="action-list-section__empty">
+                      No clubs are within reach of Distinguished for this scope.
+                    </p>
+                  ) : (
+                    <ul className="action-list-items">
+                      {sections.closeToDistinguished.map(c => (
+                        <li key={c.clubId} className="action-list-item">
+                          <Link
+                            className="action-list-item__link"
+                            to={`/district/${districtId}/club/${c.clubId}`}
+                          >
+                            {c.clubName}
+                          </Link>
+                          <span className="action-list-item__meta">
+                            {c.divisionId}/{c.areaId} · needs {c.membersNeeded}{' '}
+                            member{c.membersNeeded === 1 ? '' : 's'} +{' '}
+                            {c.goalsNeeded} DCP goal
+                            {c.goalsNeeded === 1 ? '' : 's'}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+
+                <section
+                  className="action-list-section"
+                  aria-labelledby="action-visits"
+                  data-testid="section-visits"
+                >
+                  <h3
+                    id="action-visits"
+                    className="action-list-section__heading"
+                  >
+                    Areas missing club visits
+                    <span className="action-list-section__count">
+                      {sections.visitGaps.length}
+                    </span>
+                  </h3>
+                  {sections.visitGaps.length === 0 ? (
+                    <p className="action-list-section__empty">
+                      Every area has completed the current round&rsquo;s club
+                      visits for this scope.
+                    </p>
+                  ) : (
+                    <ul className="action-list-items">
+                      {sections.visitGaps.map(g => (
+                        <li
+                          key={`${g.divisionId}-${g.areaId}`}
+                          className="action-list-item"
+                        >
+                          <Link
+                            className="action-list-item__link"
+                            to={`/district/${districtId}/division/${g.divisionId}/area/${g.areaId}`}
+                          >
+                            Area {g.areaId}
+                          </Link>
+                          <span className="action-list-item__meta">
+                            {g.missingClubs.length} club
+                            {g.missingClubs.length === 1 ? '' : 's'} unvisited ·
+                            Round {g.currentRound}, due {g.deadline}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+
+                <section
+                  className="action-list-section"
+                  aria-labelledby="action-intervention"
+                  data-testid="section-intervention"
+                >
+                  <h3
+                    id="action-intervention"
+                    className="action-list-section__heading"
+                  >
+                    Clubs needing intervention
+                    <span className="action-list-section__count">
+                      {sections.interventionRequired.length}
+                    </span>
+                  </h3>
+                  {sections.interventionRequired.length === 0 ? (
+                    <p className="action-list-section__empty">
+                      No clubs are flagged intervention-required for this scope.
+                    </p>
+                  ) : (
+                    <ul className="action-list-items">
+                      {sections.interventionRequired.map(i => (
+                        <li key={i.clubId} className="action-list-item">
+                          <Link
+                            className="action-list-item__link"
+                            to={`/district/${districtId}/club/${i.clubId}`}
+                          >
+                            {i.clubName}
+                          </Link>
+                          <span className="action-list-item__meta">
+                            {i.divisionId}/{i.areaId} · intervention required
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </ErrorBoundary>
+  )
+}
+
+export default DistrictActionListPage

--- a/frontend/src/pages/__tests__/DistrictActionListPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictActionListPage.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * District Action List Page (#1231, epic #1228 Sprint 3).
+ *
+ * Verifies the `/district/:districtId/action-list` route renders the three
+ * action sections from existing predicates/visit data, that scope filtering is
+ * URL-synced, that links resolve to canonical club/area pages, and that each
+ * section has an empty state.
+ */
+
+import React, { Suspense } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import {
+  createMemoryRouter,
+  RouterProvider,
+  type RouteObject,
+} from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '@testing-library/jest-dom'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import { DarkModeProvider } from '../../contexts/DarkModeContext'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import type {
+  AreaPerformance,
+  DivisionPerformance,
+} from '../../utils/divisionStatus'
+
+function makeClub(overrides: Partial<ClubTrend> = {}): ClubTrend {
+  return {
+    clubId: 'c1',
+    clubName: 'Club One',
+    divisionId: 'A',
+    areaId: 'A1',
+    areaName: 'Area A1',
+    membershipTrend: [
+      { date: '2025-07-01', count: 18 },
+      { date: '2025-07-15', count: 18 },
+    ],
+    dcpGoalsTrend: [
+      { date: '2025-07-01', goalsAchieved: 0 },
+      { date: '2025-07-15', goalsAchieved: 4 },
+    ],
+    membershipBase: 18,
+    aprilRenewals: null,
+    cspSubmitted: true,
+    currentStatus: 'thriving',
+    distinguishedLevel: 'NotDistinguished',
+    ...overrides,
+  } as ClubTrend
+}
+
+// A club the predicate flags (members gap 2, goals 4, CSP submitted).
+const closeClub = makeClub({
+  clubId: 'close-1',
+  clubName: 'Rising Club',
+  divisionId: 'A',
+  areaId: 'A1',
+})
+
+const interventionClub = makeClub({
+  clubId: 'int-1',
+  clubName: 'Struggling Club',
+  divisionId: 'B',
+  areaId: 'B2',
+  currentStatus: 'intervention-required',
+  // Only 1 DCP goal, so it is NOT also close-to-Distinguished — it must appear
+  // solely in the intervention section.
+  dcpGoalsTrend: [{ date: '2025-07-15', goalsAchieved: 1 }],
+})
+
+function makeArea(overrides: Partial<AreaPerformance>): AreaPerformance {
+  return {
+    areaId: 'A1',
+    currentRound: 1,
+    clubsMissingCurrentRoundVisit: [],
+    clubsMissingCurrentRoundVisitIneligible: [],
+    recognitionState: {
+      level: 'distinguished',
+      status: 'provisional',
+      pendingRounds: [{ round: 1, deadline: '2025-11-30' }],
+      failureReason: null,
+    },
+    ...overrides,
+  } as AreaPerformance
+}
+
+const divisionPerf: DivisionPerformance[] = [
+  {
+    divisionId: 'A',
+    areas: [
+      makeArea({
+        areaId: 'A1',
+        currentRound: 1,
+        clubsMissingCurrentRoundVisit: [
+          { clubNumber: '900', clubName: 'Unvisited Club' },
+        ],
+      }),
+    ],
+  } as DivisionPerformance,
+  {
+    divisionId: 'B',
+    areas: [makeArea({ areaId: 'B2', clubsMissingCurrentRoundVisit: [] })],
+  } as DivisionPerformance,
+]
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: vi.fn(() => ({
+    data: { districts: [{ id: '61', name: 'District 61' }] },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+const analyticsData = {
+  allClubs: [closeClub, interventionClub],
+  interventionRequiredClubs: [interventionClub],
+}
+
+vi.mock('../../hooks/useDistrictAnalytics', () => ({
+  useDistrictAnalytics: vi.fn(() => ({
+    data: analyticsData,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    data: {
+      dates: ['2025-07-15', '2025-07-01'],
+      dateRange: { startDate: '2025-07-01', endDate: '2025-07-15' },
+    },
+    isLoading: false,
+  })),
+}))
+
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({
+    data: { asOfDate: '2025-07-15' },
+    isLoading: false,
+  })),
+}))
+
+vi.mock('../../utils/extractDivisionPerformance', () => ({
+  extractDivisionPerformance: vi.fn(() => divisionPerf),
+}))
+
+const DistrictActionListPage = React.lazy(
+  () => import('../DistrictActionListPage')
+)
+
+const renderAt = (initialUrl: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const routes: RouteObject[] = [
+    {
+      path: '/district/:districtId/action-list',
+      element: (
+        <Suspense fallback={<div>Loading…</div>}>
+          <DistrictActionListPage />
+        </Suspense>
+      ),
+    },
+  ]
+  const router = createMemoryRouter(routes, { initialEntries: [initialUrl] })
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <DarkModeProvider>
+          <RouterProvider router={router} />
+        </DarkModeProvider>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+  return { ...utils, router }
+}
+
+describe('DistrictActionListPage (#1231)', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => cleanup())
+
+  it('renders the three action sections at /district/:id/action-list', async () => {
+    renderAt('/district/61/action-list')
+    expect(await screen.findByTestId('action-list-page')).toBeInTheDocument()
+    expect(screen.getByTestId('section-close')).toBeInTheDocument()
+    expect(screen.getByTestId('section-visits')).toBeInTheDocument()
+    expect(screen.getByTestId('section-intervention')).toBeInTheDocument()
+  })
+
+  it('shows the close-to-Distinguished club with its concrete gap, linking to the club page', async () => {
+    renderAt('/district/61/action-list')
+    const link = await screen.findByRole('link', { name: 'Rising Club' })
+    expect(link).toHaveAttribute('href', '/district/61/club/close-1')
+    // gap reused from the projection: members gap 2, goals gap 1
+    expect(
+      screen.getByText(/needs 2 members \+ 1 DCP goal/)
+    ).toBeInTheDocument()
+  })
+
+  it('lists the area missing club visits with round + deadline, linking to the area page', async () => {
+    renderAt('/district/61/action-list')
+    const link = await screen.findByRole('link', { name: 'Area A1' })
+    expect(link).toHaveAttribute('href', '/district/61/division/A/area/A1')
+    expect(
+      screen.getByText(/1 club unvisited · Round 1, due 2025-11-30/)
+    ).toBeInTheDocument()
+  })
+
+  it('lists intervention-required clubs linking to the club page', async () => {
+    renderAt('/district/61/action-list')
+    const link = await screen.findByRole('link', { name: 'Struggling Club' })
+    expect(link).toHaveAttribute('href', '/district/61/club/int-1')
+  })
+
+  it('URL-syncs scope: ?division=B drops the division-A items', async () => {
+    renderAt('/district/61/action-list?division=B')
+    await screen.findByTestId('action-list-page')
+    // Division A close club + visit gap are filtered out; B intervention stays.
+    expect(
+      screen.queryByRole('link', { name: 'Rising Club' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Area A1' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Struggling Club' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders empty states for every section when the scope matches nothing', async () => {
+    renderAt('/district/61/action-list?division=ZZ')
+    await screen.findByTestId('action-list-page')
+    expect(
+      screen.getByText(/No clubs are within reach of Distinguished/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Every area has completed the current round/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/No clubs are flagged intervention-required/)
+    ).toBeInTheDocument()
+  })
+
+  it('marks the Action List subnav item active and self-titles the document', async () => {
+    renderAt('/district/61/action-list')
+    await screen.findByTestId('action-list-page')
+    expect(
+      screen.getByRole('link', { name: 'Action List', current: 'page' })
+    ).toBeInTheDocument()
+    await waitFor(() =>
+      expect(document.title).toBe('District 61 Action List — Toast Stats')
+    )
+  })
+})

--- a/frontend/src/styles/components/action-list.css
+++ b/frontend/src/styles/components/action-list.css
@@ -1,0 +1,183 @@
+/* District Action List (#1231, epic #1228 Sprint 3) — the area-director
+   "what to do next" destination. Built entirely on theme-aware tokens
+   (--ink, --ink-3, --surface, --line) so dark mode remaps automatically with
+   no per-utility override needed (lesson 093/094 — text + background remap
+   together). Mirrors the .club-grid-page chrome from Sprint 2. */
+
+.action-list-page {
+  margin-top: 1rem;
+}
+
+.action-list-page__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.action-list-page__subtitle {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: var(--ink-3);
+  max-width: 60ch;
+}
+
+/* ── Controls: scope filter + export ───────────────────────────────────── */
+
+.action-list-page__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.75rem 1.25rem;
+  margin: 1rem 0 1.25rem;
+}
+
+.action-list-scope {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.action-list-scope__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.action-list-scope__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ink-3);
+}
+
+.action-list-scope__select {
+  /* appearance:none so the 44px min touch target is honoured in WebKit, which
+     ignores min-height on a native select with default chrome (lesson 111). */
+  appearance: none;
+  -webkit-appearance: none;
+  min-height: 44px;
+  padding: 0.4rem 2rem 0.4rem 0.65rem;
+  font-size: 0.875rem;
+  color: var(--ink);
+  background-color: var(--surface);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23888' d='M1 1l5 5 5-5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.65rem center;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md, 8px);
+}
+
+.action-list-scope__clear,
+.action-list-page__export {
+  min-height: 44px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ink);
+  background-color: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md, 8px);
+  cursor: pointer;
+}
+
+.action-list-page__export:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.action-list-scope__clear:hover:not(:disabled),
+.action-list-page__export:hover:not(:disabled) {
+  border-color: var(--ink-3);
+}
+
+/* ── Sections ──────────────────────────────────────────────────────────── */
+
+.action-list-sections {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.action-list-section {
+  padding: 1rem 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md, 8px);
+}
+
+.action-list-section__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.action-list-section__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.6rem;
+  height: 1.6rem;
+  padding: 0 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--ink);
+  background: var(--line);
+  border-radius: 999px;
+}
+
+.action-list-section__empty {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ink-3);
+}
+
+.action-list-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.action-list-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.75rem;
+  padding: 0.5rem 0;
+  border-top: 1px solid var(--line);
+}
+
+.action-list-item:first-child {
+  border-top: none;
+}
+
+.action-list-item__link {
+  font-weight: 600;
+  color: var(--link, #2563eb);
+  text-decoration: none;
+}
+
+.action-list-item__link:hover {
+  text-decoration: underline;
+}
+
+.action-list-item__meta {
+  font-size: 0.8125rem;
+  color: var(--ink-3);
+}
+
+@media (max-width: 480px) {
+  .action-list-page__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .action-list-page__export {
+    width: 100%;
+  }
+}

--- a/frontend/src/utils/__tests__/actionListData.test.ts
+++ b/frontend/src/utils/__tests__/actionListData.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { buildActionList } from '../actionListData'
+import {
+  buildActionList,
+  formatCloseGap,
+  formatVisitGap,
+} from '../actionListData'
 import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
 import type { AreaPerformance, DivisionPerformance } from '../divisionStatus'
 
@@ -266,5 +270,54 @@ describe('buildActionList', () => {
       expect(result.visitGaps).toEqual([])
       expect(result.interventionRequired).toEqual([])
     })
+  })
+})
+
+describe('formatCloseGap / formatVisitGap (shared list + CSV strings)', () => {
+  it('pluralizes the close-to-Distinguished gap', () => {
+    expect(
+      formatCloseGap({
+        clubId: 'c',
+        clubName: 'C',
+        divisionId: 'A',
+        areaId: 'A1',
+        membersNeeded: 2,
+        goalsNeeded: 1,
+      })
+    ).toBe('needs 2 members + 1 DCP goal')
+    expect(
+      formatCloseGap({
+        clubId: 'c',
+        clubName: 'C',
+        divisionId: 'A',
+        areaId: 'A1',
+        membersNeeded: 1,
+        goalsNeeded: 2,
+      })
+    ).toBe('needs 1 member + 2 DCP goals')
+  })
+
+  it('pluralizes the visit-gap summary', () => {
+    expect(
+      formatVisitGap({
+        divisionId: 'A',
+        areaId: 'A1',
+        currentRound: 1,
+        deadline: '2025-11-30',
+        missingClubs: [{ clubNumber: '1', clubName: 'X' }],
+      })
+    ).toBe('1 club unvisited · Round 1, due 2025-11-30')
+    expect(
+      formatVisitGap({
+        divisionId: 'A',
+        areaId: 'A1',
+        currentRound: 2,
+        deadline: '2026-05-31',
+        missingClubs: [
+          { clubNumber: '1', clubName: 'X' },
+          { clubNumber: '2', clubName: 'Y' },
+        ],
+      })
+    ).toBe('2 clubs unvisited · Round 2, due 2026-05-31')
   })
 })

--- a/frontend/src/utils/__tests__/actionListData.test.ts
+++ b/frontend/src/utils/__tests__/actionListData.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest'
+import { buildActionList } from '../actionListData'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import type { AreaPerformance, DivisionPerformance } from '../divisionStatus'
+
+/* Minimal ClubTrend factory — only the fields buildActionList +
+   calculateClubProjection read are meaningful; the rest are filled with inert
+   defaults so the strict ClubTrend type is satisfied. */
+function makeClub(overrides: Partial<ClubTrend> = {}): ClubTrend {
+  return {
+    clubId: 'c1',
+    clubName: 'Club One',
+    divisionId: 'A',
+    areaId: 'A1',
+    areaName: 'Area A1',
+    membershipTrend: [
+      { date: '2025-07-01', count: 18 },
+      { date: '2026-06-01', count: 18 },
+    ],
+    dcpGoalsTrend: [
+      { date: '2025-07-01', goalsAchieved: 0 },
+      { date: '2026-06-01', goalsAchieved: 4 },
+    ],
+    membershipBase: 18,
+    aprilRenewals: null,
+    cspSubmitted: true,
+    currentStatus: 'thriving',
+    distinguishedLevel: 'NotDistinguished',
+    ...overrides,
+  } as ClubTrend
+}
+
+/* A club that satisfies isCloseToDistinguished: NotDistinguished, members gap
+   = min(20-18, 3-0) = 2 (<=3), currentGoals 4 (>=3), CSP submitted. */
+const closeClub = makeClub({
+  clubId: 'close-1',
+  clubName: 'Close Club',
+  divisionId: 'A',
+  areaId: 'A1',
+})
+
+/* Not close: only 1 DCP goal. */
+const notCloseClub = makeClub({
+  clubId: 'far-1',
+  clubName: 'Far Club',
+  divisionId: 'B',
+  areaId: 'B2',
+  dcpGoalsTrend: [{ date: '2026-06-01', goalsAchieved: 1 }],
+})
+
+function makeArea(overrides: Partial<AreaPerformance>): AreaPerformance {
+  return {
+    areaId: 'A1',
+    currentRound: 1,
+    clubsMissingCurrentRoundVisit: [],
+    clubsMissingCurrentRoundVisitIneligible: [],
+    recognitionState: {
+      level: 'distinguished',
+      status: 'provisional',
+      pendingRounds: [{ round: 1, deadline: '2025-11-30' }],
+      failureReason: null,
+    },
+    ...overrides,
+  } as AreaPerformance
+}
+
+function makeDivision(
+  divisionId: string,
+  areas: AreaPerformance[]
+): DivisionPerformance {
+  return { divisionId, areas } as DivisionPerformance
+}
+
+const SNAPSHOT = '2025-10-15' // Round 1 window
+
+describe('buildActionList', () => {
+  describe('Close-to-Distinguished section', () => {
+    it('includes only clubs the predicate flags, with the concrete gap', () => {
+      const result = buildActionList({
+        clubs: [closeClub, notCloseClub],
+        interventionClubs: [],
+        divisions: [],
+        snapshotDate: SNAPSHOT,
+      })
+      expect(result.closeToDistinguished).toHaveLength(1)
+      const item = result.closeToDistinguished[0]!
+      expect(item.clubId).toBe('close-1')
+      expect(item.divisionId).toBe('A')
+      expect(item.areaId).toBe('A1')
+      // gap reused from calculateClubProjection, never re-derived (R3)
+      expect(item.membersNeeded).toBe(2)
+      expect(item.goalsNeeded).toBe(1)
+    })
+
+    it('is empty when no club qualifies', () => {
+      const result = buildActionList({
+        clubs: [notCloseClub],
+        interventionClubs: [],
+        divisions: [],
+        snapshotDate: SNAPSHOT,
+      })
+      expect(result.closeToDistinguished).toEqual([])
+    })
+  })
+
+  describe('Visit-gap section', () => {
+    it('lists areas with active clubs missing the current-round visit, with deadline', () => {
+      const gapArea = makeArea({
+        areaId: 'A1',
+        currentRound: 1,
+        clubsMissingCurrentRoundVisit: [
+          { clubNumber: '123', clubName: 'Unvisited Club' },
+        ],
+      })
+      const metArea = makeArea({
+        areaId: 'A2',
+        currentRound: 1,
+        clubsMissingCurrentRoundVisit: [],
+      })
+      const result = buildActionList({
+        clubs: [],
+        interventionClubs: [],
+        divisions: [makeDivision('A', [gapArea, metArea])],
+        snapshotDate: SNAPSHOT,
+      })
+      expect(result.visitGaps).toHaveLength(1)
+      const gap = result.visitGaps[0]!
+      expect(gap.divisionId).toBe('A')
+      expect(gap.areaId).toBe('A1')
+      expect(gap.currentRound).toBe(1)
+      // deadline reused from getAreaVisitDeadlines (R1 = Nov 30)
+      expect(gap.deadline).toBe('2025-11-30')
+      expect(gap.missingClubs.map(c => c.clubName)).toEqual(['Unvisited Club'])
+    })
+
+    it('uses the R2 deadline when the snapshot is in round 2', () => {
+      const gapArea = makeArea({
+        areaId: 'A1',
+        currentRound: 2,
+        clubsMissingCurrentRoundVisit: [{ clubNumber: '1', clubName: 'C' }],
+      })
+      const result = buildActionList({
+        clubs: [],
+        interventionClubs: [],
+        divisions: [makeDivision('A', [gapArea])],
+        snapshotDate: '2026-03-01',
+      })
+      expect(result.visitGaps[0]!.deadline).toBe('2026-05-31')
+    })
+
+    it('is empty when every area has met the current round', () => {
+      const result = buildActionList({
+        clubs: [],
+        interventionClubs: [],
+        divisions: [makeDivision('A', [makeArea({ areaId: 'A1' })])],
+        snapshotDate: SNAPSHOT,
+      })
+      expect(result.visitGaps).toEqual([])
+    })
+  })
+
+  describe('Intervention-required section', () => {
+    it('lists intervention-required clubs only', () => {
+      const intervention = makeClub({
+        clubId: 'int-1',
+        clubName: 'Intervention Club',
+        divisionId: 'C',
+        areaId: 'C3',
+        currentStatus: 'intervention-required',
+      })
+      const vulnerable = makeClub({
+        clubId: 'vuln-1',
+        currentStatus: 'vulnerable',
+      })
+      const result = buildActionList({
+        clubs: [],
+        interventionClubs: [intervention, vulnerable],
+        divisions: [],
+        snapshotDate: SNAPSHOT,
+      })
+      expect(result.interventionRequired).toHaveLength(1)
+      expect(result.interventionRequired[0]!.clubId).toBe('int-1')
+      expect(result.interventionRequired[0]!.areaId).toBe('C3')
+    })
+
+    it('is empty when there are no intervention clubs', () => {
+      const result = buildActionList({
+        clubs: [],
+        interventionClubs: [],
+        divisions: [],
+        snapshotDate: SNAPSHOT,
+      })
+      expect(result.interventionRequired).toEqual([])
+    })
+  })
+
+  describe('scope filtering (page-owned, passed as arg — R3)', () => {
+    const intervention = makeClub({
+      clubId: 'int-A1',
+      divisionId: 'A',
+      areaId: 'A1',
+      currentStatus: 'intervention-required',
+    })
+    const interventionB = makeClub({
+      clubId: 'int-B2',
+      divisionId: 'B',
+      areaId: 'B2',
+      currentStatus: 'intervention-required',
+    })
+    const divisions = [
+      makeDivision('A', [
+        makeArea({
+          areaId: 'A1',
+          clubsMissingCurrentRoundVisit: [{ clubNumber: '1', clubName: 'X' }],
+        }),
+      ]),
+      makeDivision('B', [
+        makeArea({
+          areaId: 'B2',
+          clubsMissingCurrentRoundVisit: [{ clubNumber: '2', clubName: 'Y' }],
+        }),
+      ]),
+    ]
+
+    it('filters every section to a division', () => {
+      const result = buildActionList(
+        {
+          clubs: [closeClub],
+          interventionClubs: [intervention, interventionB],
+          divisions,
+          snapshotDate: SNAPSHOT,
+        },
+        { division: 'A' }
+      )
+      expect(result.closeToDistinguished.map(c => c.divisionId)).toEqual(['A'])
+      expect(result.visitGaps.map(g => g.divisionId)).toEqual(['A'])
+      expect(result.interventionRequired.map(c => c.divisionId)).toEqual(['A'])
+    })
+
+    it('filters every section to an area', () => {
+      const result = buildActionList(
+        {
+          clubs: [closeClub],
+          interventionClubs: [intervention, interventionB],
+          divisions,
+          snapshotDate: SNAPSHOT,
+        },
+        { area: 'B2' }
+      )
+      expect(result.closeToDistinguished).toEqual([])
+      expect(result.visitGaps.map(g => g.areaId)).toEqual(['B2'])
+      expect(result.interventionRequired.map(c => c.areaId)).toEqual(['B2'])
+    })
+
+    it('an out-of-range scope yields empty sections, never throws (URL-seedable, L144)', () => {
+      const result = buildActionList(
+        {
+          clubs: [closeClub],
+          interventionClubs: [intervention],
+          divisions,
+          snapshotDate: SNAPSHOT,
+        },
+        { division: 'ZZ' }
+      )
+      expect(result.closeToDistinguished).toEqual([])
+      expect(result.visitGaps).toEqual([])
+      expect(result.interventionRequired).toEqual([])
+    })
+  })
+})

--- a/frontend/src/utils/actionListData.ts
+++ b/frontend/src/utils/actionListData.ts
@@ -95,23 +95,20 @@ export function buildActionList(
 
   const closeToDistinguished: CloseToDistinguishedItem[] = clubs
     .filter(club => inScope(club.divisionId, club.areaId, scope))
-    .filter(club =>
-      isCloseToDistinguished({
-        projection: calculateClubProjection(club),
-        cspSubmitted: club.cspSubmitted,
-      })
+    // Project once per club, then filter+map off that single projection — the
+    // projection is the most expensive call in this file (four gap passes).
+    .map(club => ({ club, projection: calculateClubProjection(club) }))
+    .filter(({ club, projection }) =>
+      isCloseToDistinguished({ projection, cspSubmitted: club.cspSubmitted })
     )
-    .map(club => {
-      const { gapToDistinguished } = calculateClubProjection(club)
-      return {
-        clubId: club.clubId,
-        clubName: club.clubName,
-        divisionId: club.divisionId,
-        areaId: club.areaId,
-        membersNeeded: gapToDistinguished.members,
-        goalsNeeded: gapToDistinguished.goals,
-      }
-    })
+    .map(({ club, projection }) => ({
+      clubId: club.clubId,
+      clubName: club.clubName,
+      divisionId: club.divisionId,
+      areaId: club.areaId,
+      membersNeeded: projection.gapToDistinguished.members,
+      goalsNeeded: projection.gapToDistinguished.goals,
+    }))
 
   const { r1, r2 } = getAreaVisitDeadlines(snapshotDate)
   const visitGaps: VisitGapArea[] = divisions.flatMap(division =>
@@ -138,4 +135,25 @@ export function buildActionList(
     }))
 
   return { closeToDistinguished, visitGaps, interventionRequired }
+}
+
+function plural(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? '' : 's'}`
+}
+
+/** "needs 2 members + 1 DCP goal" — shared by the list row and the CSV export
+ *  so the pluralization rule lives in one place. */
+export function formatCloseGap(item: CloseToDistinguishedItem): string {
+  return `needs ${plural(item.membersNeeded, 'member')} + ${plural(
+    item.goalsNeeded,
+    'DCP goal'
+  )}`
+}
+
+/** "1 club unvisited · Round 1, due 2025-11-30" — shared by the list row and
+ *  the CSV export. */
+export function formatVisitGap(gap: VisitGapArea): string {
+  return `${plural(gap.missingClubs.length, 'club')} unvisited · Round ${
+    gap.currentRound
+  }, due ${gap.deadline}`
 }

--- a/frontend/src/utils/actionListData.ts
+++ b/frontend/src/utils/actionListData.ts
@@ -1,0 +1,141 @@
+/**
+ * Area Director Action List — pure data derivation (epic #1228, Sprint 3 / #1231).
+ *
+ * Reuse-only: every section is computed from EXISTING predicates and the
+ * already-derived division/area performance. No new analytics rule lives here.
+ *
+ *   1. Close-to-Distinguished — `isCloseToDistinguished` over
+ *      `calculateClubProjection`; the gap is read straight off the projection,
+ *      never re-derived (R3 / Lesson 052).
+ *   2. Visit gaps — areas with active clubs missing the CURRENT round's
+ *      qualifying visit, reusing `AreaPerformance.clubsMissingCurrentRoundVisit`
+ *      + `currentRound` (the deadline-aware logic the divisions page already
+ *      uses, #973/#832) and `getAreaVisitDeadlines` for the round deadline.
+ *   3. Intervention-required — clubs whose health classification
+ *      (`currentStatus`) is `'intervention-required'`.
+ *
+ * Scope (`division`/`area`) is owned by the page and passed in as an argument
+ * (R3 / Lesson 124); an out-of-range scope simply yields empty sections rather
+ * than throwing, so a hand-edited/shared URL is always safe (Lesson 144).
+ */
+
+import { calculateClubProjection } from './dcpProjections'
+import { isCloseToDistinguished } from './closeToDistinguished'
+import { getAreaVisitDeadlines } from './areaRecognitionState'
+import type { ClubTrend } from '../hooks/useDistrictAnalytics'
+import type { DivisionPerformance, MissingVisitClub } from './divisionStatus'
+
+export interface ActionListScope {
+  /** Restrict to a single division id (e.g. `'A'`). Absent = all divisions. */
+  division?: string
+  /** Restrict to a single area id (e.g. `'A1'`). Absent = all areas. */
+  area?: string
+}
+
+export interface CloseToDistinguishedItem {
+  clubId: string
+  clubName: string
+  divisionId: string
+  areaId: string
+  /** Members still needed for Distinguished (from `gapToDistinguished`). */
+  membersNeeded: number
+  /** DCP goals still needed for Distinguished (from `gapToDistinguished`). */
+  goalsNeeded: number
+}
+
+export interface VisitGapArea {
+  divisionId: string
+  areaId: string
+  currentRound: 1 | 2
+  /** ISO `YYYY-MM-DD` deadline for the current round (Nov 30 / May 31). */
+  deadline: string
+  /** Active clubs in the area missing the current round's visit. */
+  missingClubs: MissingVisitClub[]
+}
+
+export interface InterventionItem {
+  clubId: string
+  clubName: string
+  divisionId: string
+  areaId: string
+}
+
+export interface ActionListSections {
+  closeToDistinguished: CloseToDistinguishedItem[]
+  visitGaps: VisitGapArea[]
+  interventionRequired: InterventionItem[]
+}
+
+export interface ActionListInput {
+  /** All clubs in the district (source for the Close-to-Distinguished scan). */
+  clubs: ClubTrend[]
+  /** Clubs already classified intervention-required by the analytics hook. */
+  interventionClubs: ClubTrend[]
+  /** Per-division performance, already carrying deadline-aware area state. */
+  divisions: DivisionPerformance[]
+  /** Snapshot/as-of date (`YYYY-MM-DD`) for the visit-round deadline. */
+  snapshotDate: string
+}
+
+function inScope(
+  divisionId: string,
+  areaId: string,
+  scope: ActionListScope
+): boolean {
+  if (scope.division && divisionId !== scope.division) return false
+  if (scope.area && areaId !== scope.area) return false
+  return true
+}
+
+export function buildActionList(
+  input: ActionListInput,
+  scope: ActionListScope = {}
+): ActionListSections {
+  const { clubs, interventionClubs, divisions, snapshotDate } = input
+
+  const closeToDistinguished: CloseToDistinguishedItem[] = clubs
+    .filter(club => inScope(club.divisionId, club.areaId, scope))
+    .filter(club =>
+      isCloseToDistinguished({
+        projection: calculateClubProjection(club),
+        cspSubmitted: club.cspSubmitted,
+      })
+    )
+    .map(club => {
+      const { gapToDistinguished } = calculateClubProjection(club)
+      return {
+        clubId: club.clubId,
+        clubName: club.clubName,
+        divisionId: club.divisionId,
+        areaId: club.areaId,
+        membersNeeded: gapToDistinguished.members,
+        goalsNeeded: gapToDistinguished.goals,
+      }
+    })
+
+  const { r1, r2 } = getAreaVisitDeadlines(snapshotDate)
+  const visitGaps: VisitGapArea[] = divisions.flatMap(division =>
+    division.areas
+      .filter(area => inScope(division.divisionId, area.areaId, scope))
+      .filter(area => area.clubsMissingCurrentRoundVisit.length > 0)
+      .map(area => ({
+        divisionId: division.divisionId,
+        areaId: area.areaId,
+        currentRound: area.currentRound,
+        deadline: area.currentRound === 1 ? r1 : r2,
+        missingClubs: area.clubsMissingCurrentRoundVisit,
+      }))
+  )
+
+  const interventionRequired: InterventionItem[] = interventionClubs
+    .filter(club => club.currentStatus === 'intervention-required')
+    .filter(club => inScope(club.divisionId, club.areaId, scope))
+    .map(club => ({
+      clubId: club.clubId,
+      clubName: club.clubName,
+      divisionId: club.divisionId,
+      areaId: club.areaId,
+    }))
+
+  return { closeToDistinguished, visitGaps, interventionRequired }
+}

--- a/frontend/src/utils/actionListData.ts
+++ b/frontend/src/utils/actionListData.ts
@@ -27,9 +27,9 @@ import type { DivisionPerformance, MissingVisitClub } from './divisionStatus'
 
 export interface ActionListScope {
   /** Restrict to a single division id (e.g. `'A'`). Absent = all divisions. */
-  division?: string
+  division?: string | undefined
   /** Restrict to a single area id (e.g. `'A1'`). Absent = all areas. */
-  area?: string
+  area?: string | undefined
 }
 
 export interface CloseToDistinguishedItem {

--- a/tasks/sprint-1231-plan.md
+++ b/tasks/sprint-1231-plan.md
@@ -1,0 +1,25 @@
+# Sprint 3 / #1231 — Area Director Action List
+
+Route `/district/:districtId/action-list`. Reuse-only (no new analytics).
+
+## Data sources (all existing)
+
+- **Close-to-Distinguished**: `useDistrictAnalytics().allClubs` → `calculateClubProjection(club)` → `isCloseToDistinguished({projection, cspSubmitted})`. Gap = `projection.gapToDistinguished.{members,goals}`.
+- **Visit gaps**: `useDistrictStatistics(id,date,'divisions')` → `extractDivisionPerformance(stats, stats.asOfDate)` → `DivisionPerformance[]`. Per `AreaPerformance`: `currentRound`, `recognitionState`, `clubsMissingCurrentRoundVisit` (deadline-aware, already derived). Area is a gap when `clubsMissingCurrentRoundVisit.length > 0`.
+- **Intervention-required**: `useDistrictAnalytics().interventionRequiredClubs` (ClubTrend, `currentStatus==='intervention-required'`).
+
+## Modules
+
+1. `utils/actionListData.ts` — pure `buildActionList(input, scope)` → 3 section arrays. Unit-tested (no page mount). Scope `{division?, area?}` filters by `divisionId`/`areaId`. (R3: page owns scope, passes as arg.)
+2. `config/districtSections.ts` — add `{ label: 'Action List', segment: 'action-list' }` (end). Update `DistrictSubnav.test` pinned list; `errorRecovery.test` derives automatically.
+3. `pages/DistrictActionListPage.tsx` — hooks → util → presentational sections. URL-synced scope via `useUrlState('division'/'area')` (page-owned, L124/L144). CSV export via `csvExport`. Dark-mode + responsive (reuse subpage chrome).
+4. `App.tsx` — lazy route.
+5. Tests: util unit test (membership + empty states); page test in `pages/__tests__/` (URL scope sync, sections render, links resolve to canonical club/area pages, empty states).
+
+## Acceptance crit mapping
+
+- Route renders 3 sections from existing predicates ✓ (modules 1,3)
+- Concrete gap reused, never re-derived (R3) ✓ — `gapToDistinguished` straight from projection
+- Visit-gap reuses deadline-aware `recognitionState`/`currentRound` (no forked rule) ✓
+- Tests cover membership + empty states; links resolve ✓
+- Verified on PR preview (Playwright, both engines) ✓


### PR DESCRIPTION
## Summary

Sprint 3 of epic #1228 (#1231) — the **Area Director Action List**, the epic's closing sprint. A deep-linkable district subpage at `/district/:districtId/action-list` that turns existing predicates into a shareable, action-oriented to-do list (the RAFFETY "Almost Distinguished" / "Area To-Do" niche), filterable to a division/area.

**Reuse-only — no new analytics (R7).** Three sections, all derived from already-computed data via a pure `buildActionList`:

1. **Clubs close to Distinguished** — `isCloseToDistinguished` over `calculateClubProjection`; the concrete gap ("needs 2 members + 1 DCP goal") is read straight off `gapToDistinguished`, never re-derived (R3).
2. **Areas missing club visits** — the deadline-aware `AreaPerformance.clubsMissingCurrentRoundVisit` + `currentRound` (the same logic the divisions page uses, #973/#832); round deadline from `getAreaVisitDeadlines`. Sourced this way (not `recognitionState.pendingRounds`, which is empty on confirmed/failed areas) so areas with unvisited clubs still surface.
3. **Clubs needing intervention** — club-health `currentStatus`.

Each item links to its canonical club/area page. URL-synced `?division=`/`?area=` scope is **page-owned** and passed to the pure util (R3/L124); an out-of-range/hand-edited scope yields empty sections rather than throwing (L144). CSV export, dark-mode + responsive via theme tokens, `appearance:none` 44px selects (L111).

## Changes
- `utils/actionListData.ts` — pure `buildActionList(input, scope)` + shared `formatCloseGap`/`formatVisitGap` (one pluralization rule for list rows + CSV).
- `pages/DistrictActionListPage.tsx` — the page (hooks → util → sections), local `ActionListSection` wrapper.
- `styles/components/action-list.css` (wired into `index.css`, L142), `App.tsx` route, `config/districtSections.ts` subnav entry (last position).

## Testing
- `actionListData.test.ts` — 12 unit tests (membership, empty states, out-of-range scope, formatter plural branches).
- `DistrictActionListPage.test.tsx` — 7 page tests (sections render, real-href links, URL scope filtering, per-section empties, subnav-active + document title).
- Full unit suite green locally: **2794 passed**. `/simplify` + fresh-context `/review` (APPROVE-WITH-NITS) run pre-push.

Refs #1231. Live verification on the PR preview channel to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)