### PR TITLE
Sprint 2 (#1321) — excise phantom DistrictStatistics.asOfDate; key division/area dates on the snapshot

### DIFF
--- a/frontend/src/components/DivisionPerformanceCards.tsx
+++ b/frontend/src/components/DivisionPerformanceCards.tsx
@@ -9,8 +9,11 @@
  * - 1.1: Display one performance card for each division in the district
  * - 1.2: Display all division performance cards simultaneously on the same page
  * - 1.3: Order division performance cards by division identifier
- * - 10.3: Display the timestamp of the current snapshot data
  * - 10.4: Indicate loading state to the user when snapshot data is being refreshed
+ *
+ * (Req 10.3 "display the snapshot timestamp" is served by the page header's
+ * freshness pill (#1310); this component's own timestamp panel was dead code
+ * bound to a phantom field and was removed in #1321.)
  *
  * The component uses the extractDivisionPerformance utility to transform raw
  * snapshot data into typed performance structures, then renders a DivisionPerformanceCard
@@ -20,7 +23,6 @@
 import React from 'react'
 import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
 import { DivisionPerformanceCard } from './DivisionPerformanceCard'
-import { formatDisplayDate } from '../utils/dateFormatting'
 import { logger } from '../utils/logger'
 
 /**
@@ -47,11 +49,10 @@ export interface DivisionPerformanceCardsProps {
  * DivisionPerformanceCards Component
  *
  * Renders a collection of division performance cards with the following features:
- * 1. Snapshot timestamp display at the top
- * 2. Loading state handling
- * 3. Error state handling for invalid data
- * 4. Ordered rendering of division cards (by division identifier)
- * 5. Empty state handling when no divisions are present
+ * 1. Loading state handling
+ * 2. Error state handling for invalid data
+ * 3. Ordered rendering of division cards (by division identifier)
+ * 4. Empty state handling when no divisions are present
  *
  * The component follows the existing patterns in DistrictDetailPage.tsx and uses
  * Toastmasters brand styling (TM Loyal Blue, Montserrat fonts) for consistency.
@@ -179,45 +180,23 @@ export const DivisionPerformanceCards: React.FC<
     )
   }
 
-  // Main render - display divisions with timestamp
+  // Main render — division cards.
+  //
+  // A "Division & Area Performance" + "Data as of {date}" panel used to sit here
+  // behind `{snapshotTimestamp && …}`. It was DEAD: its only caller
+  // (DistrictDivisionsPage) fed it `districtStatistics.asOfDate` — the phantom
+  // this sprint deletes — so the guard was always false and the panel has never
+  // rendered in production. Its unit tests passed only because their fixtures
+  // carried the phantom the wire never sends.
+  //
+  // Removed rather than resurrected (#1321). Passing the real pinned date would
+  // have switched it on as a silent side effect, and it was redundant + wrong:
+  // the header's freshness pill already reports the date (#1310), and labelling
+  // a PINNED SNAPSHOT date "Data as of" is precisely the snapshot-vs-as-of
+  // conflation epic #1319 exists to eliminate — a 5th recurrence, in new copy.
+  // `snapshotTimestamp` stays required; it gates the visit round below.
   return (
     <div className="space-y-6">
-      {/* Snapshot Timestamp Header */}
-      {snapshotTimestamp && (
-        <div className="redesign-panel">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2
-                className="font-tm-headline font-semibold text-tm-black"
-                style={{ fontSize: '18px' }}
-              >
-                Division & Area Performance
-              </h2>
-              <p
-                className="font-tm-body text-gray-600 mt-1"
-                style={{ fontSize: '14px' }}
-              >
-                Performance metrics for all divisions and areas
-              </p>
-            </div>
-            <div className="text-right">
-              <p
-                className="font-tm-body text-gray-500 uppercase tracking-wide"
-                style={{ fontSize: '12px' }}
-              >
-                Data as of
-              </p>
-              <p
-                className="font-tm-body font-medium text-gray-900"
-                style={{ fontSize: '14px' }}
-              >
-                {formatDisplayDate(snapshotTimestamp)}
-              </p>
-            </div>
-          </div>
-        </div>
-      )}
-
       {/* Division Performance Cards */}
       <div
         className="space-y-6"

--- a/frontend/src/components/DivisionPerformanceCards.tsx
+++ b/frontend/src/components/DivisionPerformanceCards.tsx
@@ -31,8 +31,13 @@ export interface DivisionPerformanceCardsProps {
   districtSnapshot: unknown
   /** Optional loading state indicator */
   isLoading?: boolean
-  /** Optional snapshot timestamp for display */
-  snapshotTimestamp?: string
+  /**
+   * The date (`YYYY-MM-DD`) the snapshot is PINNED to. Required (#1321): it
+   * gates the area visit round/deadlines, so it is load-bearing, not display —
+   * and when it was optional it fell through to the wall clock, which disagrees
+   * with the viewed snapshot every closing window.
+   */
+  snapshotTimestamp: string
   /** District id — threaded to each card so its heading links to the division
    *  page (CC-7, #872). */
   districtId?: string | undefined
@@ -57,7 +62,7 @@ export interface DivisionPerformanceCardsProps {
  * <DivisionPerformanceCards
  *   districtSnapshot={snapshot}
  *   isLoading={false}
- *   snapshotTimestamp="2024-01-15T10:30:00Z"
+ *   snapshotTimestamp="2026-06-30"
  * />
  * ```
  */

--- a/frontend/src/components/__tests__/DivisionPerformanceCards.test.tsx
+++ b/frontend/src/components/__tests__/DivisionPerformanceCards.test.tsx
@@ -219,52 +219,55 @@ describe('DivisionPerformanceCards', () => {
     })
   })
 
-  describe('Snapshot Timestamp Display (Requirement 10.3)', () => {
-    it('should display snapshot timestamp when provided', () => {
+  describe('Snapshot timestamp panel — removed (#1321)', () => {
+    /**
+     * This block used to assert a "Division & Area Performance" + "Data as of
+     * {date}" panel. That panel was DEAD in production: its only caller passed
+     * `districtStatistics.asOfDate`, a phantom absent from the live CDN
+     * envelope, so its `{snapshotTimestamp && …}` guard was never true. These
+     * tests passed only because the fixture supplied the phantom — the mock
+     * asserting the wire shape into existence (Lesson 171).
+     *
+     * It is not coming back here: the page header's freshness pill already
+     * reports the date (#1310), and "Data as of" is the wrong label for a
+     * PINNED SNAPSHOT date — the exact conflation epic #1319 exists to kill.
+     * A tripwire, not just a comment: re-adding it fails here.
+     */
+    it('renders no timestamp panel — the header pill owns the date', () => {
       vi.mocked(extractDivisionPerformance).mockReturnValue(mockDivisions)
 
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockSnapshot}
           isLoading={false}
-          snapshotTimestamp="2024-01-15T10:30:00Z"
-        />
-      )
-
-      expect(screen.getByText('Data as of')).toBeInTheDocument()
-      expect(screen.getByText(/Jan 15, 2024/i)).toBeInTheDocument()
-    })
-
-    it('should not display timestamp section when not provided', () => {
-      vi.mocked(extractDivisionPerformance).mockReturnValue(mockDivisions)
-
-      render(
-        <DivisionPerformanceCards
-          districtSnapshot={mockSnapshot}
-          isLoading={false}
+          snapshotTimestamp="2026-06-30"
         />
       )
 
       expect(screen.queryByText('Data as of')).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('Division & Area Performance')
+      ).not.toBeInTheDocument()
+      // The date itself must not appear as prose here either.
+      expect(screen.queryByText(/Jun 30, 2026/i)).not.toBeInTheDocument()
     })
 
-    it('should display section header with timestamp', () => {
+    it('still feeds the pinned date to the visit-round gate', () => {
       vi.mocked(extractDivisionPerformance).mockReturnValue(mockDivisions)
 
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockSnapshot}
           isLoading={false}
-          snapshotTimestamp="2024-01-15T10:30:00Z"
+          snapshotTimestamp="2026-06-30"
         />
       )
 
-      expect(
-        screen.getByText('Division & Area Performance')
-      ).toBeInTheDocument()
-      expect(
-        screen.getByText(/Performance metrics for all divisions and areas/i)
-      ).toBeInTheDocument()
+      // The prop is load-bearing, not decorative: it gates getCurrentVisitRound.
+      expect(extractDivisionPerformance).toHaveBeenCalledWith(
+        mockSnapshot,
+        '2026-06-30'
+      )
     })
   })
 
@@ -557,12 +560,13 @@ describe('DivisionPerformanceCards', () => {
         <DivisionPerformanceCards
           districtSnapshot={mockSnapshot}
           isLoading={false}
-          snapshotTimestamp="2024-01-15T10:30:00Z"
+          snapshotTimestamp="2026-06-30"
         />
       )
 
-      const heading = screen.getByText('Division & Area Performance')
-      expect(heading.tagName).toBe('H2')
+      expect(
+        screen.getByRole('region', { name: 'Division performance cards' })
+      ).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/hooks/__tests__/useLatestAsOfDate.test.tsx
+++ b/frontend/src/hooks/__tests__/useLatestAsOfDate.test.tsx
@@ -9,7 +9,7 @@ import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import { renderHook, waitFor, cleanup } from '@testing-library/react'
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useLatestAsOfDate } from '../useLatestAsOfDate'
+import { useLatestAsOfDate, useGlobalFreshness } from '../useLatestAsOfDate'
 
 vi.mock('../../services/cdn', () => ({
   fetchCdnRankings: vi.fn().mockResolvedValue({
@@ -47,5 +47,61 @@ describe('useLatestAsOfDate (#1310)', () => {
     // Synchronous first render — nothing fetched yet.
     expect(result.current.asOfDate).toBeUndefined()
     expect(result.current.latestSnapshotDate).toBeUndefined()
+  })
+})
+
+/**
+ * `useGlobalFreshness` (#1321) owns the rule the pill sites used to hand-write:
+ * the global as-of date only describes the viewed snapshot when that snapshot is
+ * BOTH the district's latest AND the global pinned month-end.
+ *
+ * Fixtures (above) are divergence-by-default: global as-of 2026-07-02 has
+ * advanced past the pinned month-end 2026-06-30 — the closing window.
+ */
+describe('useGlobalFreshness (#1321)', () => {
+  const render = (params: {
+    districtLatestSnapshotDate: string | undefined
+    isLatestSnapshot: boolean
+  }) => renderHook(() => useGlobalFreshness(params), { wrapper })
+
+  it('surfaces the global as-of date when the district latest IS the global latest', async () => {
+    const { result } = render({
+      districtLatestSnapshotDate: '2026-06-30',
+      isLatestSnapshot: true,
+    })
+    await waitFor(() => expect(result.current.asOfDate).toBe('2026-07-02'))
+    expect(result.current.isLatest).toBe(true)
+  })
+
+  it('withholds it while viewing a historical snapshot', async () => {
+    const { result } = render({
+      districtLatestSnapshotDate: '2026-06-30',
+      isLatestSnapshot: false,
+    })
+    await waitFor(() => expect(result.current.isLatest).toBe(false))
+    // Load-bearing: computeFreshness shows `asOfDate ?? snapshotDate`, so a
+    // leaked global date would print over the historical snapshot's own.
+    expect(result.current.asOfDate).toBeUndefined()
+  })
+
+  it("withholds it when the district's latest LAGS the global scrape", async () => {
+    // District's newest snapshot is a month behind the global pinned month-end:
+    // its data is genuinely older, so it must not claim the global as-of date
+    // (nor a month-end reconciliation it isn't part of).
+    const { result } = render({
+      districtLatestSnapshotDate: '2026-05-31',
+      isLatestSnapshot: true,
+    })
+    await waitFor(() => expect(result.current.isLatest).toBe(false))
+    expect(result.current.asOfDate).toBeUndefined()
+  })
+
+  it('is not "latest" when the district has no known snapshot date', async () => {
+    const { result } = render({
+      districtLatestSnapshotDate: undefined,
+      isLatestSnapshot: true,
+    })
+    await waitFor(() => expect(result.current.isLatest).toBe(false))
+    expect(result.current.asOfDate).toBeUndefined()
   })
 })

--- a/frontend/src/hooks/useLatestAsOfDate.ts
+++ b/frontend/src/hooks/useLatestAsOfDate.ts
@@ -16,8 +16,16 @@
  *   A consumer compares its own district-latest against this so a district whose
  *   newest snapshot LAGS the global scrape never mislabels reconciliation.
  *
- * Both queries are cached (manifest is additionally module-cached), so this is a
- * cache hit wherever rankings/manifest were already loaded.
+ * Caching, precisely (#1321 — the previous note here overclaimed):
+ * - The **manifest** query is module-cached in `services/cdn.ts`, and every page
+ *   already fetches it inside another queryFn, so it costs nothing.
+ * - The **rankings** query is NOT module-cached. It shares the
+ *   `['district-rankings', 'latest']` key + `fetchCdnRankings` queryFn +
+ *   staleTime with `useDistrictRanking`, so it's a cache hit on the pages that
+ *   already read rankings — but on a page that reads none (Division/Area), it is
+ *   a real ~126KB fetch to read one string. `v1/rankings.json` is served
+ *   uncompressed; the durable fix is to carry `sourceCsvDate` on the 152-byte
+ *   `v1/latest.json` manifest instead. See the follow-up issue.
  */
 import { useQuery } from '@tanstack/react-query'
 import { fetchCdnRankings, fetchCdnManifest } from '../services/cdn'
@@ -31,7 +39,9 @@ export interface LatestAsOfDate {
 
 export function useLatestAsOfDate(): LatestAsOfDate {
   const { data: rankings } = useQuery({
-    queryKey: ['latest-as-of-date'],
+    // Shares `useDistrictRanking`'s key/queryFn/staleTime so the two don't fetch
+    // the same 126KB rankings.json under competing keys (#1321).
+    queryKey: ['district-rankings', 'latest'],
     queryFn: fetchCdnRankings,
     staleTime: 15 * 60 * 1000,
   })
@@ -45,4 +55,45 @@ export function useLatestAsOfDate(): LatestAsOfDate {
     asOfDate: rankings?.asOfDate,
     latestSnapshotDate: manifest?.latestSnapshotDate,
   }
+}
+
+/** The freshness facts a `DataControlsBar` needs, already reconciled. */
+export interface GlobalFreshness {
+  /** The global as-of date, or undefined when the viewed snapshot isn't latest. */
+  asOfDate: string | undefined
+  /** True when the viewed snapshot is the district's latest AND the global one. */
+  isLatest: boolean
+}
+
+/**
+ * Resolve the freshness pill's inputs for a district-scoped page (#1321).
+ *
+ * Owns the rule that was previously hand-written at each pill: the global as-of
+ * date only describes the viewed snapshot when that snapshot is BOTH the
+ * district's latest AND the global pinned month-end. A district whose data lags
+ * the global scrape must NOT show the global as-of date, or its pill claims a
+ * freshness (and a month-end reconciliation) that its own data doesn't have.
+ *
+ * Returning `asOfDate: undefined` for the non-latest case is load-bearing —
+ * `computeFreshness` displays `asOfDate ?? snapshotDate` unconditionally, so
+ * handing it a global date while viewing a historical snapshot would print the
+ * global date over that snapshot's own.
+ *
+ * @param districtLatestSnapshotDate - the district's OWN newest snapshot date.
+ * @param isLatestSnapshot - whether the page is viewing that newest snapshot.
+ */
+export function useGlobalFreshness(params: {
+  districtLatestSnapshotDate: string | undefined
+  isLatestSnapshot: boolean
+}): GlobalFreshness {
+  const { asOfDate, latestSnapshotDate: globalLatestSnapshot } =
+    useLatestAsOfDate()
+  // The `!!districtLatestSnapshotDate` term matters for callers whose
+  // `isLatestSnapshot` doesn't already imply it (a bare `undefined ===
+  // undefined` would otherwise read as "latest").
+  const isLatest =
+    params.isLatestSnapshot &&
+    !!params.districtLatestSnapshotDate &&
+    params.districtLatestSnapshotDate === globalLatestSnapshot
+  return { asOfDate: isLatest ? asOfDate : undefined, isLatest }
 }

--- a/frontend/src/pages/AreaPage.tsx
+++ b/frontend/src/pages/AreaPage.tsx
@@ -22,7 +22,7 @@ import { EmptyState } from '../components/ErrorDisplay'
 import { ClubMiniList } from '../components/ClubMiniList'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDistrictProgramYearControls } from '../hooks/useDistrictProgramYearControls'
-import { useLatestAsOfDate } from '../hooks/useLatestAsOfDate'
+import { useGlobalFreshness } from '../hooks/useLatestAsOfDate'
 import { DataControlsBar } from '../components/DataControlsBar'
 
 const AreaPage: React.FC = () => {
@@ -53,16 +53,12 @@ const AreaPage: React.FC = () => {
 
   // Freshness parity (#1321): the per-district snapshot carries no as-of date —
   // the old `snapshot.asOfDate` was a phantom, so this pill was permanently
-  // blank. Read the GLOBAL as-of date, and only flag month-end reconciliation
-  // when the viewed snapshot is BOTH this district's latest AND the global
-  // pinned month-end, so a district whose data lags never mislabels it. Same
-  // shape as DistrictDetailHeader (#1310).
-  const { asOfDate: globalAsOfDate, latestSnapshotDate: globalLatestSnapshot } =
-    useLatestAsOfDate()
-  const isLatestGlobal =
-    isLatestSnapshot &&
-    !!latestSnapshotDate &&
-    latestSnapshotDate === globalLatestSnapshot
+  // blank. The shared hook owns the "is this really the latest?" rule.
+  const { asOfDate: globalAsOfDate, isLatest: isLatestGlobal } =
+    useGlobalFreshness({
+      districtLatestSnapshotDate: latestSnapshotDate,
+      isLatestSnapshot,
+    })
 
   const { data, isLoading, error } = useDistrictAnalytics(
     hasValidDates ? (districtId ?? null) : null,
@@ -195,7 +191,7 @@ const AreaPage: React.FC = () => {
         <div className="districts-page-header__actions">
           <DataControlsBar
             latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
-            asOfDate={isLatestGlobal ? globalAsOfDate : undefined}
+            asOfDate={globalAsOfDate}
             isLatest={isLatestGlobal}
             availableProgramYears={availableProgramYears}
             // Derived (healed) year so the chip value is always in its option

--- a/frontend/src/pages/AreaPage.tsx
+++ b/frontend/src/pages/AreaPage.tsx
@@ -22,6 +22,7 @@ import { EmptyState } from '../components/ErrorDisplay'
 import { ClubMiniList } from '../components/ClubMiniList'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDistrictProgramYearControls } from '../hooks/useDistrictProgramYearControls'
+import { useLatestAsOfDate } from '../hooks/useLatestAsOfDate'
 import { DataControlsBar } from '../components/DataControlsBar'
 
 const AreaPage: React.FC = () => {
@@ -50,6 +51,19 @@ const AreaPage: React.FC = () => {
     isLatestSnapshot,
   } = useDistrictProgramYearControls(districtId)
 
+  // Freshness parity (#1321): the per-district snapshot carries no as-of date —
+  // the old `snapshot.asOfDate` was a phantom, so this pill was permanently
+  // blank. Read the GLOBAL as-of date, and only flag month-end reconciliation
+  // when the viewed snapshot is BOTH this district's latest AND the global
+  // pinned month-end, so a district whose data lags never mislabels it. Same
+  // shape as DistrictDetailHeader (#1310).
+  const { asOfDate: globalAsOfDate, latestSnapshotDate: globalLatestSnapshot } =
+    useLatestAsOfDate()
+  const isLatestGlobal =
+    isLatestSnapshot &&
+    !!latestSnapshotDate &&
+    latestSnapshotDate === globalLatestSnapshot
+
   const { data, isLoading, error } = useDistrictAnalytics(
     hasValidDates ? (districtId ?? null) : null,
     undefined,
@@ -71,18 +85,21 @@ const AreaPage: React.FC = () => {
   const normalizedDivId = divId?.toUpperCase()
   const normalizedAreaId = areaId?.toUpperCase()
   const matched = React.useMemo(() => {
-    if (!snapshot || !normalizedDivId || !normalizedAreaId) return undefined
-    // The CDN snapshot carries the as-of date; pass it so historical snapshots
-    // gate visit deadlines correctly (R3).
+    if (!snapshot || !normalizedDivId || !normalizedAreaId || !effectiveEndDate)
+      return undefined
+    // Gate visit deadlines on the date this page PINNED its snapshot query to
+    // (#1321), never the wall clock — the snapshot carries no as-of date of its
+    // own (the old `snapshot.asOfDate` was a phantom, absent from the live CDN
+    // envelope, so this silently fell back to `today`).
     const division = extractDivisionPerformance(
       snapshot,
-      snapshot.asOfDate
+      effectiveEndDate
     ).find(d => d.divisionId.toUpperCase() === normalizedDivId)
     const area = division?.areas.find(
       a => a.areaId.toUpperCase() === normalizedAreaId
     )
     return area ? { area, divisionId: division!.divisionId } : undefined
-  }, [snapshot, normalizedDivId, normalizedAreaId])
+  }, [snapshot, normalizedDivId, normalizedAreaId, effectiveEndDate])
   const areaPerformance = matched?.area
 
   const areaNarrative = React.useMemo(() => {
@@ -178,8 +195,8 @@ const AreaPage: React.FC = () => {
         <div className="districts-page-header__actions">
           <DataControlsBar
             latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
-            asOfDate={snapshot?.asOfDate}
-            isLatest={isLatestSnapshot}
+            asOfDate={isLatestGlobal ? globalAsOfDate : undefined}
+            isLatest={isLatestGlobal}
             availableProgramYears={availableProgramYears}
             // Derived (healed) year so the chip value is always in its option
             // list — avoids a transient controlled-select mismatch for an

--- a/frontend/src/pages/AreaRedirectPage.tsx
+++ b/frontend/src/pages/AreaRedirectPage.tsx
@@ -13,7 +13,10 @@
 import React from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useDistrictStatistics } from '../hooks/useMembershipData'
-import { extractDivisionPerformance } from '../utils/extractDivisionPerformance'
+import {
+  extractDivisionPerformance,
+  resolveSnapshotDate,
+} from '../utils/extractDivisionPerformance'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { EmptyState } from '../components/ErrorDisplay'
 
@@ -33,12 +36,17 @@ const AreaRedirectPage: React.FC = () => {
   const normalizedAreaId = areaId?.toUpperCase()
   // Resolve BOTH the canonical division id AND the canonical area id from the
   // snapshot (the source of truth), so a mixed-case alias like /area/a1 lands on
-  // a properly-cased canonical URL — the point of a shareable shortcut. Pass the
-  // snapshot's as-of date so historical snapshots gate correctly (R3), matching
-  // AreaPage's own lookup so the alias resolves the same division.
+  // a properly-cased canonical URL — the point of a shareable shortcut.
+  //
+  // This page pins no date of its own (it always reads the latest snapshot), so
+  // it passes the snapshot's OWN date (#1321). The date only gates visit rounds,
+  // which the redirect ignores — but there is no honest wall-clock answer, and
+  // `snapshot.asOfDate` never existed on the wire.
   const target = React.useMemo(() => {
     if (!snapshot || !normalizedAreaId) return undefined
-    const divisions = extractDivisionPerformance(snapshot, snapshot.asOfDate)
+    const snapshotDate = resolveSnapshotDate(snapshot)
+    if (!snapshotDate) return undefined
+    const divisions = extractDivisionPerformance(snapshot, snapshotDate)
     const division = divisions.find(d =>
       d.areas.some(a => a.areaId.toUpperCase() === normalizedAreaId)
     )
@@ -74,8 +82,10 @@ const AreaRedirectPage: React.FC = () => {
   }
 
   // Snapshot loaded but no division owns this area → bad slug → branded 404,
-  // never 404 while loading/errored (data-unavailable ≠ not-found).
-  if (snapshot && !target) {
+  // never 404 while loading/errored (data-unavailable ≠ not-found). A snapshot
+  // that doesn't report its own date is data-unavailable too, not a bad slug —
+  // it would make `target` undefined for a perfectly valid area (#1321).
+  if (snapshot && resolveSnapshotDate(snapshot) && !target) {
     throw new Response(null, { status: 404, statusText: 'Area not found' })
   }
 

--- a/frontend/src/pages/AreaRedirectPage.tsx
+++ b/frontend/src/pages/AreaRedirectPage.tsx
@@ -42,10 +42,9 @@ const AreaRedirectPage: React.FC = () => {
   // it passes the snapshot's OWN date (#1321). The date only gates visit rounds,
   // which the redirect ignores — but there is no honest wall-clock answer, and
   // `snapshot.asOfDate` never existed on the wire.
+  const snapshotDate = resolveSnapshotDate(snapshot)
   const target = React.useMemo(() => {
-    if (!snapshot || !normalizedAreaId) return undefined
-    const snapshotDate = resolveSnapshotDate(snapshot)
-    if (!snapshotDate) return undefined
+    if (!snapshot || !normalizedAreaId || !snapshotDate) return undefined
     const divisions = extractDivisionPerformance(snapshot, snapshotDate)
     const division = divisions.find(d =>
       d.areas.some(a => a.areaId.toUpperCase() === normalizedAreaId)
@@ -56,7 +55,7 @@ const AreaRedirectPage: React.FC = () => {
     return division && area
       ? { divId: division.divisionId, areaId: area.areaId }
       : undefined
-  }, [snapshot, normalizedAreaId])
+  }, [snapshot, normalizedAreaId, snapshotDate])
 
   React.useEffect(() => {
     if (target && districtId) {
@@ -85,7 +84,7 @@ const AreaRedirectPage: React.FC = () => {
   // never 404 while loading/errored (data-unavailable ≠ not-found). A snapshot
   // that doesn't report its own date is data-unavailable too, not a bad slug —
   // it would make `target` undefined for a perfectly valid area (#1321).
-  if (snapshot && resolveSnapshotDate(snapshot) && !target) {
+  if (snapshot && snapshotDate && !target) {
     throw new Response(null, { status: 404, statusText: 'Area not found' })
   }
 

--- a/frontend/src/pages/AreaRedirectPage.tsx
+++ b/frontend/src/pages/AreaRedirectPage.tsx
@@ -80,11 +80,23 @@ const AreaRedirectPage: React.FC = () => {
     )
   }
 
+  // A snapshot that doesn't report its own date is data-UNAVAILABLE, not a bad
+  // slug (#1321) — 404-ing here would blame the user's URL for our data problem,
+  // and falling through would hang on a skeleton forever. Say so instead.
+  // Unreachable against the live wire, which always carries `data.snapshotDate`.
+  if (snapshot && !snapshotDate) {
+    return (
+      <EmptyState
+        title="Could not load area"
+        message="The district snapshot is missing its date, so this area link can't be resolved. Try again in a moment."
+        icon="data"
+      />
+    )
+  }
+
   // Snapshot loaded but no division owns this area → bad slug → branded 404,
-  // never 404 while loading/errored (data-unavailable ≠ not-found). A snapshot
-  // that doesn't report its own date is data-unavailable too, not a bad slug —
-  // it would make `target` undefined for a perfectly valid area (#1321).
-  if (snapshot && snapshotDate && !target) {
+  // never 404 while loading/errored (data-unavailable ≠ not-found).
+  if (snapshot && !target) {
     throw new Response(null, { status: 404, statusText: 'Area not found' })
   }
 

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -4,7 +4,7 @@ import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useDistricts } from '../hooks/useDistricts'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useDistrictProgramYearControls } from '../hooks/useDistrictProgramYearControls'
-import { useLatestAsOfDate } from '../hooks/useLatestAsOfDate'
+import { useGlobalFreshness } from '../hooks/useLatestAsOfDate'
 import { calculateProgramYearDay } from '../utils/programYear'
 import { DataControlsBar } from '../components/DataControlsBar'
 import { formatDisplayDate } from '../utils/dateFormatting'
@@ -206,16 +206,12 @@ const ClubDetailPage: React.FC = () => {
 
   // Freshness parity (#1321): the per-district snapshot carries no as-of date —
   // the old `districtStats.asOfDate` was a phantom, so this pill was permanently
-  // blank. Read the GLOBAL as-of date, and only flag month-end reconciliation
-  // when the viewed snapshot is BOTH this district's latest AND the global
-  // pinned month-end, so a district whose data lags never mislabels it. Same
-  // shape as DistrictDetailHeader (#1310).
-  const { asOfDate: globalAsOfDate, latestSnapshotDate: globalLatestSnapshot } =
-    useLatestAsOfDate()
-  const isLatestGlobal =
-    isLatestSnapshot &&
-    !!latestSnapshotDate &&
-    latestSnapshotDate === globalLatestSnapshot
+  // blank. The shared hook owns the "is this really the latest?" rule.
+  const { asOfDate: globalAsOfDate, isLatest: isLatestGlobal } =
+    useGlobalFreshness({
+      districtLatestSnapshotDate: latestSnapshotDate,
+      isLatestSnapshot,
+    })
 
   // Fetch district info
   const { data: districtsData } = useDistricts()
@@ -525,7 +521,7 @@ const ClubDetailPage: React.FC = () => {
               <div className="club-hero__controls">
                 <DataControlsBar
                   latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
-                  asOfDate={isLatestGlobal ? globalAsOfDate : undefined}
+                  asOfDate={globalAsOfDate}
                   isLatest={isLatestGlobal}
                   availableProgramYears={availableProgramYears}
                   // Show the DERIVED (healed) year so the chip is honest even

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -4,6 +4,7 @@ import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useDistricts } from '../hooks/useDistricts'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useDistrictProgramYearControls } from '../hooks/useDistrictProgramYearControls'
+import { useLatestAsOfDate } from '../hooks/useLatestAsOfDate'
 import { calculateProgramYearDay } from '../utils/programYear'
 import { DataControlsBar } from '../components/DataControlsBar'
 import { formatDisplayDate } from '../utils/dateFormatting'
@@ -202,6 +203,19 @@ const ClubDetailPage: React.FC = () => {
     latestSnapshotDate,
     isLatestSnapshot,
   } = useDistrictProgramYearControls(districtId, { selfHeal: false })
+
+  // Freshness parity (#1321): the per-district snapshot carries no as-of date —
+  // the old `districtStats.asOfDate` was a phantom, so this pill was permanently
+  // blank. Read the GLOBAL as-of date, and only flag month-end reconciliation
+  // when the viewed snapshot is BOTH this district's latest AND the global
+  // pinned month-end, so a district whose data lags never mislabels it. Same
+  // shape as DistrictDetailHeader (#1310).
+  const { asOfDate: globalAsOfDate, latestSnapshotDate: globalLatestSnapshot } =
+    useLatestAsOfDate()
+  const isLatestGlobal =
+    isLatestSnapshot &&
+    !!latestSnapshotDate &&
+    latestSnapshotDate === globalLatestSnapshot
 
   // Fetch district info
   const { data: districtsData } = useDistricts()
@@ -511,8 +525,8 @@ const ClubDetailPage: React.FC = () => {
               <div className="club-hero__controls">
                 <DataControlsBar
                   latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
-                  asOfDate={districtStats?.asOfDate}
-                  isLatest={isLatestSnapshot}
+                  asOfDate={isLatestGlobal ? globalAsOfDate : undefined}
+                  isLatest={isLatestGlobal}
                   availableProgramYears={availableProgramYears}
                   // Show the DERIVED (healed) year so the chip is honest even
                   // when `?py=` names a year without data — selfHeal is off here

--- a/frontend/src/pages/DistrictActionListPage.tsx
+++ b/frontend/src/pages/DistrictActionListPage.tsx
@@ -184,15 +184,14 @@ const DistrictActionListPage: React.FC = () => {
       'divisions'
     )
 
+  // The visit-round gate keys on the date this page pinned its snapshot query
+  // to (#1321), never the wall clock.
   const divisionPerformance = useMemo(
     () =>
-      districtStatistics
-        ? extractDivisionPerformance(
-            districtStatistics,
-            districtStatistics.asOfDate
-          )
+      districtStatistics && effectiveEndDate
+        ? extractDivisionPerformance(districtStatistics, effectiveEndDate)
         : [],
-    [districtStatistics]
+    [districtStatistics, effectiveEndDate]
   )
 
   const sections = useMemo<ActionListSections>(() => {
@@ -203,18 +202,11 @@ const DistrictActionListPage: React.FC = () => {
         clubs: analytics?.allClubs ?? [],
         interventionClubs: analytics?.interventionRequiredClubs ?? [],
         divisions: divisionPerformance,
-        snapshotDate: districtStatistics?.asOfDate ?? effectiveEndDate ?? '',
+        snapshotDate: effectiveEndDate ?? '',
       },
       { division, area }
     )
-  }, [
-    analytics,
-    divisionPerformance,
-    districtStatistics?.asOfDate,
-    effectiveEndDate,
-    division,
-    area,
-  ])
+  }, [analytics, divisionPerformance, effectiveEndDate, division, area])
 
   // Scope-select options come from the authoritative division/area structure.
   const scopeOptions = useMemo<ScopeOption>(() => {

--- a/frontend/src/pages/DistrictDivisionsPage.tsx
+++ b/frontend/src/pages/DistrictDivisionsPage.tsx
@@ -139,11 +139,11 @@ const DistrictDivisionsPage: React.FC = () => {
           <DistrictSubnav districtId={districtId} />
 
           <div className="space-y-4 sm:space-y-6">
-            {districtStatistics ? (
+            {districtStatistics && effectiveEndDate ? (
               <DivisionPerformanceCards
                 districtSnapshot={districtStatistics}
                 isLoading={isLoadingStatistics}
-                snapshotTimestamp={districtStatistics.asOfDate}
+                snapshotTimestamp={effectiveEndDate}
                 districtId={districtId}
               />
             ) : (
@@ -152,11 +152,11 @@ const DistrictDivisionsPage: React.FC = () => {
 
             <DistinguishedProgramCriteriaExplainer />
 
-            {districtStatistics ? (
+            {districtStatistics && effectiveEndDate ? (
               <DivisionAreaRecognitionPanel
                 divisions={extractDivisionPerformance(
                   districtStatistics,
-                  districtStatistics.asOfDate
+                  effectiveEndDate
                 )}
                 isLoading={isLoadingStatistics}
               />

--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -19,6 +19,7 @@ import { EmptyState } from '../components/ErrorDisplay'
 import { ClubMiniList } from '../components/ClubMiniList'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDistrictProgramYearControls } from '../hooks/useDistrictProgramYearControls'
+import { useLatestAsOfDate } from '../hooks/useLatestAsOfDate'
 import { DataControlsBar } from '../components/DataControlsBar'
 
 const DivisionPage: React.FC = () => {
@@ -46,6 +47,19 @@ const DivisionPage: React.FC = () => {
     isLatestSnapshot,
   } = useDistrictProgramYearControls(districtId)
 
+  // Freshness parity (#1321): the per-district snapshot carries no as-of date —
+  // the old `snapshot.asOfDate` was a phantom, so this pill was permanently
+  // blank. Read the GLOBAL as-of date, and only flag month-end reconciliation
+  // when the viewed snapshot is BOTH this district's latest AND the global
+  // pinned month-end, so a district whose data lags never mislabels it. Same
+  // shape as DistrictDetailHeader (#1310).
+  const { asOfDate: globalAsOfDate, latestSnapshotDate: globalLatestSnapshot } =
+    useLatestAsOfDate()
+  const isLatestGlobal =
+    isLatestSnapshot &&
+    !!latestSnapshotDate &&
+    latestSnapshotDate === globalLatestSnapshot
+
   const { data, isLoading, error } = useDistrictAnalytics(
     hasValidDates ? (districtId ?? null) : null,
     undefined,
@@ -63,12 +77,17 @@ const DivisionPage: React.FC = () => {
       'divisions'
     )
   const normalizedDivId = divId?.toUpperCase()
+  // Visit rounds/deadlines gate on the date this page PINNED its snapshot query
+  // to (#1321) — never the wall clock. `effectiveEndDate` is the same value fed
+  // to useDistrictStatistics above, so the extraction can't disagree with the
+  // data it describes. It is non-null whenever `snapshot` exists (the query is
+  // disabled unless `hasValidDates`), but guard rather than assert.
   const divisionPerformance = React.useMemo(() => {
-    if (!snapshot || !normalizedDivId) return undefined
-    return extractDivisionPerformance(snapshot, snapshot.asOfDate).find(
+    if (!snapshot || !normalizedDivId || !effectiveEndDate) return undefined
+    return extractDivisionPerformance(snapshot, effectiveEndDate).find(
       d => d.divisionId.toUpperCase() === normalizedDivId
     )
-  }, [snapshot, normalizedDivId])
+  }, [snapshot, normalizedDivId, effectiveEndDate])
 
   // Scoped division-level narrative — the same prose the overview's Division and
   // Area Progress Summary shows, scoped to this division (#1016 S2 refactor).
@@ -159,8 +178,8 @@ const DivisionPage: React.FC = () => {
         <div className="districts-page-header__actions">
           <DataControlsBar
             latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
-            asOfDate={snapshot?.asOfDate}
-            isLatest={isLatestSnapshot}
+            asOfDate={isLatestGlobal ? globalAsOfDate : undefined}
+            isLatest={isLatestGlobal}
             availableProgramYears={availableProgramYears}
             // Derived (healed) year so the chip value is always in its option
             // list — avoids a transient controlled-select mismatch for an

--- a/frontend/src/pages/DivisionPage.tsx
+++ b/frontend/src/pages/DivisionPage.tsx
@@ -19,7 +19,7 @@ import { EmptyState } from '../components/ErrorDisplay'
 import { ClubMiniList } from '../components/ClubMiniList'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useDistrictProgramYearControls } from '../hooks/useDistrictProgramYearControls'
-import { useLatestAsOfDate } from '../hooks/useLatestAsOfDate'
+import { useGlobalFreshness } from '../hooks/useLatestAsOfDate'
 import { DataControlsBar } from '../components/DataControlsBar'
 
 const DivisionPage: React.FC = () => {
@@ -49,16 +49,12 @@ const DivisionPage: React.FC = () => {
 
   // Freshness parity (#1321): the per-district snapshot carries no as-of date —
   // the old `snapshot.asOfDate` was a phantom, so this pill was permanently
-  // blank. Read the GLOBAL as-of date, and only flag month-end reconciliation
-  // when the viewed snapshot is BOTH this district's latest AND the global
-  // pinned month-end, so a district whose data lags never mislabels it. Same
-  // shape as DistrictDetailHeader (#1310).
-  const { asOfDate: globalAsOfDate, latestSnapshotDate: globalLatestSnapshot } =
-    useLatestAsOfDate()
-  const isLatestGlobal =
-    isLatestSnapshot &&
-    !!latestSnapshotDate &&
-    latestSnapshotDate === globalLatestSnapshot
+  // blank. The shared hook owns the "is this really the latest?" rule.
+  const { asOfDate: globalAsOfDate, isLatest: isLatestGlobal } =
+    useGlobalFreshness({
+      districtLatestSnapshotDate: latestSnapshotDate,
+      isLatestSnapshot,
+    })
 
   const { data, isLoading, error } = useDistrictAnalytics(
     hasValidDates ? (districtId ?? null) : null,
@@ -178,7 +174,7 @@ const DivisionPage: React.FC = () => {
         <div className="districts-page-header__actions">
           <DataControlsBar
             latestSnapshotDate={effectiveEndDate ?? latestSnapshotDate}
-            asOfDate={isLatestGlobal ? globalAsOfDate : undefined}
+            asOfDate={globalAsOfDate}
             isLatest={isLatestGlobal}
             availableProgramYears={availableProgramYears}
             // Derived (healed) year so the chip value is always in its option

--- a/frontend/src/pages/__tests__/AreaFlatAliasRedirect.test.tsx
+++ b/frontend/src/pages/__tests__/AreaFlatAliasRedirect.test.tsx
@@ -19,8 +19,10 @@ import {
 } from 'react-router-dom'
 import AreaRedirectPage from '../AreaRedirectPage'
 
+// The wire shape: the snapshot reports its own pinned date as `snapshotDate`.
+// It never carried an `asOfDate` — that field was a phantom, deleted in #1321.
 const SNAPSHOT = {
-  asOfDate: '2026-03-15',
+  snapshotDate: '2026-03-15',
   divisionPerformance: [
     {
       Division: 'A',

--- a/frontend/src/pages/__tests__/AreaFlatAliasRedirect.test.tsx
+++ b/frontend/src/pages/__tests__/AreaFlatAliasRedirect.test.tsx
@@ -18,6 +18,7 @@ import {
   isRouteErrorResponse,
 } from 'react-router-dom'
 import AreaRedirectPage from '../AreaRedirectPage'
+import { useDistrictStatistics } from '../../hooks/useMembershipData'
 
 // The wire shape: the snapshot reports its own pinned date as `snapshotDate`.
 // It never carried an `asOfDate` — that field was a phantom, deleted in #1321.
@@ -107,5 +108,27 @@ describe('AreaRedirectPage flat alias (#1017)', () => {
   it('throws a 404 for an area id no division owns', () => {
     renderAt('/district/61/area/99')
     expect(screen.getByTestId('boundary')).toHaveTextContent('404')
+  })
+
+  /**
+   * This page pins no date of its own (it always reads the latest snapshot), so
+   * it takes the date from the snapshot itself (#1321). A snapshot that doesn't
+   * report one is a DATA problem, not a bad URL — it must not 404 (blaming the
+   * user's link) and must not hang on a skeleton. Unreachable against the live
+   * wire, which always carries `data.snapshotDate`; pinned so the degradation
+   * stays honest if that ever changes.
+   */
+  it('shows an unavailable state (not a 404) when the snapshot reports no date', () => {
+    vi.mocked(useDistrictStatistics).mockReturnValueOnce({
+      data: { ...SNAPSHOT, snapshotDate: undefined },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useDistrictStatistics>)
+
+    renderAt('/district/61/area/10')
+
+    expect(screen.getByText('Could not load area')).toBeInTheDocument()
+    expect(screen.queryByTestId('boundary')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('area-target')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/__tests__/AreaPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/AreaPage.programYear.test.tsx
@@ -37,6 +37,15 @@ vi.mock('../../services/cdn', () => ({
     count: 3,
     generatedAt: '2026-08-02T00:00:00Z',
   }),
+  // The freshness pill's global as-of source (#1321) — the page reads it via
+  // useLatestAsOfDate now that the per-district `asOfDate` phantom is gone.
+  fetchCdnRankings: vi.fn().mockResolvedValue({
+    rankings: [],
+    asOfDate: '2026-08-05',
+  }),
+  fetchCdnManifest: vi.fn().mockResolvedValue({
+    latestSnapshotDate: '2026-08-01',
+  }),
 }))
 
 const SNAPSHOT = {

--- a/frontend/src/pages/__tests__/AreaPageParity.test.tsx
+++ b/frontend/src/pages/__tests__/AreaPageParity.test.tsx
@@ -106,6 +106,16 @@ vi.mock('../../hooks/useUrlProgramYear', async () => {
   }
 })
 
+// The freshness pill reads the GLOBAL as-of date (#1321). These tests are
+// deliberately provider-free and assert recognition data, not the pill, so stub
+// it rather than stand up a QueryClientProvider.
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  }),
+}))
+
 vi.mock('../../hooks/useMembershipData', () => ({
   useDistrictStatistics: vi.fn(() => ({
     data: SNAPSHOT,

--- a/frontend/src/pages/__tests__/AreaPageParity.test.tsx
+++ b/frontend/src/pages/__tests__/AreaPageParity.test.tsx
@@ -110,10 +110,7 @@ vi.mock('../../hooks/useUrlProgramYear', async () => {
 // deliberately provider-free and assert recognition data, not the pill, so stub
 // it rather than stand up a QueryClientProvider.
 vi.mock('../../hooks/useLatestAsOfDate', () => ({
-  useLatestAsOfDate: () => ({
-    asOfDate: undefined,
-    latestSnapshotDate: undefined,
-  }),
+  useGlobalFreshness: () => ({ asOfDate: undefined, isLatest: false }),
 }))
 
 vi.mock('../../hooks/useMembershipData', () => ({

--- a/frontend/src/pages/__tests__/ClubDetailPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.programYear.test.tsx
@@ -55,6 +55,15 @@ vi.mock('../../services/cdn', () => ({
     count: 3,
     generatedAt: '2026-08-02T00:00:00Z',
   }),
+  // The freshness pill's global as-of source (#1321) — the page reads it via
+  // useLatestAsOfDate now that the per-district `asOfDate` phantom is gone.
+  fetchCdnRankings: vi.fn().mockResolvedValue({
+    rankings: [],
+    asOfDate: '2026-08-05',
+  }),
+  fetchCdnManifest: vi.fn().mockResolvedValue({
+    latestSnapshotDate: '2026-08-01',
+  }),
 }))
 
 vi.mock('../../hooks/useMembershipData', () => ({

--- a/frontend/src/pages/__tests__/DistrictDetailPage.integration.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.integration.test.tsx
@@ -169,9 +169,11 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
         />
       )
 
-      // Verify component renders
+      // Verify component renders. The old "Division & Area Performance" panel
+      // was dead code bound to the phantom asOfDate and is gone (#1321) — the
+      // division cards themselves are the render evidence.
       expect(
-        screen.getByText('Division & Area Performance')
+        screen.getByRole('region', { name: 'Division performance cards' })
       ).toBeInTheDocument()
 
       // Verify divisions are rendered
@@ -221,7 +223,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       expect(screen.getByText('B1')).toBeInTheDocument()
     })
 
-    it('should display snapshot timestamp', () => {
+    it('renders no snapshot-timestamp panel — the header pill owns the date (#1321)', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
@@ -230,8 +232,10 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
         />
       )
 
-      expect(screen.getByText('Data as of')).toBeInTheDocument()
-      expect(screen.getByText(/Jan 15, 2024/i)).toBeInTheDocument()
+      // The timestamp panel is gone (#1321): the page header's freshness pill
+      // owns the date, and "Data as of" mislabels a pinned snapshot date.
+      expect(screen.queryByText('Data as of')).not.toBeInTheDocument()
+      expect(screen.queryByText(/Jan 15, 2024/i)).not.toBeInTheDocument()
     })
 
     it('should show loading state', () => {

--- a/frontend/src/pages/__tests__/DistrictDetailPage.integration.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.integration.test.tsx
@@ -60,7 +60,9 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
   // The extractDivisionPerformance function groups clubs by Division and Area
   const mockDistrictStatistics = {
     districtId: 'D1',
-    asOfDate: '2024-01-15T10:30:00Z',
+    // The snapshot's own pinned date (#1321). The old `asOfDate` was a phantom —
+    // never present on the wire — so it fed `undefined` into the visit-round gate.
+    snapshotDate: '2024-01-15',
     membership: {
       total: 5000,
       change: 100,
@@ -162,8 +164,8 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
-          snapshotTimestamp={mockDistrictStatistics.asOfDate}
         />
       )
 
@@ -181,6 +183,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -204,6 +207,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -221,8 +225,8 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
-          snapshotTimestamp={mockDistrictStatistics.asOfDate}
         />
       )
 
@@ -234,6 +238,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={true}
         />
       )
@@ -245,7 +250,11 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
 
     it('should handle missing data gracefully', () => {
       render(
-        <DivisionPerformanceCards districtSnapshot={null} isLoading={false} />
+        <DivisionPerformanceCards
+          districtSnapshot={null}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
+          isLoading={false}
+        />
       )
 
       expect(screen.getByText('No Data Available')).toBeInTheDocument()
@@ -261,6 +270,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -287,6 +297,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -304,6 +315,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -320,6 +332,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -338,6 +351,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -359,8 +373,8 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       const { container } = render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
-          snapshotTimestamp={mockDistrictStatistics.asOfDate}
         />
       )
 
@@ -373,6 +387,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -390,6 +405,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -409,8 +425,8 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
-          snapshotTimestamp={mockDistrictStatistics.asOfDate}
         />
       )
 
@@ -427,6 +443,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -442,6 +459,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -458,6 +476,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -470,6 +489,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={mockDistrictStatistics}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )
@@ -488,6 +508,7 @@ describe('DistrictDetailPage - Division Performance Cards Integration', () => {
       render(
         <DivisionPerformanceCards
           districtSnapshot={emptySnapshot}
+          snapshotTimestamp={mockDistrictStatistics.snapshotDate}
           isLoading={false}
         />
       )

--- a/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
@@ -56,10 +56,7 @@ vi.mock('../../hooks/useUrlProgramYear', async () => {
 // deliberately provider-free and assert recognition data, not the pill, so stub
 // it rather than stand up a QueryClientProvider.
 vi.mock('../../hooks/useLatestAsOfDate', () => ({
-  useLatestAsOfDate: () => ({
-    asOfDate: undefined,
-    latestSnapshotDate: undefined,
-  }),
+  useGlobalFreshness: () => ({ asOfDate: undefined, isLatest: false }),
 }))
 
 vi.mock('../../hooks/useMembershipData', () => ({

--- a/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionAreaStatusChip.test.tsx
@@ -52,6 +52,16 @@ vi.mock('../../hooks/useUrlProgramYear', async () => {
   }
 })
 
+// The freshness pill reads the GLOBAL as-of date (#1321). These tests are
+// deliberately provider-free and assert recognition data, not the pill, so stub
+// it rather than stand up a QueryClientProvider.
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  }),
+}))
+
 vi.mock('../../hooks/useMembershipData', () => ({
   useDistrictStatistics: vi.fn(() => ({
     data: undefined,

--- a/frontend/src/pages/__tests__/DivisionAreaWayfinding.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionAreaWayfinding.test.tsx
@@ -75,6 +75,16 @@ vi.mock('../../hooks/useUrlProgramYear', async () => {
   }
 })
 
+// The freshness pill reads the GLOBAL as-of date (#1321). These tests are
+// deliberately provider-free and assert recognition data, not the pill, so stub
+// it rather than stand up a QueryClientProvider.
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  }),
+}))
+
 vi.mock('../../hooks/useMembershipData', () => ({
   useDistrictStatistics: vi.fn(() => ({
     data: SNAPSHOT,

--- a/frontend/src/pages/__tests__/DivisionAreaWayfinding.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionAreaWayfinding.test.tsx
@@ -79,10 +79,7 @@ vi.mock('../../hooks/useUrlProgramYear', async () => {
 // deliberately provider-free and assert recognition data, not the pill, so stub
 // it rather than stand up a QueryClientProvider.
 vi.mock('../../hooks/useLatestAsOfDate', () => ({
-  useLatestAsOfDate: () => ({
-    asOfDate: undefined,
-    latestSnapshotDate: undefined,
-  }),
+  useGlobalFreshness: () => ({ asOfDate: undefined, isLatest: false }),
 }))
 
 vi.mock('../../hooks/useMembershipData', () => ({

--- a/frontend/src/pages/__tests__/DivisionPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionPage.programYear.test.tsx
@@ -39,6 +39,15 @@ vi.mock('../../services/cdn', () => ({
     count: 3,
     generatedAt: '2026-08-02T00:00:00Z',
   }),
+  // The freshness pill's global as-of source (#1321) — the page reads it via
+  // useLatestAsOfDate now that the per-district `asOfDate` phantom is gone.
+  fetchCdnRankings: vi.fn().mockResolvedValue({
+    rankings: [],
+    asOfDate: '2026-08-05',
+  }),
+  fetchCdnManifest: vi.fn().mockResolvedValue({
+    latestSnapshotDate: '2026-08-01',
+  }),
 }))
 
 const SNAPSHOT = {

--- a/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
@@ -111,10 +111,7 @@ vi.mock('../../hooks/useUrlProgramYear', async () => {
 // deliberately provider-free and assert recognition data, not the pill, so stub
 // it rather than stand up a QueryClientProvider.
 vi.mock('../../hooks/useLatestAsOfDate', () => ({
-  useLatestAsOfDate: () => ({
-    asOfDate: undefined,
-    latestSnapshotDate: undefined,
-  }),
+  useGlobalFreshness: () => ({ asOfDate: undefined, isLatest: false }),
 }))
 
 vi.mock('../../hooks/useMembershipData', () => ({

--- a/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
+++ b/frontend/src/pages/__tests__/DivisionPageParity.test.tsx
@@ -107,6 +107,16 @@ vi.mock('../../hooks/useUrlProgramYear', async () => {
   }
 })
 
+// The freshness pill reads the GLOBAL as-of date (#1321). These tests are
+// deliberately provider-free and assert recognition data, not the pill, so stub
+// it rather than stand up a QueryClientProvider.
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  }),
+}))
+
 vi.mock('../../hooks/useMembershipData', () => ({
   useDistrictStatistics: vi.fn(() => ({
     data: SNAPSHOT,

--- a/frontend/src/pages/__tests__/SnapshotDateDivergence.test.tsx
+++ b/frontend/src/pages/__tests__/SnapshotDateDivergence.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Snapshot-date divergence tests for DivisionPage + AreaPage (#1321, epic #1319
+ * Sprint 2).
+ *
+ * `DistrictStatistics.asOfDate` is a PHANTOM — verified absent from the live CDN
+ * envelope (`snapshots/2026-06-30/district_61.json` top-level keys are
+ * `{districtId, districtName, collectedAt, status, data}`; the inner payload
+ * carries `data.snapshotDate` and no `asOfDate` at either level). So
+ * `extractDivisionPerformance(snapshot, snapshot.asOfDate)` passed `undefined`
+ * and silently fell through to the `?? todayIso()` wall-clock fallback, which
+ * gates `getCurrentVisitRound` / `getAreaVisitDeadlines`.
+ *
+ * The fixtures below are DIVERGENCE-BY-DEFAULT (the epic's layer 2): the wall
+ * clock sits in July 2026 (PY 2026-2027) while the viewed snapshot is pinned to
+ * 2026-05-01 (PY 2025-2026). Those two program years disagree, so a wall-clock
+ * fallback renders the WRONG round's deadline. A fixture where the two dates
+ * agree — as every pre-existing DivisionPage/AreaPage test had — cannot see this.
+ *
+ * The area fixture earns Distinguished but MISSED its 1st-round visit. Whether
+ * that miss is a hard failure depends entirely on which program year's Nov 30
+ * deadline you measure against — which makes the badge label a year-independent
+ * discriminator (the tooltip is not: `formatShortDate` renders "May 31" with no
+ * year at all):
+ *   - pinned 2026-05-01 → PY 2025-2026 → Nov 30 2025 is PAST and unmet
+ *       → "Not Distinguished" (missed-deadline) ✅
+ *   - wall clock 2026-07-15 → PY 2026-2027 → Nov 30 2026 is still FUTURE
+ *       → "Select Distinguished (Provisional)" ❌ — the wall clock silently
+ *         whitewashes a missed deadline in a closed program year.
+ */
+import React from 'react'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import type { ClubTrend } from '../../hooks/useDistrictAnalytics'
+import DivisionPage from '../DivisionPage'
+import AreaPage from '../AreaPage'
+
+vi.mock('../../hooks/useIsMobile', () => ({ useIsMobile: () => false }))
+
+// District 61 snapshot index: PY2025 → 2025-08-01, 2026-05-01 (its latest);
+// PY2026 → 2026-08-01 (the district's overall latest).
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    data: {
+      districtId: '61',
+      dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+      count: 3,
+      dateRange: { startDate: '2025-08-01', endDate: '2026-08-01' },
+    },
+  })),
+}))
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
+    count: 3,
+    generatedAt: '2026-08-02T00:00:00Z',
+  }),
+  fetchCdnRankings: vi.fn().mockResolvedValue({
+    rankings: [],
+    // The as-of (sourceCsvDate) date, deliberately DIVERGENT from the pinned
+    // month-end below — the closing-window shape (#1315).
+    asOfDate: '2026-08-05',
+  }),
+  fetchCdnManifest: vi.fn().mockResolvedValue({
+    latestSnapshotDate: '2026-08-01',
+  }),
+}))
+
+/**
+ * Live wire shape: NO `asOfDate` key. Including one would re-create the exact
+ * fiction this sprint deletes (Lesson 171 — mock the envelope the wire sends,
+ * not the convenient shape).
+ */
+const SNAPSHOT = {
+  divisionPerformance: [
+    {
+      Division: 'A',
+      Area: '10',
+      'Club Number': '123456',
+      'Club Name': 'Ottawa Club',
+      'Division Club Base': '1',
+      'Area Club Base': '1',
+      // 1st round MISSED, 2nd round done. Under PY 2025-2026 the Nov 30 2025
+      // deadline has passed unmet (hard fail); under PY 2026-2027 Nov 30 2026
+      // is still ahead (merely provisional).
+      'Nov Visit award': '0',
+      'May Visit award': '1',
+    },
+  ],
+  clubPerformance: [
+    {
+      'Club Number': '123456',
+      'Club Name': 'Ottawa Club',
+      'Club Status': 'Active',
+      'Club Distinguished Status': 'Select Distinguished',
+    },
+  ],
+}
+
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({
+    data: SNAPSHOT,
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+const CLUB: ClubTrend = {
+  clubId: '123456',
+  clubName: 'Ottawa Club',
+  divisionId: 'A',
+  divisionName: 'Division A',
+  areaId: '10',
+  areaName: 'Area 10',
+  distinguishedLevel: 'Select',
+  currentStatus: 'thriving',
+  riskFactors: [],
+  membershipTrend: [{ date: '2026-05-01', count: 25 }],
+  dcpGoalsTrend: [{ date: '2026-05-01', goalsAchieved: 8 }],
+}
+
+vi.mock('../../hooks/useDistrictAnalytics', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../hooks/useDistrictAnalytics')
+  >('../../hooks/useDistrictAnalytics')
+  return {
+    ...actual,
+    useDistrictAnalytics: vi.fn(() => ({
+      data: { allClubs: [CLUB] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })),
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+  // Wall clock in the NEW program year (2026-2027) while the viewed snapshot
+  // stays pinned in the prior one — the July rollover + closing window.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.setSystemTime(new Date('2026-07-15T12:00:00Z'))
+})
+
+const renderAt = (url: string, path: string, element: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <Routes>
+            <Route path={path} element={element} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('snapshot-date divergence — visit deadlines key on the SNAPSHOT (#1321)', () => {
+  it('DivisionPage gates the area visit deadline on the pinned snapshot year, not the wall clock', async () => {
+    renderAt(
+      '/district/61/division/A?py=2025-2026',
+      '/district/:districtId/division/:divId',
+      <DivisionPage />
+    )
+
+    const badge = await screen.findByLabelText(/^Recognition status: /i)
+    // PY 2025-2026's Nov 30 2025 round-1 deadline passed unmet → hard fail.
+    expect(badge).toHaveTextContent('Not Distinguished')
+    expect(badge).not.toHaveTextContent(/Provisional/i)
+  })
+
+  it('AreaPage gates the area visit deadline on the pinned snapshot year, not the wall clock', async () => {
+    renderAt(
+      '/district/61/division/A/area/10?py=2025-2026',
+      '/district/:districtId/division/:divId/area/:areaId',
+      <AreaPage />
+    )
+
+    const badge = await screen.findByLabelText(/recognition: /i)
+    expect(badge).toHaveTextContent('Not Distinguished')
+    expect(badge).not.toHaveTextContent(/Provisional/i)
+  })
+})

--- a/frontend/src/pages/__tests__/SnapshotDateDivergence.test.tsx
+++ b/frontend/src/pages/__tests__/SnapshotDateDivergence.test.tsx
@@ -194,3 +194,38 @@ describe('snapshot-date divergence — visit deadlines key on the SNAPSHOT (#132
     expect(badge).not.toHaveTextContent(/Provisional/i)
   })
 })
+
+/**
+ * The freshness pill on these pages was bound to the same phantom, so it fell
+ * back to showing the pinned snapshot date and could never show the advancing
+ * as-of date — silently hiding exactly the closing-window divergence it exists
+ * to communicate. It now reads the global as-of date (#1310's shared source).
+ *
+ * Fixtures: district latest = global latest = 2026-08-01 (pinned), as-of =
+ * 2026-08-05 (advanced).
+ */
+describe('freshness pill reads the global as-of date (#1321)', () => {
+  it('DivisionPage shows the as-of date, not the pinned snapshot date, on the latest snapshot', async () => {
+    renderAt(
+      '/district/61/division/A',
+      '/district/:districtId/division/:divId',
+      <DivisionPage />
+    )
+
+    const pill = await screen.findByTestId('freshness-pill')
+    expect(pill).toHaveTextContent('Aug 5, 2026')
+    expect(pill).not.toHaveTextContent('Aug 1, 2026')
+  })
+
+  it('AreaPage shows the as-of date, not the pinned snapshot date, on the latest snapshot', async () => {
+    renderAt(
+      '/district/61/division/A/area/10',
+      '/district/:districtId/division/:divId/area/:areaId',
+      <AreaPage />
+    )
+
+    const pill = await screen.findByTestId('freshness-pill')
+    expect(pill).toHaveTextContent('Aug 5, 2026')
+    expect(pill).not.toHaveTextContent('Aug 1, 2026')
+  })
+})

--- a/frontend/src/types/districts.ts
+++ b/frontend/src/types/districts.ts
@@ -67,7 +67,6 @@ export interface EducationalAwardsResponse {
 
 export interface DistrictStatistics {
   districtId: string
-  asOfDate: string
   membership: MembershipStats
   clubs: ClubStats
   education: EducationStats

--- a/frontend/src/utils/__tests__/extractDivisionPerformance.test.ts
+++ b/frontend/src/utils/__tests__/extractDivisionPerformance.test.ts
@@ -12,7 +12,19 @@ import {
   extractDivisionPerformance,
   determineDistinguishedLevel,
   countVisitCompletions,
+  resolveSnapshotDate,
 } from '../extractDivisionPerformance.js'
+
+/**
+ * Snapshot date for the cases below that don't exercise the visit round (#1321).
+ *
+ * `snapshotDate` used to be optional and defaulted to the wall clock, so these
+ * cases were implicitly asserted against "today" — which silently re-dated them
+ * on every run (and put them in a different PROGRAM YEAR each July). The
+ * round-sensitive cases all pass their own date explicitly; see the
+ * "visit round" describe block below.
+ */
+const SNAPSHOT_DATE = '2026-02-15'
 
 describe('extractDivisionPerformance', () => {
   /**
@@ -35,7 +47,7 @@ describe('extractDivisionPerformance', () => {
       clubPerformance: [],
     }
 
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     expect(result).toHaveLength(1)
     expect(result[0].clubBase).toBe(17)
@@ -55,7 +67,7 @@ describe('extractDivisionPerformance', () => {
     }
 
     // Act: Extract division performance
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     // Assert: Should return empty array
     expect(result).toEqual([])
@@ -72,7 +84,7 @@ describe('extractDivisionPerformance', () => {
     }
 
     // Act: Extract division performance
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     // Assert: Should return empty array
     expect(result).toEqual([])
@@ -87,7 +99,7 @@ describe('extractDivisionPerformance', () => {
     const snapshot = null
 
     // Act: Extract division performance
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     // Assert: Should return empty array
     expect(result).toEqual([])
@@ -102,7 +114,7 @@ describe('extractDivisionPerformance', () => {
     const snapshot = undefined
 
     // Act: Extract division performance
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     // Assert: Should return empty array
     expect(result).toEqual([])
@@ -127,7 +139,7 @@ describe('extractDivisionPerformance', () => {
     }
 
     // Act: Extract division performance
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     // Assert: Should return division with empty areas array
     expect(result).toHaveLength(1)
@@ -156,7 +168,7 @@ describe('extractDivisionPerformance', () => {
     }
 
     // Act: Extract division performance
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     // Assert: Invalid "Division Club Base" falls back to counting clubs (1 club in this case)
     expect(result).toHaveLength(1)
@@ -196,7 +208,7 @@ describe('extractDivisionPerformance', () => {
     }
 
     // Act: Extract division performance
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     // Assert: Divisions should be sorted alphabetically
     expect(result).toHaveLength(3)
@@ -253,7 +265,7 @@ describe('extractDivisionPerformance', () => {
     }
 
     // Act: Extract division performance
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     // Assert: Areas should be sorted alphabetically
     expect(result).toHaveLength(1)
@@ -293,7 +305,7 @@ describe('extractDivisionPerformance', () => {
     }
 
     // Act: Extract division performance
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     // Assert: Should have 2 divisions (A and B) with clubs grouped
     expect(result).toHaveLength(2)
@@ -338,7 +350,7 @@ describe('extractDivisionPerformance', () => {
     }
 
     // Act: Extract division performance
-    const result = extractDivisionPerformance(snapshot)
+    const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
     // Assert: Should have 2 unique divisions (clubs grouped)
     expect(result).toHaveLength(2)
@@ -382,7 +394,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should use the "Division Club Base" value (15), not the club count (3)
       expect(result).toHaveLength(1)
@@ -413,7 +425,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should use the "Division Club Base" value from first club
       expect(result).toHaveLength(1)
@@ -443,7 +455,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should handle numeric value correctly
       expect(result).toHaveLength(1)
@@ -479,7 +491,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (4 clubs)
       expect(result).toHaveLength(1)
@@ -515,7 +527,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (3 clubs)
       expect(result).toHaveLength(1)
@@ -546,7 +558,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (2 clubs) since 0 is invalid
       expect(result).toHaveLength(1)
@@ -582,7 +594,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (3 clubs) since negative is invalid
       expect(result).toHaveLength(1)
@@ -613,7 +625,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (2 clubs)
       expect(result).toHaveLength(1)
@@ -659,7 +671,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (5 clubs)
       expect(result).toHaveLength(1)
@@ -710,7 +722,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Each division should have correct "Division Club Base"
       expect(result).toHaveLength(3)
@@ -763,7 +775,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should use the "Area Club Base" value (8), not the club count (3)
       expect(result).toHaveLength(1)
@@ -799,7 +811,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should use the "Area Club Base" value from first club
       expect(result).toHaveLength(1)
@@ -834,7 +846,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should handle numeric value correctly
       expect(result).toHaveLength(1)
@@ -879,7 +891,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (4 clubs)
       expect(result).toHaveLength(1)
@@ -922,7 +934,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (3 clubs)
       expect(result).toHaveLength(1)
@@ -958,7 +970,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (2 clubs) since 0 is invalid
       expect(result).toHaveLength(1)
@@ -1001,7 +1013,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (3 clubs) since negative is invalid
       expect(result).toHaveLength(1)
@@ -1037,7 +1049,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (2 clubs)
       expect(result).toHaveLength(1)
@@ -1094,7 +1106,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should fall back to counting clubs (5 clubs)
       expect(result).toHaveLength(1)
@@ -1158,7 +1170,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Each area should have correct "Area Club Base"
       expect(result).toHaveLength(1)
@@ -1205,7 +1217,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act: Extract division performance
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Each division's area should have correct "Area Club Base"
       expect(result).toHaveLength(2)
@@ -1277,7 +1289,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Division should have 4 distinguished clubs
       expect(result).toHaveLength(1)
@@ -1331,7 +1343,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Area should have 3 distinguished clubs
       expect(result).toHaveLength(1)
@@ -1383,7 +1395,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should count 3 distinguished (2 from status field, 1 from DCP calculation)
       // Club1: Presidents Distinguished (from status)
@@ -1451,7 +1463,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should count 3 distinguished (calculated from DCP)
       // Club1: Distinguished (5 goals + 20 members)
@@ -1520,7 +1532,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should count only 2 distinguished (those with CSP submitted)
       // Club1: Smedley (CSP submitted)
@@ -1585,7 +1597,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Division should have 4 distinguished clubs (all levels count)
       expect(result).toHaveLength(1)
@@ -1668,7 +1680,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Each division should have correct distinguished count
       expect(result).toHaveLength(3)
@@ -1723,7 +1735,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Division and area should have 0 distinguished clubs
       expect(result).toHaveLength(1)
@@ -1775,7 +1787,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Should count 2 distinguished (CSP field absence = historical data = allowed)
       // Club1: Distinguished (from status)
@@ -1843,7 +1855,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Both rounds should have completed count equal to club count (4)
       expect(result).toHaveLength(1)
@@ -1898,7 +1910,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Both rounds should have 0 completed visits
       expect(result).toHaveLength(1)
@@ -1972,7 +1984,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: First round = 3 completed, Second round = 2 completed
       expect(result).toHaveLength(1)
@@ -2044,7 +2056,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: First round = 2 (Club1, Club2), Second round = 2 (Club1, Club3)
       expect(result).toHaveLength(1)
@@ -2132,7 +2144,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Area 01 has all visits, Area 02 has none
       expect(result).toHaveLength(1)
@@ -2199,7 +2211,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: Numeric values should be counted correctly
       expect(result).toHaveLength(1)
@@ -2261,7 +2273,7 @@ describe('extractDivisionPerformance', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: 3 out of 4 = 75%, meets threshold
       expect(result).toHaveLength(1)
@@ -2296,7 +2308,7 @@ describe('extractDivisionPerformance', () => {
         const snapshot = 'not an object'
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should return empty array, not throw
         expect(result).toEqual([])
@@ -2307,7 +2319,7 @@ describe('extractDivisionPerformance', () => {
         const snapshot = 12345
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should return empty array, not throw
         expect(result).toEqual([])
@@ -2318,7 +2330,7 @@ describe('extractDivisionPerformance', () => {
         const snapshot = [1, 2, 3]
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should return empty array, not throw
         expect(result).toEqual([])
@@ -2329,7 +2341,7 @@ describe('extractDivisionPerformance', () => {
         const snapshot = true
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should return empty array, not throw
         expect(result).toEqual([])
@@ -2340,7 +2352,7 @@ describe('extractDivisionPerformance', () => {
         const snapshot = () => ({ divisionPerformance: [] })
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should return empty array, not throw
         expect(result).toEqual([])
@@ -2360,7 +2372,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should return empty array
         expect(result).toEqual([])
@@ -2379,7 +2391,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should extract division with defaults for missing club performance data
         expect(result).toHaveLength(1)
@@ -2412,7 +2424,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should only include clubs with Division field
         expect(result).toHaveLength(1)
@@ -2429,7 +2441,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should return empty array
         expect(result).toEqual([])
@@ -2460,7 +2472,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should skip invalid Division and process valid one
         expect(result).toHaveLength(1)
@@ -2486,7 +2498,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should skip invalid Division and process valid one
         expect(result).toHaveLength(1)
@@ -2511,7 +2523,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should use fallback values
         expect(result).toHaveLength(1)
@@ -2530,7 +2542,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should return empty array
         expect(result).toEqual([])
@@ -2554,7 +2566,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should skip invalid entries and process valid one
         expect(result).toHaveLength(1)
@@ -2586,7 +2598,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should skip empty Division and process valid one
         expect(result).toHaveLength(1)
@@ -2612,7 +2624,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should fall back to counting clubs (2)
         expect(result).toHaveLength(1)
@@ -2640,7 +2652,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should only include area with valid Area field
         expect(result).toHaveLength(1)
@@ -2671,7 +2683,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Should fall back to counting clubs in area (2)
         expect(result).toHaveLength(1)
@@ -2706,7 +2718,7 @@ describe('extractDivisionPerformance', () => {
         }
 
         // Act: Extract division performance
-        const result = extractDivisionPerformance(snapshot)
+        const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
         // Assert: Only Club2 has first round visit completed
         expect(result).toHaveLength(1)
@@ -3682,7 +3694,7 @@ describe('countVisitCompletions', () => {
       }
 
       // Act
-      const result = extractDivisionPerformance(snapshot)
+      const result = extractDivisionPerformance(snapshot, SNAPSHOT_DATE)
 
       // Assert: First round = 3 (Club1, Club2, Club4), Second round = 2 (Club1, Club3)
       expect(result).toHaveLength(1)
@@ -3814,5 +3826,54 @@ describe('AreaPerformance — per-area current-round missing club-visit list (#9
     const area = extractDivisionPerformance(snapshot, '2025-09-15')[0].areas[0]
     expect(area.clubsMissingCurrentRoundVisit).toEqual([])
     expect(area.clubsMissingCurrentRoundVisitIneligible).toEqual([])
+  })
+})
+
+/**
+ * `resolveSnapshotDate` reads a dated CDN snapshot's OWN pinned date (#1321),
+ * for the callers that read the latest snapshot and pin no date themselves.
+ *
+ * The shapes below mirror the LIVE envelope, verified against
+ * `snapshots/2026-06-30/district_61.json`: `{districtId, districtName,
+ * collectedAt, status, data}` with the date at `data.snapshotDate` — and NO
+ * `asOfDate` at either level (Lesson 171 — shape the fixture to the wire).
+ */
+describe('resolveSnapshotDate (#1321)', () => {
+  it('reads the date from a wrapped PerDistrictData envelope', () => {
+    expect(
+      resolveSnapshotDate({
+        districtId: '61',
+        districtName: 'District 61',
+        collectedAt: '2026-07-01T04:12:00Z',
+        status: 'success',
+        data: { districtId: '61', snapshotDate: '2026-06-30', clubs: [] },
+      })
+    ).toBe('2026-06-30')
+  })
+
+  it('reads the date from an unwrapped payload', () => {
+    expect(resolveSnapshotDate({ snapshotDate: '2026-05-01' })).toBe(
+      '2026-05-01'
+    )
+  })
+
+  it('prefers the inner envelope date over a stray top-level one', () => {
+    expect(
+      resolveSnapshotDate({
+        snapshotDate: '2026-07-05',
+        data: { snapshotDate: '2026-06-30' },
+      })
+    ).toBe('2026-06-30')
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a non-object', 'nope'],
+    ['an object with no date', { data: { clubs: [] } }],
+    ['a non-string date', { data: { snapshotDate: 20260630 } }],
+    ['an empty-string date', { data: { snapshotDate: '' } }],
+  ])('returns undefined for %s', (_label, input) => {
+    expect(resolveSnapshotDate(input)).toBeUndefined()
   })
 })

--- a/frontend/src/utils/areaRecognitionState.ts
+++ b/frontend/src/utils/areaRecognitionState.ts
@@ -16,8 +16,9 @@
  *   - 'provisional'         — a round is unmet but its deadline has NOT passed
  *   - 'not-distinguished'   — a round's deadline has passed unmet (hard fail)
  *
- * Reference date is the snapshot's `asOfDate` (not wall-clock) so historical
- * snapshots gate correctly.
+ * Reference date is the caller's PINNED snapshot date (not wall-clock) so
+ * historical snapshots gate correctly. It used to say `asOfDate` — a field that
+ * never existed on the wire, which is exactly how the wall clock got in (#1321).
  *
  * `AreaPerformanceRow` is a pure presenter that reads this state — it must
  * NOT re-derive deadline-blind provisional logic locally. See #832.

--- a/frontend/src/utils/extractDivisionPerformance.ts
+++ b/frontend/src/utils/extractDivisionPerformance.ts
@@ -84,13 +84,33 @@ function clubNameOf(club: Record<string, unknown>): string {
 }
 
 /**
- * Fallback snapshot date when none is provided by the caller. Today's date
- * preserves the legacy wall-clock behaviour for unwired callers (tests,
- * stories), while wired callers (DistrictDivisionsPage) MUST pass
- * `districtStatistics.asOfDate` so historical snapshots gate correctly.
+ * Read a dated CDN snapshot's OWN pinned date (#1321).
+ *
+ * The live envelope is `{districtId, districtName, collectedAt, status, data}`
+ * with the real date at `data.snapshotDate` — verified against
+ * `snapshots/2026-06-30/district_61.json`. Unwrapped payloads carry it at the
+ * top level, so both shapes are supported, mirroring the unwrap
+ * `extractDivisionPerformance` already does.
+ *
+ * For callers that pin a date themselves, pass THAT date — it's the honest
+ * answer to "which snapshot am I showing". This is for the few callers reading
+ * the *latest* snapshot with no pinned date of their own (AreaRedirectPage),
+ * where the snapshot's self-reported date is the only non-racy source: a
+ * separate manifest query can still be in flight after the snapshot resolves.
  */
-function todayIso(): string {
-  return new Date().toISOString().slice(0, 10)
+export function resolveSnapshotDate(
+  districtSnapshot: unknown
+): string | undefined {
+  if (typeof districtSnapshot !== 'object' || districtSnapshot === null) {
+    return undefined
+  }
+  const raw = districtSnapshot as Record<string, unknown>
+  const inner =
+    typeof raw['data'] === 'object' && raw['data'] !== null
+      ? (raw['data'] as Record<string, unknown>)
+      : raw
+  const date = inner['snapshotDate']
+  return typeof date === 'string' && date !== '' ? date : undefined
 }
 
 /**
@@ -373,6 +393,14 @@ export function countVisitCompletions(
  * for each. Divisions and areas are sorted by their identifiers.
  *
  * @param districtSnapshot - Raw district snapshot data (unknown type for safety)
+ * @param snapshotDate - The date the snapshot is PINNED to (`YYYY-MM-DD`).
+ *   REQUIRED (#1321): it gates `getCurrentVisitRound` / `getAreaVisitDeadlines`,
+ *   so a wrong date silently reports the wrong program year's visit round. This
+ *   used to fall back to the wall clock when omitted, which diverges from the
+ *   viewed snapshot for the ~1-3 week closing window each month — and for all of
+ *   July, when the pinned June close still belongs to the PRIOR program year.
+ *   Callers pass the date their page pinned its own query to; there is
+ *   deliberately no default, so TypeScript names every site that can't.
  * @returns Array of DivisionPerformance objects, sorted by division identifier
  *
  * @example
@@ -381,17 +409,15 @@ export function countVisitCompletions(
  *     { Division: "A", "Club Base": "10", "Paid Clubs": "12", "Distinguished Clubs": "6" }
  *   ]
  * }
- * const divisions = extractDivisionPerformance(snapshot)
+ * const divisions = extractDivisionPerformance(snapshot, '2026-06-30')
  * // Returns array of DivisionPerformance objects with calculated metrics
  *
  * Requirements: 1.1, 1.3, 1.4, 6.8
  */
 export function extractDivisionPerformance(
   districtSnapshot: unknown,
-  snapshotDate?: string
+  snapshotDate: string
 ): DivisionPerformance[] {
-  const effectiveSnapshotDate = snapshotDate ?? todayIso()
-
   // Type guard: ensure districtSnapshot is an object
   if (typeof districtSnapshot !== 'object' || districtSnapshot === null) {
     return []
@@ -561,7 +587,7 @@ export function extractDivisionPerformance(
       divisionId,
       clubDataRaw,
       clubPerformanceMap,
-      effectiveSnapshotDate
+      snapshotDate
     )
 
     // Add division to results

--- a/frontend/src/utils/extractDivisionPerformance.ts
+++ b/frontend/src/utils/extractDivisionPerformance.ts
@@ -84,13 +84,29 @@ function clubNameOf(club: Record<string, unknown>): string {
 }
 
 /**
- * Read a dated CDN snapshot's OWN pinned date (#1321).
+ * Unwrap a district snapshot to its payload — the single place that knows a
+ * dated CDN snapshot is a `PerDistrictData` envelope.
  *
- * The live envelope is `{districtId, districtName, collectedAt, status, data}`
- * with the real date at `data.snapshotDate` — verified against
- * `snapshots/2026-06-30/district_61.json`. Unwrapped payloads carry it at the
- * top level, so both shapes are supported, mirroring the unwrap
- * `extractDivisionPerformance` already does.
+ * The live file is `{districtId, districtName, collectedAt, status, data}` with
+ * the payload at `.data` (verified against `snapshots/2026-06-30/district_61.json`).
+ * Already-unwrapped payloads are passed through, so both shapes work.
+ *
+ * Returns `undefined` for anything that isn't an object.
+ */
+function unwrapSnapshotPayload(
+  districtSnapshot: unknown
+): Record<string, unknown> | undefined {
+  if (typeof districtSnapshot !== 'object' || districtSnapshot === null) {
+    return undefined
+  }
+  const raw = districtSnapshot as Record<string, unknown>
+  return typeof raw['data'] === 'object' && raw['data'] !== null
+    ? (raw['data'] as Record<string, unknown>)
+    : raw
+}
+
+/**
+ * Read a dated CDN snapshot's OWN pinned date (#1321).
  *
  * For callers that pin a date themselves, pass THAT date — it's the honest
  * answer to "which snapshot am I showing". This is for the few callers reading
@@ -101,15 +117,7 @@ function clubNameOf(club: Record<string, unknown>): string {
 export function resolveSnapshotDate(
   districtSnapshot: unknown
 ): string | undefined {
-  if (typeof districtSnapshot !== 'object' || districtSnapshot === null) {
-    return undefined
-  }
-  const raw = districtSnapshot as Record<string, unknown>
-  const inner =
-    typeof raw['data'] === 'object' && raw['data'] !== null
-      ? (raw['data'] as Record<string, unknown>)
-      : raw
-  const date = inner['snapshotDate']
+  const date = unwrapSnapshotPayload(districtSnapshot)?.['snapshotDate']
   return typeof date === 'string' && date !== '' ? date : undefined
 }
 
@@ -418,20 +426,8 @@ export function extractDivisionPerformance(
   districtSnapshot: unknown,
   snapshotDate: string
 ): DivisionPerformance[] {
-  // Type guard: ensure districtSnapshot is an object
-  if (typeof districtSnapshot !== 'object' || districtSnapshot === null) {
-    return []
-  }
-
-  const rawSnapshot = districtSnapshot as Record<string, unknown>
-
-  // CDN snapshots wrap their payload in a `.data` key
-  // (e.g. { districtId, data: { divisionPerformance, clubPerformance, … } })
-  // Support both the wrapped and unwrapped shapes.
-  const snapshot =
-    typeof rawSnapshot['data'] === 'object' && rawSnapshot['data'] !== null
-      ? (rawSnapshot['data'] as Record<string, unknown>)
-      : rawSnapshot
+  const snapshot = unwrapSnapshotPayload(districtSnapshot)
+  if (!snapshot) return []
 
   // The divisionPerformance array contains club-level data organized by division/area
   // The clubPerformance array contains club status and distinguished status

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,6 +2,7 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `a-phantom-field-is-a-live-default-every-read-of-it-silently-becomes-the-fallback.md` — A phantom field (typed but never on the wire) doesn't fail — it silently becomes its fallback, so the default is the real code path; grep the primitive, and a `?? today` default hides it forever  (2026-07-15)
 - `key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate.md` — During month-end closing the CSV as-of date (sourceCsvDate / data.date) drifts past the pinned snapshot date — key every per-snapshot fetch and date-scoped lookup on the snapshot date, never data.date  (2026-07-06)
 - `renaming-a-typed-field-the-prod-compiler-misses-test-only-typed-fixtures-and-untyped-mocks.md` — When you rename a widely-typed field, the prod `tsc` enumerates prod consumers but is blind to test-only typed fixtures (caught only by non-CI `typecheck:test`) and to untyped mocks (caught by nothing) — sweep both by hand  (2026-07-06)
 - `a-self-heal-hook-that-writes-the-url-on-mount-clobbers-a-consumers-navigation-state.md` — A shared "self-heal" hook that rewrites the URL on mount clobbers a consumer's navigation state; gate the write for pages that receive location.state  (2026-07-04)

--- a/tasks/lessons/lessons/a-phantom-field-is-a-live-default-every-read-of-it-silently-becomes-the-fallback.md
+++ b/tasks/lessons/lessons/a-phantom-field-is-a-live-default-every-read-of-it-silently-becomes-the-fallback.md
@@ -1,0 +1,102 @@
+---
+date: 2026-07-15
+tier: principle
+summary: A phantom field (typed but never on the wire) doesn't fail — it silently becomes its fallback, so the default is the real code path; grep the primitive, and a `?? today` default hides it forever
+tags:
+  [
+    frontend,
+    contracts,
+    types,
+    closing-period,
+    snapshot-date,
+    dead-code,
+    verification,
+    regression-class,
+  ]
+---
+
+# Principle — A phantom field is a live default, not a missing value
+
+**Date:** 2026-07-15
+**Issue:** #1321 (epic #1319 Sprint 2 — snapshot-date guard)
+
+## What happened
+
+`DistrictStatistics.asOfDate` was declared, typed `string` (not optional), and
+read at five production sites. It has **never existed on the wire**. One `curl`
+settles it — the live envelope is
+`{districtId, districtName, collectedAt, status, data}` and the payload carries
+`data.snapshotDate` only:
+
+```
+asOfDate at top? False    asOfDate in data? False    data.snapshotDate = 2026-06-30
+```
+
+Nothing crashed, because every read fed a fallback:
+
+```ts
+extractDivisionPerformance(snapshot, snapshot.asOfDate) // → undefined
+const effectiveSnapshotDate = snapshotDate ?? todayIso() // → the WALL CLOCK
+```
+
+So the "fallback for unwired callers" was the **only** path the wired callers
+ever took. On 2026-07-15, viewing the pinned 2026-06-30 close, the page reported
+visit **round 1 of PY 2026-2027** instead of **round 2 of PY 2025-2026** —
+whitewashing deadlines that had passed unmet as merely "provisional". Live, for
+as long as the field existed.
+
+## Why it survives every gate
+
+- **TypeScript endorses it.** `asOfDate: string` is not optional, so `?.` isn't
+  even required and no reader looks twice. The type is the *claim*, not the data.
+- **The tests prove the fixture, not the wire.** Every page fixture carried
+  `asOfDate: '2026-03-15'` — the mock asserting the phantom into existence. Green
+  on mocks, dead on live (Lesson 171's structural sibling).
+- **The default absorbs the signal.** `?? todayIso()` converts "this field is
+  missing" into a plausible, *wrong* value. A throw would have surfaced it on day
+  one; the default made it a silent 340-days-a-year-correct bug.
+
+The compounding shape: a phantom field + a forgiving default = a bug that is
+invisible to types, tests, and reviewers, and only wrong during the closing
+window — when it matters most.
+
+## The rule
+
+- **A field's presence is a claim about the wire; verify it against the wire.**
+  Before wiring or trusting any field, `curl` the real artifact. Free, decisive.
+  (R7 + the "name can lie" lesson, one step further: not just *is it populated*,
+  but *does it exist at all*.)
+- **Make the load-bearing parameter required and delete the default.** No
+  default means TypeScript enumerates every call site that can't supply one — the
+  guard is the *absence* of the fallback. Here it immediately named two sites the
+  issue's change set had missed.
+- **Grep the primitive, not the named function.** The issue named 3 call sites;
+  grepping `asOfDate` / `todayIso` found **5** (`DistrictDivisionsPage`,
+  `AreaRedirectPage`). A ticket's list is a lower bound.
+- **`{phantom && <Panel/>}` is dead code with a pulse.** A phantom guarding a
+  render is a panel that has never shipped. Fixing the field silently *turns it
+  on* — verify what a phantom was suppressing before you fix it, or a bug fix
+  becomes an unrequested release. Here the resurrected panel would have printed
+  "Data as of {pinned snapshot date}" — planting a 5th recurrence of the very
+  conflation the epic was killing, in fresh UI copy.
+
+## How to apply
+
+- Deleting a phantom is not enough if the *type* that spawned it is still
+  fiction. `useDistrictStatistics` still types the `PerDistrictData` envelope as
+  `DistrictStatistics`, so `membership` / `education` / `clubs` remain phantoms
+  on that type — the generator is still running (filed separately). A guard
+  minted from a lying type is a lock on a door in a fictional wall.
+- When a test's fixture is the only reason a field "exists", the fixture is the
+  bug. Shape fixtures to the wire, and set the two dates **apart** — a fixture
+  where `sourceCsvDate === snapshotDate` cannot see this class at all.
+
+Related:
+[[key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate]] —
+the same divergence at the fetch key.
+[[a-dated-cdn-snapshot-is-a-perdistrictdata-envelope-mock-the-wrapper-or-the-page-reads-empty-on-live]]
+— the envelope mis-typing that generated this phantom.
+[[a-fields-name-and-comment-can-lie-about-whether-its-populated-in-your-surface]]
+— populated-ness; this is its harsher case: existence.
+[[fix-a-date-derivation-bug-by-grepping-the-primitive-not-the-named-function]] —
+why the ticket's 3 sites were 5.


### PR DESCRIPTION
Sprint 2 of epic #1319 — part of the layered guard against the closing-window date-conflation bug. Fixes a **live** latent bug. Refs #1321.

## The bug, live today

`DistrictStatistics.asOfDate` never existed on the wire. Verified against the live CDN:

```
$ curl --compressed .../snapshots/2026-06-30/district_61.json
top-level keys: [districtId, districtName, collectedAt, status, data]
asOfDate at top? False   asOfDate in data? False   data.snapshotDate = 2026-06-30
```

Every read of it was `undefined`, so `extractDivisionPerformance(snapshot, snapshot.asOfDate)` fell through to `?? todayIso()` and gated visit rounds on the **wall clock**. The "fallback for unwired callers" was the only path the wired callers ever took.

**Impact today (2026-07-15):** viewing the pinned June-30 close reports round 1 of PY 2026-2027 instead of round 2 of PY 2025-2026 — silently whitewashing visit deadlines that passed unmet as merely "provisional".

## Change set

- `types/districts.ts` — delete the phantom.
- `extractDivisionPerformance` — `snapshotDate` **required**, wall-clock fallback deleted. The guard is the *absence* of the default: TS now names every call site that can't supply a date.
- `DivisionPerformanceCards.snapshotTimestamp` — required (it gates the round; the "optional … for display" comment was wrong on both counts).
- Call sites pass the date their page pinned its own query to (`effectiveEndDate`).
- Freshness pills on Division/Area/Club — were permanently blank, bound to the phantom; now read the global as-of date via the shared `useGlobalFreshness`.

**The issue named 3 call sites; grepping the primitive rather than the named function found 5** — `DistrictDivisionsPage` and `AreaRedirectPage` were also reading the phantom. `diffAreaDivisionStatus.ts` was already correct and is untouched.

## Acceptance criteria

- [x] `asOfDate` gone from `types/districts.ts`; no `snapshot.asOfDate` / `districtStatistics.asOfDate` reads remain.
- [x] `extractDivisionPerformance` has no wall-clock fallback; TS forces a date at every **production** call site.
- [x] Divergence-window render tests pass; full suite green (3634 passing).

## TDD

Divergence-by-default fixtures: wall clock July 2026 (PY 2026-27), snapshot pinned 2026-05-01 (PY 2025-26). The pending-round tooltip can't discriminate (`formatShortDate` renders "May 31" with **no year**), so the test uses a year-independent discriminator — a round-1 deadline passed unmet reads `Not Distinguished` under the snapshot's PY but `Distinguished (Provisional)` under the wall clock.

Both reds falsified against pre-fix code rather than assumed: the badge asserts `Distinguished (Provisional)`, and the pill renders `Data fresh · Aug 1, 2026` (the pinned date) where the as-of date is Aug 5.

## Reviews

`/simplify` (4 parallel agents) and a fresh-context `/review` (**APPROVE-WITH-NITS, no High findings**) both ran. The reviewer independently falsified the assertion-pinning hypothesis: it re-ran the 68 re-dated util cases at `2026-09-15` / `2025-12-01` / `2026-06-30` — 148 pass at every date, no expectation touched. Those cases were previously asserted against *today*, i.e. silently re-dated every run.

**The review's catch:** `DivisionPerformanceCards` had a "Division & Area Performance" + "Data as of {date}" panel behind `{snapshotTimestamp && …}`. It was **dead** — the guard was always false because its only caller fed it the phantom. Passing the real date would have switched it on as a silent, unrequested UI change, and its "Data as of" label on a *pinned snapshot date* re-mints the exact conflation this epic exists to kill — a 5th recurrence in fresh UI copy. Removed, and the tests that asserted it are inverted into a tripwire rather than deleted. Those tests are themselves the lesson: they passed only because the fixture supplied the phantom the wire never sends.

## Operator notes / follow-ups (deliberately out of scope)

1. **`useDistrictStatistics` still types the `PerDistrictData` envelope as `DistrictStatistics`** — the root that spawned this phantom. `membership` / `education` / `clubs` are phantoms on that type too (`EducationalAwardsChart:116` reads `statistics?.membership.total`, though it's currently unreachable — no page renders it). Sprint 3/4 will mint a branded `SnapshotDate` from data flowing through this type; worth fixing there. Not done here: it's a different bug class needing its own tests.
2. **Tests are not in the frontend tsconfig project**, so "TS forces a date at every call site" holds for production code only — test call sites fail at runtime instead.
3. **`v1/rankings.json` is 126KB served *uncompressed*** and the pill reads one string from it. This PR unifies the query key so it stops being fetched under competing keys, but the durable fix is carrying `sourceCsvDate` on the 152-byte `v1/latest.json`.
4. `utils/csvExport.ts:367,387` has a surviving structural `asOfDate` — test-only caller, pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oGJ8cszCfNGMeAzYbmue2
