### PR TITLE
ops: move daily pipeline trigger off GitHub cron to local launchd (#1242)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -17,9 +17,16 @@
 name: Data Pipeline
 
 on:
-  schedule:
-    # Primary daily run at 08:00 UTC (4 AM EST / 5 AM EDT).
-    - cron: '0 8 * * *'
+  # The daily run is intentionally NOT scheduled here. GitHub's cron fires
+  # late or drops events under load, which is unacceptable for the freshness-
+  # critical daily pipeline (#1242). It is triggered on time by an external
+  # launchd job on the operator Mac at 05:00 America/Toronto (DST-aware):
+  #   gh workflow run data-pipeline.yml --ref main -f mode=daily
+  # Runbook: docs/runbooks/local-daily-pipeline-trigger.md
+  #
+  # The quarterly-prune cron remains operator-gated (#1148) and is not wired
+  # as a trigger yet; when flipped on it is matched by its exact expression in
+  # the Determine-mode step below.
   workflow_dispatch:
     inputs:
       mode:

--- a/docs/runbooks/local-daily-pipeline-trigger.md
+++ b/docs/runbooks/local-daily-pipeline-trigger.md
@@ -1,0 +1,83 @@
+# Runbook — Local daily-pipeline trigger (launchd)
+
+**Issue:** #1242 · **Added:** 2026-06-23
+
+## Why
+
+GitHub Actions `schedule:` triggers fire late or get dropped under load. The
+daily data pipeline's entire value is on-time freshness, so its cron was removed
+from `.github/workflows/data-pipeline.yml`. The daily run is now triggered
+**deterministically by a launchd job on the operator Mac** at **05:00
+America/Toronto**.
+
+- The pipeline workflow is unchanged except for the removed `schedule:` block —
+  it still runs on GitHub's runners. We only moved the *trigger*.
+- `workflow_dispatch` (mode defaults to `daily`) is the entry point.
+- The quarterly-prune cron stays operator-gated (#1148) and is unaffected.
+
+## Components
+
+| Piece | Repo (canonical) | Installed (live) |
+| --- | --- | --- |
+| Trigger script | `scripts/trigger-daily-pipeline.sh` | `~/Library/Application Support/toast-stats/trigger-daily-pipeline.sh` |
+| launchd job | `scripts/launchd/red.taverns.toast-stats.daily-pipeline.plist` | `~/Library/LaunchAgents/red.taverns.toast-stats.daily-pipeline.plist` |
+| Logs | — | `~/Library/Logs/toast-stats/daily-pipeline-trigger.log` (+ `launchd.{out,err}.log`) |
+
+The live script is a **stable copy** outside the repo working tree so it does not
+depend on which branch is checked out. After changing the repo script, re-copy it
+(see Update below).
+
+## Install
+
+```bash
+# 1. Stable copy of the trigger script
+mkdir -p "$HOME/Library/Application Support/toast-stats" "$HOME/Library/Logs/toast-stats"
+cp scripts/trigger-daily-pipeline.sh "$HOME/Library/Application Support/toast-stats/trigger-daily-pipeline.sh"
+chmod +x "$HOME/Library/Application Support/toast-stats/trigger-daily-pipeline.sh"
+
+# 2. Install + load the launchd job
+cp scripts/launchd/red.taverns.toast-stats.daily-pipeline.plist "$HOME/Library/LaunchAgents/"
+launchctl bootout  "gui/$(id -u)/red.taverns.toast-stats.daily-pipeline" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/red.taverns.toast-stats.daily-pipeline.plist"
+
+# 3. Verify it is loaded and scheduled
+launchctl print "gui/$(id -u)/red.taverns.toast-stats.daily-pipeline" | grep -E "state|runs|next"
+```
+
+## Test (fires a real, idempotent run)
+
+```bash
+# Run the trigger now. The daily flow is idempotent (re-scrapes today's date),
+# uploads to STAGING (promotion to prod is separately gated), so a test run is safe.
+bash "$HOME/Library/Application Support/toast-stats/trigger-daily-pipeline.sh"
+tail -n 20 "$HOME/Library/Logs/toast-stats/daily-pipeline-trigger.log"
+gh run list --workflow data-pipeline.yml --limit 3
+```
+
+## Update (after editing the repo script)
+
+```bash
+cp scripts/trigger-daily-pipeline.sh "$HOME/Library/Application Support/toast-stats/trigger-daily-pipeline.sh"
+# No launchctl reload needed unless the plist itself changed.
+```
+
+## Uninstall / revert
+
+```bash
+launchctl bootout "gui/$(id -u)/red.taverns.toast-stats.daily-pipeline"
+rm "$HOME/Library/LaunchAgents/red.taverns.toast-stats.daily-pipeline.plist"
+# To restore GitHub scheduling, re-add the `schedule: - cron: '0 8 * * *'`
+# block to .github/workflows/data-pipeline.yml on main.
+```
+
+## Caveats & safety net
+
+- **Mac must be awake (or wake) at 05:00.** launchd does not power on a sleeping
+  Mac; it runs a *missed* `StartCalendarInterval` job once on next wake. To
+  guarantee on-time runs, schedule a wake:
+  `sudo pmset repeat wakeorpoweron MTWRFSU 04:58:00`
+- **Independent freshness alarm.** `pipeline-freshness-monitor.yml` still runs on
+  GitHub and alerts if the published data goes stale — the backstop if the local
+  trigger silently fails (Mac off, `gh` token expired, network down).
+- **Token scope.** The trigger needs `gh` authenticated with the `workflow`
+  scope. Check with `gh auth status`.

--- a/scripts/launchd/red.taverns.toast-stats.daily-pipeline.plist
+++ b/scripts/launchd/red.taverns.toast-stats.daily-pipeline.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Local launchd trigger for the Toast Stats daily data pipeline (#1242).
+
+  Fires at 05:00 America/Toronto. launchd's StartCalendarInterval uses the Mac's
+  LOCAL wall-clock, so this automatically tracks EST/EDT — no UTC drift like the
+  old GitHub cron.
+
+  This is a TEMPLATE. The installed copy lives at:
+    ~/Library/LaunchAgents/red.taverns.toast-stats.daily-pipeline.plist
+  and points at the operator-stable script copy (see runbook). Replace the home
+  path below if the operator account differs.
+
+  Install / reload:
+    launchctl bootout  gui/$(id -u)/red.taverns.toast-stats.daily-pipeline 2>/dev/null || true
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/red.taverns.toast-stats.daily-pipeline.plist
+  Verify:
+    launchctl print gui/$(id -u)/red.taverns.toast-stats.daily-pipeline
+-->
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>red.taverns.toast-stats.daily-pipeline</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>/Users/rservant/Library/Application Support/toast-stats/trigger-daily-pipeline.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+      <key>Hour</key>
+      <integer>5</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+
+    <!-- Do not fire on load/login; only on the calendar schedule. -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- If the Mac was asleep at 05:00, launchd runs the missed job once on wake. -->
+    <key>StandardOutPath</key>
+    <string>/Users/rservant/Library/Logs/toast-stats/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/rservant/Library/Logs/toast-stats/launchd.err.log</string>
+  </dict>
+</plist>

--- a/scripts/trigger-daily-pipeline.sh
+++ b/scripts/trigger-daily-pipeline.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Triggers the Toast Stats daily data pipeline on GitHub via workflow_dispatch.
+#
+# WHY THIS EXISTS (#1242): GitHub Actions `schedule:` triggers fire late or get
+# dropped under load. The daily pipeline's value is on-time data freshness, so
+# its cron was removed from .github/workflows/data-pipeline.yml and replaced by
+# this script, invoked deterministically by a local launchd job at
+# 05:00 America/Toronto (DST-aware via the Mac's local wall clock).
+#
+# launchd runs with a minimal environment and PATH, so everything is absolute.
+# This is a LaunchAgent (runs as the logged-in user) so `gh` reads its token
+# from the login keychain without prompting.
+#
+set -euo pipefail
+
+REPO="taverns-red/toast-stats"
+WORKFLOW="data-pipeline.yml"
+REF="main"            # scheduled/dispatched workflows resolve from the default branch
+GH="/opt/homebrew/bin/gh"
+
+LOG_DIR="${HOME}/Library/Logs/toast-stats"
+mkdir -p "${LOG_DIR}"
+LOG="${LOG_DIR}/daily-pipeline-trigger.log"
+
+ts() { date "+%Y-%m-%dT%H:%M:%S%z"; }
+log() { echo "[$(ts)] $*" | tee -a "${LOG}"; }
+
+fail() {
+  log "ERROR: $*"
+  /usr/bin/osascript -e "display notification \"Daily pipeline trigger FAILED: $* (see ${LOG})\" with title \"Toast Stats\"" 2>/dev/null || true
+  exit 1
+}
+
+[ -x "${GH}" ] || fail "gh not found/executable at ${GH}"
+
+log "Triggering ${WORKFLOW} (mode=daily) on ${REPO}@${REF}"
+if "${GH}" workflow run "${WORKFLOW}" --repo "${REPO}" --ref "${REF}" -f mode=daily >>"${LOG}" 2>&1; then
+  log "Dispatch accepted."
+else
+  fail "gh workflow run exited non-zero"
+fi


### PR DESCRIPTION
## What
Removes the daily `schedule: 0 8 * * *` cron from `data-pipeline.yml` and moves the daily trigger to a local **launchd** job on the operator Mac that fires at **05:00 America/Toronto** (DST-aware) via `gh workflow run ... -f mode=daily`.

GitHub Actions scheduled triggers fire late / drop events under load — unacceptable for the freshness-critical daily pipeline. The pipeline itself still runs on GitHub's runners; only the *trigger* moved.

## Scope
- `workflow_dispatch` and the operator-gated quarterly-prune mode logic (#1148) are **unchanged**.
- Determine-mode still defaults a dispatch to `daily`; nothing else in the pipeline changes.

## Files
- `scripts/trigger-daily-pipeline.sh` — absolute-`gh` dispatch + logging + failure notification.
- `scripts/launchd/red.taverns.toast-stats.daily-pipeline.plist` — `StartCalendarInterval` 05:00 local.
- `docs/runbooks/local-daily-pipeline-trigger.md` — install/test/revert + Mac-asleep caveat + freshness-monitor backstop.

Refs #1242. `lint:yaml` passes; launchd job already installed + loaded on the operator Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)