### PR TITLE
test(ui): unblock release #1253 — pin current PY in DistrictClubsPage test

### DIFF
--- a/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictClubsPage.test.tsx
@@ -93,6 +93,16 @@ const TEST_CLUBS: ClubTrend[] = [
   },
 ]
 
+// Pin the "current" program year to 2025-2026 (this file's fixture PY) so the
+// app doesn't append ?py=2025 to URLs after the July calendar rollover flips
+// getCurrentProgramYear() to 2026-2027. Interim guard until epic #1298 Sprint 1
+// (#1300) makes the default data-driven; without it the release PR #1253 is
+// blocked. See #1285 for the wall-clock-coupling pattern.
+vi.mock('../../utils/programYear', async importActual => {
+  const actual = await importActual<typeof import('../../utils/programYear')>()
+  return { ...actual, getCurrentProgramYear: () => actual.getProgramYear(2025) }
+})
+
 vi.mock('../../hooks/useDistricts', () => ({
   useDistricts: vi.fn(() => ({
     data: {


### PR DESCRIPTION
## Why

Release PR #1253 (2.30.0) is blocked by `DistrictClubsPage.test.tsx:277`: after the July calendar rollover, `getCurrentProgramYear()` returns 2026-2027, so the app appends `?py=2025` to club-nav URLs and the test's expected `?status=vulnerable` becomes `?status=vulnerable&py=2025`.

## What

Mock `getCurrentProgramYear` to the fixture's program year (2025-2026) in this test file, so `py` is omitted again. Deterministic, no fake timers.

**Interim guard.** Epic #1298 Sprint 1 (#1300, running now) makes the default program year data-driven and removes the need for this mock. This unblocks the release today rather than waiting for that sprint to land.

## Verification

- `DistrictClubsPage.test.tsx`: 21/21 pass. Full frontend suite green (pre-push hook).
- Once merged, release-please rebuilds #1253 → Test Suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)