### PR TITLE
feat(frontend): PY selector on Division, Area, Club detail/history pages (#1302)

### DIFF
--- a/frontend/src/components/ClubHistoryTable.tsx
+++ b/frontend/src/components/ClubHistoryTable.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import type { ClubHistoryRow, ClubTierCode } from '../utils/clubHistory'
 import { EM_DASH } from '../utils/clubHistory'
 import { SortableHeader } from './SortableHeader'
@@ -48,9 +49,20 @@ function signedNet(value: number | null): string {
 export interface ClubHistoryTableProps {
   rows: ClubHistoryRow[]
   clubName: string
+  /** When both are provided (#1302), each year label becomes a deep link to
+   *  ClubDetailPage focused on that program year (`?py=<startYear>`), so a user
+   *  reading the multi-year table can jump into a single year. Omitted → plain
+   *  text (keeps the component usable outside a Router). */
+  districtId?: string | undefined
+  clubId?: string | undefined
 }
 
-export function ClubHistoryTable({ rows, clubName }: ClubHistoryTableProps) {
+export function ClubHistoryTable({
+  rows,
+  clubName,
+  districtId,
+  clubId,
+}: ClubHistoryTableProps) {
   const [sortField, setSortField] = useState<SortField>('year')
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
 
@@ -156,7 +168,16 @@ export function ClubHistoryTable({ rows, clubName }: ClubHistoryTableProps) {
           {sortedRows.map(row => (
             <tr key={row.startYear}>
               <th scope="row" className="club-history-td club-history-td--year">
-                {row.label}
+                {districtId && clubId ? (
+                  <Link
+                    to={`/district/${districtId}/club/${clubId}?py=${row.startYear}`}
+                    className="club-history-year-link"
+                  >
+                    {row.label}
+                  </Link>
+                ) : (
+                  row.label
+                )}
               </th>
               <td className="club-history-td club-history-td--num">
                 {row.dcpGoals == null ? EM_DASH : `${row.dcpGoals} / 10`}

--- a/frontend/src/components/__tests__/ClubHistoryTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubHistoryTable.test.tsx
@@ -11,6 +11,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import { ClubHistoryTable } from '../ClubHistoryTable'
 import type { ClubHistoryRow } from '../../utils/clubHistory'
 
@@ -107,5 +108,32 @@ describe('ClubHistoryTable (#1229)', () => {
     render(<ClubHistoryTable rows={rows} clubName="Test Club" />)
     const bodyRows = screen.getAllByRole('row').slice(1)
     expect(within(bodyRows[0]!).getByText('2023-2024')).toBeInTheDocument()
+  })
+})
+
+describe('ClubHistoryTable — per-year focus links (#1302)', () => {
+  it('links each program-year row to that year on the club detail page', () => {
+    render(
+      <MemoryRouter>
+        <ClubHistoryTable
+          rows={rows}
+          clubName="Test Club"
+          districtId="61"
+          clubId="00000606"
+        />
+      </MemoryRouter>
+    )
+    // The year label becomes a deep link to ClubDetailPage focused on that PY,
+    // so a user reading the multi-year table can jump into a single year.
+    const link = screen.getByRole('link', { name: '2023-2024' })
+    expect(link).toHaveAttribute('href', '/district/61/club/00000606?py=2023')
+    const older = screen.getByRole('link', { name: '2022-2023' })
+    expect(older).toHaveAttribute('href', '/district/61/club/00000606?py=2022')
+  })
+
+  it('renders plain year labels (no links) when district/club are absent', () => {
+    render(<ClubHistoryTable rows={rows} clubName="Test Club" />)
+    expect(screen.queryByRole('link', { name: '2023-2024' })).toBeNull()
+    expect(screen.getByText('2023-2024')).toBeInTheDocument()
   })
 })

--- a/frontend/src/hooks/__tests__/useDistrictProgramYearControls.test.tsx
+++ b/frontend/src/hooks/__tests__/useDistrictProgramYearControls.test.tsx
@@ -80,10 +80,28 @@ describe('useDistrictProgramYearControls (#1302)', () => {
     const { result } = renderHook(() => useDistrictProgramYearControls('61'), {
       wrapper: wrapperFor('/district/61?py=2019'),
     })
-    // 2019 has no snapshots → effective year falls back to the newest (2026).
+    // 2019 has no snapshots → effective year falls back to the newest (2026)
+    // AND the selected year is rewritten to match (selfHeal default).
     await waitFor(() =>
       expect(result.current.effectiveProgramYear?.year).toBe(2026)
     )
+    await waitFor(() =>
+      expect(result.current.selectedProgramYear.year).toBe(2026)
+    )
+    expect(result.current.effectiveEndDate).toBe('2026-08-01')
+  })
+
+  it('with selfHeal:false, derives the effective year WITHOUT rewriting the selection', async () => {
+    const { result } = renderHook(
+      () => useDistrictProgramYearControls('61', { selfHeal: false }),
+      { wrapper: wrapperFor('/district/61?py=2019') }
+    )
+    // Effective year still heals to the newest with data...
+    await waitFor(() =>
+      expect(result.current.effectiveProgramYear?.year).toBe(2026)
+    )
+    // ...but the selected year stays put — no URL write to clobber nav state.
+    expect(result.current.selectedProgramYear.year).toBe(2019)
     expect(result.current.effectiveEndDate).toBe('2026-08-01')
   })
 })

--- a/frontend/src/hooks/__tests__/useDistrictProgramYearControls.test.tsx
+++ b/frontend/src/hooks/__tests__/useDistrictProgramYearControls.test.tsx
@@ -71,8 +71,11 @@ describe('useDistrictProgramYearControls (#1302)', () => {
       expect(result.current.effectiveProgramYear?.year).toBe(2025)
     )
     expect(result.current.effectiveEndDate).toBe('2026-05-01')
-    // Dates within the selected PY, newest first.
-    expect(result.current.availableDates).toEqual(['2026-05-01', '2025-08-01'])
+    // Dates within the selected PY (order is DataControlsBar's concern).
+    expect([...result.current.availableDates].sort()).toEqual([
+      '2025-08-01',
+      '2026-05-01',
+    ])
     expect(result.current.hasValidDates).toBe(true)
   })
 

--- a/frontend/src/hooks/__tests__/useDistrictProgramYearControls.test.tsx
+++ b/frontend/src/hooks/__tests__/useDistrictProgramYearControls.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * useDistrictProgramYearControls (#1302, epic #1298 Sprint 3).
+ *
+ * District-scoped sibling of useProgramYearControls: the shared PY/date wiring
+ * that DivisionPage, AreaPage, and ClubDetailPage need. Dates come from the
+ * per-district snapshot index (useDistrictCachedDates), not the global
+ * ['available-dates'] query — but the derivation (available PYs, in-PY dates,
+ * effective end date, self-heal to newest) mirrors the proven inline logic in
+ * DistrictClubsPage / DistrictDivisionsPage.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import { useDistrictProgramYearControls } from '../useDistrictProgramYearControls'
+
+// District 61 snapshot index: PY2025 → 2025-08-01, 2026-05-01 (latest);
+// PY2026 → 2026-08-01 (latest).
+vi.mock('../../services/cdn', () => ({
+  fetchCdnSnapshotIndex: vi.fn().mockResolvedValue({
+    '61': ['2025-08-01', '2026-05-01', '2026-08-01'],
+  }),
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+    count: 3,
+    generatedAt: '2026-08-02T00:00:00Z',
+  }),
+}))
+
+afterEach(() => cleanup())
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+const wrapperFor = (url: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ProgramYearProvider>
+          <MemoryRouter initialEntries={[url]}>{children}</MemoryRouter>
+        </ProgramYearProvider>
+      </QueryClientProvider>
+    )
+  }
+}
+
+describe('useDistrictProgramYearControls (#1302)', () => {
+  it('derives available program years (newest first) from the district index', async () => {
+    const { result } = renderHook(() => useDistrictProgramYearControls('61'), {
+      wrapper: wrapperFor('/district/61'),
+    })
+    await waitFor(() =>
+      expect(result.current.availableProgramYears.length).toBe(2)
+    )
+    expect(result.current.availableProgramYears.map(py => py.year)).toEqual([
+      2026, 2025,
+    ])
+  })
+
+  it('honors a ?py= deep link: effective end date is that PY latest snapshot', async () => {
+    const { result } = renderHook(() => useDistrictProgramYearControls('61'), {
+      wrapper: wrapperFor('/district/61?py=2025'),
+    })
+    await waitFor(() =>
+      expect(result.current.effectiveProgramYear?.year).toBe(2025)
+    )
+    expect(result.current.effectiveEndDate).toBe('2026-05-01')
+    // Dates within the selected PY, newest first.
+    expect(result.current.availableDates).toEqual(['2026-05-01', '2025-08-01'])
+    expect(result.current.hasValidDates).toBe(true)
+  })
+
+  it('self-heals a PY with no district data to the newest available year', async () => {
+    const { result } = renderHook(() => useDistrictProgramYearControls('61'), {
+      wrapper: wrapperFor('/district/61?py=2019'),
+    })
+    // 2019 has no snapshots → effective year falls back to the newest (2026).
+    await waitFor(() =>
+      expect(result.current.effectiveProgramYear?.year).toBe(2026)
+    )
+    expect(result.current.effectiveEndDate).toBe('2026-08-01')
+  })
+})

