### PR TITLE
feat(changes): add 'Club status changes' group — club operational-status transitions (#1247)

### DIFF
--- a/docs/runbooks/local-daily-pipeline-trigger.md
+++ b/docs/runbooks/local-daily-pipeline-trigger.md
@@ -11,17 +11,17 @@ from `.github/workflows/data-pipeline.yml`. The daily run is now triggered
 America/Toronto**.
 
 - The pipeline workflow is unchanged except for the removed `schedule:` block —
-  it still runs on GitHub's runners. We only moved the *trigger*.
+  it still runs on GitHub's runners. We only moved the _trigger_.
 - `workflow_dispatch` (mode defaults to `daily`) is the entry point.
 - The quarterly-prune cron stays operator-gated (#1148) and is unaffected.
 
 ## Components
 
-| Piece | Repo (canonical) | Installed (live) |
-| --- | --- | --- |
-| Trigger script | `scripts/trigger-daily-pipeline.sh` | `~/Library/Application Support/toast-stats/trigger-daily-pipeline.sh` |
-| launchd job | `scripts/launchd/red.taverns.toast-stats.daily-pipeline.plist` | `~/Library/LaunchAgents/red.taverns.toast-stats.daily-pipeline.plist` |
-| Logs | — | `~/Library/Logs/toast-stats/daily-pipeline-trigger.log` (+ `launchd.{out,err}.log`) |
+| Piece          | Repo (canonical)                                               | Installed (live)                                                                    |
+| -------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Trigger script | `scripts/trigger-daily-pipeline.sh`                            | `~/Library/Application Support/toast-stats/trigger-daily-pipeline.sh`               |
+| launchd job    | `scripts/launchd/red.taverns.toast-stats.daily-pipeline.plist` | `~/Library/LaunchAgents/red.taverns.toast-stats.daily-pipeline.plist`               |
+| Logs           | —                                                              | `~/Library/Logs/toast-stats/daily-pipeline-trigger.log` (+ `launchd.{out,err}.log`) |
 
 The live script is a **stable copy** outside the repo working tree so it does not
 depend on which branch is checked out. After changing the repo script, re-copy it
@@ -73,7 +73,7 @@ rm "$HOME/Library/LaunchAgents/red.taverns.toast-stats.daily-pipeline.plist"
 ## Caveats & safety net
 
 - **Mac must be awake (or wake) at 05:00.** launchd does not power on a sleeping
-  Mac; it runs a *missed* `StartCalendarInterval` job once on next wake. To
+  Mac; it runs a _missed_ `StartCalendarInterval` job once on next wake. To
   guarantee on-time runs, schedule a wake:
   `sudo pmset repeat wakeorpoweron MTWRFSU 04:58:00`
 - **Independent freshness alarm.** `pipeline-freshness-monitor.yml` still runs on

--- a/frontend/src/hooks/__tests__/useSnapshotDiff.test.tsx
+++ b/frontend/src/hooks/__tests__/useSnapshotDiff.test.tsx
@@ -172,6 +172,31 @@ describe('useSnapshotDiff', () => {
     })
   })
 
