### PR TITLE
feat(frontend): PY selector on Regions, Region, and Awards pages (#1301)

### DIFF
--- a/frontend/src/__tests__/accessibility/RegionPage.axe.test.tsx
+++ b/frontend/src/__tests__/accessibility/RegionPage.axe.test.tsx
@@ -15,6 +15,7 @@ import { render, screen, cleanup } from '@testing-library/react'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import RegionPage from '../../pages/RegionPage'
 
 // @ts-expect-error - jest-axe matcher types vs vitest expect
@@ -42,11 +43,19 @@ vi.mock('../../services/cdn', () => {
     overallRank: 1,
     aggregateScore: score,
   })
+  // #1301 — the page hosts the shared PY selector; provide a dates index +
+  // per-date fetch so the DataControlsBar toolbar is fully populated for the
+  // a11y scan.
+  const rankings = {
+    date: '2026-05-12',
+    rankings: [ranking('60', '07', 500), ranking('61', '07', 350)],
+  }
   return {
-    fetchCdnRankings: vi.fn().mockResolvedValue({
-      date: '2026-05-12',
-      rankings: [ranking('60', '07', 500), ranking('61', '07', 350)],
-    }),
+    fetchCdnDates: vi
+      .fn()
+      .mockResolvedValue({ dates: ['2026-05-12'], count: 1 }),
+    fetchCdnRankings: vi.fn().mockResolvedValue(rankings),
+    fetchCdnRankingsForDate: vi.fn().mockResolvedValue(rankings),
     fetchCdnCompetitiveAwards: vi.fn().mockResolvedValue(null),
     fetchCdnManifest: vi.fn().mockResolvedValue({
       latestSnapshotDate: '2026-05-12',
@@ -61,11 +70,13 @@ const renderPage = () => {
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={['/region/07']}>
-        <Routes>
-          <Route path="/region/:n" element={<RegionPage />} />
-        </Routes>
-      </MemoryRouter>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={['/region/07']}>
+          <Routes>
+            <Route path="/region/:n" element={<RegionPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/__tests__/accessibility/RegionsPage.axe.test.tsx
+++ b/frontend/src/__tests__/accessibility/RegionsPage.axe.test.tsx
@@ -14,6 +14,7 @@ import userEvent from '@testing-library/user-event'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import RegionsPage from '../../pages/RegionsPage'
 
 // @ts-expect-error - jest-axe matcher types vs vitest expect
@@ -54,15 +55,23 @@ vi.mock('../../services/cdn', () => {
     latePayments: 0,
     charterPayments: 0,
   })
+  // #1301 — the page hosts the shared PY selector; provide a dates index +
+  // per-date fetch so the DataControlsBar toolbar is fully populated for the
+  // a11y scan.
+  const rankings = {
+    date: '2026-05-12',
+    rankings: [
+      baseRanking('01', '01', 500),
+      baseRanking('07', '57', 350),
+      baseRanking('14', '88', 200),
+    ],
+  }
   return {
-    fetchCdnRankings: vi.fn().mockResolvedValue({
-      date: '2026-05-12',
-      rankings: [
-        baseRanking('01', '01', 500),
-        baseRanking('07', '57', 350),
-        baseRanking('14', '88', 200),
-      ],
-    }),
+    fetchCdnDates: vi
+      .fn()
+      .mockResolvedValue({ dates: ['2026-05-12'], count: 1 }),
+    fetchCdnRankings: vi.fn().mockResolvedValue(rankings),
+    fetchCdnRankingsForDate: vi.fn().mockResolvedValue(rankings),
   }
 })
 
@@ -72,11 +81,13 @@ const renderPage = () => {
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={['/regions']}>
-        <Routes>
-          <Route path="/regions" element={<RegionsPage />} />
-        </Routes>
-      </MemoryRouter>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={['/regions']}>
+          <Routes>
+            <Route path="/regions" element={<RegionsPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/hooks/__tests__/useProgramYearControls.test.tsx
+++ b/frontend/src/hooks/__tests__/useProgramYearControls.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Tests for useProgramYearControls (#1301, epic #1298 Sprint 2).
+ *
+ * The shared PY-controls hook the region/aggregate pages (RegionsPage,
+ * RegionPage, AwardsPage) use to drive a DataControlsBar. It wraps
+ * useUrlProgramYear (URL-synced ?py=/?date=) plus the ['available-dates']
+ * CDN dates query, and derives:
+ *   - availableProgramYears (newest first, only years WITH data)
+ *   - cachedDates (dates within the selected PY)
+ *   - effectiveDate (explicit ?date= or the latest date in the selected PY)
+ * It self-heals a ?py= that has no data to the newest available PY (L124).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+
+// Dates spanning three program years (Jul 1 – Jun 30 each), two per year.
+//   PY2026: 2026-08-01, 2026-09-15
+//   PY2025: 2025-08-01, 2026-05-01
+//   PY2024: 2024-08-01, 2025-03-01
+// vi.mock is hoisted — the fixture is inlined in the factory (can't close over
+// an outer const that initializes later).
+vi.mock('../../services/cdn', () => {
+  const dates = [
+    '2024-08-01',
+    '2025-03-01',
+    '2025-08-01',
+    '2026-05-01',
+    '2026-08-01',
+    '2026-09-15',
+  ]
+  return {
+    fetchCdnDates: vi.fn().mockResolvedValue({
+      dates,
+      count: dates.length,
+      generatedAt: '2026-09-16T00:00:00Z',
+    }),
+  }
+})
+
+import { useProgramYearControls } from '../useProgramYearControls'
+
+function createWrapper(initialEntries: string[] = ['/']) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('useProgramYearControls (#1301)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('derives availableProgramYears from CDN dates, newest first, data-only', async () => {
+    const { result } = renderHook(() => useProgramYearControls(), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() =>
+      expect(result.current.availableProgramYears.length).toBe(3)
+    )
+    expect(result.current.availableProgramYears.map(py => py.year)).toEqual([
+      2026, 2025, 2024,
+    ])
+  })
+
+  it('defaults to the newest PY with data and its latest date', async () => {
+    const { result } = renderHook(() => useProgramYearControls(), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() =>
+      expect(result.current.selectedProgramYear.year).toBe(2026)
+    )
+    // effectiveDate = latest date within PY2026.
+    await waitFor(() => expect(result.current.effectiveDate).toBe('2026-09-15'))
+    expect(result.current.cachedDates.sort()).toEqual([
+      '2026-08-01',
+      '2026-09-15',
+    ])
+  })
+
+  it('honors ?py= and reports that PY latest date', async () => {
+    const { result } = renderHook(() => useProgramYearControls(), {
+      wrapper: createWrapper(['/?py=2025']),
+    })
+    await waitFor(() =>
+      expect(result.current.selectedProgramYear.year).toBe(2025)
+    )
+    await waitFor(() => expect(result.current.effectiveDate).toBe('2026-05-01'))
+    expect(result.current.cachedDates.sort()).toEqual([
+      '2025-08-01',
+      '2026-05-01',
+    ])
+  })
+
+  it('honors an explicit ?date= over the PY latest', async () => {
+    const { result } = renderHook(() => useProgramYearControls(), {
+      wrapper: createWrapper(['/?py=2025&date=2025-08-01']),
+    })
+    await waitFor(() => expect(result.current.effectiveDate).toBe('2025-08-01'))
+    expect(result.current.selectedDate).toBe('2025-08-01')
+  })
+
+  it('self-heals a ?py= with no data to the newest available PY (L124)', async () => {
+    const { result } = renderHook(() => useProgramYearControls(), {
+      wrapper: createWrapper(['/?py=1999']),
+    })
+    // 1999 has no snapshots → falls back to the newest PY-with-data (2026).
+    await waitFor(() =>
+      expect(result.current.selectedProgramYear.year).toBe(2026)
+    )
+  })
+})

--- a/frontend/src/hooks/useProgramYearControls.ts
+++ b/frontend/src/hooks/useProgramYearControls.ts
@@ -49,6 +49,10 @@ export interface ProgramYearControls {
   cachedDates: string[]
   /** The date the page should fetch: `?date=` if set, else the PY's latest. */
   effectiveDate: string | undefined
+  /** True when the selected date is the most recent snapshot in the PY (or no
+   * explicit date is chosen). Drives the freshness pill's reconciliation axis
+   * (#1296) — memoized here so each consuming page doesn't re-sort per render. */
+  isLatestSnapshot: boolean
   /** True while the dates index query is in flight (freshness-pill reserve). */
   isDatesPending: boolean
 }
@@ -103,6 +107,16 @@ export function useProgramYearControls(): ProgramYearControls {
     )
   }, [selectedDate, allCachedDates, selectedProgramYear])
 
+  // Whether the selection is the newest snapshot in the PY — the freshness
+  // pill only flags month-end reconciliation for the latest snapshot (#1296).
+  // Memoized once here so every consuming page skips the per-render re-sort.
+  const isLatestSnapshot = useMemo(() => {
+    if (!selectedDate) return true
+    if (cachedDates.length === 0) return false
+    const latest = [...cachedDates].sort((a, b) => b.localeCompare(a))[0]
+    return selectedDate === latest
+  }, [selectedDate, cachedDates])
+
   return {
     selectedProgramYear,
     setSelectedProgramYear,
@@ -111,6 +125,7 @@ export function useProgramYearControls(): ProgramYearControls {
     availableProgramYears,
     cachedDates,
     effectiveDate,
+    isLatestSnapshot,
     isDatesPending,
   }
 }

--- a/frontend/src/hooks/useProgramYearControls.ts
+++ b/frontend/src/hooks/useProgramYearControls.ts
@@ -83,6 +83,10 @@ export function useProgramYearControls(): ProgramYearControls {
 
   // Self-heal a selected PY that has no data (e.g. a hand-edited ?py=) to the
   // newest available year — never strand the user on an empty grid (L124).
+  // Invariant: availableProgramYears[0] is the same year useDefaultProgramYear
+  // resolves to — both derive from the shared ['available-dates'] query — so
+  // healing to it deletes `?py=` rather than pinning the default year on. If
+  // that shared-cache invariant ever breaks, this would flip `?py=` back on.
   useEffect(() => {
     if (availableProgramYears.length === 0) return
     const isAvailable = availableProgramYears.some(

--- a/frontend/src/hooks/useProgramYearControls.ts
+++ b/frontend/src/hooks/useProgramYearControls.ts
@@ -1,0 +1,116 @@
+/**
+ * useProgramYearControls — shared PY-selector state for PY-scoped aggregate
+ * pages (#1301, epic #1298 Sprint 2).
+ *
+ * RegionsPage, RegionPage, and AwardsPage all show program-year-scoped data
+ * but historically had no way to choose the year (they defaulted to "latest").
+ * This hook packages everything a DataControlsBar needs so those pages own the
+ * PY state at the page level (R3) and thread the selected year/date into their
+ * own data query — never re-deriving it from the response.
+ *
+ * It composes:
+ *   - useUrlProgramYear — URL-synced `?py=` / `?date=`, with Sprint 1's
+ *     data-driven default (the newest PY WITH data, not the calendar year).
+ *   - the shared `['available-dates']` CDN dates query (same cache key as
+ *     useDefaultProgramYear + DateSelector) → the set of snapshot dates.
+ *
+ * and derives:
+ *   - `availableProgramYears` — newest first, only years that have snapshots.
+ *   - `cachedDates` — snapshot dates within the selected PY.
+ *   - `effectiveDate` — the explicit `?date=` selection, else the latest date
+ *     within the selected PY (what the page should fetch).
+ *
+ * Self-healing (L124): if a hand-edited / shared `?py=` names a year with no
+ * data, it falls back to the newest available PY so the user is never stranded
+ * on an empty year — validated at the page, not the picker.
+ */
+
+import { useEffect, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchCdnDates } from '../services/cdn'
+import { useUrlProgramYear } from './useUrlProgramYear'
+import {
+  getAvailableProgramYears,
+  filterDatesByProgramYear,
+  getMostRecentDateInProgramYear,
+} from '../utils/programYear'
+import type { ProgramYear } from '../utils/programYear'
+
+const EMPTY_DATES: string[] = []
+
+export interface ProgramYearControls {
+  selectedProgramYear: ProgramYear
+  setSelectedProgramYear: (py: ProgramYear) => void
+  selectedDate: string | undefined
+  setSelectedDate: (date: string | undefined) => void
+  /** Program years that actually have snapshots, newest first. */
+  availableProgramYears: ProgramYear[]
+  /** Snapshot dates within the selected program year. */
+  cachedDates: string[]
+  /** The date the page should fetch: `?date=` if set, else the PY's latest. */
+  effectiveDate: string | undefined
+  /** True while the dates index query is in flight (freshness-pill reserve). */
+  isDatesPending: boolean
+}
+
+export function useProgramYearControls(): ProgramYearControls {
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+  } = useUrlProgramYear()
+
+  // Shares the ['available-dates'] cache with useDefaultProgramYear and the
+  // DateSelector so the PY list and the data-driven default always agree.
+  const { data, isPending: isDatesPending } = useQuery({
+    queryKey: ['available-dates'],
+    queryFn: fetchCdnDates,
+    staleTime: 15 * 60 * 1000, // 15 minutes
+    retry: false,
+  })
+
+  const allCachedDates = data?.dates ?? EMPTY_DATES
+
+  const availableProgramYears = useMemo(
+    () => getAvailableProgramYears(allCachedDates),
+    [allCachedDates]
+  )
+
+  // Self-heal a selected PY that has no data (e.g. a hand-edited ?py=) to the
+  // newest available year — never strand the user on an empty grid (L124).
+  useEffect(() => {
+    if (availableProgramYears.length === 0) return
+    const isAvailable = availableProgramYears.some(
+      py => py.year === selectedProgramYear.year
+    )
+    if (!isAvailable) {
+      const newest = availableProgramYears[0]
+      if (newest) setSelectedProgramYear(newest)
+    }
+  }, [availableProgramYears, selectedProgramYear.year, setSelectedProgramYear])
+
+  const cachedDates = useMemo(
+    () => filterDatesByProgramYear(allCachedDates, selectedProgramYear),
+    [allCachedDates, selectedProgramYear]
+  )
+
+  const effectiveDate = useMemo(() => {
+    if (selectedDate) return selectedDate
+    return (
+      getMostRecentDateInProgramYear(allCachedDates, selectedProgramYear) ??
+      undefined
+    )
+  }, [selectedDate, allCachedDates, selectedProgramYear])
+
+  return {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+    availableProgramYears,
+    cachedDates,
+    effectiveDate,
+    isDatesPending,
+  }
+}

--- a/frontend/src/pages/AwardsPage.tsx
+++ b/frontend/src/pages/AwardsPage.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
+import { useProgramYearControls } from '../hooks/useProgramYearControls'
+import { DataControlsBar } from '../components/DataControlsBar'
+import { computeFreshness } from '../utils/dataFreshness'
 import type {
   CompetitiveAwardRanking,
   CompetitiveAwardStandings,
@@ -49,12 +52,47 @@ const AWARDS: ReadonlyArray<AwardSpec> = [
 ]
 
 const AwardsPage: React.FC = () => {
-  // Latest snapshot — pass undefined and let the hook resolve.
-  const { data: standings, isLoading } = useCompetitiveAwards(undefined)
+  // PY selector state (#1301) — the page owns program year/date (R3) and
+  // fetches the awards snapshot for the SELECTED program year, so switching
+  // the year re-queries (was hardcoded "latest").
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+    availableProgramYears,
+    cachedDates,
+    effectiveDate,
+    isDatesPending,
+  } = useProgramYearControls()
+
+  const { data: standings, isLoading } = useCompetitiveAwards(effectiveDate)
+
+  // Freshness pill (#1296). The awards standings carry no `sourceCsvDate`, so
+  // the pill shows the snapshot date itself (no month-end reconciliation axis).
+  const freshness = computeFreshness({
+    asOfDate: effectiveDate,
+    snapshotDate: effectiveDate,
+    isLatest: !selectedDate,
+  })
 
   return (
     <div className="awards-page">
       <header className="awards-page__header">
+        <div className="districts-page-header__actions">
+          <DataControlsBar
+            latestSnapshotDate={effectiveDate}
+            asOfDate={freshness.displayDate}
+            reconcilingMonthLabel={freshness.reconcilingMonthLabel}
+            availableProgramYears={availableProgramYears}
+            selectedProgramYear={selectedProgramYear}
+            onProgramYearChange={setSelectedProgramYear}
+            availableDates={cachedDates}
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+            freshnessPending={isDatesPending}
+          />
+        </div>
         <p className="placeholder-page__eyebrow">
           Awards · {standings?.metadata?.totalDistricts ?? 117} districts
         </p>

--- a/frontend/src/pages/AwardsPage.tsx
+++ b/frontend/src/pages/AwardsPage.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
 import { useProgramYearControls } from '../hooks/useProgramYearControls'
 import { DataControlsBar } from '../components/DataControlsBar'
-import { computeFreshness } from '../utils/dataFreshness'
 import type {
   CompetitiveAwardRanking,
   CompetitiveAwardStandings,
@@ -68,22 +67,35 @@ const AwardsPage: React.FC = () => {
 
   const { data: standings, isLoading } = useCompetitiveAwards(effectiveDate)
 
-  // Freshness pill (#1296). The awards standings carry no `sourceCsvDate`, so
-  // the pill shows the snapshot date itself (no month-end reconciliation axis).
-  const freshness = computeFreshness({
-    asOfDate: effectiveDate,
-    snapshotDate: effectiveDate,
-    isLatest: !selectedDate,
-  })
-
   return (
     <div className="awards-page">
-      <header className="awards-page__header">
+      {/* Adopt the shared page-header layout (Districts/Regions/Region) so the
+          DataControlsBar toolbar lays out top-right on desktop and stacks on
+          mobile — awards-page__header keeps its own bottom-margin. The awards
+          standings carry no `sourceCsvDate`, so the freshness pill just shows
+          the snapshot date (no month-end reconciliation axis). */}
+      <header className="districts-page-header awards-page__header">
+        <div className="districts-page-header__intro">
+          <p className="placeholder-page__eyebrow">
+            Awards · {standings?.metadata?.totalDistricts ?? 117} districts
+          </p>
+          <h1 className="placeholder-page__title">District Awards</h1>
+          <p className="placeholder-page__body">
+            Competitive district-level awards from Toastmasters International.
+            Rankings are computed from the same public data as the District
+            leaderboard — see the{' '}
+            <Link
+              to="/methodology#borda-count"
+              className="districts-methodology-callout__link"
+            >
+              Methodology
+            </Link>{' '}
+            page for the full Borda definition and per-award threshold notes.
+          </p>
+        </div>
         <div className="districts-page-header__actions">
           <DataControlsBar
             latestSnapshotDate={effectiveDate}
-            asOfDate={freshness.displayDate}
-            reconcilingMonthLabel={freshness.reconcilingMonthLabel}
             availableProgramYears={availableProgramYears}
             selectedProgramYear={selectedProgramYear}
             onProgramYearChange={setSelectedProgramYear}
@@ -93,22 +105,6 @@ const AwardsPage: React.FC = () => {
             freshnessPending={isDatesPending}
           />
         </div>
-        <p className="placeholder-page__eyebrow">
-          Awards · {standings?.metadata?.totalDistricts ?? 117} districts
-        </p>
-        <h1 className="placeholder-page__title">District Awards</h1>
-        <p className="placeholder-page__body">
-          Competitive district-level awards from Toastmasters International.
-          Rankings are computed from the same public data as the District
-          leaderboard — see the{' '}
-          <Link
-            to="/methodology#borda-count"
-            className="districts-methodology-callout__link"
-          >
-            Methodology
-          </Link>{' '}
-          page for the full Borda definition and per-award threshold notes.
-        </p>
       </header>
 
       {isLoading && (

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -6,12 +6,15 @@
 import React from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { fetchCdnRankings } from '../services/cdn'
+import { fetchCdnRankings, fetchCdnRankingsForDate } from '../services/cdn'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 import type { DistrictRanking } from '../types/districts'
 import { computeTiedRanks } from '../utils/tieRankingUtils'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
+import { useProgramYearControls } from '../hooks/useProgramYearControls'
+import { DataControlsBar } from '../components/DataControlsBar'
+import { computeFreshness } from '../utils/dataFreshness'
 import type { DistinguishedDistrictTier } from '../services/cdn'
 import {
   getDistinguishedCountdown,
@@ -263,13 +266,40 @@ const RegionPage: React.FC = () => {
     defaultDirection: 'desc',
   })
 
+  // PY selector state (#1301) — the page owns program year/date (R3) and
+  // threads the selected snapshot date into the rankings query so switching
+  // the year re-queries (the awards query below follows via data.date).
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+    availableProgramYears,
+    cachedDates,
+    effectiveDate,
+    isDatesPending,
+  } = useProgramYearControls()
+
   const { data, isLoading, error } = useQuery({
-    queryKey: ['district-rankings', 'latest'],
+    queryKey: ['district-rankings', effectiveDate ?? 'latest'],
     queryFn: async () => {
+      if (effectiveDate) return fetchCdnRankingsForDate(effectiveDate)
       const cdnData = await fetchCdnRankings()
       return { rankings: cdnData.rankings, date: cdnData.date }
     },
     staleTime: 15 * 60 * 1000,
+    placeholderData: prev => prev,
+  })
+
+  // Freshness pill (#1296) — as-of date + month-end reconciliation state.
+  const isLatestSnapshot =
+    !selectedDate ||
+    (cachedDates.length > 0 &&
+      selectedDate === [...cachedDates].sort((a, b) => b.localeCompare(a))[0])
+  const freshness = computeFreshness({
+    asOfDate: data?.date,
+    snapshotDate: effectiveDate,
+    isLatest: isLatestSnapshot,
   })
 
   // Distinguished District prerequisite gaps. Pin to the rankings
@@ -399,6 +429,20 @@ const RegionPage: React.FC = () => {
             {regionDistricts.length === 1 ? '' : 's'} in this region. Click a
             district to drill into its clubs.
           </p>
+        </div>
+        <div className="districts-page-header__actions">
+          <DataControlsBar
+            latestSnapshotDate={effectiveDate}
+            asOfDate={freshness.displayDate}
+            reconcilingMonthLabel={freshness.reconcilingMonthLabel}
+            availableProgramYears={availableProgramYears}
+            selectedProgramYear={selectedProgramYear}
+            onProgramYearChange={setSelectedProgramYear}
+            availableDates={cachedDates}
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+            freshnessPending={isDatesPending}
+          />
         </div>
       </header>
 

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -277,6 +277,7 @@ const RegionPage: React.FC = () => {
     availableProgramYears,
     cachedDates,
     effectiveDate,
+    isLatestSnapshot,
     isDatesPending,
   } = useProgramYearControls()
 
@@ -292,10 +293,6 @@ const RegionPage: React.FC = () => {
   })
 
   // Freshness pill (#1296) — as-of date + month-end reconciliation state.
-  const isLatestSnapshot =
-    !selectedDate ||
-    (cachedDates.length > 0 &&
-      selectedDate === [...cachedDates].sort((a, b) => b.localeCompare(a))[0])
   const freshness = computeFreshness({
     asOfDate: data?.date,
     snapshotDate: effectiveDate,

--- a/frontend/src/pages/RegionsPage.tsx
+++ b/frontend/src/pages/RegionsPage.tsx
@@ -43,6 +43,7 @@ const RegionsPage: React.FC = () => {
     availableProgramYears,
     cachedDates,
     effectiveDate,
+    isLatestSnapshot,
     isDatesPending,
   } = useProgramYearControls()
 
@@ -61,10 +62,6 @@ const RegionsPage: React.FC = () => {
 
   // Freshness pill: show the "as of" date and flag month-end reconciliation
   // when viewing the latest snapshot (#1296).
-  const isLatestSnapshot =
-    !selectedDate ||
-    (cachedDates.length > 0 &&
-      selectedDate === [...cachedDates].sort((a, b) => b.localeCompare(a))[0])
   const freshness = computeFreshness({
     asOfDate: data?.date,
     snapshotDate: effectiveDate,

--- a/frontend/src/pages/RegionsPage.tsx
+++ b/frontend/src/pages/RegionsPage.tsx
@@ -1,12 +1,15 @@
 import React, { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { fetchCdnRankings } from '../services/cdn'
+import { fetchCdnRankings, fetchCdnRankingsForDate } from '../services/cdn'
 import { aggregateRegions } from '../utils/aggregateRegions'
 import { RegionsLeaderboard } from '../components/RegionsLeaderboard'
 import { RegionFinder } from '../components/RegionFinder'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 import { useUrlState } from '../hooks/useUrlState'
+import { useProgramYearControls } from '../hooks/useProgramYearControls'
+import { DataControlsBar } from '../components/DataControlsBar'
+import { computeFreshness } from '../utils/dataFreshness'
 
 /* Region selection is URL state (#979) so it survives reload, back, and shared
    links — `?region=07`. Module-level options keep a stable reference so
@@ -29,13 +32,43 @@ const REGION_URL_OPTIONS = {
    count is visible without polluting the leaderboard. */
 
 const RegionsPage: React.FC = () => {
+  // PY selector state (#1301) — the page owns program year/date (R3) and
+  // threads the selected snapshot date into its own rankings query so
+  // switching the year re-queries.
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+    availableProgramYears,
+    cachedDates,
+    effectiveDate,
+    isDatesPending,
+  } = useProgramYearControls()
+
   const { data, isLoading, error } = useQuery({
-    queryKey: ['district-rankings', 'latest'],
+    queryKey: ['district-rankings', effectiveDate ?? 'latest'],
     queryFn: async () => {
+      if (effectiveDate) return fetchCdnRankingsForDate(effectiveDate)
       const cdn = await fetchCdnRankings()
       return { rankings: cdn.rankings, date: cdn.date }
     },
     staleTime: 15 * 60 * 1000,
+    // Keep the prior snapshot visible while a PY switch re-queries, so the
+    // leaderboard doesn't flash back to the full-page skeleton.
+    placeholderData: prev => prev,
+  })
+
+  // Freshness pill: show the "as of" date and flag month-end reconciliation
+  // when viewing the latest snapshot (#1296).
+  const isLatestSnapshot =
+    !selectedDate ||
+    (cachedDates.length > 0 &&
+      selectedDate === [...cachedDates].sort((a, b) => b.localeCompare(a))[0])
+  const freshness = computeFreshness({
+    asOfDate: data?.date,
+    snapshotDate: effectiveDate,
+    isLatest: isLatestSnapshot,
   })
 
   const [selectedRegion, setSelectedRegion] = useUrlState<string | null>(
@@ -103,6 +136,20 @@ const RegionsPage: React.FC = () => {
             Aggregate ranking of all 14 Toastmasters regions. Click any region
             to drill into its districts.
           </p>
+        </div>
+        <div className="districts-page-header__actions">
+          <DataControlsBar
+            latestSnapshotDate={effectiveDate}
+            asOfDate={freshness.displayDate}
+            reconcilingMonthLabel={freshness.reconcilingMonthLabel}
+            availableProgramYears={availableProgramYears}
+            selectedProgramYear={selectedProgramYear}
+            onProgramYearChange={setSelectedProgramYear}
+            availableDates={cachedDates}
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+            freshnessPending={isDatesPending}
+          />
         </div>
       </header>
 

--- a/frontend/src/pages/__tests__/AwardsPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/AwardsPage.programYear.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * PY-selector tests for AwardsPage (#1301, epic #1298 Sprint 2).
+ *
+ * The competitive-awards standings are PY-scoped but the page historically
+ * fetched only "latest". It must now expose the shared DataControlsBar PY chip,
+ * re-query the awards snapshot when the PY changes, and honor a `?py=` deep
+ * link.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import AwardsPage from '../AwardsPage'
+import { fetchCdnCompetitiveAwards } from '../../services/cdn'
+
+const LocationProbe = () => {
+  const { search } = useLocation()
+  return <div data-testid="loc-search">{search}</div>
+}
+
+afterEach(() => cleanup())
+
+vi.mock('../../services/cdn', () => {
+  const standings = {
+    metadata: {
+      snapshotId: 'snap',
+      calculatedAt: '2026-08-01T00:00:00Z',
+      totalDistricts: 117,
+    },
+    extensionAward: [
+      {
+        districtId: '01',
+        districtName: 'District 01',
+        region: '01',
+        rank: 1,
+        value: 5,
+        isWinner: true,
+      },
+    ],
+    twentyPlusAward: [],
+    retentionAward: [],
+    byDistrict: {},
+  }
+  return {
+    // PY2025: 2025-08-01, 2026-05-01 (latest) · PY2026: 2026-08-01 (latest)
+    fetchCdnDates: vi.fn().mockResolvedValue({
+      dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+      count: 3,
+      generatedAt: '2026-08-02T00:00:00Z',
+    }),
+    fetchCdnManifest: vi
+      .fn()
+      .mockResolvedValue({ latestSnapshotDate: '2026-08-01' }),
+    fetchCdnCompetitiveAwards: vi.fn().mockResolvedValue(standings),
+  }
+})
+
+const mockedAwards = vi.mocked(fetchCdnCompetitiveAwards)
+
+const renderAt = (url: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <LocationProbe />
+          <Routes>
+            <Route path="/awards" element={<AwardsPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('AwardsPage — program year selector (#1301)', () => {
+  it('renders the PY selector chip', async () => {
+    renderAt('/awards')
+    expect(await screen.findByTestId('py-chip')).toBeInTheDocument()
+  })
+
+  it('defaults to the newest PY-with-data and fetches its awards snapshot', async () => {
+    renderAt('/awards')
+    await screen.findByTestId('py-chip')
+    await waitFor(() => expect(mockedAwards).toHaveBeenCalledWith('2026-08-01'))
+    expect(screen.getByTestId('loc-search').textContent).not.toContain('py=')
+  })
+
+  it('honors a ?py= deep link and fetches that PY awards snapshot', async () => {
+    renderAt('/awards?py=2025')
+    await screen.findByTestId('py-chip')
+    // The PY options come from the dates query — wait for it to populate so the
+    // select can resolve its value against a matching <option>.
+    await waitFor(() =>
+      expect(screen.getByTestId('py-chip-select')).toHaveValue('2025')
+    )
+    await waitFor(() => expect(mockedAwards).toHaveBeenCalledWith('2026-05-01'))
+  })
+
+  it('re-queries when the PY selector changes', async () => {
+    renderAt('/awards')
+    await screen.findByTestId('py-chip')
+    await waitFor(() => expect(mockedAwards).toHaveBeenCalledWith('2026-08-01'))
+    mockedAwards.mockClear()
+
+    await userEvent.selectOptions(screen.getByTestId('py-chip-select'), '2025')
+    await waitFor(() => expect(mockedAwards).toHaveBeenCalledWith('2026-05-01'))
+    await waitFor(() =>
+      expect(screen.getByTestId('loc-search').textContent).toContain('py=2025')
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/AwardsPage.test.tsx
+++ b/frontend/src/pages/__tests__/AwardsPage.test.tsx
@@ -6,7 +6,16 @@ import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import type { CompetitiveAwardStandings } from '../../services/cdn'
+
+// #1301 — AwardsPage now hosts the shared PY selector (useProgramYearControls
+// → the ['available-dates'] CDN query). An empty dates index keeps
+// effectiveDate undefined, so the awards fetch (mocked below) is unchanged.
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({ dates: [], count: 0 }),
+}))
 
 const mockStandings: CompetitiveAwardStandings = {
   metadata: {
@@ -81,12 +90,20 @@ vi.mock('../../hooks/useCompetitiveAwards', () => ({
 
 import AwardsPage from '../AwardsPage'
 
-const renderPage = () =>
-  render(
-    <MemoryRouter>
-      <AwardsPage />
-    </MemoryRouter>
+const renderPage = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <MemoryRouter>
+          <AwardsPage />
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
   )
+}
 
 describe('AwardsPage (#371-#373)', () => {
   beforeEach(() => vi.clearAllMocks())

--- a/frontend/src/pages/__tests__/RegionPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.programYear.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * PY-selector tests for RegionPage (#1301, epic #1298 Sprint 2).
+ *
+ * Single-region rankings must expose the shared DataControlsBar PY chip,
+ * re-query when the PY changes, and honor a `?py=` deep link.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import RegionPage from '../RegionPage'
+import { fetchCdnRankingsForDate } from '../../services/cdn'
+
+const LocationProbe = () => {
+  const { search } = useLocation()
+  return <div data-testid="loc-search">{search}</div>
+}
+
+afterEach(() => cleanup())
+
+vi.mock('../../services/cdn', () => {
+  const baseRanking = (region: string, districtId: string, score: number) => ({
+    districtId,
+    districtName: `District ${districtId}`,
+    region,
+    paidClubs: 50,
+    paidClubBase: 48,
+    clubGrowthPercent: 4,
+    totalPayments: 2000,
+    paymentBase: 1900,
+    paymentGrowthPercent: 5,
+    activeClubs: 50,
+    distinguishedClubs: 20,
+    selectDistinguished: 5,
+    presidentsDistinguished: 3,
+    distinguishedPercent: 40,
+    clubsRank: 1,
+    paymentsRank: 1,
+    distinguishedRank: 1,
+    overallRank: 1,
+    aggregateScore: score,
+  })
+  const rankingsFor = (date: string) => ({
+    date,
+    rankings: [baseRanking('07', '57', 350), baseRanking('07', '60', 300)],
+  })
+  return {
+    // PY2025: 2025-08-01, 2026-05-01 (latest) · PY2026: 2026-08-01 (latest)
+    fetchCdnDates: vi.fn().mockResolvedValue({
+      dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+      count: 3,
+      generatedAt: '2026-08-02T00:00:00Z',
+    }),
+    fetchCdnRankings: vi.fn().mockResolvedValue(rankingsFor('2026-08-01')),
+    fetchCdnRankingsForDate: vi
+      .fn()
+      .mockImplementation((date: string) => Promise.resolve(rankingsFor(date))),
+    fetchCdnCompetitiveAwards: vi.fn().mockResolvedValue(null),
+    fetchCdnManifest: vi
+      .fn()
+      .mockResolvedValue({ latestSnapshotDate: '2026-08-01' }),
+  }
+})
+
+const mockedForDate = vi.mocked(fetchCdnRankingsForDate)
+
+const renderAt = (url: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <LocationProbe />
+          <Routes>
+            <Route path="/region/:n" element={<RegionPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('RegionPage — program year selector (#1301)', () => {
+  it('renders the PY selector chip', async () => {
+    renderAt('/region/07')
+    await screen.findByRole('table', { name: /region 07 district rankings/i })
+    expect(screen.getByTestId('py-chip')).toBeInTheDocument()
+  })
+
+  it('honors a ?py= deep link and fetches that PY latest snapshot', async () => {
+    renderAt('/region/07?py=2025')
+    await screen.findByRole('table', { name: /region 07 district rankings/i })
+    expect(screen.getByTestId('py-chip-select')).toHaveValue('2025')
+    await waitFor(() =>
+      expect(mockedForDate).toHaveBeenCalledWith('2026-05-01')
+    )
+  })
+
+  it('re-queries when the PY selector changes', async () => {
+    renderAt('/region/07')
+    await screen.findByRole('table', { name: /region 07 district rankings/i })
+    await waitFor(() =>
+      expect(mockedForDate).toHaveBeenCalledWith('2026-08-01')
+    )
+    mockedForDate.mockClear()
+
+    await userEvent.selectOptions(screen.getByTestId('py-chip-select'), '2025')
+    await waitFor(() =>
+      expect(mockedForDate).toHaveBeenCalledWith('2026-05-01')
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('loc-search').textContent).toContain('py=2025')
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/RegionPage.responsive.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.responsive.test.tsx
@@ -14,11 +14,16 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import RegionPage from '../RegionPage'
 import { fetchCdnRankings } from '../../services/cdn'
 
+// #1301 — empty dates index keeps effectiveDate undefined → the page uses its
+// existing fetchCdnRankings ("latest") path, so these fixtures are unchanged.
 vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({ dates: [], count: 0 }),
   fetchCdnRankings: vi.fn(),
+  fetchCdnRankingsForDate: vi.fn(),
   fetchCdnCompetitiveAwards: vi.fn().mockResolvedValue(null),
   fetchCdnManifest: vi
     .fn()
@@ -54,11 +59,13 @@ const renderRegion = (region: string) => {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={[`/region/${region}`]}>
-        <Routes>
-          <Route path="/region/:n" element={<RegionPage />} />
-        </Routes>
-      </MemoryRouter>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[`/region/${region}`]}>
+          <Routes>
+            <Route path="/region/:n" element={<RegionPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/pages/__tests__/RegionPage.sortable.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.sortable.test.tsx
@@ -13,12 +13,17 @@ import {
 } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import '@testing-library/jest-dom/vitest'
 import RegionPage from '../RegionPage'
 import { fetchCdnRankings } from '../../services/cdn'
 
+// #1301 — empty dates index keeps effectiveDate undefined → the page uses its
+// existing fetchCdnRankings ("latest") path, so these fixtures are unchanged.
 vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({ dates: [], count: 0 }),
   fetchCdnRankings: vi.fn(),
+  fetchCdnRankingsForDate: vi.fn(),
   fetchCdnCompetitiveAwards: vi.fn().mockResolvedValue(null),
   fetchCdnManifest: vi
     .fn()
@@ -88,11 +93,13 @@ const renderRegion = (region: string, initialPath?: string) => {
   const path = initialPath ?? `/region/${region}`
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={[path]}>
-        <Routes>
-          <Route path="/region/:n" element={<RegionPage />} />
-        </Routes>
-      </MemoryRouter>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[path]}>
+          <Routes>
+            <Route path="/region/:n" element={<RegionPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import RegionPage from '../RegionPage'
 import {
   fetchCdnRankings,
@@ -15,8 +16,13 @@ import {
   type CompetitiveAwardStandings,
 } from '../../services/cdn'
 
+// #1301 — RegionPage now hosts the shared PY selector. An empty dates index
+// keeps effectiveDate undefined, so the page uses its existing fetchCdnRankings
+// ("latest") path and these fixtures/assertions are unchanged.
 vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({ dates: [], count: 0 }),
   fetchCdnRankings: vi.fn(),
+  fetchCdnRankingsForDate: vi.fn(),
   fetchCdnCompetitiveAwards: vi.fn().mockResolvedValue(null),
   fetchCdnManifest: vi
     .fn()
@@ -55,11 +61,13 @@ const renderRegion = (region: string) => {
   })
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={[`/region/${region}`]}>
-        <Routes>
-          <Route path="/region/:n" element={<RegionPage />} />
-        </Routes>
-      </MemoryRouter>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[`/region/${region}`]}>
+          <Routes>
+            <Route path="/region/:n" element={<RegionPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
     </QueryClientProvider>
   )
 }
@@ -77,15 +85,17 @@ const renderRegionWithRegionsRoute = (region: string) => {
   })
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={[`/region/${region}`]}>
-        <Routes>
-          <Route path="/region/:n" element={<RegionPage />} />
-          <Route
-            path="/regions"
-            element={<div data-testid="regions-overview">All regions</div>}
-          />
-        </Routes>
-      </MemoryRouter>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[`/region/${region}`]}>
+          <Routes>
+            <Route path="/region/:n" element={<RegionPage />} />
+            <Route
+              path="/regions"
+              element={<div data-testid="regions-overview">All regions</div>}
+            />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/pages/__tests__/RegionsPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/RegionsPage.programYear.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * PY-selector tests for RegionsPage (#1301, epic #1298 Sprint 2).
+ *
+ * RegionsPage shows program-year-scoped aggregation but historically had no
+ * way to choose the year (it fetched "latest"). It must now render the shared
+ * DataControlsBar PY chip, re-query when the PY changes, and honor a `?py=`
+ * deep link — defaulting to the data-driven latest PY-with-data.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import RegionsPage from '../RegionsPage'
+import { fetchCdnRankings, fetchCdnRankingsForDate } from '../../services/cdn'
+
+const LocationProbe = () => {
+  const { search } = useLocation()
+  return <div data-testid="loc-search">{search}</div>
+}
+
+afterEach(() => cleanup())
+
+vi.mock('../../services/cdn', () => {
+  const baseRanking = (region: string, districtId: string, score: number) => ({
+    districtId,
+    districtName: `District ${districtId}`,
+    region,
+    paidClubs: 50,
+    paidClubBase: 48,
+    clubGrowthPercent: 4,
+    totalPayments: 2000,
+    paymentBase: 1900,
+    paymentGrowthPercent: 5,
+    activeClubs: 50,
+    distinguishedClubs: 20,
+    selectDistinguished: 5,
+    presidentsDistinguished: 3,
+    distinguishedPercent: 40,
+    clubsRank: 1,
+    paymentsRank: 1,
+    distinguishedRank: 1,
+    overallRank: 1,
+    aggregateScore: score,
+  })
+  const rankingsFor = (date: string) => ({
+    date,
+    rankings: [baseRanking('01', '01', 500), baseRanking('07', '57', 350)],
+  })
+  return {
+    // PY2025: 2025-08-01, 2026-05-01 (latest) · PY2026: 2026-08-01 (latest)
+    fetchCdnDates: vi.fn().mockResolvedValue({
+      dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+      count: 3,
+      generatedAt: '2026-08-02T00:00:00Z',
+    }),
+    fetchCdnRankings: vi.fn().mockResolvedValue(rankingsFor('2026-08-01')),
+    fetchCdnRankingsForDate: vi
+      .fn()
+      .mockImplementation((date: string) => Promise.resolve(rankingsFor(date))),
+  }
+})
+
+const mockedForDate = vi.mocked(fetchCdnRankingsForDate)
+const mockedLatest = vi.mocked(fetchCdnRankings)
+
+const renderAt = (url: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <LocationProbe />
+          <Routes>
+            <Route path="/regions" element={<RegionsPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('RegionsPage — program year selector (#1301)', () => {
+  it('renders the PY selector chip', async () => {
+    renderAt('/regions')
+    await screen.findByRole('link', { name: /^region 01/i })
+    expect(screen.getByTestId('py-chip')).toBeInTheDocument()
+  })
+
+  it('defaults to the newest PY-with-data and fetches its latest snapshot', async () => {
+    renderAt('/regions')
+    await screen.findByRole('link', { name: /^region 01/i })
+    // Newest PY with data is 2026 → latest snapshot 2026-08-01.
+    await waitFor(() =>
+      expect(mockedForDate).toHaveBeenCalledWith('2026-08-01')
+    )
+    // Default PY writes no ?py= (data-driven default, Sprint 1).
+    expect(screen.getByTestId('loc-search').textContent).not.toContain('py=')
+  })
+
+  it('honors a ?py= deep link and fetches that PY latest snapshot', async () => {
+    renderAt('/regions?py=2025')
+    await screen.findByRole('link', { name: /^region 01/i })
+    expect(screen.getByTestId('py-chip-select')).toHaveValue('2025')
+    await waitFor(() =>
+      expect(mockedForDate).toHaveBeenCalledWith('2026-05-01')
+    )
+  })
+
+  it('re-queries when the PY selector changes', async () => {
+    renderAt('/regions')
+    await screen.findByRole('link', { name: /^region 01/i })
+    await waitFor(() =>
+      expect(mockedForDate).toHaveBeenCalledWith('2026-08-01')
+    )
+    mockedForDate.mockClear()
+
+    await userEvent.selectOptions(screen.getByTestId('py-chip-select'), '2025')
+    // Switching to PY2025 re-queries its latest snapshot and writes ?py=2025.
+    await waitFor(() =>
+      expect(mockedForDate).toHaveBeenCalledWith('2026-05-01')
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('loc-search').textContent).toContain('py=2025')
+    )
+  })
+
+  it('still renders when the dates index is unavailable (fallback to latest)', async () => {
+    mockedLatest.mockResolvedValueOnce({
+      date: '2026-08-01',
+      rankings: [
+        {
+          districtId: '01',
+          districtName: 'District 01',
+          region: '01',
+          paidClubs: 50,
+          paidClubBase: 48,
+          clubGrowthPercent: 4,
+          totalPayments: 2000,
+          paymentBase: 1900,
+          paymentGrowthPercent: 5,
+          activeClubs: 50,
+          distinguishedClubs: 20,
+          selectDistinguished: 5,
+          presidentsDistinguished: 3,
+          distinguishedPercent: 40,
+          clubsRank: 1,
+          paymentsRank: 1,
+          distinguishedRank: 1,
+          overallRank: 1,
+          aggregateScore: 500,
+        },
+      ],
+    } as never)
+    renderAt('/regions')
+    expect(
+      await screen.findByRole('link', { name: /^region 01/i })
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/RegionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionsPage.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import RegionsPage from '../RegionsPage'
 
 /* Reads the live URL search string so URL-sync round-trips are assertable
@@ -58,17 +59,27 @@ vi.mock('../../services/cdn', () => {
     latePayments: 0,
     charterPayments: 0,
   })
+  const rankings = {
+    date: '2026-05-12',
+    rankings: [
+      baseRanking('01', '01', 500),
+      baseRanking('01', '02', 400),
+      baseRanking('07', '57', 350),
+      baseRanking('07', '60', 300),
+      baseRanking('DNAR', '99', 50),
+    ],
+  }
   return {
-    fetchCdnRankings: vi.fn().mockResolvedValue({
-      date: '2026-05-12',
-      rankings: [
-        baseRanking('01', '01', 500),
-        baseRanking('01', '02', 400),
-        baseRanking('07', '57', 350),
-        baseRanking('07', '60', 300),
-        baseRanking('DNAR', '99', 50),
-      ],
+    // #1301 — RegionsPage now threads the selected PY's snapshot date through
+    // its query. The dates index + per-date fetch return the same fixture so
+    // the leaderboard content is unchanged regardless of which path resolves.
+    fetchCdnDates: vi.fn().mockResolvedValue({
+      dates: ['2026-05-12'],
+      count: 1,
+      generatedAt: '2026-05-13T00:00:00Z',
     }),
+    fetchCdnRankings: vi.fn().mockResolvedValue(rankings),
+    fetchCdnRankingsForDate: vi.fn().mockResolvedValue(rankings),
   }
 })
 
@@ -78,11 +89,13 @@ const renderPage = () => {
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={['/regions']}>
-        <Routes>
-          <Route path="/regions" element={<RegionsPage />} />
-        </Routes>
-      </MemoryRouter>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={['/regions']}>
+          <Routes>
+            <Route path="/regions" element={<RegionsPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
     </QueryClientProvider>
   )
 }
@@ -93,12 +106,14 @@ const renderPageAt = (url: string) => {
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[url]}>
-        <LocationProbe />
-        <Routes>
-          <Route path="/regions" element={<RegionsPage />} />
-        </Routes>
-      </MemoryRouter>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <LocationProbe />
+          <Routes>
+            <Route path="/regions" element={<RegionsPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
     </QueryClientProvider>
   )
 }


### PR DESCRIPTION
## Sprint 2 of epic #1298 — PY selector on Regions, Region, and Awards pages (#1301)

Adds the shared Program Year selector (`DataControlsBar`) to the three PY-scoped
aggregate pages that previously had no way to choose the year and defaulted to
"latest": **RegionsPage** (`/regions`), **RegionPage** (`/region/:n`), and
**AwardsPage** (`/awards`).

### What changed
- **New shared hook** `useProgramYearControls` — wraps `useUrlProgramYear`
  (URL-synced `?py=` / `?date=`, with Sprint 1's data-driven default) + the
  shared `['available-dates']` CDN dates query, and derives
  `availableProgramYears` / `cachedDates` / `effectiveDate` / `isLatestSnapshot`.
  Each page owns PY state (R3) and threads the selected snapshot date into its
  own data query, so **switching the PY re-queries** and `?py=` / `?date=` deep
  links work. Self-heals an invalid/hand-edited `?py=` to the newest
  year-with-data (L124).
- The three pages render `DataControlsBar` in their header and fetch data for the
  **selected** program year (`fetchCdnRankingsForDate` / date-scoped
  `useCompetitiveAwards`), not hardcoded latest.
- Freshness pill matches #1296 (as-of date + month-end reconciliation) on
  Regions/Region; Awards shows the snapshot date (its standings carry no
  `sourceCsvDate`).
- AwardsPage adopts the shared `districts-page-header` flex layout so the toolbar
  lays out top-right on desktop / stacks on mobile.

### Acceptance criteria
- [x] Each page renders a working PY selector; changing it re-queries + updates; `?py=` deep links work.
- [x] Defaults to the data-driven latest-PY-with-data (Sprint 1); no empty-year default at the July rollover.
- [x] Tests: selector present, PY change re-queries, deep-link honored. Full frontend suite green (3590 tests).
- [ ] Verified on the PR preview channel at 375/768/1280 + dark mode (evidence to follow on #1301).

### Quality gates
- TDD red→green per page; new hook + 3 page test suites (`useProgramYearControls`, `*.programYear.test.tsx`).
- Existing region/awards tests adapted for the new provider + data deps (no assertion pinning; empty-dates path keeps the "latest" behavior unchanged).
- `/simplify` pass (dedup `isLatestSnapshot`, fix Awards header altitude) + fresh-context review (APPROVE-WITH-NITS; nit applied).
- R22 no-page-mounts guard passes; page-mount tests in `src/pages/__tests__/`.

Part of epic #1298. Sprint 2, sub-issue #1301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
