### PR TITLE
feat(frontend): normalize the freshness pill on every page (#1310)

### DIFF
--- a/frontend/src/components/DataControlsBar.tsx
+++ b/frontend/src/components/DataControlsBar.tsx
@@ -1,17 +1,24 @@
 import React from 'react'
 import type { ProgramYear } from '../utils/programYear'
 import { formatDisplayDate } from '../utils/dateFormatting'
+import { computeFreshness } from '../utils/dataFreshness'
 
 /* Tight horizontal cluster of three pill-styled controls — freshness
    pill, PY chip, date chip — shared by /districts and /district/:id. */
 
 export interface DataControlsBarProps {
+  /** The pinned snapshot date currently being viewed (the month-end during
+   * closing). Also the fallback pill date when no as-of date is known. */
   latestSnapshotDate: string | undefined
   /** The "as of" date (sourceCsvDate) — shown in the pill when set, instead of
    * the pinned snapshot date (#1296). Falls back to latestSnapshotDate. */
   asOfDate?: string | undefined
-  /** When set, the pill renders a month-end reconciliation state (#1296). */
-  reconcilingMonthLabel?: string | undefined
+  /** True when viewing the most recent available snapshot. DataControlsBar
+   * derives the month-end reconciliation state itself via computeFreshness
+   * (#1310) — a single source of truth so no consumer can render the pill in a
+   * different freshness state than another. A finalized historical month-end
+   * (isLatest=false) is never flagged as reconciling. */
+  isLatest?: boolean
   availableProgramYears: ProgramYear[]
   selectedProgramYear: ProgramYear
   onProgramYearChange: (py: ProgramYear) => void
@@ -133,7 +140,7 @@ const formatPyShort = (py: ProgramYear): string =>
 export const DataControlsBar: React.FC<DataControlsBarProps> = ({
   latestSnapshotDate,
   asOfDate,
-  reconcilingMonthLabel,
+  isLatest = false,
   availableProgramYears,
   selectedProgramYear,
   onProgramYearChange,
@@ -143,7 +150,16 @@ export const DataControlsBar: React.FC<DataControlsBarProps> = ({
   freshnessPending = false,
 }) => {
   const sortedDates = [...availableDates].sort((a, b) => b.localeCompare(a))
-  const pillDate = asOfDate ?? latestSnapshotDate
+  // Single source of truth for the pill (#1310): derive the display date and
+  // the month-end reconciliation state here so every consumer only supplies raw
+  // facts (asOfDate, the pinned snapshotDate, isLatest) and can't drift.
+  const freshness = computeFreshness({
+    asOfDate,
+    snapshotDate: latestSnapshotDate,
+    isLatest,
+  })
+  const pillDate = freshness.displayDate
+  const reconcilingMonthLabel = freshness.reconcilingMonthLabel
 
   return (
     <div

--- a/frontend/src/components/DistrictDetailHeader.tsx
+++ b/frontend/src/components/DistrictDetailHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { DataControlsBar } from './DataControlsBar'
 import { HeaderActionsMenu } from './HeaderActionsMenu'
 import { ProgramYearTitleSuffix } from './ProgramYearTitleSuffix'
+import { useLatestAsOfDate } from '../hooks/useLatestAsOfDate'
 import type { ProgramYear } from '../utils/programYear'
 
 /* District detail page header (#358). Extracted from DistrictDetailPage so
@@ -36,6 +37,19 @@ export const DistrictDetailHeader: React.FC<DistrictDetailHeaderProps> = ({
   availableDates,
   latestSnapshotDate,
 }) => {
+  // Freshness parity (#1310): every district detail + subnav page shares this
+  // header, and most fetch no per-district snapshot, so the as-of date comes
+  // from the shared global source. The pill reflects the VIEWED date and only
+  // flags month-end reconciliation when the viewed snapshot is BOTH the
+  // district's latest AND the global pinned month-end — a district whose latest
+  // snapshot lags the global scrape never mislabels reconciliation.
+  const { asOfDate: globalAsOfDate, latestSnapshotDate: globalLatestSnapshot } =
+    useLatestAsOfDate()
+  const viewedDate = selectedDate ?? latestSnapshotDate
+  const isLatest =
+    (!selectedDate || selectedDate === latestSnapshotDate) &&
+    !!latestSnapshotDate &&
+    latestSnapshotDate === globalLatestSnapshot
   return (
     <>
       {/* Breadcrumb removed per #442 — duplicated the AppShell's active
@@ -63,7 +77,9 @@ export const DistrictDetailHeader: React.FC<DistrictDetailHeaderProps> = ({
 
         <div className="district-detail-page-header__actions">
           <DataControlsBar
-            latestSnapshotDate={latestSnapshotDate}
+            latestSnapshotDate={viewedDate}
+            asOfDate={isLatest ? globalAsOfDate : undefined}
+            isLatest={isLatest}
             availableProgramYears={availableProgramYears}
             selectedProgramYear={selectedProgramYear}
             onProgramYearChange={setSelectedProgramYear}

--- a/frontend/src/components/__tests__/DataControlsBar.test.tsx
+++ b/frontend/src/components/__tests__/DataControlsBar.test.tsx
@@ -43,13 +43,18 @@ describe('DataControlsBar (#529 #528)', () => {
     expect(pill).not.toHaveTextContent(/Jun 30/)
   })
 
-  it('renders a month-end reconciliation state (amber dot, tooltip) when reconciling (#1296)', () => {
+  // #1310 — DataControlsBar now OWNS the freshness derivation: given the raw
+  // facts (asOfDate, the pinned snapshotDate, and whether we're viewing the
+  // latest snapshot) it calls computeFreshness itself, so no consumer can pass
+  // an inconsistent reconciliation state. The month label is derived from the
+  // pinned snapshot date, not supplied by the caller.
+  it('derives the month-end reconciliation state (amber dot, tooltip) from isLatest (#1310)', () => {
     render(
       <DataControlsBar
         {...baseProps}
         latestSnapshotDate="2026-06-30"
         asOfDate="2026-07-02"
-        reconcilingMonthLabel="June 2026"
+        isLatest
       />
     )
     const pill = screen.getByTestId('freshness-pill')
@@ -61,6 +66,26 @@ describe('DataControlsBar (#529 #528)', () => {
     )
     const dot = pill.querySelector('[data-testid="freshness-dot"]')
     expect(dot?.className).toMatch(/amber/)
+  })
+
+  // A finalized historical month-end selected via the date picker must NEVER be
+  // mislabelled as reconciling, even if an as-of date in a later month is passed
+  // — the guard is isLatest=false (computeFreshness enforces it, #1310).
+  it('does NOT flag reconciliation for a historical snapshot (isLatest=false) (#1310)', () => {
+    render(
+      <DataControlsBar
+        {...baseProps}
+        latestSnapshotDate="2026-06-30"
+        asOfDate="2026-07-02"
+        isLatest={false}
+      />
+    )
+    const pill = screen.getByTestId('freshness-pill')
+    expect(pill).not.toHaveTextContent(/month-end reconciliation/i)
+    expect(pill.getAttribute('data-reconciling')).toBeNull()
+    expect(pill).toHaveTextContent(/Data fresh/i)
+    const dot = pill.querySelector('[data-testid="freshness-dot"]')
+    expect(dot?.className).toMatch(/green/)
   })
 
   it('renders the PY chip showing the selected program year as "PY YYYY–YY"', () => {

--- a/frontend/src/components/__tests__/DistrictDetailHeader.test.tsx
+++ b/frontend/src/components/__tests__/DistrictDetailHeader.test.tsx
@@ -1,11 +1,28 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { DistrictDetailHeader } from '../DistrictDetailHeader'
 import { getProgramYear } from '../../utils/programYear'
+import { useLatestAsOfDate } from '../../hooks/useLatestAsOfDate'
+
+// Mock the global freshness source so the presentational header stays testable
+// without a QueryClientProvider. Default: no reconciliation.
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: vi.fn(() => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  })),
+}))
+const mockUseLatestAsOfDate = vi.mocked(useLatestAsOfDate)
 
 afterEach(() => cleanup())
+beforeEach(() =>
+  mockUseLatestAsOfDate.mockReturnValue({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  })
+)
 
 const py2526 = getProgramYear(2025)
 
@@ -93,5 +110,52 @@ describe('DistrictDetailHeader action cluster consolidation (#676)', () => {
     ).toBeInTheDocument()
     expect(screen.getByTestId('py-chip')).toBeInTheDocument()
     expect(screen.getByTestId('date-chip')).toBeInTheDocument()
+  })
+})
+
+describe('DistrictDetailHeader freshness parity (#1310)', () => {
+  it('shows the month-end reconciliation pill when the global as-of date has advanced past the district month-end', () => {
+    mockUseLatestAsOfDate.mockReturnValue({
+      asOfDate: '2026-07-02',
+      latestSnapshotDate: '2026-06-30',
+    })
+    // Viewing the district's latest snapshot (no explicit date), and that latest
+    // === the global pinned month-end → reconciliation is live.
+    renderHeader({ selectedDate: undefined, latestSnapshotDate: '2026-06-30' })
+    const pill = screen.getByTestId('freshness-pill')
+    expect(pill).toHaveTextContent(/As of Jul 2, 2026/)
+    expect(pill).toHaveTextContent(/month-end reconciliation/i)
+    expect(pill.getAttribute('data-reconciling')).toBe('true')
+  })
+
+  it('does NOT flag reconciliation for a district whose latest snapshot lags the global scrape', () => {
+    mockUseLatestAsOfDate.mockReturnValue({
+      asOfDate: '2026-07-02',
+      latestSnapshotDate: '2026-06-30',
+    })
+    // District's newest is May 31 — it lags behind the global June month-end, so
+    // the July as-of date must not paint a spurious "May reconciliation".
+    renderHeader({ selectedDate: undefined, latestSnapshotDate: '2026-05-31' })
+    const pill = screen.getByTestId('freshness-pill')
+    expect(pill).not.toHaveTextContent(/month-end reconciliation/i)
+    expect(pill.getAttribute('data-reconciling')).toBeNull()
+    expect(pill).toHaveTextContent(/Data fresh · May 31, 2026/)
+  })
+
+  it('does NOT flag reconciliation when viewing a finalized historical date', () => {
+    mockUseLatestAsOfDate.mockReturnValue({
+      asOfDate: '2026-07-02',
+      latestSnapshotDate: '2026-06-30',
+    })
+    // A specific past date is selected (not the latest) → isLatest false. The
+    // pill reflects the VIEWED date, matching DistrictsPage.
+    renderHeader({
+      selectedDate: '2026-05-31',
+      latestSnapshotDate: '2026-06-30',
+    })
+    const pill = screen.getByTestId('freshness-pill')
+    expect(pill).not.toHaveTextContent(/month-end reconciliation/i)
+    expect(pill.getAttribute('data-reconciling')).toBeNull()
+    expect(pill).toHaveTextContent(/Data fresh · May 31, 2026/)
   })
 })

--- a/frontend/src/hooks/__tests__/useDistrictProgramYearControls.test.tsx
+++ b/frontend/src/hooks/__tests__/useDistrictProgramYearControls.test.tsx
@@ -77,6 +77,23 @@ describe('useDistrictProgramYearControls (#1302)', () => {
       '2026-05-01',
     ])
     expect(result.current.hasValidDates).toBe(true)
+    // Viewing a prior PY's latest (2026-05-01) is NOT the district's overall
+    // newest snapshot (2026-08-01) → freshness must not flag reconciliation.
+    expect(result.current.latestSnapshotDate).toBe('2026-08-01')
+    expect(result.current.isLatestSnapshot).toBe(false)
+  })
+
+  it('flags isLatestSnapshot when the effective end date is the district newest (#1310)', async () => {
+    const { result } = renderHook(() => useDistrictProgramYearControls('61'), {
+      wrapper: wrapperFor('/district/61?py=2026'),
+    })
+    await waitFor(() =>
+      expect(result.current.effectiveProgramYear?.year).toBe(2026)
+    )
+    // PY2026 latest === the district's overall newest snapshot.
+    expect(result.current.effectiveEndDate).toBe('2026-08-01')
+    expect(result.current.latestSnapshotDate).toBe('2026-08-01')
+    expect(result.current.isLatestSnapshot).toBe(true)
   })
 
   it('self-heals a PY with no district data to the newest available year', async () => {

--- a/frontend/src/hooks/__tests__/useLatestAsOfDate.test.tsx
+++ b/frontend/src/hooks/__tests__/useLatestAsOfDate.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * useLatestAsOfDate (#1310) — the GLOBAL "as of" date (sourceCsvDate) + the
+ * global pinned latest-snapshot date, for pages that render the freshness pill
+ * but don't fetch a per-district snapshot (the district detail/subnav header,
+ * AwardsPage). Sources the as-of date from rankings.json (`date`) and the pinned
+ * month-end from the CDN manifest.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useLatestAsOfDate } from '../useLatestAsOfDate'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnRankings: vi.fn().mockResolvedValue({
+    rankings: [],
+    date: '2026-07-02', // sourceCsvDate — advanced past the pinned month-end
+    generatedAt: '2026-07-02T00:00:00Z',
+  }),
+  fetchCdnManifest: vi.fn().mockResolvedValue({
+    latestSnapshotDate: '2026-06-30', // pinned month-end during reconciliation
+    generatedAt: '2026-07-02T00:00:00Z',
+  }),
+}))
+
+afterEach(() => cleanup())
+beforeEach(() => vi.clearAllMocks())
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useLatestAsOfDate (#1310)', () => {
+  it('returns the global as-of date (rankings.date) and pinned latest snapshot (manifest)', async () => {
+    const { result } = renderHook(() => useLatestAsOfDate(), { wrapper })
+    await waitFor(() => expect(result.current.asOfDate).toBe('2026-07-02'))
+    expect(result.current.latestSnapshotDate).toBe('2026-06-30')
+  })
+
+  it('returns undefined dates before the queries resolve (no crash)', () => {
+    const { result } = renderHook(() => useLatestAsOfDate(), { wrapper })
+    // Synchronous first render — nothing fetched yet.
+    expect(result.current.asOfDate).toBeUndefined()
+    expect(result.current.latestSnapshotDate).toBeUndefined()
+  })
+})

--- a/frontend/src/hooks/useDistrictProgramYearControls.ts
+++ b/frontend/src/hooks/useDistrictProgramYearControls.ts
@@ -60,6 +60,10 @@ export interface DistrictProgramYearControls {
   hasValidDates: boolean
   /** The district's overall most-recent snapshot date (for the freshness pill). */
   latestSnapshotDate: string | undefined
+  /** True when the effective end date is the district's newest snapshot — the
+   * signal computeFreshness needs to flag month-end reconciliation only on the
+   * live snapshot, never a finalized historical date (#1310). */
+  isLatestSnapshot: boolean
 }
 
 export function useDistrictProgramYearControls(
@@ -142,6 +146,10 @@ export function useDistrictProgramYearControls(
   const hasValidDates =
     effectiveProgramYear !== null && effectiveEndDate !== null
 
+  const latestSnapshotDate = cachedDatesData?.dateRange?.endDate
+  const isLatestSnapshot =
+    !!effectiveEndDate && effectiveEndDate === latestSnapshotDate
+
   // Dates within the selected PY. Left unsorted — DataControlsBar (the only
   // consumer) sorts newest-first itself, matching the sibling
   // useProgramYearControls which also returns its in-PY dates unsorted.
@@ -163,6 +171,7 @@ export function useDistrictProgramYearControls(
     effectiveProgramYear,
     effectiveEndDate,
     hasValidDates,
-    latestSnapshotDate: cachedDatesData?.dateRange?.endDate,
+    latestSnapshotDate,
+    isLatestSnapshot,
   }
 }

--- a/frontend/src/hooks/useLatestAsOfDate.ts
+++ b/frontend/src/hooks/useLatestAsOfDate.ts
@@ -1,0 +1,48 @@
+/**
+ * useLatestAsOfDate — the GLOBAL freshness inputs for pages that render the
+ * data-freshness pill but don't already fetch a per-district snapshot (#1310).
+ *
+ * The landing/region pages read the as-of date (`sourceCsvDate`) from their
+ * rankings query, and Division/Area/Club read it from their per-district
+ * snapshot. But the eight district detail/subnav pages share a single
+ * presentational `DistrictDetailHeader` (and five of them fetch no snapshot with
+ * an as-of date), and AwardsPage's standings carry no `sourceCsvDate`. Rather
+ * than add a heavy snapshot fetch to each, they read the GLOBAL as-of date here
+ * — one shared, cached source so every page's pill agrees.
+ *
+ * - `asOfDate` comes from `rankings.json` (`date` = `metadata.sourceCsvDate`),
+ *   the lightest CDN index that carries the dashboard "as of" date.
+ * - `latestSnapshotDate` comes from the CDN manifest — the pinned month-end.
+ *   A consumer compares its own district-latest against this so a district whose
+ *   newest snapshot LAGS the global scrape never mislabels reconciliation.
+ *
+ * Both queries are cached (manifest is additionally module-cached), so this is a
+ * cache hit wherever rankings/manifest were already loaded.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { fetchCdnRankings, fetchCdnManifest } from '../services/cdn'
+
+export interface LatestAsOfDate {
+  /** Global dashboard "as of" date (sourceCsvDate) — undefined until loaded. */
+  asOfDate: string | undefined
+  /** Global pinned latest-snapshot (month-end) date — undefined until loaded. */
+  latestSnapshotDate: string | undefined
+}
+
+export function useLatestAsOfDate(): LatestAsOfDate {
+  const { data: rankings } = useQuery({
+    queryKey: ['latest-as-of-date'],
+    queryFn: fetchCdnRankings,
+    staleTime: 15 * 60 * 1000,
+  })
+  const { data: manifest } = useQuery({
+    queryKey: ['cdn-manifest'],
+    queryFn: fetchCdnManifest,
+    staleTime: 15 * 60 * 1000,
+  })
+
+  return {
+    asOfDate: rankings?.date,
+    latestSnapshotDate: manifest?.latestSnapshotDate,
+  }
+}

--- a/frontend/src/pages/AreaPage.tsx
+++ b/frontend/src/pages/AreaPage.tsx
@@ -47,6 +47,7 @@ const AreaPage: React.FC = () => {
     effectiveEndDate,
     hasValidDates,
     latestSnapshotDate,
+    isLatestSnapshot,
   } = useDistrictProgramYearControls(districtId)
 
   const { data, isLoading, error } = useDistrictAnalytics(
@@ -178,6 +179,7 @@ const AreaPage: React.FC = () => {
           <DataControlsBar
             latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
             asOfDate={snapshot?.asOfDate}
+            isLatest={isLatestSnapshot}
             availableProgramYears={availableProgramYears}
             // Derived (healed) year so the chip value is always in its option
             // list — avoids a transient controlled-select mismatch for an

--- a/frontend/src/pages/AwardsPage.tsx
+++ b/frontend/src/pages/AwardsPage.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
 import { useProgramYearControls } from '../hooks/useProgramYearControls'
+import { useLatestAsOfDate } from '../hooks/useLatestAsOfDate'
 import { DataControlsBar } from '../components/DataControlsBar'
 import type {
   CompetitiveAwardRanking,
@@ -62,18 +63,25 @@ const AwardsPage: React.FC = () => {
     availableProgramYears,
     cachedDates,
     effectiveDate,
+    isLatestSnapshot,
     isDatesPending,
   } = useProgramYearControls()
 
   const { data: standings, isLoading } = useCompetitiveAwards(effectiveDate)
 
+  // Awards standings carry no `sourceCsvDate`, so source the as-of date from the
+  // shared global freshness signal so the pill matches every other page (#1310).
+  // Gated on isLatestSnapshot: the global as-of date only describes the latest
+  // snapshot, never a finalized historical date selected via the picker.
+  const { asOfDate: globalAsOfDate } = useLatestAsOfDate()
+
   return (
     <div className="awards-page">
       {/* Adopt the shared page-header layout (Districts/Regions/Region) so the
           DataControlsBar toolbar lays out top-right on desktop and stacks on
-          mobile — awards-page__header keeps its own bottom-margin. The awards
-          standings carry no `sourceCsvDate`, so the freshness pill just shows
-          the snapshot date (no month-end reconciliation axis). */}
+          mobile — awards-page__header keeps its own bottom-margin. The as-of
+          date + month-end reconciliation state come from the shared global
+          freshness source (#1310), matching every other page's pill. */}
       <header className="districts-page-header awards-page__header">
         <div className="districts-page-header__intro">
           <p className="placeholder-page__eyebrow">
@@ -96,6 +104,8 @@ const AwardsPage: React.FC = () => {
         <div className="districts-page-header__actions">
           <DataControlsBar
             latestSnapshotDate={effectiveDate}
+            asOfDate={isLatestSnapshot ? globalAsOfDate : undefined}
+            isLatest={isLatestSnapshot}
             availableProgramYears={availableProgramYears}
             selectedProgramYear={selectedProgramYear}
             onProgramYearChange={setSelectedProgramYear}

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -200,6 +200,7 @@ const ClubDetailPage: React.FC = () => {
     effectiveEndDate,
     hasValidDates,
     latestSnapshotDate,
+    isLatestSnapshot,
   } = useDistrictProgramYearControls(districtId, { selfHeal: false })
 
   // Fetch district info
@@ -510,6 +511,8 @@ const ClubDetailPage: React.FC = () => {
               <div className="club-hero__controls">
                 <DataControlsBar
                   latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
+                  asOfDate={districtStats?.asOfDate}
+                  isLatest={isLatestSnapshot}
                   availableProgramYears={availableProgramYears}
                   // Show the DERIVED (healed) year so the chip is honest even
                   // when `?py=` names a year without data — selfHeal is off here

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -7,7 +7,6 @@ import {
   fetchCdnRankingsForDate,
 } from '../services/cdn'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
-import { computeFreshness } from '../utils/dataFreshness'
 import { AwardsRaceSection } from '../components/AwardsRaceSection'
 import { LazyHistoricalRankChart as HistoricalRankChart } from '../components/LazyCharts'
 import { ChartSparklineExpand } from '../components/ChartSparklineExpand'
@@ -277,17 +276,13 @@ const DistrictsPage: React.FC = () => {
     placeholderData: prev => prev,
   })
 
-  // Freshness pill: show the "as of" date (sourceCsvDate) and flag month-end
-  // reconciliation when the latest snapshot is still finalizing (#1296).
+  // Freshness pill: DataControlsBar derives the "as of" date + month-end
+  // reconciliation state itself from these raw facts (#1310). isLatestSnapshot
+  // gates reconciliation to the live snapshot only.
   const isLatestSnapshot =
     !selectedDate ||
     (cachedDates.length > 0 &&
       selectedDate === [...cachedDates].sort((a, b) => b.localeCompare(a))[0])
-  const freshness = computeFreshness({
-    asOfDate: data?.date,
-    snapshotDate: effectiveRankingsDate,
-    isLatest: isLatestSnapshot,
-  })
 
   // Fetch competitive award standings for the same snapshot (#331).
   // isLoading reserves the AwardsRaceSection slot so its late arrival (this
@@ -889,8 +884,8 @@ const DistrictsPage: React.FC = () => {
           <div className="districts-page-header__actions">
             <DataControlsBar
               latestSnapshotDate={effectiveRankingsDate}
-              asOfDate={freshness.displayDate}
-              reconcilingMonthLabel={freshness.reconcilingMonthLabel}
+              asOfDate={data?.date}
+              isLatest={isLatestSnapshot}
               availableProgramYears={availableProgramYears}
               selectedProgramYear={selectedProgramYear}
               onProgramYearChange={setSelectedProgramYear}

--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -43,6 +43,7 @@ const DivisionPage: React.FC = () => {
     effectiveEndDate,
     hasValidDates,
     latestSnapshotDate,
+    isLatestSnapshot,
   } = useDistrictProgramYearControls(districtId)
 
   const { data, isLoading, error } = useDistrictAnalytics(
@@ -159,6 +160,7 @@ const DivisionPage: React.FC = () => {
           <DataControlsBar
             latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
             asOfDate={snapshot?.asOfDate}
+            isLatest={isLatestSnapshot}
             availableProgramYears={availableProgramYears}
             // Derived (healed) year so the chip value is always in its option
             // list — avoids a transient controlled-select mismatch for an

--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -14,7 +14,6 @@ import { computeTiedRanks } from '../utils/tieRankingUtils'
 import { useCompetitiveAwards } from '../hooks/useCompetitiveAwards'
 import { useProgramYearControls } from '../hooks/useProgramYearControls'
 import { DataControlsBar } from '../components/DataControlsBar'
-import { computeFreshness } from '../utils/dataFreshness'
 import type { DistinguishedDistrictTier } from '../services/cdn'
 import {
   getDistinguishedCountdown,
@@ -292,13 +291,6 @@ const RegionPage: React.FC = () => {
     placeholderData: prev => prev,
   })
 
-  // Freshness pill (#1296) — as-of date + month-end reconciliation state.
-  const freshness = computeFreshness({
-    asOfDate: data?.date,
-    snapshotDate: effectiveDate,
-    isLatest: isLatestSnapshot,
-  })
-
   // Distinguished District prerequisite gaps. Pin to the rankings
   // snapshot date so the countdown/tier columns can never drift to a
   // newer snapshot than the row they describe — two independent "latest"
@@ -430,8 +422,8 @@ const RegionPage: React.FC = () => {
         <div className="districts-page-header__actions">
           <DataControlsBar
             latestSnapshotDate={effectiveDate}
-            asOfDate={freshness.displayDate}
-            reconcilingMonthLabel={freshness.reconcilingMonthLabel}
+            asOfDate={data?.date}
+            isLatest={isLatestSnapshot}
             availableProgramYears={availableProgramYears}
             selectedProgramYear={selectedProgramYear}
             onProgramYearChange={setSelectedProgramYear}

--- a/frontend/src/pages/RegionsPage.tsx
+++ b/frontend/src/pages/RegionsPage.tsx
@@ -9,7 +9,6 @@ import { EmptyState } from '../components/ErrorDisplay'
 import { useUrlState } from '../hooks/useUrlState'
 import { useProgramYearControls } from '../hooks/useProgramYearControls'
 import { DataControlsBar } from '../components/DataControlsBar'
-import { computeFreshness } from '../utils/dataFreshness'
 
 /* Region selection is URL state (#979) so it survives reload, back, and shared
    links — `?region=07`. Module-level options keep a stable reference so
@@ -58,14 +57,6 @@ const RegionsPage: React.FC = () => {
     // Keep the prior snapshot visible while a PY switch re-queries, so the
     // leaderboard doesn't flash back to the full-page skeleton.
     placeholderData: prev => prev,
-  })
-
-  // Freshness pill: show the "as of" date and flag month-end reconciliation
-  // when viewing the latest snapshot (#1296).
-  const freshness = computeFreshness({
-    asOfDate: data?.date,
-    snapshotDate: effectiveDate,
-    isLatest: isLatestSnapshot,
   })
 
   const [selectedRegion, setSelectedRegion] = useUrlState<string | null>(
@@ -137,8 +128,8 @@ const RegionsPage: React.FC = () => {
         <div className="districts-page-header__actions">
           <DataControlsBar
             latestSnapshotDate={effectiveDate}
-            asOfDate={freshness.displayDate}
-            reconcilingMonthLabel={freshness.reconcilingMonthLabel}
+            asOfDate={data?.date}
+            isLatest={isLatestSnapshot}
             availableProgramYears={availableProgramYears}
             selectedProgramYear={selectedProgramYear}
             onProgramYearChange={setSelectedProgramYear}

--- a/frontend/src/pages/__tests__/AwardsPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/AwardsPage.programYear.test.tsx
@@ -21,6 +21,16 @@ const LocationProbe = () => {
   return <div data-testid="loc-search">{search}</div>
 }
 
+// AwardsPage now sources the freshness as-of date from this shared hook (#1310).
+// This suite exercises the PY/date selector, not the pill — stub it so the pill
+// falls back to the snapshot date (its prior behaviour here).
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  }),
+}))
+
 afterEach(() => cleanup())
 
 vi.mock('../../services/cdn', () => {

--- a/frontend/src/pages/__tests__/AwardsPage.test.tsx
+++ b/frontend/src/pages/__tests__/AwardsPage.test.tsx
@@ -17,6 +17,16 @@ vi.mock('../../services/cdn', () => ({
   fetchCdnDates: vi.fn().mockResolvedValue({ dates: [], count: 0 }),
 }))
 
+// AwardsPage now sources the freshness as-of date from this shared hook (#1310).
+// These tests exercise the award tables, not the pill — stub it to undefined so
+// the pill falls back to the snapshot date (its prior behaviour here).
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  }),
+}))
+
 const mockStandings: CompetitiveAwardStandings = {
   metadata: {
     snapshotId: '2026-04-15',

--- a/frontend/src/pages/__tests__/DistrictDetailPage.redesign.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.redesign.test.tsx
@@ -7,7 +7,7 @@
    that already smoke-test the header indirectly. */
 
 import React from 'react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { readFileSync } from 'fs'
@@ -15,6 +15,15 @@ import { resolve } from 'path'
 import { MemoryRouter } from 'react-router-dom'
 import { DistrictDetailHeader } from '../../components/DistrictDetailHeader'
 import type { ProgramYear } from '../../utils/programYear'
+
+// The header sources the freshness as-of date from this shared hook (#1310);
+// mock it so the presentational header mounts without a QueryClientProvider.
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  }),
+}))
 
 const mockProgramYear: ProgramYear = {
   year: 2025,


### PR DESCRIPTION
Part of epic #1309. Closes the freshness-pill inconsistency: same underlying data rendered a different pill on the landing page ("As of Jul 2 · month-end reconciliation") vs a district detail page ("Data fresh · Jun 30").

## What changed

**Centralized the derivation** so a consumer can no longer render the pill wrong:

- `DataControlsBar` now takes raw facts — `asOfDate`, the pinned `latestSnapshotDate`, and an `isLatest` flag — and calls `computeFreshness` itself. The drift-prone `reconcilingMonthLabel` prop is gone.
- `useDistrictProgramYearControls` exposes `isLatestSnapshot` (effective end date === the district's newest snapshot) so Division/Area/Club gate reconciliation to the live snapshot only.
- New shared `useLatestAsOfDate()` hook returns the GLOBAL as-of date (`rankings.json`) + pinned month-end (manifest) for pages that fetch no per-district snapshot.
- `DistrictDetailHeader` sources it once → all **8** district detail/subnav pages match DistrictsPage with a single edit. It guards a district whose latest snapshot lags the global scrape (`districtLatest === globalLatestSnapshot`) so it never paints a spurious reconciliation.

**Wired every consumer:** landing trio (Districts/Region/Regions), Division/Area/Club (per-district `snapshot.asOfDate`), Awards (global source — its standings carry no `sourceCsvDate`).

## Acceptance criteria

- [x] Every freshness-pill page shows the same behavior: as-of date + amber month-end reconciliation, with the historical-month-end guard intact (`isLatest=false` never reconciles).
- [x] District detail + all subnav (via `DistrictDetailHeader`), Awards, Club, Division, Area match DistrictsPage.
- [x] Failing tests added first (DataControlsBar centralization, `isLatestSnapshot`, header parity + lagging-district guard, `useLatestAsOfDate`). Full frontend suite green (3613 passed).
- [ ] Verified on the PR preview channel @375/768/1280 + dark (pending preview deploy).
- [x] No CLS regression — the `#922` freshness skeleton slot is untouched.

## Testing

`npm run test` (frontend) — 299 files / 3613 tests pass. Typecheck, ESLint, prettier, and `test:no-page-mounts:check` (R22) all green. Reconciliation only reproduces during the month-end window, so it's proven by unit tests (code-proof); preview screenshots will show the identical green "as of" pills across pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)