### PR TITLE
ci: add .npmrc scope config so Dependabot can resolve internal workspace packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+# Map our internal scopes to the public npm registry so Dependabot has the
+# "explicit configuration" it requires for scoped deps and stops erroring
+# "can't access a private package registry" on our workspace-internal packages
+# (@toastmasters/* + @taverns-red/*). npm workspaces still resolve these locally
+# (workspace resolution precedes the registry); this only tells the resolver the
+# scope is public, not a private registry needing auth. (#1250 / Dependabot unblock)
+@toastmasters:registry=https://registry.npmjs.org/
+@taverns-red:registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Problem
Dependabot errors *"can't access a private package registry without explicit configuration"* and refuses to rebase/open **any** npm PR — blocking version **and** security updates (6 open alerts, incl. 5 hono / 1 high CORS). Cause: our internal scoped workspace packages (`@toastmasters/*`, `@taverns-red/*`) are unpublished, and with no `.npmrc` Dependabot has no registry mapping for the scope → treats them as an inaccessible private registry.

## Fix
Per [GitHub Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot), scoped deps need their registry declared in a root `.npmrc`. Map both internal scopes → public npm.

**Build-safe (verified locally):** `npm ci` exit 0; `node_modules/@toastmasters/shared-contracts` stays a local symlink to the workspace (no registry fetch); build + 2806 frontend unit tests green. npm workspaces shadow the registry, so resolution is unchanged. Covers both scopes so it holds before **and** after the #1258 rename.

**Verification boundary:** Dependabot's behaviour is only confirmable on its next run — I'll `@dependabot recreate` #1244 after merge to test whether it can now rebase + clear the hono alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)