### PR TITLE
fix(ci): firebase deploys via FIREBASE_TOKEN (WIF external_account broken upstream) (#1250)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,10 @@ jobs:
           firebase deploy --only hosting:production --project ${{ secrets.GCP_PROJECT_ID }}
         env:
           VITE_APP_VERSION: v${{ steps.pkg.outputs.version }}
+          # TEMP (#1250): firebase-tools can't use our WIF external_account ADC since
+          # ~2026-06-27 (gcloud still can). Use FIREBASE_TOKEN (firebase's refresh-token
+          # auth path, unaffected) until upstream fixes external_account. WIF stays for gcloud/GCS.
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 
       - name: Record DORA deploy metrics
         if: success()

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -61,6 +61,11 @@ jobs:
         uses: google-github-actions/setup-gcloud@v3
 
       - name: Delete preview channel
+        env:
+          # TEMP (#1250): firebase-tools can't use our WIF external_account ADC since
+          # ~2026-06-27 (gcloud still can). Use FIREBASE_TOKEN (firebase's refresh-token
+          # auth path, unaffected) until upstream fixes external_account. WIF stays for gcloud/GCS.
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
           set -o pipefail
           npm install -g firebase-tools

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -87,6 +87,11 @@ jobs:
 
       - name: Deploy preview channel
         id: deploy
+        env:
+          # TEMP (#1250): firebase-tools can't use our WIF external_account ADC since
+          # ~2026-06-27 (gcloud still can). Use FIREBASE_TOKEN (firebase's refresh-token
+          # auth path, unaffected) until upstream fixes external_account. WIF stays for gcloud/GCS.
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         # Use firebase-tools directly (matches deploy.yml) rather than
         # FirebaseExtended/action-hosting-deploy, which expects a JSON
         # service-account key — incompatible with our WIF-only setup.


### PR DESCRIPTION
## Incident fix — deploys restored
firebase-tools cannot consume our **WIF `external_account`** credential since ~2026-06-27 (gcloud reads the same credential fine → upstream firebase regression in its bundled google-auth-library). **Proven version-independent:** the last-green CLI 15.22.0 fails identically today. A service-account key is blocked by the `iam.disableServiceAccountKeyCreation` org policy (our keyless control), so this uses **`FIREBASE_TOKEN`** — firebase-tools' refresh-token auth path, independent of the broken ADC.

- Adds `FIREBASE_TOKEN` env to the firebase steps in `pr-preview.yml`, `deploy.yml`, `pr-preview-cleanup.yml`.
- **WIF auth steps stay** so gcloud / GCS / DORA-metrics keep working.
- Temporary; WIF/ADC restored once firebase fixes `external_account`.

**Proof:** this PR's preview run authenticates via `FIREBASE_TOKEN` — a green deploy confirms the fix. Refs #1250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)