### PR TITLE
feat(pipeline): invalidate Cloud CDN cache after promotion (#1294)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -1646,6 +1646,28 @@ jobs:
           echo "## ✅ Promotion Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "Staging data synced to production bucket." >> "$GITHUB_STEP_SUMMARY"
 
+      # Purge the Cloud CDN edge so freshly-promoted data is served immediately
+      # (#1294). Without this, cdn.taverns.red keeps the previous objects until
+      # their max-age TTL expires (~1h), making a successful promotion look
+      # stale. Non-fatal: a promotion must never be undone by an invalidation
+      # hiccup, and the edge expires on its own TTL as a fallback. Note this
+      # purges the EDGE only — an already-open browser tab still honours the
+      # response's max-age until it reloads.
+      - name: Invalidate CDN cache after promotion (#1294)
+        if: steps.diff.outputs.promote == 'true' && steps.valuediff.outputs.value_promote == 'true' && steps.mode.outputs.mode != 'prune'
+        continue-on-error: true
+        run: |
+          echo "Invalidating Cloud CDN cache (toast-stats-cdn-url-map, cdn.taverns.red)..."
+          if gcloud compute url-maps invalidate-cdn-cache toast-stats-cdn-url-map \
+               --path '/*' --async; then
+            echo "## 🧹 CDN Cache Invalidated" >> "$GITHUB_STEP_SUMMARY"
+            echo "Purged cdn.taverns.red edge — promoted data is served immediately." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::CDN invalidation failed — promotion succeeded, but the" \
+              "edge may serve stale data until max-age expires (~1h). Grant the" \
+              "pipeline SA 'compute.urlMaps.invalidateCache' (see #1294)."
+          fi
+
       - name: Promotion blocked
         if: (steps.diff.outputs.promote == 'false' || steps.valuediff.outputs.value_promote == 'false') && steps.mode.outputs.mode != 'prune'
         run: |


### PR DESCRIPTION
## Why

After a staging→prod promotion (`gsutil rsync` to `toast-stats-data-ca`), the Cloud CDN edge at `cdn.taverns.red` keeps serving the previous objects until their `max-age=3600` TTL expires (~1h). Data is promoted but fresh page loads look stale — which twice made a successful promotion look like a failure.

## What

New step after `Promote staging to production` (same gate condition):

```
gcloud compute url-maps invalidate-cdn-cache toast-stats-cdn-url-map --path '/*' --async
```

- `continue-on-error` + a clear `::warning::` — an invalidation hiccup or missing permission never fails/undoes a promotion; the edge expires on its own TTL as fallback.
- url-map `toast-stats-cdn-url-map` (ADR-007). Verified the command works against it manually (invalidation accepted).
- Purges the **edge** only — an already-open browser tab still honours `max-age` until it reloads (documented in the step comment).

## Prerequisite (operator — IAM change, I can't make it)

The pipeline SA `toast-stats-deployer` has `storage.admin` but no compute permission. Grant `compute.urlMaps.invalidateCache` (least-privilege custom role) — command in #1294. Until then the step logs a warning and the pipeline still succeeds.

Closes #1294

🤖 Generated with [Claude Code](https://claude.com/claude-code)