+  it('merges club operational-status transitions into the events list (#1247)', async () => {
+    // Club 001 flips Low → Active between the two snapshots — a club-status
+    // transition the analytics-core club diff never produces.
+    mockedFetch.mockImplementation((date: string) => {
+      const snap = wrapper(date, 20)
+      snap.data.clubs[0]!.clubStatus = date === '2026-05-26' ? 'Active' : 'Low'
+      return Promise.resolve(snap as unknown) as Promise<unknown>
+    })
+
+    const { result } = renderHook(
+      () => useSnapshotDiff('61', '2026-05-25', '2026-05-26'),
+      { wrapper: makeWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const statusEvent = result.current.data?.events.find(
+      e => e.category === 'club-status'
+    )
+    expect(statusEvent).toMatchObject({
+      clubId: '001',
+      clubName: 'Club 001',
+      label: 'Club 001 became Active (was Low)',
+    })
+  })
+
   it('is disabled (does not fetch) when from or to is missing', () => {
     renderHook(() => useSnapshotDiff('61', undefined, '2026-05-26'), {
       wrapper: makeWrapper(),

--- a/frontend/src/hooks/useSnapshotDiff.ts
+++ b/frontend/src/hooks/useSnapshotDiff.ts
@@ -6,6 +6,7 @@ import type {
   SnapshotDiff,
 } from '@toastmasters/shared-contracts'
 import { diffAreaDivisionStatus } from '../utils/diffAreaDivisionStatus'
+import { diffClubStatus } from '../utils/diffClubStatus'
 
 /**
  * Resolve the default "since the previous recorded date" pair from a district's
@@ -49,11 +50,16 @@ export function useSnapshotDiff(
         fetchCdnDistrictSnapshot<PerDistrictData>(to!, districtId!),
       ])
       // Club-scoped diff (analytics-core engine) + area/division recognition
-      // transitions (frontend source-of-truth, #1014). The page buckets events
-      // by category, so the two streams coexist in one flat `events` list.
+      // transitions and club operational-status transitions (both frontend
+      // source-of-truth, #1014/#1247). The page buckets events by category, so
+      // the streams coexist in one flat `events` list.
       const diff = diffSnapshots(fromSnap.data, toSnap.data)
       const areaDivision = diffAreaDivisionStatus(fromSnap.data, toSnap.data)
-      return { ...diff, events: [...diff.events, ...areaDivision] }
+      const clubStatus = diffClubStatus(fromSnap.data, toSnap.data)
+      return {
+        ...diff,
+        events: [...diff.events, ...areaDivision, ...clubStatus],
+      }
     },
     enabled: !!districtId && !!from && !!to,
     staleTime: 5 * 60 * 1000,

--- a/frontend/src/pages/DistrictChangesPage.tsx
+++ b/frontend/src/pages/DistrictChangesPage.tsx
@@ -37,10 +37,13 @@ function fmtDate(iso: string): string {
 
 /* Display order + headings for the grouped change list. Roster moves first
    (most material), then club / division / area recognition, then the per-club
-   metric churn. Division & area status changes (#1014) sit with the club
-   distinguished group as the "recognition" band. */
+   metric churn. Club operational-status changes (#1247) sit adjacent to the
+   club-added group (a reactivation reads next to "joined", not folded into it).
+   Division & area status changes (#1014) sit with the club distinguished group
+   as the "recognition" band. */
 const CATEGORY_GROUPS: { category: DiffEventCategory; heading: string }[] = [
   { category: 'club-added', heading: 'Clubs that joined' },
+  { category: 'club-status', heading: 'Club status changes' },
   { category: 'club-removed', heading: 'Clubs that left' },
   { category: 'distinguished', heading: 'Distinguished status changes' },
   { category: 'division-status', heading: 'Division status changes' },

--- a/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictChangesPage.test.tsx
@@ -146,6 +146,53 @@ describe('DistrictChangesPage', () => {
     )
   })
 
+  it('renders a Club status changes group adjacent to Clubs that joined, club name linked (#1247)', () => {
+    mockedDates.mockReturnValue({
+      data: { dates: ['2026-05-25', '2026-05-26'] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useDistrictCachedDates>)
+    mockedDiff.mockReturnValue({
+      data: diffFixture({
+        events: [
+          {
+            category: 'club-added',
+            clubId: '28680300',
+            clubName: 'iA Montreal Toastmasters',
+            label: 'iA Montreal Toastmasters (Active) joined the roster',
+            magnitude: 1,
+          },
+          {
+            category: 'club-status',
+            clubId: '00001234',
+            clubName: 'Health Canada Club',
+            label: 'Health Canada Club became Active (was Low)',
+            magnitude: 1,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useSnapshotDiff>)
+
+    const { container } = renderPage()
+    expect(screen.getByText(/Club status changes/)).toBeInTheDocument()
+    // The club name links to its scoped route (ChangeLabel, #1013).
+    expect(
+      screen.getByRole('link', { name: 'Health Canada Club' })
+    ).toHaveAttribute('href', '/district/61/club/00001234')
+    expect(screen.getByText(/became Active \(was Low\)/)).toBeInTheDocument()
+
+    // Adjacency (operator decision): the Club-status group renders immediately
+    // after the Clubs-that-joined group, not folded into it.
+    const headings = Array.from(
+      container.querySelectorAll('details summary')
+    ).map(s => s.textContent ?? '')
+    const joined = headings.findIndex(h => /Clubs that joined/.test(h))
+    const status = headings.findIndex(h => /Club status changes/.test(h))
+    expect(joined).toBeGreaterThanOrEqual(0)
+    expect(status).toBe(joined + 1)
+  })
+
   it('renders the date-pair picker when at least two snapshots exist (#794)', () => {
     mockedDates.mockReturnValue({
       data: { dates: ['2026-05-25', '2026-05-26'] },

--- a/frontend/src/utils/__tests__/diffClubStatus.test.ts
+++ b/frontend/src/utils/__tests__/diffClubStatus.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import { diffClubStatus } from '../diffClubStatus'
+import type {
+  DistrictStatisticsFile,
+  ClubStatisticsFile,
+} from '@toastmasters/shared-contracts'
+
+/* Pure diff helper for club OPERATIONAL-status transitions (#1247). It compares
+   the `clubStatus` (Active/Low/Suspended/Ineligible) already present on both
+   dated snapshots and emits a `club-status` DiffEvent for every club whose
+   status changed, in either direction. Computed in the frontend, mirroring
+   `diffAreaDivisionStatus` (#1014, Lesson 117) — recognition/status diffs are
+   frontend source-of-truth. No page mount (R22). */
+
+/** Minimal club row carrying just the fields the status diff reads. */
+function club(o: {
+  clubId: string
+  clubName: string
+  clubStatus?: string
+  status?: string
+}): ClubStatisticsFile {
+  return {
+    clubId: o.clubId,
+    clubName: o.clubName,
+    clubStatus: o.clubStatus,
+    status: o.status ?? '',
+  } as unknown as ClubStatisticsFile
+}
+
+function snapshot(
+  snapshotDate: string,
+  clubs: ClubStatisticsFile[]
+): DistrictStatisticsFile {
+  return {
+    districtId: '61',
+    snapshotDate,
+    clubs,
+  } as unknown as DistrictStatisticsFile
+}
+
+const HEALTH = {
+  clubId: '00001234',
+  clubName: 'Health Canada Club',
+}
+
+/** Build a from→to pair where the single shared club flips status. */
+function pair(fromStatus: string, toStatus: string) {
+  return {
+    from: snapshot('2026-06-20', [club({ ...HEALTH, clubStatus: fromStatus })]),
+    to: snapshot('2026-06-27', [club({ ...HEALTH, clubStatus: toStatus })]),
+  }
+}
+
+describe('diffClubStatus (#1247)', () => {
+  it('emits a directional improvement label for Low → Active', () => {
+    const { from, to } = pair('Low', 'Active')
+    const events = diffClubStatus(from, to)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      category: 'club-status',
+      clubId: HEALTH.clubId,
+      clubName: HEALTH.clubName,
+      label: 'Health Canada Club became Active (was Low)',
+    })
+    // label begins with the club name so ChangeLabel auto-links it (#1013).
+    expect(events[0].label.startsWith(HEALTH.clubName)).toBe(true)
+    // improvement → positive magnitude.
+    expect(events[0].magnitude).toBeGreaterThan(0)
+  })
+
+  it('emits "became Active (was Suspended)" for Suspended → Active', () => {
+    const { from, to } = pair('Suspended', 'Active')
+    const events = diffClubStatus(from, to)
+    expect(events).toHaveLength(1)
+    expect(events[0].label).toBe(
+      'Health Canada Club became Active (was Suspended)'
+    )
+  })
+
+  it('emits a decline label for Active → Low', () => {
+    const { from, to } = pair('Active', 'Low')
+    const events = diffClubStatus(from, to)
+    expect(events).toHaveLength(1)
+    expect(events[0].label).toBe(
+      'Health Canada Club dropped to Low (was Active)'
+    )
+    expect(events[0].magnitude).toBeLessThan(0)
+  })
+
+  it('emits a suspension label for Active → Suspended', () => {
+    const { from, to } = pair('Active', 'Suspended')
+    const events = diffClubStatus(from, to)
+    expect(events[0].label).toBe(
+      'Health Canada Club was suspended (was Active)'
+    )
+  })
+
+  it('emits an ineligible label for Active → Ineligible', () => {
+    const { from, to } = pair('Active', 'Ineligible')
+    const events = diffClubStatus(from, to)
+    expect(events[0].label).toBe(
+      'Health Canada Club became Ineligible (was Active)'
+    )
+  })
+
+  it('emits a generic label for a move not involving Active', () => {
+    const { from, to } = pair('Low', 'Suspended')
+    const events = diffClubStatus(from, to)
+    expect(events[0].label).toBe(
+      'Health Canada Club changed status: Low → Suspended'
+    )
+  })
+
+  it('emits nothing when the status is unchanged', () => {
+    const { from, to } = pair('Active', 'Active')
+    expect(diffClubStatus(from, to)).toEqual([])
+  })
+
+  it('falls back to the legacy `status` field when `clubStatus` is absent', () => {
+    const from = snapshot('2026-06-20', [club({ ...HEALTH, status: 'Low' })])
+    const to = snapshot('2026-06-27', [club({ ...HEALTH, status: 'Active' })])
+    const events = diffClubStatus(from, to)
+    expect(events).toHaveLength(1)
+    expect(events[0].label).toBe('Health Canada Club became Active (was Low)')
+  })
+
+  it('emits nothing for a club present in only one snapshot (roster change, not status change)', () => {
+    const from = snapshot('2026-06-20', [
+      club({ clubId: 'a', clubName: 'Alpha', clubStatus: 'Active' }),
+    ])
+    const to = snapshot('2026-06-27', [
+      club({ clubId: 'a', clubName: 'Alpha', clubStatus: 'Active' }),
+      club({ clubId: 'b', clubName: 'Bravo', clubStatus: 'Active' }),
+    ])
+    expect(diffClubStatus(from, to)).toEqual([])
+  })
+
+  it('emits nothing when one side has an empty/missing status (covered by roster add/remove)', () => {
+    const from = snapshot('2026-06-20', [club({ ...HEALTH, clubStatus: '' })])
+    const to = snapshot('2026-06-27', [
+      club({ ...HEALTH, clubStatus: 'Active' }),
+    ])
+    expect(diffClubStatus(from, to)).toEqual([])
+  })
+
+  it('sorts the biggest status swing first', () => {
+    const from = snapshot('2026-06-20', [
+      club({ clubId: 'a', clubName: 'Alpha', clubStatus: 'Active' }), // → Low (small decline)
+      club({ clubId: 'b', clubName: 'Bravo', clubStatus: 'Ineligible' }), // → Active (big improvement)
+    ])
+    const to = snapshot('2026-06-27', [
+      club({ clubId: 'a', clubName: 'Alpha', clubStatus: 'Low' }),
+      club({ clubId: 'b', clubName: 'Bravo', clubStatus: 'Active' }),
+    ])
+    const events = diffClubStatus(from, to)
+    expect(events).toHaveLength(2)
+    expect(events[0].clubName).toBe('Bravo')
+  })
+})

--- a/frontend/src/utils/diffClubStatus.ts
+++ b/frontend/src/utils/diffClubStatus.ts
@@ -1,20 +1,115 @@
 /**
- * Club operational-status diff (#1247).
+ * Club operational-status diff (#1247, epic #1246 Sprint 1).
  *
- * Stub — RED phase. Returns no events so the spec fails on assertions (not on
- * compilation). The real derivation lands in the GREEN commit.
+ * Pure helper that derives `club-status` change events between two dated
+ * district snapshots — a club's operational status (`Active` / `Low` /
+ * `Suspended` / `Ineligible`) moving in EITHER direction. This is distinct from
+ * `distinguished`, which is a recognition *tier*, not operational health.
+ *
+ * Computed in the frontend, mirroring `diffAreaDivisionStatus` (#1014): #799
+ * made the frontend the source-of-truth for recognition/status diffs to avoid
+ * the analytics-core engine diverging from the rendered tables (Lesson 117).
+ * The `clubStatus` field is already present on both snapshots (the club
+ * added/removed roster labels read it), so this needs zero new data plumbing.
+ *
+ * NOTE — closing-overlay behaviour (intended, not a bug): this compares the
+ * BASE `clubStatus` recorded on each snapshot. The read-time club-status overlay
+ * (`clubStatusOverlay.ts`, which promotes-only-to-Active during the dues-renewal
+ * closing window) is NOT applied here. So a Low→Active flip that exists only in
+ * the daily Dues-Renewal overlay won't surface on the Changes feed until the
+ * official snapshot itself reports Active. That is deliberate: the Changes feed
+ * shows *confirmed* transitions, not provisional closing-window promotions.
+ *
+ * Each emitted `DiffEvent` carries `clubId` + `clubName` and a `label` that
+ * BEGINS with the club name, so `ChangeLabel` auto-links the leading token to
+ * the club's scoped route exactly as the other club events do (#1013).
  *
  * @module diffClubStatus
  */
 
 import type {
   DistrictStatisticsFile,
+  ClubStatisticsFile,
   DiffEvent,
 } from '@toastmasters/shared-contracts'
 
+/** Operational status, base field with the legacy `status` fallback the rest of
+ *  the diff uses (`diffSnapshots` reads `clubStatus ?? status` identically). */
+function statusOf(club: ClubStatisticsFile): string {
+  return club.clubStatus ?? club.status ?? ''
+}
+
+/** Health rank (higher = healthier) — drives the signed `magnitude` sort key. */
+function statusRank(status: string): number {
+  switch (status) {
+    case 'Active':
+      return 3
+    case 'Low':
+      return 2
+    case 'Suspended':
+      return 1
+    case 'Ineligible':
+      return 0
+    default:
+      return 0
+  }
+}
+
+/**
+ * Directional label, always beginning with the club name. Improvements to
+ * Active and declines from Active get bespoke prose; any other move (e.g.
+ * Low→Suspended) falls back to a neutral "changed status: <from> → <to>".
+ */
+function statusLabel(name: string, from: string, to: string): string {
+  if (to === 'Active') return `${name} became Active (was ${from})`
+  if (from === 'Active' && to === 'Low')
+    return `${name} dropped to Low (was Active)`
+  if (from === 'Active' && to === 'Suspended')
+    return `${name} was suspended (was Active)`
+  if (from === 'Active' && to === 'Ineligible')
+    return `${name} became Ineligible (was Active)`
+  return `${name} changed status: ${from} → ${to}`
+}
+
+/**
+ * Compute club operational-status transition events between two dated snapshots.
+ * Only clubs present in BOTH snapshots are diffed — a club in only one snapshot
+ * is a roster add/remove, already surfaced by `club-added`/`club-removed`. A
+ * transition is skipped when either side has an empty/missing status (the same
+ * roster-change case). Returns events sorted by descending magnitude of swing.
+ */
 export function diffClubStatus(
-  _from: DistrictStatisticsFile,
-  _to: DistrictStatisticsFile
+  from: DistrictStatisticsFile,
+  to: DistrictStatisticsFile
 ): DiffEvent[] {
-  return []
+  const fromClubs = new Map(from.clubs.map(c => [c.clubId, c]))
+  const events: DiffEvent[] = []
+
+  for (const toClub of to.clubs) {
+    const fromClub = fromClubs.get(toClub.clubId)
+    if (!fromClub) continue
+
+    const fromStatus = statusOf(fromClub)
+    const toStatus = statusOf(toClub)
+    // Empty on either side → a roster add/remove, not an operational change.
+    if (!fromStatus || !toStatus) continue
+    if (fromStatus === toStatus) continue
+
+    events.push({
+      category: 'club-status',
+      clubId: toClub.clubId,
+      clubName: toClub.clubName,
+      label: statusLabel(toClub.clubName, fromStatus, toStatus),
+      magnitude: statusRank(toStatus) - statusRank(fromStatus),
+    })
+  }
+
+  // Biggest absolute health swing first; stable tie-break by club name.
+  events.sort((a, b) => {
+    const byMag = Math.abs(b.magnitude) - Math.abs(a.magnitude)
+    if (byMag !== 0) return byMag
+    return a.clubName.localeCompare(b.clubName)
+  })
+
+  return events
 }

--- a/frontend/src/utils/diffClubStatus.ts
+++ b/frontend/src/utils/diffClubStatus.ts
@@ -62,12 +62,11 @@ function statusRank(status: string): number {
  */
 function statusLabel(name: string, from: string, to: string): string {
   if (to === 'Active') return `${name} became Active (was ${from})`
-  if (from === 'Active' && to === 'Low')
-    return `${name} dropped to Low (was Active)`
-  if (from === 'Active' && to === 'Suspended')
-    return `${name} was suspended (was Active)`
-  if (from === 'Active' && to === 'Ineligible')
-    return `${name} became Ineligible (was Active)`
+  if (from === 'Active') {
+    if (to === 'Low') return `${name} dropped to Low (was Active)`
+    if (to === 'Suspended') return `${name} was suspended (was Active)`
+    if (to === 'Ineligible') return `${name} became Ineligible (was Active)`
+  }
   return `${name} changed status: ${from} → ${to}`
 }
 

--- a/frontend/src/utils/diffClubStatus.ts
+++ b/frontend/src/utils/diffClubStatus.ts
@@ -1,0 +1,20 @@
+/**
+ * Club operational-status diff (#1247).
+ *
+ * Stub — RED phase. Returns no events so the spec fails on assertions (not on
+ * compilation). The real derivation lands in the GREEN commit.
+ *
+ * @module diffClubStatus
+ */
+
+import type {
+  DistrictStatisticsFile,
+  DiffEvent,
+} from '@toastmasters/shared-contracts'
+
+export function diffClubStatus(
+  _from: DistrictStatisticsFile,
+  _to: DistrictStatisticsFile
+): DiffEvent[] {
+  return []
+}

--- a/packages/shared-contracts/src/schemas/snapshot-diff.schema.ts
+++ b/packages/shared-contracts/src/schemas/snapshot-diff.schema.ts
@@ -33,6 +33,12 @@ export type AggregateDelta = z.infer<typeof AggregateDeltaSchema>
  * analytics-core engine (which deliberately dropped tier logic in #799 to avoid
  * divergence — Lesson 117). Such events set `areaId`/`divisionId` rather than a
  * `clubId`.
+ *
+ * `club-status` (#1247) carries club OPERATIONAL-status transitions
+ * (`Active`/`Low`/`Suspended`/`Ineligible`) — distinct from `distinguished`, a
+ * recognition tier. Like the area/division transitions it is derived in the
+ * frontend (`diffClubStatus`), comparing the `clubStatus` already present on
+ * both snapshots; it is club-scoped (sets `clubId`/`clubName`).
  */
 export const DiffEventCategorySchema = z.enum([
   'membership',
@@ -40,6 +46,7 @@ export const DiffEventCategorySchema = z.enum([
   'distinguished',
   'club-added',
   'club-removed',
+  'club-status',
   'area-status',
   'division-status',
 ])


### PR DESCRIPTION
## What & why

Closes the operator-reported gap (#1247, epic #1246): the Changes page (`/district/:id/changes`) showed that a club *gained a member* but **not** that the same club changed **operational status** (e.g. Health Canada Club went **Low → Active**). Club status transitions are exactly the district-health signal a director wants on this feed, and they were invisible.

## Approach (mirrors `diffAreaDivisionStatus`, #1014 / Lesson 117)

Recognition/status diffs are frontend source-of-truth (#799), so this is a new **frontend** util — no analytics-core change, zero new data plumbing (`clubStatus` is already on both snapshots).

1. **`frontend/src/utils/diffClubStatus.ts`** — iterates clubs present in **both** snapshots; emits a `category: 'club-status'` event when `(clubStatus ?? status)` differs. Directional labels beginning with the club name (so `ChangeLabel` auto-links, #1013):
   - improvement to Active: `… became Active (was Low/Suspended)`
   - decline from Active: `… dropped to Low / was suspended / became Ineligible (was Active)`
   - other moves: generic `… changed status: <from> → <to>`
   - **All transitions, both directions** (operator decision). Skips clubs in only one snapshot or with an empty status (already covered by club-added/removed).
2. **`useSnapshotDiff.ts`** — merges the new events alongside `areaDivision`.
3. **`snapshot-diff.schema.ts`** — `'club-status'` added to `DiffEventCategorySchema`; shared-contracts rebuilt (R16).
4. **`DistrictChangesPage.tsx`** — `{ category: 'club-status', heading: 'Club status changes' }` placed **immediately after** club-added (adjacent group, operator decision).

## Known behaviour (documented, not a bug)

The diff compares **base** `clubStatus`; the read-time closing-window overlay (`clubStatusOverlay.ts`, promote-only-to-Active) is **not** applied. A Low→Active flip that exists only in the daily overlay won't appear on Changes until the official snapshot reports Active — intended (Changes = confirmed transitions). Documented in a code comment.

## Tests (TDD, Red→Green per commit)

- `diffClubStatus.test.ts` — Low→Active, Active→Low, Active→Suspended, Suspended→Active, Active→Ineligible, generic, legacy `status` fallback, unchanged → none, single-snapshot → none, empty-status → none, sort-by-swing.
- `useSnapshotDiff.test.tsx` — merge point asserts a `club-status` event lands in `events`.
- `DistrictChangesPage.test.tsx` — group heading renders, club name links to `/district/:id/club/:clubId`, adjacency (status === joined + 1).
- Full frontend suite: **3560 passed, 0 regressions**. `/simplify` + fresh-context `/review` (APPROVE-WITH-NITS) passes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)