### PR TITLE
fix(monitor): retry transient GCS read in closing-registry-check (#1267)

### DIFF
--- a/scripts/closing-registry-check.ts
+++ b/scripts/closing-registry-check.ts
@@ -39,6 +39,7 @@ import {
   buildRegistryStaleTitle,
   buildRegistryStaleBody,
 } from './lib/registryFreshness.js'
+import { retryAsync } from './lib/retry.js'
 
 const BODY_FILE = '/tmp/closing-registry-stale-body.md'
 
@@ -63,18 +64,31 @@ async function main(): Promise<void> {
   const registryMonths = (await registry.read()).months
   log(`registry: ${registryMonths.length} committed entries`)
 
+  const storage = new Storage()
   let entries: RawCSVEntry[] = []
   try {
-    entries = await readRecentRawCSVEntries(
-      new Storage(),
-      bucket,
-      windowDays,
-      log
+    // The GCS read can throw on a TRANSIENT WIF/STS token exchange
+    // (`sts.googleapis.com/v1/token: Premature close`, #1245). Retry with
+    // bounded backoff so a single flaky token fetch no longer fires a false
+    // empty-feed STALE alert. If it still fails after the attempts are spent
+    // the catch below leaves entries empty → emptyFeed=true → stale: the
+    // monitor must not pass when it genuinely cannot read (fail-closed, L107).
+    entries = await retryAsync(
+      () => readRecentRawCSVEntries(storage, bucket, windowDays, log),
+      {
+        attempts: 3,
+        baseDelayMs: 2000,
+        onRetry: (err, attempt, delayMs) =>
+          log(
+            `GCS metadata read attempt ${attempt} failed (${(err as Error).message}); ` +
+              `retrying in ${delayMs}ms`
+          ),
+      }
     )
   } catch (err) {
-    // Feed failure → evaluate with an empty feed, which reports stale with
-    // emptyFeed=true. The monitor must not pass when it cannot read.
-    log(`GCS metadata fetch failed: ${(err as Error).message}`)
+    // Persistent feed failure → evaluate with an empty feed, which reports
+    // stale with emptyFeed=true. The monitor must not pass when it cannot read.
+    log(`GCS metadata fetch failed after retries: ${(err as Error).message}`)
   }
 
   const result = evaluateRegistryFreshness(registryMonths, entries)

--- a/scripts/lib/__tests__/retry.test.ts
+++ b/scripts/lib/__tests__/retry.test.ts
@@ -1,0 +1,109 @@
+/**
+ * retryAsync — unit tests (#1267, epic #1266)
+ *
+ * The closing-date registry freshness check reads raw-csv metadata from GCS;
+ * a transient Workload-Identity/STS token-exchange failure
+ * (`sts.googleapis.com/v1/token: Premature close`, observed 2026-06-26/27)
+ * threw on the first GCS call and was laundered into an empty-feed STALE
+ * alert (#1245). retryAsync absorbs that transient class with bounded
+ * backoff so a single flaky token fetch no longer cries wolf, while a
+ * genuinely-broken read still surfaces after the attempts are spent
+ * (fail-closed preserved — L107).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { retryAsync } from '../retry.js'
+
+/** A sleep stub that records each requested delay and resolves immediately. */
+function recordingSleep(): {
+  fn: (ms: number) => Promise<void>
+  delays: number[]
+} {
+  const delays: number[] = []
+  return {
+    delays,
+    fn: (ms: number) => {
+      delays.push(ms)
+      return Promise.resolve()
+    },
+  }
+}
+
+describe('retryAsync', () => {
+  it('returns the value and never sleeps when fn succeeds first try', async () => {
+    const sleep = recordingSleep()
+    const fn = vi.fn().mockResolvedValue('ok')
+
+    await expect(retryAsync(fn, { sleep: sleep.fn })).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(sleep.delays).toEqual([])
+  })
+
+  it('retries after a transient failure and returns the eventual success', async () => {
+    const sleep = recordingSleep()
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Premature close'))
+      .mockResolvedValueOnce('recovered')
+
+    await expect(
+      retryAsync(fn, { attempts: 3, baseDelayMs: 100, sleep: sleep.fn })
+    ).resolves.toBe('recovered')
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(sleep.delays).toEqual([100]) // one wait between the two attempts
+  })
+
+  it('throws the last error after exhausting all attempts (fail-closed)', async () => {
+    const sleep = recordingSleep()
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail-1'))
+      .mockRejectedValueOnce(new Error('fail-2'))
+      .mockRejectedValueOnce(new Error('fail-3'))
+
+    await expect(
+      retryAsync(fn, { attempts: 3, baseDelayMs: 100, sleep: sleep.fn })
+    ).rejects.toThrow('fail-3')
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(sleep.delays).toHaveLength(2) // waits only BETWEEN attempts
+  })
+
+  it('backs off exponentially from baseDelayMs', async () => {
+    const sleep = recordingSleep()
+    const fn = vi.fn().mockRejectedValue(new Error('always'))
+
+    await expect(
+      retryAsync(fn, { attempts: 4, baseDelayMs: 250, sleep: sleep.fn })
+    ).rejects.toThrow('always')
+    expect(sleep.delays).toEqual([250, 500, 1000])
+  })
+
+  it('reports each retry to onRetry with attempt index and delay', async () => {
+    const sleep = recordingSleep()
+    const onRetry = vi.fn()
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('ok')
+
+    await retryAsync(fn, {
+      attempts: 3,
+      baseDelayMs: 100,
+      sleep: sleep.fn,
+      onRetry,
+    })
+    expect(onRetry).toHaveBeenCalledTimes(1)
+    expect(onRetry).toHaveBeenCalledWith(expect.any(Error), 1, 100)
+  })
+
+  it('does not retry past a single attempt when attempts=1', async () => {
+    const sleep = recordingSleep()
+    const fn = vi.fn().mockRejectedValue(new Error('once'))
+
+    await expect(
+      retryAsync(fn, { attempts: 1, sleep: sleep.fn })
+    ).rejects.toThrow('once')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(sleep.delays).toEqual([])
+  })
+})

--- a/scripts/lib/retry.ts
+++ b/scripts/lib/retry.ts
@@ -1,0 +1,61 @@
+/**
+ * retryAsync — bounded retry with exponential backoff (#1267, epic #1266)
+ *
+ * A tiny, dependency-free helper for absorbing TRANSIENT I/O failures. Built
+ * for the closing-date registry freshness check, whose single GCS read can
+ * throw on a flaky Workload-Identity/STS token exchange
+ * (`sts.googleapis.com/v1/token: Premature close`) — a one-off that the old
+ * code laundered into a false empty-feed STALE alert (#1245).
+ *
+ * It retries ANY thrown error up to `attempts` times, waiting
+ * `baseDelayMs * 2^n` between tries. This intentionally does not classify
+ * errors: the caller's fallback after exhaustion is still to alert
+ * (fail-closed, L107), so retrying a genuinely-permanent failure a couple of
+ * extra times costs only a few seconds and never hides it.
+ *
+ * `sleep` is injectable so tests run instantly without real timers. No GCS or
+ * other I/O lives here — it is pure control flow.
+ */
+
+export interface RetryOptions {
+  /** Total attempts, including the first (default 3). Values < 1 run once. */
+  attempts?: number
+  /** Delay before the FIRST retry, in ms (default 500). Doubles each retry. */
+  baseDelayMs?: number
+  /** Injectable wait — defaults to a real setTimeout-backed sleep. */
+  sleep?: (ms: number) => Promise<void>
+  /** Called before each backoff wait with the error, 1-based retry #, and delay. */
+  onRetry?: (err: unknown, attempt: number, delayMs: number) => void
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * Run `fn`, retrying on any rejection with exponential backoff. Resolves with
+ * the first successful result; rejects with the LAST error once attempts are
+ * spent.
+ */
+export async function retryAsync<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const attempts = Math.max(1, options.attempts ?? 3)
+  const baseDelayMs = options.baseDelayMs ?? 500
+  const sleep = options.sleep ?? defaultSleep
+
+  let lastError: unknown
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+      const isLastAttempt = i === attempts - 1
+      if (isLastAttempt) break
+      const delayMs = baseDelayMs * 2 ** i
+      options.onRetry?.(err, i + 1, delayMs)
+      await sleep(delayMs)
+    }
+  }
+  throw lastError
+}

--- a/tasks/lessons/175-a-fail-closed-monitor-whose-single-read-can-fail-transiently-cries-wolf-pull-the-live-log-before-trusting-the-diagnosis.md
+++ b/tasks/lessons/175-a-fail-closed-monitor-whose-single-read-can-fail-transiently-cries-wolf-pull-the-live-log-before-trusting-the-diagnosis.md
@@ -1,0 +1,79 @@
+---
+id: '175'
+category: lesson
+tags: [ci, automation, monitoring, data-pipeline, gcs, verification, tdd]
+auto_load: true
+date: 2026-06-27
+issues: [1267, 1266, 1245, 1128]
+---
+
+# Lesson 175 — A fail-closed monitor whose single read can fail transiently cries wolf; pull the live log before trusting the issue's diagnosis
+
+**Date:** 2026-06-27
+**Issue:** #1267 (epic #1266 — closing-registry monitor false alerts)
+**PR:** _(record on merge)_
+
+## What happened
+
+The issue diagnosed a daily `closing-registry-stale` false alert (#1245) as a
+**verdict-logic conflation**: the freshness check supposedly flagged
+`stale=true` whenever the raw-csv window had no closing-period months
+mid-cycle (`emptyFeed=true`), and asked to relax that benign case to fresh.
+
+Before writing any code I re-ran the check locally and pulled the live CI
+step log. Both contradicted the diagnosis:
+
+- **Locally the verdict was already `fresh=true`.** The window is 130 raw-csv
+  date dirs (~4 closing windows), so it *always* spans a recent completed
+  closing month (May's closing runs early June, derivable all month). The
+  "benign no-closing-months mid-cycle" state the issue described **cannot
+  occur** with a 130-dir window; `emptyFeed` only fires on `entries.length===0`.
+- **The real cause** (identical on the 06-26 and 06-27 runs):
+  `GCS metadata fetch failed: … https://sts.googleapis.com/v1/token: Premature
+  close` → the read threw on a flaky Workload-Identity/STS token exchange →
+  caught into `entries=[]` → `emptyFeed=true` → false stale.
+
+Critically, the issue's *own* prescribed fix kept `emptyFeed` from "a genuine
+read/exception failure" as stale — which is exactly what was firing — so it
+would not have cleared #1245. Its acceptance criterion "#1245 auto-clears"
+failed by construction. The current fail-closed logic was *correct* (L107);
+the read was just *flakily* failing.
+
+The fix was therefore not in the verdict but in the read: wrap the single GCS
+read in a bounded `retryAsync` (3 attempts, exponential backoff). A transient
+token fetch now recovers on attempt 2/3; a persistent failure still falls
+through to `emptyFeed` stale (fail-closed preserved). I stopped and got
+operator sign-off on the redirected approach before implementing.
+
+## The transferable principle
+
+**A fail-closed monitor is only as quiet as its read is reliable: if the
+single I/O it depends on can fail transiently, "cannot tell → alert" turns
+every network blip into a false alarm. Make the read survive a transient
+(bounded retry + backoff) *before* relaxing any verdict — relaxing the
+verdict to silence a flaky read would blind the monitor to the real outage it
+exists to catch. And when an issue hands you a confident root-cause, re-run
+the check and read the live failing log first: a plausible diagnosis
+(`emptyFeed` = "no closing months") can be the wrong mechanism
+(`emptyFeed` = "the auth token died"), and the prescribed fix can fail its own
+acceptance criteria.**
+
+## How to apply
+
+- A monitor/guard that fails closed on a read error: ask "what's the transient
+  failure rate of this read?" Wrap it in retry with backoff; keep the
+  fail-closed fallback after attempts are spent. Don't widen the pass
+  condition to mask flakiness.
+- `sts.googleapis.com/v1/token: Premature close` (and kin) is a transient WIF
+  token-exchange error on ephemeral runners — retry, don't treat as a verdict.
+- Distrust a diagnosis you can falsify in two commands: re-run the tool, then
+  `gh run view <id> --log | grep` the failing step. The verdict line + the
+  error line together name the real mechanism. (Reinforces prove-before-claiming.)
+
+## Related
+
+- [[158-a-parameterized-monitors-self-clear-must-be-scoped-to-the-signal-it-alarms-on]]
+  — sibling monitor-honesty lesson: scope the *clear*; this one hardens the *read*.
+- [[158-a-fail-closed-chain-is-only-as-honest-as-its-writers-a-persisted-default-reads-as-a-decision]]
+  — a swallowed default reads as a decision; a swallowed transient read reads as an outage.
+- `scripts/closing-registry-check.ts`, `scripts/lib/retry.ts`, #1245 (the false alert this clears).

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -170,3 +170,4 @@
 - **172** [frontend, react, data-pipeline, scope, verification, accessibility] — A new status-consuming surface must resolve the read-time overlay, not the frozen base (#1230, #1228)
 - **173** [ci, deploy, firebase, node, auth, wif] — A Node security patch (not firebase-tools) broke all firebase deploys via keep-alive (#1250) _(ref-only)_
 - **174** [monorepo, refactor, tests, verification, process, ci] — A scope-rename "grep-proof" must also search the regex-escaped-slash form (#1258, #1257)
+- **175** [ci, automation, monitoring, data-pipeline, gcs, verification, tdd] — A fail-closed monitor whose single read can fail transiently cries wolf; pull the live log before trusting the issue's diagnosis (#1267, #1266, #1245, #1128)


### PR DESCRIPTION
## Summary

Fixes the daily `closing-registry-stale` false alert (#1245) by hardening the
monitor's GCS **read**, not its verdict.

### Root cause (corrected from the issue's hypothesis)
The issue diagnosed a verdict-logic conflation (benign empty feed mid-cycle →
stale). Re-running the check and pulling the live CI logs falsified that:

- Locally the verdict is already `fresh=true`; a 130-dir window always spans a
  recent completed closing window, so the "no closing months mid-cycle" state
  cannot occur (`emptyFeed` only fires on `entries.length === 0`).
- The real cause, identical on the 06-26 and 06-27 runs:
  `GCS metadata fetch failed: … sts.googleapis.com/v1/token: Premature close`
  → the read threw on a flaky WIF/STS token exchange → caught into
  `entries=[]` → `emptyFeed=true` → false stale. The issue's prescribed fix
  kept that exception case as stale, so it would not have cleared #1245.

Operator approved the redirected approach before implementation.

## Change
- **`scripts/lib/retry.ts`** — new dependency-free `retryAsync` (bounded
  attempts + exponential backoff, injectable sleep).
- **`scripts/closing-registry-check.ts`** — wrap the single GCS read in
  `retryAsync` (3 attempts, 2s exponential backoff). A transient token fetch
  recovers on attempt 2/3; a persistent failure still falls through to
  `emptyFeed` stale — **fail-closed preserved (L107)**.

The verdict logic (`evaluateRegistryFreshness`) is unchanged — it was correct.

## Verification (infra-only; no frontend/packages, so no PR preview surface)
- `npm run test:scripts` — 356/356 green, incl. 6 new `retryAsync` tests
  (success-first, retry-then-succeed, exhaust-then-throw, exponential backoff,
  onRetry reporting, attempts=1).
- Full frontend suite green on pre-push (2806/2806).
- **Live code-proof against staging GCS:**
  - happy path → `fresh=true` on first read (no retries).
  - canary (bogus bucket) → `attempt 1 … retrying in 2000ms` → `attempt 2 …
    retrying in 4000ms` → `fetch failed after retries` → `emptyFeed=true`
    stale. Both the retry loop and the fail-closed fallback proven.

#1245 auto-clears on the next daily run that reads cleanly (referenced as
plain text per R15 ordering).

## Lesson
`tasks/lessons/175-*` — harden a fail-closed monitor's flaky read, not its
verdict; pull the live log before trusting an issue's diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