--- a/frontend/src/hooks/useDistrictProgramYearControls.ts
+++ b/frontend/src/hooks/useDistrictProgramYearControls.ts
@@ -19,6 +19,13 @@
  * Self-healing (L124): a hand-edited / shared `?py=` naming a year with no
  * district data falls back to the newest available PY, so the user is never
  * stranded on an empty grid — validated at the page, not the picker.
+ *
+ * `selfHeal` (default true) controls whether that fallback is WRITTEN back to
+ * the URL. Pages reached via a plain Link (DivisionPage, AreaPage) want the
+ * write so the chip and `?py=` agree. ClubDetailPage receives navigation state
+ * (`location.state.fromClubsSearch`, the #577 filter round-trip) that a mount-
+ * time `setSearchParams` would clobber, so it opts OUT and instead renders the
+ * derived `effectiveProgramYear` in the chip — honest without touching the URL.
  */
 
 import { useEffect, useMemo } from 'react'
@@ -54,7 +61,8 @@ export interface DistrictProgramYearControls {
 }
 
 export function useDistrictProgramYearControls(
-  districtId: string | null | undefined
+  districtId: string | null | undefined,
+  { selfHeal = true }: { selfHeal?: boolean } = {}
 ): DistrictProgramYearControls {
   const {
     selectedProgramYear,
@@ -76,7 +84,11 @@ export function useDistrictProgramYearControls(
 
   // Self-heal a selected PY that has no district data (e.g. a hand-edited ?py=)
   // to the newest available year — never strand the user on an empty grid (L124).
+  // Skipped when selfHeal is false so a mount-time URL write can't clobber the
+  // caller's navigation state (ClubDetailPage's #577 filter round-trip); that
+  // caller instead reads the derived effectiveProgramYear below.
   useEffect(() => {
+    if (!selfHeal) return
     if (availableProgramYears.length === 0) return
     const has = availableProgramYears.some(
       py => py.year === selectedProgramYear.year
@@ -85,7 +97,12 @@ export function useDistrictProgramYearControls(
       const newest = availableProgramYears[0]
       if (newest) setSelectedProgramYear(newest)
     }
-  }, [availableProgramYears, selectedProgramYear.year, setSelectedProgramYear])
+  }, [
+    selfHeal,
+    availableProgramYears,
+    selectedProgramYear.year,
+    setSelectedProgramYear,
+  ])
 
   // Derive (don't sync) the reconciled selection so the fetched date can never
   // lag a render behind the self-heal effect above.

--- a/frontend/src/hooks/useDistrictProgramYearControls.ts
+++ b/frontend/src/hooks/useDistrictProgramYearControls.ts
@@ -1,0 +1,140 @@
+/**
+ * useDistrictProgramYearControls — shared PY-selector state for DISTRICT-scoped
+ * pages (#1302, epic #1298 Sprint 3).
+ *
+ * DivisionPage, AreaPage, and ClubDetailPage all show program-year-scoped data
+ * for one district but historically either hardcoded "latest snapshot" or read
+ * `?py=` with no selector UI. This hook packages everything those pages (and a
+ * shared DataControlsBar) need so each page owns the PY/date state at the page
+ * level (R3) and threads the selected date into its own data query — never
+ * re-deriving it from the response.
+ *
+ * It is the district-scoped sibling of useProgramYearControls: the dates come
+ * from the per-district snapshot index (useDistrictCachedDates), NOT the global
+ * ['available-dates'] query. The derivation (available PYs, in-PY dates,
+ * effective end date, self-heal to the newest year) mirrors the proven inline
+ * logic that DistrictClubsPage / DistrictDivisionsPage already ship, so those
+ * routes and these leaf pages behave identically (R6 — real code overlap).
+ *
+ * Self-healing (L124): a hand-edited / shared `?py=` naming a year with no
+ * district data falls back to the newest available PY, so the user is never
+ * stranded on an empty grid — validated at the page, not the picker.
+ */
+
+import { useEffect, useMemo } from 'react'
+import { useDistrictCachedDates } from './useDistrictData'
+import { useUrlProgramYear } from './useUrlProgramYear'
+import {
+  getAvailableProgramYears,
+  filterDatesByProgramYear,
+  getMostRecentDateInProgramYear,
+  isDateInProgramYear,
+} from '../utils/programYear'
+import type { ProgramYear } from '../utils/programYear'
+
+const EMPTY_DATES: string[] = []
+
+export interface DistrictProgramYearControls {
+  selectedProgramYear: ProgramYear
+  setSelectedProgramYear: (py: ProgramYear) => void
+  selectedDate: string | undefined
+  setSelectedDate: (date: string | undefined) => void
+  /** Program years that actually have snapshots for this district, newest first. */
+  availableProgramYears: ProgramYear[]
+  /** Snapshot dates within the selected PY, newest first — feeds the date chip. */
+  availableDates: string[]
+  /** The selected PY reconciled to one with data (self-heal); null until dates load. */
+  effectiveProgramYear: ProgramYear | null
+  /** The date the page should fetch: `?date=` when in-PY, else the PY's latest. */
+  effectiveEndDate: string | null
+  /** True once a program year AND an end date have resolved. */
+  hasValidDates: boolean
+  /** The district's overall most-recent snapshot date (for the freshness pill). */
+  latestSnapshotDate: string | undefined
+}
+
+export function useDistrictProgramYearControls(
+  districtId: string | null | undefined
+): DistrictProgramYearControls {
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+  } = useUrlProgramYear()
+
+  const { data: cachedDatesData } = useDistrictCachedDates(districtId || '')
+  const allCachedDates = useMemo(
+    () => cachedDatesData?.dates || EMPTY_DATES,
+    [cachedDatesData?.dates]
+  )
+
+  const availableProgramYears = useMemo(
+    () => getAvailableProgramYears(allCachedDates),
+    [allCachedDates]
+  )
+
+  // Self-heal a selected PY that has no district data (e.g. a hand-edited ?py=)
+  // to the newest available year — never strand the user on an empty grid (L124).
+  useEffect(() => {
+    if (availableProgramYears.length === 0) return
+    const has = availableProgramYears.some(
+      py => py.year === selectedProgramYear.year
+    )
+    if (!has) {
+      const newest = availableProgramYears[0]
+      if (newest) setSelectedProgramYear(newest)
+    }
+  }, [availableProgramYears, selectedProgramYear.year, setSelectedProgramYear])
+
+  // Derive (don't sync) the reconciled selection so the fetched date can never
+  // lag a render behind the self-heal effect above.
+  const effectiveProgramYear = useMemo(() => {
+    if (availableProgramYears.length === 0) return null
+    const has = availableProgramYears.some(
+      py => py.year === selectedProgramYear.year
+    )
+    if (has) return selectedProgramYear
+    return availableProgramYears[0] ?? null
+  }, [availableProgramYears, selectedProgramYear])
+
+  const effectiveEndDate = useMemo(() => {
+    if (!effectiveProgramYear) return null
+    if (
+      selectedDate &&
+      isDateInProgramYear(selectedDate, effectiveProgramYear)
+    ) {
+      return selectedDate
+    }
+    return (
+      getMostRecentDateInProgramYear(allCachedDates, effectiveProgramYear) ||
+      effectiveProgramYear.endDate
+    )
+  }, [selectedDate, effectiveProgramYear, allCachedDates])
+
+  const hasValidDates =
+    effectiveProgramYear !== null && effectiveEndDate !== null
+
+  const availableDates = useMemo(
+    () =>
+      effectiveProgramYear
+        ? filterDatesByProgramYear(allCachedDates, effectiveProgramYear).sort(
+            (a, b) => b.localeCompare(a)
+          )
+        : EMPTY_DATES,
+    [allCachedDates, effectiveProgramYear]
+  )
+
+  return {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+    availableProgramYears,
+    availableDates,
+    effectiveProgramYear,
+    effectiveEndDate,
+    hasValidDates,
+    latestSnapshotDate: cachedDatesData?.dateRange?.endDate,
+  }
+}

--- a/frontend/src/hooks/useDistrictProgramYearControls.ts
+++ b/frontend/src/hooks/useDistrictProgramYearControls.ts
@@ -12,9 +12,11 @@
  * It is the district-scoped sibling of useProgramYearControls: the dates come
  * from the per-district snapshot index (useDistrictCachedDates), NOT the global
  * ['available-dates'] query. The derivation (available PYs, in-PY dates,
- * effective end date, self-heal to the newest year) mirrors the proven inline
- * logic that DistrictClubsPage / DistrictDivisionsPage already ship, so those
- * routes and these leaf pages behave identically (R6 — real code overlap).
+ * effective end date, self-heal to the newest year) is lifted from the proven
+ * inline logic that DistrictClubsPage / DistrictDivisionsPage still ship — those
+ * two index pages feed a DistrictDetailHeader and haven't been migrated to this
+ * hook yet (a deliberate scope boundary for #1302); the shared derivation keeps
+ * both behaving the same until they are.
  *
  * Self-healing (L124): a hand-edited / shared `?py=` naming a year with no
  * district data falls back to the newest available PY, so the user is never
@@ -48,7 +50,7 @@ export interface DistrictProgramYearControls {
   setSelectedDate: (date: string | undefined) => void
   /** Program years that actually have snapshots for this district, newest first. */
   availableProgramYears: ProgramYear[]
-  /** Snapshot dates within the selected PY, newest first — feeds the date chip. */
+  /** Snapshot dates within the selected PY — feeds the date chip (which sorts). */
   availableDates: string[]
   /** The selected PY reconciled to one with data (self-heal); null until dates load. */
   effectiveProgramYear: ProgramYear | null
@@ -132,12 +134,13 @@ export function useDistrictProgramYearControls(
   const hasValidDates =
     effectiveProgramYear !== null && effectiveEndDate !== null
 
+  // Dates within the selected PY. Left unsorted — DataControlsBar (the only
+  // consumer) sorts newest-first itself, matching the sibling
+  // useProgramYearControls which also returns its in-PY dates unsorted.
   const availableDates = useMemo(
     () =>
       effectiveProgramYear
-        ? filterDatesByProgramYear(allCachedDates, effectiveProgramYear).sort(
-            (a, b) => b.localeCompare(a)
-          )
+        ? filterDatesByProgramYear(allCachedDates, effectiveProgramYear)
         : EMPTY_DATES,
     [allCachedDates, effectiveProgramYear]
   )

--- a/frontend/src/hooks/useDistrictProgramYearControls.ts
+++ b/frontend/src/hooks/useDistrictProgramYearControls.ts
@@ -89,6 +89,14 @@ export function useDistrictProgramYearControls(
   // Skipped when selfHeal is false so a mount-time URL write can't clobber the
   // caller's navigation state (ClubDetailPage's #577 filter round-trip); that
   // caller instead reads the derived effectiveProgramYear below.
+  //
+  // NOTE (vs. the sibling useProgramYearControls): that hook heals to a year
+  // drawn from the SAME global ['available-dates'] cache that useUrlProgramYear's
+  // default is computed from, so healing to it deletes `?py=`. Here the healed
+  // year comes from the per-DISTRICT index, which can lag the global newest —
+  // so when a district's data trails, healing may WRITE `?py=<districtNewest>`
+  // rather than clear it. Still correct (it points at data that exists); the
+  // "heal clears ?py=" parity with the sibling simply doesn't hold district-side.
   useEffect(() => {
     if (!selfHeal) return
     if (availableProgramYears.length === 0) return

--- a/frontend/src/pages/AreaPage.tsx
+++ b/frontend/src/pages/AreaPage.tsx
@@ -21,6 +21,8 @@ import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 import { ClubMiniList } from '../components/ClubMiniList'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useDistrictProgramYearControls } from '../hooks/useDistrictProgramYearControls'
+import { DataControlsBar } from '../components/DataControlsBar'
 
 const AreaPage: React.FC = () => {
   const { districtId, divId, areaId } = useParams<{
@@ -31,10 +33,25 @@ const AreaPage: React.FC = () => {
   const navigate = useNavigate()
   const isMobile = useIsMobile()
 
+  // PY selector state (#1302) — the page owns program year/date (R3) and threads
+  // the selected PY's effective end date into its own queries so switching the
+  // year re-queries. Was hardcoded to "latest snapshot only" (undefined dates).
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+    availableProgramYears,
+    availableDates,
+    effectiveEndDate,
+    hasValidDates,
+    latestSnapshotDate,
+  } = useDistrictProgramYearControls(districtId)
+
   const { data, isLoading, error } = useDistrictAnalytics(
-    districtId ?? '',
+    hasValidDates ? (districtId ?? null) : null,
     undefined,
-    undefined
+    effectiveEndDate ?? undefined
   )
 
   // Recognition / gap / visit data come from the same raw snapshot the Divisions
@@ -44,7 +61,11 @@ const AreaPage: React.FC = () => {
   // it. Per Lesson 147, this surface is fed by the snapshot and must NOT be
   // hidden behind the allClubs emptiness check below.
   const { data: snapshot, isLoading: isLoadingSnapshot } =
-    useDistrictStatistics(districtId ?? '', undefined, 'divisions')
+    useDistrictStatistics(
+      hasValidDates ? (districtId ?? null) : null,
+      effectiveEndDate ?? undefined,
+      'divisions'
+    )
   const normalizedDivId = divId?.toUpperCase()
   const normalizedAreaId = areaId?.toUpperCase()
   const matched = React.useMemo(() => {
@@ -151,6 +172,18 @@ const AreaPage: React.FC = () => {
               ? 'Area recognition standing for this program year.'
               : `${clubs.length} club${clubs.length === 1 ? '' : 's'} in this area.`}
           </p>
+        </div>
+        <div className="districts-page-header__actions">
+          <DataControlsBar
+            latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
+            asOfDate={snapshot?.asOfDate}
+            availableProgramYears={availableProgramYears}
+            selectedProgramYear={selectedProgramYear}
+            onProgramYearChange={setSelectedProgramYear}
+            availableDates={availableDates}
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+          />
         </div>
       </header>
 

--- a/frontend/src/pages/AreaPage.tsx
+++ b/frontend/src/pages/AreaPage.tsx
@@ -43,6 +43,7 @@ const AreaPage: React.FC = () => {
     setSelectedDate,
     availableProgramYears,
     availableDates,
+    effectiveProgramYear,
     effectiveEndDate,
     hasValidDates,
     latestSnapshotDate,
@@ -178,7 +179,10 @@ const AreaPage: React.FC = () => {
             latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
             asOfDate={snapshot?.asOfDate}
             availableProgramYears={availableProgramYears}
-            selectedProgramYear={selectedProgramYear}
+            // Derived (healed) year so the chip value is always in its option
+            // list — avoids a transient controlled-select mismatch for an
+            // out-of-range ?py= before the self-heal effect fires.
+            selectedProgramYear={effectiveProgramYear ?? selectedProgramYear}
             onProgramYearChange={setSelectedProgramYear}
             availableDates={availableDates}
             selectedDate={selectedDate}

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -3,14 +3,9 @@ import { useParams, useNavigate, useLocation, Link } from 'react-router-dom'
 import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useDistricts } from '../hooks/useDistricts'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
-import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
-import { useDistrictCachedDates } from '../hooks/useDistrictData'
-import {
-  getAvailableProgramYears,
-  getMostRecentDateInProgramYear,
-  calculateProgramYearDay,
-  type ProgramYear,
-} from '../utils/programYear'
+import { useDistrictProgramYearControls } from '../hooks/useDistrictProgramYearControls'
+import { calculateProgramYearDay } from '../utils/programYear'
+import { DataControlsBar } from '../components/DataControlsBar'
 import { formatDisplayDate } from '../utils/dateFormatting'
 import { formatCharterDate } from '../utils/formatCharterDate'
 import { getClubAnniversary } from '../utils/clubAnniversary'
@@ -190,7 +185,22 @@ const ClubDetailPage: React.FC = () => {
       ? (location.state as { fromClubsSearch: string }).fromClubsSearch
       : ''
 
-  const { selectedProgramYear } = useUrlProgramYear()
+  // PY selector state (#1302) — the page owns program year/date (R3). Previously
+  // this read `?py=` and computed the effective PY/date inline with no selector
+  // UI (users had to edit the URL / use back); the shared district-scoped hook
+  // now packages that wiring AND feeds the DataControlsBar chip in the hero.
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+    availableProgramYears,
+    availableDates,
+    effectiveProgramYear,
+    effectiveEndDate,
+    hasValidDates,
+    latestSnapshotDate,
+  } = useDistrictProgramYearControls(districtId, { selfHeal: false })
 
   // Fetch district info
   const { data: districtsData } = useDistricts()
@@ -199,38 +209,6 @@ const ClubDetailPage: React.FC = () => {
   )
   const rawName = selectedDistrict?.name || districtId || ''
   const districtName = /^\d+$/.test(rawName) ? `District ${rawName}` : rawName
-
-  // Fetch cached dates to determine effective date range
-  const { data: cachedDatesData } = useDistrictCachedDates(districtId || '')
-  const allCachedDates = useMemo(
-    () => cachedDatesData?.dates || [],
-    [cachedDatesData?.dates]
-  )
-
-  // Determine effective program year
-  const availableProgramYears = useMemo(
-    () => getAvailableProgramYears(allCachedDates),
-    [allCachedDates]
-  )
-
-  const effectiveProgramYear: ProgramYear | null = useMemo(() => {
-    if (availableProgramYears.length === 0) return null
-    const match = availableProgramYears.find(
-      py => py.year === selectedProgramYear.year
-    )
-    return match ?? availableProgramYears[0] ?? null
-  }, [availableProgramYears, selectedProgramYear.year])
-
-  const effectiveEndDate = useMemo(() => {
-    if (!effectiveProgramYear) return null
-    return (
-      getMostRecentDateInProgramYear(allCachedDates, effectiveProgramYear) ||
-      effectiveProgramYear.endDate
-    )
-  }, [effectiveProgramYear, allCachedDates])
-
-  const hasValidDates =
-    effectiveProgramYear !== null && effectiveEndDate !== null
 
   // Fetch district analytics to get this club's data
   const {
@@ -526,6 +504,26 @@ const ClubDetailPage: React.FC = () => {
               >
                 View multi-year history →
               </Link>
+              {/* #1302 — PY selector replaces the URL-edit / back workaround.
+                  The page already filtered trends by `?py=`; this surfaces the
+                  control so users can switch year (and snapshot date) directly. */}
+              <div className="club-hero__controls">
+                <DataControlsBar
+                  latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
+                  availableProgramYears={availableProgramYears}
+                  // Show the DERIVED (healed) year so the chip is honest even
+                  // when `?py=` names a year without data — selfHeal is off here
+                  // to protect the #577 navigation state, so nothing writes it
+                  // back to the URL until the user explicitly changes it.
+                  selectedProgramYear={
+                    effectiveProgramYear ?? selectedProgramYear
+                  }
+                  onProgramYearChange={setSelectedProgramYear}
+                  availableDates={availableDates}
+                  selectedDate={selectedDate}
+                  onDateChange={setSelectedDate}
+                />
+              </div>
             </div>
 
             <div className="club-hero__pills">

--- a/frontend/src/pages/ClubHistoryPage.tsx
+++ b/frontend/src/pages/ClubHistoryPage.tsx
@@ -83,7 +83,12 @@ export default function ClubHistoryPage() {
           message={`No completed program years on file yet for ${heading}. History appears once a program year closes (June 30).`}
         />
       ) : (
-        <ClubHistoryTable rows={rows} clubName={heading} />
+        <ClubHistoryTable
+          rows={rows}
+          clubName={heading}
+          districtId={districtId}
+          clubId={clubId}
+        />
       )}
 
       <p className="club-history-page__back">

--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -18,6 +18,8 @@ import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 import { ClubMiniList } from '../components/ClubMiniList'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useDistrictProgramYearControls } from '../hooks/useDistrictProgramYearControls'
+import { DataControlsBar } from '../components/DataControlsBar'
 
 const DivisionPage: React.FC = () => {
   const { districtId, divId } = useParams<{
@@ -27,10 +29,25 @@ const DivisionPage: React.FC = () => {
   const navigate = useNavigate()
   const isMobile = useIsMobile()
 
+  // PY selector state (#1302) — the page owns program year/date (R3) and threads
+  // the selected PY's effective end date into its own queries so switching the
+  // year re-queries. Was hardcoded to "latest snapshot only" (undefined dates).
+  const {
+    selectedProgramYear,
+    setSelectedProgramYear,
+    selectedDate,
+    setSelectedDate,
+    availableProgramYears,
+    availableDates,
+    effectiveEndDate,
+    hasValidDates,
+    latestSnapshotDate,
+  } = useDistrictProgramYearControls(districtId)
+
   const { data, isLoading, error } = useDistrictAnalytics(
-    districtId ?? '',
+    hasValidDates ? (districtId ?? null) : null,
     undefined,
-    undefined
+    effectiveEndDate ?? undefined
   )
 
   // Recognition / gap / visit data come from the same raw snapshot the
@@ -38,7 +55,11 @@ const DivisionPage: React.FC = () => {
   // overview's extractDivisionPerformance util + DivisionPerformanceCard rather
   // than re-deriving from allClubs, so this scoped page can't drift from it.
   const { data: snapshot, isLoading: isLoadingSnapshot } =
-    useDistrictStatistics(districtId ?? '', undefined, 'divisions')
+    useDistrictStatistics(
+      hasValidDates ? (districtId ?? null) : null,
+      effectiveEndDate ?? undefined,
+      'divisions'
+    )
   const normalizedDivId = divId?.toUpperCase()
   const divisionPerformance = React.useMemo(() => {
     if (!snapshot || !normalizedDivId) return undefined
@@ -132,6 +153,18 @@ const DivisionPage: React.FC = () => {
               ? 'Division recognition standing for this program year.'
               : `${clubs.length} club${clubs.length === 1 ? '' : 's'} across ${areas.length} area${areas.length === 1 ? '' : 's'} in this division.`}
           </p>
+        </div>
+        <div className="districts-page-header__actions">
+          <DataControlsBar
+            latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
+            asOfDate={snapshot?.asOfDate}
+            availableProgramYears={availableProgramYears}
+            selectedProgramYear={selectedProgramYear}
+            onProgramYearChange={setSelectedProgramYear}
+            availableDates={availableDates}
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+          />
         </div>
       </header>
 

--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -39,6 +39,7 @@ const DivisionPage: React.FC = () => {
     setSelectedDate,
     availableProgramYears,
     availableDates,
+    effectiveProgramYear,
     effectiveEndDate,
     hasValidDates,
     latestSnapshotDate,
@@ -159,7 +160,10 @@ const DivisionPage: React.FC = () => {
             latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
             asOfDate={snapshot?.asOfDate}
             availableProgramYears={availableProgramYears}
-            selectedProgramYear={selectedProgramYear}
+            // Derived (healed) year so the chip value is always in its option
+            // list — avoids a transient controlled-select mismatch for an
+            // out-of-range ?py= before the self-heal effect fires.
+            selectedProgramYear={effectiveProgramYear ?? selectedProgramYear}
             onProgramYearChange={setSelectedProgramYear}
             availableDates={availableDates}
             selectedDate={selectedDate}

--- a/frontend/src/pages/__tests__/AreaPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/AreaPage.programYear.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * PY-selector tests for AreaPage (#1302, epic #1298 Sprint 3).
+ *
+ * AreaPage historically hardcoded "latest snapshot only" (undefined dates).
+ * It must now expose the shared DataControlsBar PY chip, thread the selected
+ * PY's effective end date into its district-analytics + snapshot queries (R3),
+ * and honor a `?py=` deep link.
+ */
+import React from 'react'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import AreaPage from '../AreaPage'
+import { useDistrictAnalytics } from '../../hooks/useDistrictAnalytics'
+
+vi.mock('../../hooks/useIsMobile', () => ({ useIsMobile: () => false }))
+
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    data: {
+      districtId: '61',
+      dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+      count: 3,
+      dateRange: { startDate: '2025-08-01', endDate: '2026-08-01' },
+    },
+  })),
+}))
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+    count: 3,
+    generatedAt: '2026-08-02T00:00:00Z',
+  }),
+}))
+
+const SNAPSHOT = {
+  asOfDate: '2026-03-15',
+  divisionPerformance: [
+    {
+      Division: 'A',
+      Area: '10',
+      'Club Number': '123456',
+      'Club Name': 'Ottawa Club',
+      'Division Club Base': '3',
+      'Area Club Base': '1',
+      'Nov Visit award': '1',
+      'May Visit award': '0',
+    },
+  ],
+  clubPerformance: [
+    {
+      'Club Number': '123456',
+      'Club Name': 'Ottawa Club',
+      'Club Status': 'Active',
+      'Club Distinguished Status': 'Select Distinguished',
+    },
+  ],
+}
+
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({
+    data: SNAPSHOT,
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+const CLUB: ClubTrend = {
+  clubId: '123456',
+  clubName: 'Ottawa Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '10',
+  areaName: 'Area 10',
+  distinguishedLevel: 'Select',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: '2026-03-15', count: 25 }],
+  dcpGoalsTrend: [{ date: '2026-03-15', goalsAchieved: 8 }],
+}
+
+vi.mock('../../hooks/useDistrictAnalytics', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../hooks/useDistrictAnalytics')
+  >('../../hooks/useDistrictAnalytics')
+  return {
+    ...actual,
+    useDistrictAnalytics: vi.fn(() => ({
+      data: { allClubs: [CLUB] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })),
+  }
+})
+
+const mockedAnalytics = vi.mocked(useDistrictAnalytics)
+
+const LocationProbe = () => {
+  const { search } = useLocation()
+  return <div data-testid="loc-search">{search}</div>
+}
+
+afterEach(() => cleanup())
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+const renderAt = (url: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <LocationProbe />
+          <Routes>
+            <Route
+              path="/district/:districtId/division/:divId/area/:areaId"
+              element={<AreaPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+const lastAnalyticsEndDate = () => {
+  const calls = mockedAnalytics.mock.calls
+  return calls[calls.length - 1]?.[2]
+}
+
+describe('AreaPage — program year selector (#1302)', () => {
+  it('renders the PY selector chip', async () => {
+    renderAt('/district/61/division/A/area/10')
+    expect(await screen.findByTestId('py-chip')).toBeInTheDocument()
+  })
+
+  it('honors a ?py= deep link and fetches that PY latest snapshot', async () => {
+    renderAt('/district/61/division/A/area/10?py=2025')
+    await screen.findByTestId('py-chip')
+    expect(screen.getByTestId('py-chip-select')).toHaveValue('2025')
+    await waitFor(() => expect(lastAnalyticsEndDate()).toBe('2026-05-01'))
+  })
+
+  it('re-queries when the PY selector changes', async () => {
+    renderAt('/district/61/division/A/area/10')
+    await screen.findByTestId('py-chip')
+    await waitFor(() => expect(lastAnalyticsEndDate()).toBe('2026-08-01'))
+
+    await userEvent.selectOptions(screen.getByTestId('py-chip-select'), '2025')
+    await waitFor(() => expect(lastAnalyticsEndDate()).toBe('2026-05-01'))
+    await waitFor(() =>
+      expect(screen.getByTestId('loc-search').textContent).toContain('py=2025')
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/AreaPageParity.test.tsx
+++ b/frontend/src/pages/__tests__/AreaPageParity.test.tsx
@@ -81,6 +81,31 @@ const SNAPSHOT = {
   ],
 }
 
+// PY-selector wiring (#1302): DivisionPage/AreaPage now own program-year state
+// via useDistrictProgramYearControls. Mock its two dependencies so these tests
+// stay provider-free and PY-agnostic (fixed to the snapshot's PY 2025-2026).
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: () => ({
+    data: {
+      districtId: '61',
+      dates: ['2026-03-15'],
+      count: 1,
+      dateRange: { startDate: '2026-03-15', endDate: '2026-03-15' },
+    },
+  }),
+}))
+vi.mock('../../hooks/useUrlProgramYear', async () => {
+  const { getProgramYear } = await import('../../utils/programYear')
+  return {
+    useUrlProgramYear: () => ({
+      selectedProgramYear: getProgramYear(2025),
+      setSelectedProgramYear: () => {},
+      selectedDate: undefined,
+      setSelectedDate: () => {},
+    }),
+  }
+})
+
 vi.mock('../../hooks/useMembershipData', () => ({
   useDistrictStatistics: vi.fn(() => ({
     data: SNAPSHOT,

--- a/frontend/src/pages/__tests__/ClubDetailPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.programYear.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * PY-selector tests for ClubDetailPage (#1302, epic #1298 Sprint 3).
+ *
+ * ClubDetailPage already read `?py=` and filtered trends by it, but rendered NO
+ * selector — users had to edit the URL or use back. It must now expose the
+ * shared DataControlsBar PY chip, re-query when the PY changes, and honor a
+ * `?py=` deep link (data-driven default from Sprint 1).
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { screen, render, cleanup, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import { DarkModeProvider } from '../../contexts/DarkModeContext'
+import ClubDetailPage from '../ClubDetailPage'
+import { useDistrictAnalytics } from '../../hooks/useDistrictAnalytics'
+
+Object.defineProperty(window, 'matchMedia', {
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+  writable: true,
+})
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: vi.fn(() => ({
+    data: { districts: [{ id: '61', name: 'District 61' }] },
+  })),
+}))
+
+// PY2025 → 2025-08-01, 2026-05-01 (latest); PY2026 → 2026-08-01 (latest).
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    data: {
+      districtId: '61',
+      dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+      count: 3,
+      dateRange: { startDate: '2025-08-01', endDate: '2026-08-01' },
+    },
+  })),
+}))
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+    count: 3,
+    generatedAt: '2026-08-02T00:00:00Z',
+  }),
+}))
+
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+const baseMockClub = {
+  clubId: '00000606',
+  clubName: 'St Lawrence Toastmasters',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: 'A1',
+  areaName: 'Area A1',
+  membershipTrend: [{ date: '2026-05-01', count: 46 }],
+  dcpGoalsTrend: [{ date: '2026-05-01', goalsAchieved: 8 }],
+  membershipBase: 46,
+  currentStatus: 'thriving' as const,
+  riskFactors: [],
+  distinguishedLevel: 'NotDistinguished' as const,
+}
+
+vi.mock('../../hooks/useDistrictAnalytics', () => ({
+  useDistrictAnalytics: vi.fn(() => ({
+    data: { districtId: '61', allClubs: [baseMockClub] },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+  ClubTrend: {},
+}))
+
+const mockedAnalytics = vi.mocked(useDistrictAnalytics)
+
+const LocationProbe = () => {
+  const { search } = useLocation()
+  return <div data-testid="loc-search">{search}</div>
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+afterEach(() => cleanup())
+beforeEach(() => vi.clearAllMocks())
+
+function renderAt(url: string) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <DarkModeProvider>
+          <MemoryRouter initialEntries={[url]}>
+            <LocationProbe />
+            <Routes>
+              <Route
+                path="/district/:districtId/club/:clubId"
+                element={<ClubDetailPage />}
+              />
+            </Routes>
+          </MemoryRouter>
+        </DarkModeProvider>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+const lastAnalyticsEndDate = () => {
+  const calls = mockedAnalytics.mock.calls
+  return calls[calls.length - 1]?.[2]
+}
+
+describe('ClubDetailPage — program year selector (#1302)', () => {
+  it('renders the PY selector chip (replaces URL-edit/back workaround)', async () => {
+    renderAt('/district/61/club/00000606')
+    expect(await screen.findByTestId('py-chip')).toBeInTheDocument()
+  })
+
+  it('honors a ?py= deep link and fetches that PY latest snapshot', async () => {
+    renderAt('/district/61/club/00000606?py=2025')
+    await screen.findByTestId('py-chip')
+    expect(screen.getByTestId('py-chip-select')).toHaveValue('2025')
+    await waitFor(() => expect(lastAnalyticsEndDate()).toBe('2026-05-01'))
+  })
+
+  it('re-queries and updates the URL when the PY selector changes', async () => {
+    renderAt('/district/61/club/00000606')
+    await screen.findByTestId('py-chip')
+    await waitFor(() => expect(lastAnalyticsEndDate()).toBe('2026-08-01'))
+
+    await userEvent.selectOptions(screen.getByTestId('py-chip-select'), '2025')
+    await waitFor(() => expect(lastAnalyticsEndDate()).toBe('2026-05-01'))
+    await waitFor(() =>
+      expect(screen.getByTestId('loc-search').textContent).toContain('py=2025')
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
@@ -27,6 +27,31 @@ vi.mock('../../hooks/useIsMobile', () => ({
 // DivisionPerformanceCard (#1015). This suite only exercises the club
 // mini-table de-table behaviour, so stub the snapshot query as "no data" —
 // the recognition card is absent and the club list (under test) renders.
+// PY-selector wiring (#1302): DivisionPage/AreaPage now own program-year state
+// via useDistrictProgramYearControls. Mock its two dependencies so these tests
+// stay provider-free and PY-agnostic (fixed to the snapshot's PY 2025-2026).
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: () => ({
+    data: {
+      districtId: '61',
+      dates: ['2026-03-15'],
+      count: 1,
+      dateRange: { startDate: '2026-03-15', endDate: '2026-03-15' },
+    },
+  }),
+}))
+vi.mock('../../hooks/useUrlProgramYear', async () => {
+  const { getProgramYear } = await import('../../utils/programYear')
+  return {
+    useUrlProgramYear: () => ({
+      selectedProgramYear: getProgramYear(2025),
+      setSelectedProgramYear: () => {},
+      selectedDate: undefined,
+      setSelectedDate: () => {},
+    }),
+  }
+})
+
 vi.mock('../../hooks/useMembershipData', () => ({
   useDistrictStatistics: vi.fn(() => ({
     data: undefined,

--- a/frontend/src/pages/__tests__/DivisionAreaWayfinding.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionAreaWayfinding.test.tsx
@@ -50,6 +50,31 @@ const SNAPSHOT = {
 
 vi.mock('../../hooks/useIsMobile', () => ({ useIsMobile: () => false }))
 
+// PY-selector wiring (#1302): DivisionPage/AreaPage now own program-year state
+// via useDistrictProgramYearControls. Mock its two dependencies so these tests
+// stay provider-free and PY-agnostic (fixed to the snapshot's PY 2025-2026).
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: () => ({
+    data: {
+      districtId: '61',
+      dates: ['2026-03-15'],
+      count: 1,
+      dateRange: { startDate: '2026-03-15', endDate: '2026-03-15' },
+    },
+  }),
+}))
+vi.mock('../../hooks/useUrlProgramYear', async () => {
+  const { getProgramYear } = await import('../../utils/programYear')
+  return {
+    useUrlProgramYear: () => ({
+      selectedProgramYear: getProgramYear(2025),
+      setSelectedProgramYear: () => {},
+      selectedDate: undefined,
+      setSelectedDate: () => {},
+    }),
+  }
+})
+
 vi.mock('../../hooks/useMembershipData', () => ({
   useDistrictStatistics: vi.fn(() => ({
     data: SNAPSHOT,

--- a/frontend/src/pages/__tests__/DivisionPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionPage.programYear.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * PY-selector tests for DivisionPage (#1302, epic #1298 Sprint 3).
+ *
+ * DivisionPage historically hardcoded "latest snapshot only" (undefined dates).
+ * It must now expose the shared DataControlsBar PY chip, thread the selected
+ * PY's effective end date into its district-analytics + snapshot queries (R3),
+ * and honor a `?py=` deep link.
+ */
+import React from 'react'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import DivisionPage from '../DivisionPage'
+import { useDistrictAnalytics } from '../../hooks/useDistrictAnalytics'
+
+vi.mock('../../hooks/useIsMobile', () => ({ useIsMobile: () => false }))
+
+// District 61 snapshot index: PY2025 → 2025-08-01, 2026-05-01 (latest);
+// PY2026 → 2026-08-01 (latest).
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    data: {
+      districtId: '61',
+      dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+      count: 3,
+      dateRange: { startDate: '2025-08-01', endDate: '2026-08-01' },
+    },
+  })),
+}))
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+    count: 3,
+    generatedAt: '2026-08-02T00:00:00Z',
+  }),
+}))
+
+const SNAPSHOT = {
+  asOfDate: '2026-03-15',
+  divisionPerformance: [
+    {
+      Division: 'A',
+      Area: '10',
+      'Club Number': '123456',
+      'Club Name': 'Ottawa Club',
+      'Division Club Base': '3',
+      'Area Club Base': '1',
+      'Nov Visit award': '1',
+      'May Visit award': '0',
+    },
+  ],
+  clubPerformance: [
+    {
+      'Club Number': '123456',
+      'Club Name': 'Ottawa Club',
+      'Club Status': 'Active',
+      'Club Distinguished Status': 'Select Distinguished',
+    },
+  ],
+}
+
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({
+    data: SNAPSHOT,
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+const CLUB: ClubTrend = {
+  clubId: '123456',
+  clubName: 'Ottawa Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '10',
+  areaName: 'Area 10',
+  distinguishedLevel: 'Select',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: '2026-03-15', count: 25 }],
+  dcpGoalsTrend: [{ date: '2026-03-15', goalsAchieved: 8 }],
+}
+
+vi.mock('../../hooks/useDistrictAnalytics', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../hooks/useDistrictAnalytics')
+  >('../../hooks/useDistrictAnalytics')
+  return {
+    ...actual,
+    useDistrictAnalytics: vi.fn(() => ({
+      data: { allClubs: [CLUB] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })),
+  }
+})
+
+const mockedAnalytics = vi.mocked(useDistrictAnalytics)
+
+const LocationProbe = () => {
+  const { search } = useLocation()
+  return <div data-testid="loc-search">{search}</div>
+}
+
+afterEach(() => cleanup())
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+const renderAt = (url: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <LocationProbe />
+          <Routes>
+            <Route
+              path="/district/:districtId/division/:divId"
+              element={<DivisionPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+/** The end-date (3rd) arg of the most recent useDistrictAnalytics call. */
+const lastAnalyticsEndDate = () => {
+  const calls = mockedAnalytics.mock.calls
+  return calls[calls.length - 1]?.[2]
+}
+
+describe('DivisionPage — program year selector (#1302)', () => {
+  it('renders the PY selector chip', async () => {
+    renderAt('/district/61/division/A')
+    expect(await screen.findByTestId('py-chip')).toBeInTheDocument()
+  })
+
+  it('fetches the newest PY latest snapshot by default', async () => {
+    renderAt('/district/61/division/A')
+    await screen.findByTestId('py-chip')
+    await waitFor(() => expect(lastAnalyticsEndDate()).toBe('2026-08-01'))
+  })
+
+  it('honors a ?py= deep link and fetches that PY latest snapshot', async () => {
+    renderAt('/district/61/division/A?py=2025')
+    await screen.findByTestId('py-chip')
+    expect(screen.getByTestId('py-chip-select')).toHaveValue('2025')
+    await waitFor(() => expect(lastAnalyticsEndDate()).toBe('2026-05-01'))
+  })
+
+  it('re-queries when the PY selector changes', async () => {
+    renderAt('/district/61/division/A')
+    await screen.findByTestId('py-chip')
+    await waitFor(() => expect(lastAnalyticsEndDate()).toBe('2026-08-01'))
+
+    await userEvent.selectOptions(screen.getByTestId('py-chip-select'), '2025')
+    await waitFor(() => expect(lastAnalyticsEndDate()).toBe('2026-05-01'))
+    await waitFor(() =>
+      expect(screen.getByTestId('loc-search').textContent).toContain('py=2025')
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
@@ -82,6 +82,31 @@ const SNAPSHOT = {
   ],
 }
 
+// PY-selector wiring (#1302): DivisionPage/AreaPage now own program-year state
+// via useDistrictProgramYearControls. Mock its two dependencies so these tests
+// stay provider-free and PY-agnostic (fixed to the snapshot's PY 2025-2026).
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: () => ({
+    data: {
+      districtId: '61',
+      dates: ['2026-03-15'],
+      count: 1,
+      dateRange: { startDate: '2026-03-15', endDate: '2026-03-15' },
+    },
+  }),
+}))
+vi.mock('../../hooks/useUrlProgramYear', async () => {
+  const { getProgramYear } = await import('../../utils/programYear')
+  return {
+    useUrlProgramYear: () => ({
+      selectedProgramYear: getProgramYear(2025),
+      setSelectedProgramYear: () => {},
+      selectedDate: undefined,
+      setSelectedDate: () => {},
+    }),
+  }
+})
+
 vi.mock('../../hooks/useMembershipData', () => ({
   useDistrictStatistics: vi.fn(() => ({
     data: SNAPSHOT,

--- a/frontend/src/styles/components/club-history.css
+++ b/frontend/src/styles/components/club-history.css
@@ -186,6 +186,20 @@
   text-align: left;
 }
 
+/* #1302 — the year label deep-links into ClubDetailPage for that program year.
+   Reads as a link (accent colour, underline on hover/focus) without disturbing
+   the sticky identity column's weight/alignment. */
+.club-history-year-link {
+  color: var(--rt-stats, var(--accent, currentColor));
+  text-decoration: none;
+  font-weight: inherit;
+}
+
+.club-history-year-link:hover,
+.club-history-year-link:focus-visible {
+  text-decoration: underline;
+}
+
 /* Sticky identity column — keeps the program year visible while metrics scroll. */
 .club-history-table thead th:first-child,
 .club-history-table tbody th:first-child {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       }
     },
     "frontend": {
-      "version": "3.13.0",
+      "version": "3.14.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.1",
@@ -8638,7 +8638,7 @@
     },
     "packages/analytics-core": {
       "name": "@taverns-red/analytics-core",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "license": "MIT",
       "dependencies": {
         "@taverns-red/shared-contracts": "^1.0.0",
@@ -8678,7 +8678,7 @@
     },
     "packages/collector-cli": {
       "name": "@taverns-red/collector-cli",
-      "version": "1.5.2",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.21.0",
@@ -8727,7 +8727,7 @@
     },
     "packages/mcp-server": {
       "name": "@taverns-red/toast-stats-mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -8771,7 +8771,7 @@
     },
     "packages/shared-contracts": {
       "name": "@taverns-red/shared-contracts",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,6 +2,7 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `a-self-heal-hook-that-writes-the-url-on-mount-clobbers-a-consumers-navigation-state.md` — A shared "self-heal" hook that rewrites the URL on mount clobbers a consumer's navigation state; gate the write for pages that receive location.state  (2026-07-04)
 - `resolve-the-active-program-year-by-data-not-the-calendar.md` — Resolve the active Toastmasters program year by probing data, not the calendar — TM's rollover lags July 1  (2026-07-02)
 - `a-delete-path-must-reconcile-derived-indexes-not-only-the-additive-path.md` — A delete/prune path must reconcile its derived indexes, not just the additive path  (2026-06-29)
 - `order-additive-set-level-keep-passes-by-whose-reason-should-win.md` — Order additive set-level keep passes by whose reason should win, and have later passes yield to already-set state  (2026-06-29)

--- a/tasks/lessons/lessons/a-self-heal-hook-that-writes-the-url-on-mount-clobbers-a-consumers-navigation-state.md
+++ b/tasks/lessons/lessons/a-self-heal-hook-that-writes-the-url-on-mount-clobbers-a-consumers-navigation-state.md
@@ -1,0 +1,56 @@
+---
+date: 2026-07-04
+tier: principle
+summary: A shared "self-heal" hook that rewrites the URL on mount clobbers a consumer's navigation state; gate the write for pages that receive location.state
+tags: [frontend, react-router, hooks, program-year, navigation-state, self-heal, shared-hook]
+legacy_id: 177
+---
+
+# Principle — A mount-time URL self-heal clobbers a consumer's navigation state
+
+**Date:** 2026-07-04
+**Issue:** #1302 (epic #1298 Sprint 3 — PY selector on Division/Area/Club pages)
+
+## The failure
+
+Extracting the district-scoped PY/date wiring into a shared hook
+(`useDistrictProgramYearControls`) added a **self-heal effect**: when the
+selected program year has no data, the effect calls
+`setSelectedProgramYear(newest)` → `setSearchParams(..., { replace: true })`
+so the chip and `?py=` agree (L124, never strand the user on an empty grid).
+
+DivisionPage/AreaPage — reached via plain `<Link>` — were fine. But
+ClubDetailPage **receives navigation state**: `ClubsTable` passes the prior
+filtered search via `location.state.fromClubsSearch` so the "Clubs" breadcrumb
+can round-trip the user back to their filtered list (#577). React Router's
+`setSearchParams` writes a **new location with `state: undefined`** — so the
+mount-time self-heal silently wiped `fromClubsSearch`, and the crumb regressed
+to the unfiltered `/district/:id/clubs`. Three pre-existing tests caught it
+(the crumb href assertion + two `mockReturnValueOnce` tests that the *extra
+re-render* consumed).
+
+## The transferable insight
+
+**A shared hook that writes the URL as a side effect is safe only for pages
+that own their whole URL. A page that was navigated to *with state* must not
+auto-rewrite its URL on mount** — the rewrite drops `location.state`.
+
+The original ClubDetailPage was correct precisely because it only *derived*
+`effectiveProgramYear` (a `useMemo`) and never wrote back. The extraction
+regressed it by generalizing the write to every consumer.
+
+## How to apply
+
+- Make the URL-writing side effect **opt-out**: `useDistrictProgramYearControls(id, { selfHeal: false })`. Pages reached via plain links keep `selfHeal: true`; a page that reads `location.state` passes `false`.
+- The opted-out page stays honest by rendering the **derived** value
+  (`effectiveProgramYear ?? selectedProgramYear`) in the chip — the picker shows
+  the year whose data is displayed without any URL write. The URL only changes
+  on an explicit user action, which is an acceptable moment to drop stale state.
+- When you extract shared inline logic into a hook, **enumerate what each
+  consumer differs on** before assuming parity (R6). Here the differentiator was
+  invisible in the types: one caller had incoming `location.state`, the others
+  didn't. A green extraction that only ran the *new* callers' tests would have
+  shipped the regression — run the migrated caller's existing suite too.
+- Fragile test smell: `mockReturnValueOnce` breaks when a change adds a render.
+  That breakage is a *signal* the component now re-renders more — investigate the
+  new render, don't just switch to `mockReturnValue`.


### PR DESCRIPTION
Part of epic #1298 — **Sprint 3**. Brings the remaining PY-scoped pages onto the shared Program Year selector and adds per-year deep links.

## What changed
- **New shared hook** `useDistrictProgramYearControls` — district-scoped sibling of `useProgramYearControls` (dates from the per-district snapshot index). Packages the PY/date wiring that DivisionPage/AreaPage/ClubDetailPage need (R3: page owns state, threads `effectiveEndDate` into its own queries).
- **DivisionPage / AreaPage** — add the `DataControlsBar` PY chip; thread the selected PY's effective end date into `useDistrictAnalytics` + `useDistrictStatistics` (were hardcoded to "latest snapshot only").
- **ClubDetailPage** — migrate inline PY logic to the hook and add the selector to the hero (replaces the URL-edit/back workaround). Uses `{ selfHeal: false }` so a mount-time URL rewrite can't clobber `location.state` (the #577 filter round-trip); renders the derived `effectiveProgramYear` in the chip instead.
- **ClubHistoryTable** — each program-year row deep-links to `/district/:d/club/:c?py=<startYear>` (per-year focus). Optional `districtId`/`clubId` props keep the component router-free.

## Acceptance criteria
- [x] Each page renders a working PY selector; PY change re-queries; `?py=` deep links work; data-driven default (Sprint 1).
- [x] ClubDetailPage selector replaces the URL-edit/back workaround.
- [x] Tests cover selector presence + PY change + deep link. Full frontend suite green (298 files / 3606 tests).
- [ ] Verified on the PR preview channel at 375/768/1280px + dark mode (in progress).

## Quality gates
- TDD Red→Green per unit; `/simplify` pass (dropped a redundant date sort; honest hook doc); fresh-context `/review` → **APPROVE-WITH-NITS**, nits applied.

## Known low-priority tradeoffs (fresh-context review)
- A ClubHistory row for a completed year that predates the district analytics index links to `?py=<that year>`; ClubDetailPage self-heals the chip to the newest PY with data (L124), so the URL says the clicked year while the chip shows the healed year. Accepted as-is (gating would couple the table to the analytics index).
- ClubDetailPage's hero `DataControlsBar` omits `asOfDate`, so its freshness pill skips the month-end reconciliation label that Division/Area show. Minor asymmetry, intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
