### PR TITLE
fix(region): countdown/tier columns blank during reconciliation (#1315)

### DIFF
--- a/frontend/src/pages/RegionPage.tsx
+++ b/frontend/src/pages/RegionPage.tsx
@@ -291,11 +291,12 @@ const RegionPage: React.FC = () => {
     placeholderData: prev => prev,
   })
 
-  // Distinguished District prerequisite gaps. Pin to the rankings
-  // snapshot date so the countdown/tier columns can never drift to a
-  // newer snapshot than the row they describe — two independent "latest"
-  // calls would race during a publish.
-  const { data: awards } = useCompetitiveAwards(data?.date)
+  // Distinguished District prerequisite gaps. Pin to the rankings SNAPSHOT
+  // date (effectiveDate), NOT data.date (the as-of sourceCsvDate). The
+  // competitive-awards file is stored under the snapshot date; during
+  // month-end reconciliation the sourceCsvDate advances past it, so keying on
+  // data.date 404s and blanks the countdown/tier columns (#1315).
+  const { data: awards } = useCompetitiveAwards(effectiveDate)
 
   // Region ranks are ALWAYS computed from aggregate score, regardless of
   // the visible sort order — a district's regional rank is a property of

--- a/frontend/src/pages/__tests__/RegionPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.programYear.test.tsx
@@ -12,12 +12,40 @@ import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import RegionPage from '../RegionPage'
-import { fetchCdnRankingsForDate } from '../../services/cdn'
+import {
+  fetchCdnRankingsForDate,
+  fetchCdnCompetitiveAwards,
+} from '../../services/cdn'
 
 const LocationProbe = () => {
   const { search } = useLocation()
   return <div data-testid="loc-search">{search}</div>
 }
+
+const mockedAwards = vi.mocked(fetchCdnCompetitiveAwards)
+
+// Minimal region-07 ranking rows for override scenarios.
+const mkRanking = (districtId: string, score: number) => ({
+  districtId,
+  districtName: `District ${districtId}`,
+  region: '07',
+  paidClubs: 50,
+  paidClubBase: 48,
+  clubGrowthPercent: 4,
+  totalPayments: 2000,
+  paymentBase: 1900,
+  paymentGrowthPercent: 5,
+  activeClubs: 50,
+  distinguishedClubs: 20,
+  selectDistinguished: 5,
+  presidentsDistinguished: 3,
+  distinguishedPercent: 40,
+  clubsRank: 1,
+  paymentsRank: 1,
+  distinguishedRank: 1,
+  overallRank: 1,
+  aggregateScore: score,
+})
 
 afterEach(() => cleanup())
 
@@ -95,6 +123,24 @@ describe('RegionPage — program year selector (#1301)', () => {
     renderAt('/region/07')
     await screen.findByRole('table', { name: /region 07 district rankings/i })
     expect(screen.getByTestId('py-chip')).toBeInTheDocument()
+  })
+
+  it('keys competitive-awards on the SNAPSHOT date, not the as-of sourceCsvDate (month-end reconciliation)', async () => {
+    // Reconciliation window: the 2026-05-01 snapshot's sourceCsvDate has
+    // advanced to 2026-05-20. The countdown/tier columns read from the awards
+    // file, which is stored under the SNAPSHOT date — keying it on the advanced
+    // sourceCsvDate 404s and blanks those columns.
+    mockedForDate.mockImplementation((date: string) =>
+      Promise.resolve({
+        date: date === '2026-05-01' ? '2026-05-20' : date,
+        rankings: [mkRanking('57', 350), mkRanking('60', 300)],
+      })
+    )
+    renderAt('/region/07?py=2025') // latest in PY2025 = 2026-05-01
+    await screen.findByRole('table', { name: /region 07 district rankings/i })
+    await waitFor(() => expect(mockedAwards).toHaveBeenCalled())
+    expect(mockedAwards).toHaveBeenCalledWith('2026-05-01')
+    expect(mockedAwards).not.toHaveBeenCalledWith('2026-05-20')
   })
 
   it('honors a ?py= deep link and fetches that PY latest snapshot', async () => {


### PR DESCRIPTION
## Why

On `/region/:n`, the **Remaining to Distinguished** and **Education/Training + Tier** columns rendered `—` for every district during the month-end reconciliation window.

## Root cause

`RegionPage` fetched awards via `useCompetitiveAwards(data?.date)`. `data.date` is the **sourceCsvDate** (as-of date); the competitive-awards file is stored under the **snapshot date**. Mid-month they're equal, but during reconciliation the sourceCsvDate advances past the pinned snapshot (as-of Jul 5 vs snapshot Jun 30), so `snapshots/{sourceCsvDate}/competitive-awards.json` 404s → `awards` null → those columns (which read `awards.distinguishedDistrict`) blank. Same sourceCsvDate-vs-snapshotDate divergence class as #1289/#1296. The other three award consumers (Districts, DistrictDetail, Awards) already key on the snapshot date.

## Fix

One line: `useCompetitiveAwards(data?.date)` → `useCompetitiveAwards(effectiveDate)`.

## Verification

- TDD: a reconciliation-scenario test asserts awards key on the snapshot date, not the advanced sourceCsvDate (fails before, passes after).
- RegionPage suite: 41 pass.
- **Live** (dev server on staging CDN, /region/05): the countdown/tier columns now populate — D10/D86/D61 show "Distinguished" tiers and ✓ remaining; others show real remaining counts.

Closes #1315

🤖 Generated with [Claude Code](https://claude.com/claude-code)