### PR TITLE
fix(ci): treat 'already the current active version' as a deploy no-op success (#1250)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,9 +88,22 @@ jobs:
 
       - name: Build and deploy production
         run: |
+          set -o pipefail
           npm run build:frontend
           npm install -g firebase-tools
-          firebase deploy --only hosting:production --project ${{ secrets.GCP_PROJECT_ID }}
+          # firebase-tools exits non-zero when the finalized version already IS the
+          # live version (unchanged frontend content, or an internal retry re-issuing
+          # the release after it already succeeded). Hosting then already serves the
+          # intended build, so treat that one condition as a no-op success — the same
+          # defensive pattern pr-preview-cleanup.yml uses to tolerate a 404 (#1250).
+          if firebase deploy --only hosting:production --project ${{ secrets.GCP_PROJECT_ID }} 2>&1 | tee /tmp/deploy.log; then
+            : # released a new version
+          elif grep -qiE "is the current active version" /tmp/deploy.log; then
+            echo "::notice::Hosting already serves this exact version — no-op success (#1250)"
+          else
+            echo "::error::firebase deploy failed"
+            exit 1
+          fi
         env:
           VITE_APP_VERSION: v${{ steps.pkg.outputs.version }}
           # TEMP (#1250): firebase-tools can't use our WIF external_account ADC since


### PR DESCRIPTION
Follow-up to the FIREBASE_TOKEN auth fix. A prod release with unchanged frontend content (or a firebase-tools internal release retry) makes `firebase deploy` exit non-zero with *'is the current active version'* — even though hosting already serves the intended build, false-redding a successful deploy.

Tolerate **only** that exact condition as a no-op success (any other error still fails), mirroring the 404 tolerance already in `pr-preview-cleanup.yml`.

Scope: `deploy.yml` only (the recurring prod case). Proof: after merge I re-dispatch the prod deploy — unchanged content hits this condition, so a green run proves it. Refs #1250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)