### PR TITLE
fix(promote-gate): allow counter moves freely during closing (#1292)

### DIFF
--- a/docs/investigations/closing-period-promote-policy-2026-06-03.md
+++ b/docs/investigations/closing-period-promote-policy-2026-06-03.md
@@ -11,6 +11,11 @@ decrease floor are superseded.
 **Amended 2026-07-02 (#1289):** the §4 **base** rule is now **any move allowed**
 (bases reconcile during closing) — see [Amendment](#amendment-2026-07-02-1289--bases-reconcile-during-closing)
 at the end of this doc.
+**Amended 2026-07-03 (#1292):** the §4 **counter** magnitude cap is **removed**
+— counters reconcile in lumps during closing (charters land ~20+ payments at
+once); see [Amendment](#amendment-2026-07-03-1292--counters-reconcile-in-lumps-the-cap-is-removed)
+at the end of this doc. §3(b) reversal-blocking and §7's cap-based residual-risk
+framing are superseded.
 
 ## 1. Problem (verified)
 
@@ -92,13 +97,13 @@ read errors) is unchanged.
    disappearing on an overlap date blocks (the #1034 D61 protection).
 3. Per district, per field, by class:
 
-| Field class       | Fields                                                                                                                                                                                                                                                                           | Rule                                                                           |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| **Counters**      | `paidClubs`, `activeClubs`, `totalPayments`, `newPayments`, `aprilPayments`, `octoberPayments`, `latePayments`, `charterPayments`, `distinguishedClubs`, `selectDistinguished`, `presidentsDistinguished`, `smedleyDistinguished`, `clubsWith20PlusMembers`, `newCharteredClubs` | `0 ≤ Δ ≤ max(50, 10% × prodValue)` — non-decreasing, magnitude-capped          |
-| **Bases**         | `paidClubBase`, `paymentBase`                                                                                                                                                                                                                                                    | **Any move allowed** as provenance (reconciles during closing — amended #1289) |
-| **Identity**      | `districtId`, `districtName`, `region`                                                                                                                                                                                                                                           | Must be **equal**                                                              |
-| **Plan booleans** | `dspSubmitted`, `trainingMet`, `marketAnalysisSubmitted`, `communicationPlanSubmitted`, `regionAdvisorVisitMet`                                                                                                                                                                  | `false→true` allowed; `true→false` blocks                                      |
-| **Derived**       | `clubGrowthPercent`, `paymentGrowthPercent`, `distinguishedPercent`, `clubsRank`, `paymentsRank`, `distinguishedRank`, `overallRank`, `aggregateScore`                                                                                                                           | **Excluded** from the check (re-derived, zero-sum across districts)            |
+| Field class       | Fields                                                                                                                                                                                                                                                                           | Rule                                                                                   |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **Counters**      | `paidClubs`, `activeClubs`, `totalPayments`, `newPayments`, `aprilPayments`, `octoberPayments`, `latePayments`, `charterPayments`, `distinguishedClubs`, `selectDistinguished`, `presidentsDistinguished`, `smedleyDistinguished`, `clubsWith20PlusMembers`, `newCharteredClubs` | **Any move allowed** as provenance (reconcile in lumps during closing — amended #1292) |
+| **Bases**         | `paidClubBase`, `paymentBase`                                                                                                                                                                                                                                                    | **Any move allowed** as provenance (reconciles during closing — amended #1289)         |
+| **Identity**      | `districtId`, `districtName`, `region`                                                                                                                                                                                                                                           | Must be **equal**                                                                      |
+| **Plan booleans** | `dspSubmitted`, `trainingMet`, `marketAnalysisSubmitted`, `communicationPlanSubmitted`, `regionAdvisorVisitMet`                                                                                                                                                                  | `false→true` allowed; `true→false` blocks                                              |
+| **Derived**       | `clubGrowthPercent`, `paymentGrowthPercent`, `distinguishedPercent`, `clubsRank`, `paymentsRank`, `distinguishedRank`, `overallRank`, `aggregateScore`                                                                                                                           | **Excluded** from the check (re-derived, zero-sum across districts)                    |
 
 4. **Optionality transitions block:** a field `undefined` in one side and
    present in the other (in any class except Derived) ⇒ block. During closing
@@ -296,3 +301,29 @@ Residual risk: a re-derive bug that corrupts a base (collapse-to-zero, ×10)
 during closing would now auto-promote. Accepted by the operator — promotion is
 recoverable (deterministic re-derive from raw-csv + re-promote), moves are in
 the provenance table, and historical-date changes still block.
+
+## Amendment 2026-07-03 (#1292) — counters reconcile in lumps; the cap is removed
+
+§4 capped counter moves at `|Δ| ≤ max(50, 10% × prod)` (direction-agnostic
+since #1092). That cap still blocked routine closing days: the 2026-07-03
+promotion was held on `2026-06-30 D82 charterPayments 106→186 (Δ +80)` —
+verified against live TI data (D82 Charter Payments = 186), a real charter
+spike, not a re-derive bug. Charter payments and dues reconcile in **lumps**
+during the closing/charter window (a chartering club lands ~20+ payments at
+once), so counter moves routinely exceed the floor of 50 — a different
+field/district tripping it most days, forcing a daily manual override.
+
+**Amended rule:** counter value moves are **allowed, any magnitude/direction**,
+recorded as delta provenance — never blocking, matching the #1289 base rule.
+CPAA now blocks a closing-pinned date only on **identity** drift, a
+**plan-boolean** revert (`true→false`), an **optionality transition**
+(structural), a district-set change, or a **non-closing-pinned** changed date
+(a re-derive of history). Counters and bases are pure provenance.
+
+Residual risk (supersedes §7's cap-based framing): a systematic re-derive bug
+(every district +30%) or a unit-scale (×10) error during closing would now
+auto-promote. Accepted by the operator (2026-07-03): closing reconciliation
+genuinely carries lots of change, especially at the July program-year rollover;
+promotion is recoverable (deterministic re-derive from raw-csv + re-promote),
+every move is in the provenance table, and non-closing-pinned/historical dates
+still block.

--- a/packages/collector-cli/src/services/SnapshotValueDiff.ts
+++ b/packages/collector-cli/src/services/SnapshotValueDiff.ts
@@ -42,7 +42,8 @@ export const FIELD_CLASSIFICATION: Record<string, FieldClass> = {
   districtId: 'identity',
   districtName: 'identity',
   region: 'identity',
-  // Counters — non-decreasing, magnitude-capped during closing
+  // Counters — reconcile in lumps during closing; any move allowed as
+  // provenance, no magnitude cap (#1292)
   paidClubs: 'counter',
   activeClubs: 'counter',
   totalPayments: 'counter',
@@ -168,7 +169,7 @@ export interface ClosingAutoAllowResult {
  * the closing-remap signature in STAGING's own metadata, the district set is
  * identical, and every changed field obeys its class rule:
  *
- *   counter      |Δ| ≤ max(50, 10% × prod)   (direction-agnostic, #1092)
+ *   counter      any move allowed as provenance (reconciles in lumps, #1292)
  *   base         any move allowed as provenance (reconciles during closing, #1289)
  *   identity     must be equal
  *   planBoolean  false→true allowed; true→false blocks
@@ -277,33 +278,18 @@ export function evaluateClosingAutoAllow(
       }
 
       switch (cls) {
-        case 'counter': {
-          const prod = prodValue as number
-          const staging = stagingValue as number
-          const delta = staging - prod
-          // Direction-agnostic (#1092): closing reconciliation legitimately
-          // moves counters BOTH ways (payments reversed, a club slipping
-          // under a threshold). Only an implausible MAGNITUDE blocks — the
-          // symmetric cap catches systematic re-derive inflation or a
-          // collapse-to-zero, never a per-unit downward correction.
-          const cap = Math.max(50, 0.1 * prod)
-          if (Math.abs(delta) > cap) {
-            reasons.push(
-              `${date} D${id} ${field}: counter move ${prod}→${staging} ` +
-                `(Δ ${delta > 0 ? '+' : ''}${delta}) exceeds symmetric cap ` +
-                `${cap} = max(50, 10% × ${prod})`
-            )
-          } else {
-            deltas.push({ districtId: id, field, prod, staging, delta })
-          }
-          break
-        }
+        case 'counter':
         case 'base':
-          // Bases reconcile during the closing window too — and CPAA only ever
-          // runs on closing-pinned dates, so a base move here is routine
-          // reconciliation, not an anomaly. Allow any magnitude/direction and
-          // record it as provenance (operator decision 2026-07-02, #1289). A
-          // base optionality transition still blocks above (structural change).
+          // Counters and bases both reconcile during the closing window — and
+          // CPAA only ever runs on closing-pinned dates. Closing moves are
+          // legitimately large and either-directional: charter payments land in
+          // lumps (~20+ at once), dues reverse, a club slips under a threshold,
+          // a base is corrected. The magnitude cap forced a manual override
+          // most days through the closing window (a different field/district
+          // each day), so both classes now allow ANY move, recorded as delta
+          // provenance (operator decisions 2026-07-02 #1289 base, 2026-07-03
+          // #1292 counter). A value optionality transition still blocks above
+          // (structural / schema change, not data reconciliation).
           deltas.push({
             districtId: id,
             field,

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffClosing.test.ts
@@ -357,15 +357,33 @@ describe('evaluateClosingAutoAllow — edges (decision doc §8.3)', () => {
     expect(evaluateClosingAutoAllow(s, p).allowed).toBe(true)
   })
 
-  it('blocks a counter exceeding the max(50, 10%) cap', () => {
-    // Δ +600 on prod 5000: cap is max(50, 500) = 500.
+  it('allows a large counter move during closing — no cap (#1292)', () => {
+    // Δ +600 on prod 5000. Charter payments and dues reconcile in lumps during
+    // closing (charters land ~20+ payments at once); the magnitude cap forced
+    // needless daily overrides. Operator decision 2026-07-03: allow freely.
     const [s, p] = syntheticPair({ totalPayments: 5600 })
     const res = evaluateClosingAutoAllow(s, p)
-    expect(res.allowed).toBe(false)
-    expect(res.reasons.join(' ')).toMatch(/cap/i)
+    expect(res.allowed).toBe(true)
+    expect(
+      res.deltas.some(d => d.field === 'totalPayments' && d.delta === 600)
+    ).toBe(true)
   })
 
-  it('allows a counter decrease within the cap — direction-agnostic (#1092)', () => {
+  it('allows the D82-style lumpy charterPayments spike (#1292)', () => {
+    // The live case that blocked 2026-07-03: charterPayments 106→186 (+80),
+    // verified against upstream TM data.
+    const [s, p] = syntheticPair(
+      { charterPayments: 186 },
+      { charterPayments: 106 }
+    )
+    const res = evaluateClosingAutoAllow(s, p)
+    expect(res.allowed).toBe(true)
+    expect(
+      res.deltas.some(d => d.field === 'charterPayments' && d.delta === 80)
+    ).toBe(true)
+  })
+
+  it('allows a counter decrease during closing — direction-agnostic (#1292)', () => {
     const [s, p] = syntheticPair({ totalPayments: 4999 })
     const res = evaluateClosingAutoAllow(s, p)
     expect(res.allowed).toBe(true)
@@ -380,20 +398,15 @@ describe('evaluateClosingAutoAllow — edges (decision doc §8.3)', () => {
     ])
   })
 
-  it('blocks an implausible-magnitude decrease (symmetric cap, #1092)', () => {
-    // Δ −600 on prod 5000: symmetric cap is max(50, 500) = 500. A per-unit
-    // reconciliation never moves this much — a collapse is a regression.
+  it('allows a large counter decrease during closing — no cap (#1292)', () => {
+    // Δ −600 on prod 5000: a charter reversal / bulk correction. Recorded as
+    // provenance, not blocked.
     const [s, p] = syntheticPair({ totalPayments: 4400 })
     const res = evaluateClosingAutoAllow(s, p)
-    expect(res.allowed).toBe(false)
-    expect(res.reasons.join(' ')).toMatch(/cap/i)
-  })
-
-  it('blocks a counter collapsing to zero on a large base (#1092)', () => {
-    const [s, p] = syntheticPair({ totalPayments: 0 })
-    const res = evaluateClosingAutoAllow(s, p)
-    expect(res.allowed).toBe(false)
-    expect(res.reasons.join(' ')).toMatch(/cap/i)
+    expect(res.allowed).toBe(true)
+    expect(
+      res.deltas.some(d => d.field === 'totalPayments' && d.delta === -600)
+    ).toBe(true)
   })
 
   it('allows base drift during closing — bases reconcile too (#1289)', () => {
@@ -567,13 +580,15 @@ describe('evaluatePromote CPAA wiring (#1086)', () => {
     ])
   })
 
-  it('keeps blocking when CPAA finds a cap breach, surfacing the violation', () => {
-    const { report, digests } = promoteCase({ totalPayments: 4400 }) // Δ −600
+  it('keeps blocking when CPAA finds a real violation, surfacing it (identity drift)', () => {
+    // Counters/bases now allow freely (#1292/#1289); identity drift still
+    // blocks, so it exercises the "CPAA found a violation" wiring.
+    const { report, digests } = promoteCase({ districtName: 'Renamed' })
     const decision = evaluatePromote(report, {}, digests)
     expect(decision.promote).toBe(false)
     expect(decision.requiresReview).toBe(true)
     expect(decision.autoAllowed).toBeUndefined()
-    expect(decision.reasons.join(' ')).toMatch(/cap/i)
+    expect(decision.reasons.join(' ')).toMatch(/identity/i)
   })
 
   it('blocks when ANY changed date lacks the closing signature, even if another passes', () => {
@@ -657,26 +672,14 @@ describe('evaluatePromote CPAA wiring (#1086)', () => {
   })
 })
 
-describe('evaluateClosingAutoAllow — absolute-floor cap boundary (review nit)', () => {
-  // On a small base (prod 100, 10% = 10) the cap resolves to the absolute
-  // floor of 50: Δ +50 is the last allowed step, Δ +51 blocks.
-  it('allows Δ = 50 and blocks Δ = 51 when the cap is the absolute floor', () => {
-    const [allowS, allowP] = syntheticPair({ paidClubs: 150 }) // prod 100, Δ +50
-    expect(evaluateClosingAutoAllow(allowS, allowP).allowed).toBe(true)
+describe('evaluateClosingAutoAllow — counters allow freely during closing (#1292)', () => {
+  // The magnitude cap was removed: on a closing-pinned date, a counter move of
+  // any size and direction auto-allows, recorded as delta provenance.
+  it('allows large moves either direction on a small base', () => {
+    const [upS, upP] = syntheticPair({ paidClubs: 151 }) // prod 100, Δ +51
+    expect(evaluateClosingAutoAllow(upS, upP).allowed).toBe(true)
 
-    const [blockS, blockP] = syntheticPair({ paidClubs: 151 }) // prod 100, Δ +51
-    const res = evaluateClosingAutoAllow(blockS, blockP)
-    expect(res.allowed).toBe(false)
-    expect(res.reasons.join(' ')).toMatch(/cap/i)
-  })
-
-  it('applies the same boundary on the decrease side (Δ −50 allows, Δ −51 blocks) (#1092)', () => {
-    const [allowS, allowP] = syntheticPair({ paidClubs: 50 }) // prod 100, Δ −50
-    expect(evaluateClosingAutoAllow(allowS, allowP).allowed).toBe(true)
-
-    const [blockS, blockP] = syntheticPair({ paidClubs: 49 }) // prod 100, Δ −51
-    const res = evaluateClosingAutoAllow(blockS, blockP)
-    expect(res.allowed).toBe(false)
-    expect(res.reasons.join(' ')).toMatch(/cap/i)
+    const [downS, downP] = syntheticPair({ paidClubs: 49 }) // prod 100, Δ −51
+    expect(evaluateClosingAutoAllow(downS, downP).allowed).toBe(true)
   })
 })

--- a/packages/collector-cli/src/services/__tests__/SnapshotValueDiffLoader.test.ts
+++ b/packages/collector-cli/src/services/__tests__/SnapshotValueDiffLoader.test.ts
@@ -181,7 +181,7 @@ describe('runValueDiff — Closing-Pinned Auto-Allow end-to-end (#1086)', () => 
     expect(exitCode).toBe(0)
   })
 
-  it('still blocks (exit 1) an implausible-magnitude closing decrease (#1092)', () => {
+  it('auto-allows (exit 0) a large closing counter move — no cap (#1292)', () => {
     const staging = join(tmp, 'staging')
     const prod = join(tmp, 'prod')
     writeSnapshot(
@@ -192,15 +192,17 @@ describe('runValueDiff — Closing-Pinned Auto-Allow end-to-end (#1086)', () => 
     writeSnapshot(
       staging,
       '2026-05-31',
-      closingRankings('2026-05-31', '2026-06-02', 4400) // Δ −600 > cap 500
+      closingRankings('2026-05-31', '2026-06-02', 4400) // Δ −600, no longer capped
     )
     const { decision, exitCode } = runValueDiff({
       stagingDir: staging,
       prodDir: prod,
     })
-    expect(decision.promote).toBe(false)
-    expect(decision.autoAllowed).toBeUndefined()
-    expect(decision.reasons.join(' ')).toMatch(/cap/i)
-    expect(exitCode).toBe(1)
+    expect(decision.promote).toBe(true)
+    expect(decision.autoAllowed).toBe('closing-reconciliation')
+    expect(decision.closingDeltas).toEqual([
+      expect.objectContaining({ delta: -600 }),
+    ])
+    expect(exitCode).toBe(0)
   })
 })


### PR DESCRIPTION
## Why

Follow-up to #1289 (bases). The CPAA value gate's **counter** cap (`|Δ| ≤ max(50, 10%×prod)`) still blocked routine closing days — it held the 2026-07-03 promotion on `2026-06-30 D82 charterPayments 106→186 (Δ +80)`. Verified against live TM data (D82 Charter Payments = **186**): a real charter spike, not a re-derive bug. Charter payments and dues reconcile in **lumps** during the closing/charter window (a chartering club lands ~20+ payments at once), so counters routinely exceed the floor of 50 — a different field/district each day, forcing a daily manual override.

## What (operator decision 2026-07-03)

Counter value moves now auto-allow during closing at **any magnitude/direction**, recorded as delta provenance — never blocking, matching the #1289 base rule. CPAA still blocks a closing-pinned date on **identity** drift, a **plan-boolean** revert, an **optionality transition** (structural), a district-set change, or a **non-closing-pinned** changed date (re-derive of history).

- `evaluateClosingAutoAllow`: `counter` folded into the same allow-with-provenance path as `base`; cap removed.
- Decision doc §4 amended (+ top pointer + amendment section).

## Verification

- TDD: flipped the cap-block tests to auto-allow (incl. the live D82 charterPayments case) + a large-decrease case; removed the obsolete cap-boundary block. Repointed the CPAA "still blocks" wiring test to identity drift.
- Full collector-cli suite: **1009 pass**. Typecheck clean.

Accepted residual risk: a systematic re-derive bug (every district +30%) or unit-scale (×10) during closing would now auto-promote. Recoverable (deterministic re-derive + re-promote); moves are in the provenance table; historical dates still block.

Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)