### PR TITLE
fix(promote-gate): allow base moves during closing (#1289)

### DIFF
--- a/docs/investigations/closing-period-promote-policy-2026-06-03.md
+++ b/docs/investigations/closing-period-promote-policy-2026-06-03.md
@@ -8,6 +8,9 @@
 **direction-agnostic** — see [Amendment](#amendment-2026-06-04-1092--decreases-are-normal-the-counter-rule-is-direction-agnostic)
 at the end of this doc. §3(b)'s "decreases must still block" reading and §4's
 decrease floor are superseded.
+**Amended 2026-07-02 (#1289):** the §4 **base** rule is now **any move allowed**
+(bases reconcile during closing) — see [Amendment](#amendment-2026-07-02-1289--bases-reconcile-during-closing)
+at the end of this doc.
 
 ## 1. Problem (verified)
 
@@ -89,13 +92,13 @@ read errors) is unchanged.
    disappearing on an overlap date blocks (the #1034 D61 protection).
 3. Per district, per field, by class:
 
-| Field class       | Fields                                                                                                                                                                                                                                                                           | Rule                                                                    |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| **Counters**      | `paidClubs`, `activeClubs`, `totalPayments`, `newPayments`, `aprilPayments`, `octoberPayments`, `latePayments`, `charterPayments`, `distinguishedClubs`, `selectDistinguished`, `presidentsDistinguished`, `smedleyDistinguished`, `clubsWith20PlusMembers`, `newCharteredClubs` | `0 ≤ Δ ≤ max(50, 10% × prodValue)` — non-decreasing, magnitude-capped   |
-| **Bases**         | `paidClubBase`, `paymentBase`                                                                                                                                                                                                                                                    | Must be **equal** (fixed at program-year start; any move is an anomaly) |
-| **Identity**      | `districtId`, `districtName`, `region`                                                                                                                                                                                                                                           | Must be **equal**                                                       |
-| **Plan booleans** | `dspSubmitted`, `trainingMet`, `marketAnalysisSubmitted`, `communicationPlanSubmitted`, `regionAdvisorVisitMet`                                                                                                                                                                  | `false→true` allowed; `true→false` blocks                               |
-| **Derived**       | `clubGrowthPercent`, `paymentGrowthPercent`, `distinguishedPercent`, `clubsRank`, `paymentsRank`, `distinguishedRank`, `overallRank`, `aggregateScore`                                                                                                                           | **Excluded** from the check (re-derived, zero-sum across districts)     |
+| Field class       | Fields                                                                                                                                                                                                                                                                           | Rule                                                                           |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| **Counters**      | `paidClubs`, `activeClubs`, `totalPayments`, `newPayments`, `aprilPayments`, `octoberPayments`, `latePayments`, `charterPayments`, `distinguishedClubs`, `selectDistinguished`, `presidentsDistinguished`, `smedleyDistinguished`, `clubsWith20PlusMembers`, `newCharteredClubs` | `0 ≤ Δ ≤ max(50, 10% × prodValue)` — non-decreasing, magnitude-capped          |
+| **Bases**         | `paidClubBase`, `paymentBase`                                                                                                                                                                                                                                                    | **Any move allowed** as provenance (reconciles during closing — amended #1289) |
+| **Identity**      | `districtId`, `districtName`, `region`                                                                                                                                                                                                                                           | Must be **equal**                                                              |
+| **Plan booleans** | `dspSubmitted`, `trainingMet`, `marketAnalysisSubmitted`, `communicationPlanSubmitted`, `regionAdvisorVisitMet`                                                                                                                                                                  | `false→true` allowed; `true→false` blocks                                      |
+| **Derived**       | `clubGrowthPercent`, `paymentGrowthPercent`, `distinguishedPercent`, `clubsRank`, `paymentsRank`, `distinguishedRank`, `overallRank`, `aggregateScore`                                                                                                                           | **Excluded** from the check (re-derived, zero-sum across districts)            |
 
 4. **Optionality transitions block:** a field `undefined` in one side and
    present in the other (in any class except Derived) ⇒ block. During closing
@@ -271,3 +274,25 @@ Residual risk (replaces §7 bullet 2): a genuine systematic error that moves
 every district **downward** ≤ cap during closing would now auto-promote, the
 mirror of §7 bullet 1's upward case — same mitigations (full delta
 provenance, deterministic re-derive recovery, historical dates still block).
+
+## Amendment 2026-07-02 (#1289) — bases reconcile during closing
+
+§4 originally classified `paidClubBase`/`paymentBase` as **must be equal**
+("fixed at program-year start; any move is an anomaly"). That premise is wrong
+for the closing window — **the only time CPAA runs**. Bases legitimately
+reconcile during closing (late charters, corrections), and the July
+program-year rollover in particular carries lots of change. The equality rule
+forced needless operator overrides during the busiest reconciliation period
+(it held the 2026-07-01 promotion on `2026-06-30 D85 paymentBase 4774→4769`, a
+−5 / 0.1% move).
+
+**Amended rule:** base value moves are **allowed, any magnitude/direction**,
+recorded as delta provenance in the run summary — never blocking. A base
+_optionality transition_ (a base field appearing/vanishing) still blocks: that
+is a schema/code change, not data reconciliation. Non-closing-pinned changed
+dates are unaffected (they block earlier as a re-derive review).
+
+Residual risk: a re-derive bug that corrupts a base (collapse-to-zero, ×10)
+during closing would now auto-promote. Accepted by the operator — promotion is
+recoverable (deterministic re-derive from raw-csv + re-promote), moves are in
+the provenance table, and historical-date changes still block.

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -57,7 +57,8 @@ export const FIELD_CLASSIFICATION: Record<string, FieldClass> = {
   smedleyDistinguished: 'counter',
   clubsWith20PlusMembers: 'counter',
   newCharteredClubs: 'counter',
-  // Bases — fixed at program-year start; any move is an anomaly
+  // Bases — reconcile during the closing window (the only time CPAA runs);
+  // base value moves are allowed as provenance, any magnitude (#1289).
   paidClubBase: 'base',
   paymentBase: 'base',
   // Plan booleans — one-way false→true
@@ -168,7 +169,7 @@ export interface ClosingAutoAllowResult {
  * identical, and every changed field obeys its class rule:
  *
  *   counter      |Δ| ≤ max(50, 10% × prod)   (direction-agnostic, #1092)
- *   base         must be equal
+ *   base         any move allowed as provenance (reconciles during closing, #1289)
  *   identity     must be equal
  *   planBoolean  false→true allowed; true→false blocks
  *   derived      excluded (zero-sum re-derivations)
@@ -298,10 +299,18 @@ export function evaluateClosingAutoAllow(
           break
         }
         case 'base':
-          reasons.push(
-            `${date} D${id} ${field}: base drift ${String(prodValue)}→` +
-              `${String(stagingValue)} blocks (fixed at program-year start)`
-          )
+          // Bases reconcile during the closing window too — and CPAA only ever
+          // runs on closing-pinned dates, so a base move here is routine
+          // reconciliation, not an anomaly. Allow any magnitude/direction and
+          // record it as provenance (operator decision 2026-07-02, #1289). A
+          // base optionality transition still blocks above (structural change).
+          deltas.push({
+            districtId: id,
+            field,
+            prod: prodValue as number,
+            staging: stagingValue as number,
+            delta: (stagingValue as number) - (prodValue as number),
+          })
           break
         case 'identity':
           reasons.push(

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
@@ -396,11 +396,37 @@ describe('evaluateClosingAutoAllow — edges (decision doc §8.3)', () => {
     expect(res.reasons.join(' ')).toMatch(/cap/i)
   })
 
-  it('blocks base drift (paymentBase moved)', () => {
+  it('allows base drift during closing — bases reconcile too (#1289)', () => {
+    // paymentBase 4800→4801: bases legitimately move during the closing window
+    // (this is the only time CPAA runs). Operator decision 2026-07-02.
     const [s, p] = syntheticPair({ paymentBase: 4801 })
     const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(true)
+    // recorded as provenance
+    expect(
+      res.deltas.some(d => d.field === 'paymentBase' && d.delta === 1)
+    ).toBe(true)
+  })
+
+  it('allows a large base move during closing — any magnitude (#1289)', () => {
+    // No cap on base during closing (operator: "lots of change in July").
+    const [s, p] = syntheticPair({ paidClubBase: 40 }) // prod 98 → 40
+    const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(true)
+    expect(
+      res.deltas.some(d => d.field === 'paidClubBase' && d.delta === -58)
+    ).toBe(true)
+  })
+
+  it('still blocks a base optionality transition (structural, not reconciliation) (#1289)', () => {
+    // A base field vanishing is a schema/code change, not data reconciliation.
+    const [s, p] = syntheticPair(
+      { paymentBase: undefined as unknown as number },
+      {}
+    )
+    const res = evaluateClosingAutoAllow(s, p)
     expect(res.allowed).toBe(false)
-    expect(res.reasons.join(' ')).toMatch(/base/i)
+    expect(res.reasons.join(' ')).toMatch(/optionality/i)
   })
 
   it('blocks identity drift (districtName changed)', () => {


### PR DESCRIPTION
## Why

The Closing-Pinned Auto-Allow value gate (epic #1083) classified `paymentBase`/`paidClubBase` as 'must be equal — any move is an anomaly'. But that rule only ever runs on closing-pinned dates, and **bases legitimately reconcile during closing** (late charters, corrections); the July program-year rollover carries lots of change. It held the 2026-07-01 promotion on `2026-06-30 D85 paymentBase 4774→4769` — a −5 (0.1%) move.

## What (operator decision 2026-07-02)

Base **value** moves now auto-allow during closing at **any magnitude/direction**, recorded as delta provenance in the run summary — never blocking. A base **optionality transition** (a base field appearing/vanishing) still blocks: that is a schema/code change, not data reconciliation. Non-closing-pinned changed dates are unaffected (they still block as a re-derive review).

- `SnapshotValueDiff.evaluateClosingAutoAllow`: `base` case records a delta, no blocking reason.
- Decision doc §4 amended + top-of-doc pointer.

## Verification

- TDD: flipped the base-drift test to auto-allow + added large-move and optionality-transition cases (Red → Green).
- Full collector-cli suite: **1010 pass**. Typecheck clean.
- Identity drift, plan-boolean revert, and counter cap-exceed still block (no regression).

Closes #1289

🤖 Generated with [Claude Code](https://claude.com/claude-code)