### PR TITLE
build: auto-build workspace dists in root prepare (fix fresh-context dist failures)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "quality:check": "npm run lint && npm run lint:yaml && npm run typecheck && npm run format:check && npm run test",
     "quality:fix": "npm run lint --workspaces -- --fix && npm run format",
     "pre-commit": "npm run typecheck && npm run lint && npm run lint:yaml",
-    "prepare": "husky install",
+    "prepare": "husky install && npm run build:shared-contracts && npm run build:analytics-core",
     "cleanup:test-dirs": "bash scripts/cleanup-all-test-dirs.sh",
     "cleanup:frontend": "bash frontend/scripts/cleanup-test-dirs.sh",
     "pipeline:dry-run": "npx tsx scripts/prune-month-end-pipeline.ts --dry-run",


### PR DESCRIPTION
## Problem
Runner sessions, pre-push, and local dev on **fresh context** repeatedly fail with `Failed to resolve import @taverns-red/analytics-core` — the gitignored workspace dists aren't built. Lesson 092 documents the manual rebuild, but it's followed **<10% of the time** because it depends on remembering.

## Fix
Make it automatic: root `prepare` runs `husky install` **AND** builds shared-contracts + analytics-core (dependency order), so every `npm ci`/`npm install` produces the dists. The manual step stops existing.

**Verified:** `rm -rf dist node_modules && npm ci` → husky hooks installed ✓, both dists built ✓, frontend unit suite (209 files) green with **zero manual build** ✓.

Supersedes the manual-build step in Lesson 092 (will retire it). Part of the runner-reliability work (problem #2); the general pattern becomes a red-barkeep onboarding item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)