### PR TITLE
fix(ui): freshness badge shows as-of date + month-end reconciliation (#1296)

### DIFF
--- a/frontend/src/components/DataControlsBar.tsx
+++ b/frontend/src/components/DataControlsBar.tsx
@@ -59,7 +59,7 @@ const FreshnessPill: React.FC<{
       />
       <span>
         {reconciling
-          ? `As of ${formatDisplayDate(date)} · reconciling`
+          ? `As of ${formatDisplayDate(date)} · month-end reconciliation`
           : `Data fresh · ${formatDisplayDate(date)}`}
       </span>
     </div>

--- a/frontend/src/components/DataControlsBar.tsx
+++ b/frontend/src/components/DataControlsBar.tsx
@@ -7,6 +7,11 @@ import { formatDisplayDate } from '../utils/dateFormatting'
 
 export interface DataControlsBarProps {
   latestSnapshotDate: string | undefined
+  /** The "as of" date (sourceCsvDate) — shown in the pill when set, instead of
+   * the pinned snapshot date (#1296). Falls back to latestSnapshotDate. */
+  asOfDate?: string | undefined
+  /** When set, the pill renders a month-end reconciliation state (#1296). */
+  reconcilingMonthLabel?: string | undefined
   availableProgramYears: ProgramYear[]
   selectedProgramYear: ProgramYear
   onProgramYearChange: (py: ProgramYear) => void
@@ -30,20 +35,36 @@ export interface DataControlsBarProps {
 const CHIP_BASE =
   'inline-flex items-center gap-1.5 min-h-[44px] px-3 py-1.5 rounded-full text-xs font-medium border bg-white border-gray-200 text-gray-700 theme-dark:bg-gray-800 theme-dark:border-gray-700 theme-dark:text-gray-200'
 
-const FreshnessPill: React.FC<{ date: string }> = ({ date }) => (
-  <div
-    data-testid="freshness-pill"
-    className={CHIP_BASE}
-    title={`Latest snapshot: ${date}`}
-  >
-    <span
-      data-testid="freshness-dot"
-      aria-hidden="true"
-      className="w-2 h-2 rounded-full bg-green-500"
-    />
-    <span>Data fresh · {formatDisplayDate(date)}</span>
-  </div>
-)
+const FreshnessPill: React.FC<{
+  date: string
+  /** When set, the pill shows a month-end reconciliation state (#1296). */
+  reconcilingMonthLabel?: string | undefined
+}> = ({ date, reconcilingMonthLabel }) => {
+  const reconciling = Boolean(reconcilingMonthLabel)
+  return (
+    <div
+      data-testid="freshness-pill"
+      data-reconciling={reconciling ? 'true' : undefined}
+      className={CHIP_BASE}
+      title={
+        reconciling
+          ? `${reconcilingMonthLabel} month-end reconciliation — figures update daily until finalized. As of ${formatDisplayDate(date)}.`
+          : `Latest snapshot: ${date}`
+      }
+    >
+      <span
+        data-testid="freshness-dot"
+        aria-hidden="true"
+        className={`w-2 h-2 rounded-full ${reconciling ? 'bg-amber-500' : 'bg-green-500'}`}
+      />
+      <span>
+        {reconciling
+          ? `As of ${formatDisplayDate(date)} · reconciling`
+          : `Data fresh · ${formatDisplayDate(date)}`}
+      </span>
+    </div>
+  )
+}
 
 /** #922 — width of the pill-slot placeholder rendered while the snapshot
  * date is pending. Matches the rendered pill ("Data fresh · <Mon D, YYYY>",
@@ -111,6 +132,8 @@ const formatPyShort = (py: ProgramYear): string =>
 
 export const DataControlsBar: React.FC<DataControlsBarProps> = ({
   latestSnapshotDate,
+  asOfDate,
+  reconcilingMonthLabel,
   availableProgramYears,
   selectedProgramYear,
   onProgramYearChange,
@@ -120,6 +143,7 @@ export const DataControlsBar: React.FC<DataControlsBarProps> = ({
   freshnessPending = false,
 }) => {
   const sortedDates = [...availableDates].sort((a, b) => b.localeCompare(a))
+  const pillDate = asOfDate ?? latestSnapshotDate
 
   return (
     <div
@@ -127,8 +151,11 @@ export const DataControlsBar: React.FC<DataControlsBarProps> = ({
       aria-label="Data controls"
       className="flex flex-wrap items-center gap-2"
     >
-      {latestSnapshotDate ? (
-        <FreshnessPill date={latestSnapshotDate} />
+      {pillDate ? (
+        <FreshnessPill
+          date={pillDate}
+          reconcilingMonthLabel={reconcilingMonthLabel}
+        />
       ) : (
         freshnessPending && <FreshnessPillSkeleton />
       )}

--- a/frontend/src/components/__tests__/DataControlsBar.test.tsx
+++ b/frontend/src/components/__tests__/DataControlsBar.test.tsx
@@ -53,7 +53,7 @@ describe('DataControlsBar (#529 #528)', () => {
       />
     )
     const pill = screen.getByTestId('freshness-pill')
-    expect(pill).toHaveTextContent(/reconciling/i)
+    expect(pill).toHaveTextContent(/month-end reconciliation/i)
     expect(pill).toHaveTextContent(/Jul 2, 2026/)
     expect(pill.getAttribute('data-reconciling')).toBe('true')
     expect(pill.getAttribute('title')).toMatch(

--- a/frontend/src/components/__tests__/DataControlsBar.test.tsx
+++ b/frontend/src/components/__tests__/DataControlsBar.test.tsx
@@ -30,6 +30,39 @@ describe('DataControlsBar (#529 #528)', () => {
     expect(pill.querySelector('[data-testid="freshness-dot"]')).not.toBeNull()
   })
 
+  it('shows the as-of date (not the pinned snapshot date) when provided (#1296)', () => {
+    render(
+      <DataControlsBar
+        {...baseProps}
+        latestSnapshotDate="2026-06-30"
+        asOfDate="2026-07-02"
+      />
+    )
+    const pill = screen.getByTestId('freshness-pill')
+    expect(pill).toHaveTextContent(/Jul 2, 2026/)
+    expect(pill).not.toHaveTextContent(/Jun 30/)
+  })
+
+  it('renders a month-end reconciliation state (amber dot, tooltip) when reconciling (#1296)', () => {
+    render(
+      <DataControlsBar
+        {...baseProps}
+        latestSnapshotDate="2026-06-30"
+        asOfDate="2026-07-02"
+        reconcilingMonthLabel="June 2026"
+      />
+    )
+    const pill = screen.getByTestId('freshness-pill')
+    expect(pill).toHaveTextContent(/reconciling/i)
+    expect(pill).toHaveTextContent(/Jul 2, 2026/)
+    expect(pill.getAttribute('data-reconciling')).toBe('true')
+    expect(pill.getAttribute('title')).toMatch(
+      /June 2026 month-end reconciliation/
+    )
+    const dot = pill.querySelector('[data-testid="freshness-dot"]')
+    expect(dot?.className).toMatch(/amber/)
+  })
+
   it('renders the PY chip showing the selected program year as "PY YYYY–YY"', () => {
     render(<DataControlsBar {...baseProps} />)
     const py = screen.getByTestId('py-chip')

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -7,6 +7,7 @@ import {
   fetchCdnRankingsForDate,
 } from '../services/cdn'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
+import { computeFreshness } from '../utils/dataFreshness'
 import { AwardsRaceSection } from '../components/AwardsRaceSection'
 import { LazyHistoricalRankChart as HistoricalRankChart } from '../components/LazyCharts'
 import { ChartSparklineExpand } from '../components/ChartSparklineExpand'
@@ -274,6 +275,18 @@ const DistrictsPage: React.FC = () => {
     },
     staleTime: 15 * 60 * 1000, // 15 minutes
     placeholderData: prev => prev,
+  })
+
+  // Freshness pill: show the "as of" date (sourceCsvDate) and flag month-end
+  // reconciliation when the latest snapshot is still finalizing (#1296).
+  const isLatestSnapshot =
+    !selectedDate ||
+    (cachedDates.length > 0 &&
+      selectedDate === [...cachedDates].sort((a, b) => b.localeCompare(a))[0])
+  const freshness = computeFreshness({
+    asOfDate: data?.date,
+    snapshotDate: effectiveRankingsDate,
+    isLatest: isLatestSnapshot,
   })
 
   // Fetch competitive award standings for the same snapshot (#331).
@@ -876,6 +889,8 @@ const DistrictsPage: React.FC = () => {
           <div className="districts-page-header__actions">
             <DataControlsBar
               latestSnapshotDate={effectiveRankingsDate}
+              asOfDate={freshness.displayDate}
+              reconcilingMonthLabel={freshness.reconcilingMonthLabel}
               availableProgramYears={availableProgramYears}
               selectedProgramYear={selectedProgramYear}
               onProgramYearChange={setSelectedProgramYear}

--- a/frontend/src/utils/__tests__/dataFreshness.test.ts
+++ b/frontend/src/utils/__tests__/dataFreshness.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { computeFreshness } from '../dataFreshness'
+
+describe('computeFreshness (#1296)', () => {
+  it('displays the as-of date (sourceCsvDate), not the pinned snapshot date', () => {
+    const f = computeFreshness({
+      asOfDate: '2026-07-02',
+      snapshotDate: '2026-06-30',
+      isLatest: true,
+    })
+    expect(f.displayDate).toBe('2026-07-02')
+  })
+
+  it('flags reconciliation when the latest month-end has advanced into a later month', () => {
+    const f = computeFreshness({
+      asOfDate: '2026-07-02',
+      snapshotDate: '2026-06-30',
+      isLatest: true,
+    })
+    expect(f.reconciling).toBe(true)
+    expect(f.reconcilingMonthLabel).toBe('June 2026')
+  })
+
+  it('handles the December→January program-year-agnostic rollover', () => {
+    const f = computeFreshness({
+      asOfDate: '2026-01-05',
+      snapshotDate: '2025-12-31',
+      isLatest: true,
+    })
+    expect(f.reconciling).toBe(true)
+    expect(f.reconcilingMonthLabel).toBe('December 2025')
+  })
+
+  it('does NOT flag reconciliation mid-month (as-of == snapshot date)', () => {
+    const f = computeFreshness({
+      asOfDate: '2026-03-15',
+      snapshotDate: '2026-03-15',
+      isLatest: true,
+    })
+    expect(f.reconciling).toBe(false)
+    expect(f.reconcilingMonthLabel).toBeUndefined()
+    expect(f.displayDate).toBe('2026-03-15')
+  })
+
+  it('does NOT flag reconciliation for a finalized historical month-end (not latest)', () => {
+    // Selecting an old month-end via the date picker: its sourceCsvDate is also
+    // in the next month, but it is finalized — must not read as "reconciling".
+    const f = computeFreshness({
+      asOfDate: '2026-04-05',
+      snapshotDate: '2026-03-31',
+      isLatest: false,
+    })
+    expect(f.reconciling).toBe(false)
+  })
+
+  it('falls back to the snapshot date when the as-of date is unknown', () => {
+    const f = computeFreshness({
+      asOfDate: undefined,
+      snapshotDate: '2026-06-30',
+      isLatest: true,
+    })
+    expect(f.displayDate).toBe('2026-06-30')
+    expect(f.reconciling).toBe(false)
+  })
+})

--- a/frontend/src/utils/dataFreshness.ts
+++ b/frontend/src/utils/dataFreshness.ts
@@ -1,0 +1,63 @@
+import { formatDisplayDate } from './dateFormatting'
+
+/**
+ * Freshness state for the data pill (#1296).
+ *
+ * During month-end closing the snapshot DATE is pinned to the month-end (e.g.
+ * 2026-06-30) while the dashboard "as of" date (`metadata.sourceCsvDate`)
+ * advances into the next month (e.g. 2026-07-02) as figures reconcile. The pill
+ * should show the real as-of date and signal that reconciliation is ongoing.
+ */
+export interface FreshnessState {
+  /** Date to display in the pill — the "as of" (sourceCsvDate) when known. */
+  displayDate: string | undefined
+  /** True when the latest month-end is still reconciling into a later month. */
+  reconciling: boolean
+  /** e.g. "June 2026" — the month being reconciled (only when reconciling). */
+  reconcilingMonthLabel?: string
+}
+
+/** YYYY-MM month key from an ISO date (date-only or datetime). */
+function monthKey(isoDate: string): string {
+  return isoDate.slice(0, 7)
+}
+
+/**
+ * Derive the freshness display date + reconciliation state.
+ *
+ * Reconciliation is flagged only when **all** hold, so a finalized historical
+ * month-end selected via the date picker is never mislabelled:
+ *   - we're viewing the latest snapshot (`isLatest`), and
+ *   - the as-of date has advanced past the pinned snapshot date, into a
+ *     different (later) month.
+ */
+export function computeFreshness(params: {
+  /** metadata.sourceCsvDate — the dashboard "as of" date. */
+  asOfDate: string | undefined
+  /** The pinned snapshot date currently being viewed. */
+  snapshotDate: string | undefined
+  /** True when viewing the most recent available snapshot. */
+  isLatest: boolean
+}): FreshnessState {
+  const { asOfDate, snapshotDate, isLatest } = params
+  const displayDate = asOfDate ?? snapshotDate
+
+  const reconciling =
+    isLatest &&
+    !!asOfDate &&
+    !!snapshotDate &&
+    asOfDate > snapshotDate &&
+    monthKey(asOfDate) !== monthKey(snapshotDate)
+
+  if (reconciling && snapshotDate) {
+    return {
+      displayDate,
+      reconciling: true,
+      reconcilingMonthLabel: formatDisplayDate(snapshotDate, {
+        month: 'long',
+        year: 'numeric',
+      }),
+    }
+  }
+  return { displayDate, reconciling: false }
+}


### PR DESCRIPTION
## Why

During month-end closing the snapshot is pinned to the month-end (e.g. Jun 30) while the dashboard 'as of' date (`metadata.sourceCsvDate`) has advanced (e.g. Jul 2). The freshness pill showed 'Data fresh · Jun 30, 2026' — not the real as-of date, and no signal that June is still reconciling.

## What

- Show the **as-of date** (`sourceCsvDate`, already surfaced by `fetchCdnRankingsForDate`).
- When viewing the **latest** snapshot and the as-of month has advanced past the pinned month, render an amber **'As of <date> · month-end reconciliation'** state (tooltip names the month). Gated on 'latest' so finalized historical month-ends viewed via the date picker are not mislabelled.
- Mid-month (as-of == snapshot) is unchanged: green 'Data fresh · <date>'.
- New tested `computeFreshness` helper (incl. Dec→Jan rollover; historical-month-end guard).

## Verification

- Unit: 6 helper cases + 2 pill-rendering cases; full frontend unit suite green (2814).
- **Live (staging data):** confirmed the pill renders '🟠 As of Jul 2, 2026 · month-end reconciliation' on /districts for the 2025-2026 latest snapshot, no overflow.

Closes #1296

🤖 Generated with [Claude Code](https://claude.com/claude-code)