### PR TITLE
Sprint 3 (#1322) — divergence-by-default fixtures + per-consumer snapshot-date reconciliation tests

### DIFF
--- a/frontend/src/__tests__/integration/mockCdnHarness.test.ts
+++ b/frontend/src/__tests__/integration/mockCdnHarness.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Self-test for the CDN fixture harness's snapshot-date honesty (#1322, epic
+ * #1319 Sprint 3).
+ *
+ * The harness is the thing every page/journey test trusts, so its own
+ * divergence contract needs a guard. Two properties, and BOTH must hold or the
+ * divergence-by-default fixtures are decoration:
+ *
+ *  1. `sourceCsvDate` diverges from the snapshot date by default, so every test
+ *     runs inside the month-end closing window.
+ *  2. `/snapshots/{date}/…` resolves ONLY under a date the bucket really has.
+ *     Property 1 without property 2 is inert: the route table matches on
+ *     `path.includes(filename)` and is otherwise date-blind, so a consumer
+ *     keying on the as-of date would be handed the snapshot's own fixture and
+ *     pass — reproducing the #1315 blind spot inside the harness meant to catch
+ *     it.
+ *
+ * @see tasks/lessons/lessons/key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate.md
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  setupCdnFetchMock,
+  cdnMocks,
+  SNAPSHOT_DATE,
+  SOURCE_CSV_DATE,
+  KNOWN_SNAPSHOT_DATES,
+} from './utils/mockCdnData'
+
+const baseUrl = 'https://cdn.taverns.red'
+const originalFetch = global.fetch
+
+// Block body, not a concise arrow: `setupCdnFetchMock` RETURNS the mock fn, and
+// vitest treats a function returned from beforeEach as that test's teardown —
+// it would call the fetch mock with no args at cleanup (`input.toString()` of
+// undefined). Swallow the return value.
+beforeEach(() => {
+  setupCdnFetchMock()
+})
+afterEach(() => {
+  global.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+describe('CDN fixture harness — snapshot-date honesty (#1322)', () => {
+  it('diverges the as-of sourceCsvDate from the snapshot date by default', () => {
+    // The whole guard rests on this: equal dates make the wrong keying
+    // unobservable, which is how #1315 shipped.
+    expect(SOURCE_CSV_DATE).not.toEqual(SNAPSHOT_DATE)
+    expect(SOURCE_CSV_DATE > SNAPSHOT_DATE).toBe(true)
+  })
+
+  it('never lists the as-of date as a snapshot date', () => {
+    // The as-of date is display/provenance only — no file is stored under it.
+    expect(KNOWN_SNAPSHOT_DATES).toContain(SNAPSHOT_DATE)
+    expect(KNOWN_SNAPSHOT_DATES).not.toContain(SOURCE_CSV_DATE)
+  })
+
+  it('serves the per-snapshot rankings file under the snapshot date, carrying the advanced as-of date', async () => {
+    const res = await fetch(
+      `${baseUrl}/snapshots/${SNAPSHOT_DATE}/all-districts-rankings.json`
+    )
+    expect(res.ok).toBe(true)
+    const body = (await res.json()) as { metadata: { sourceCsvDate: string } }
+    expect(body.metadata.sourceCsvDate).toBe(SOURCE_CSV_DATE)
+  })
+
+  it('404s a per-snapshot file requested under the as-of date', async () => {
+    // This is the live behaviour a wrongly-keyed consumer hits during closing:
+    // no file exists under the as-of date. `fetchCdnCompetitiveAwards` maps the
+    // 404 to null → the blank UI of #1315.
+    const res = await fetch(
+      `${baseUrl}/snapshots/${SOURCE_CSV_DATE}/competitive-awards.json`
+    )
+    expect(res.ok).toBe(false)
+    expect(res.status).toBe(404)
+  })
+
+  it('404s every per-snapshot path under an unknown date, not just awards', async () => {
+    // The gate is keyed on the date segment, so it must hold for the whole
+    // /snapshots/{date}/ family — a per-file allowlist would rot.
+    for (const file of [
+      'all-districts-rankings.json',
+      'district_61.json',
+      'analytics/district_61_analytics.json',
+    ]) {
+      const res = await fetch(`${baseUrl}/snapshots/${SOURCE_CSV_DATE}/${file}`)
+      expect(res.status).toBe(404)
+    }
+  })
+
+  it('still serves undated v1 routes, which are not snapshot-scoped', async () => {
+    // Guard against the date gate over-reaching: v1/latest.json has no snapshot
+    // date segment and must stay reachable.
+    const res = await fetch(`${baseUrl}/v1/latest.json`)
+    expect(res.ok).toBe(true)
+    expect(await res.json()).toEqual(cdnMocks.latest)
+  })
+
+  it('exposes the latest snapshot manifest and the rankings as-of date as DIFFERENT dates', async () => {
+    // v1/latest.json pins the snapshot; v1/rankings.json carries the as-of date
+    // as a bare `date`. Conflating the two is the root of the bug class.
+    const manifest = (await (
+      await fetch(`${baseUrl}/v1/latest.json`)
+    ).json()) as { latestSnapshotDate: string }
+    const rankings = (await (
+      await fetch(`${baseUrl}/v1/rankings.json`)
+    ).json()) as { date: string }
+
+    expect(manifest.latestSnapshotDate).toBe(SNAPSHOT_DATE)
+    expect(rankings.date).toBe(SOURCE_CSV_DATE)
+    expect(rankings.date).not.toBe(manifest.latestSnapshotDate)
+  })
+})

--- a/frontend/src/__tests__/integration/utils/mockCdnData.ts
+++ b/frontend/src/__tests__/integration/utils/mockCdnData.ts
@@ -5,10 +5,56 @@ import { queryClient } from '../../../config/queryClient'
 
 const baseUrl = 'https://cdn.taverns.red'
 
+/**
+ * DIVERGENCE-BY-DEFAULT fixture dates (#1322, epic #1319 Sprint 3).
+ *
+ * THE RULE: a per-snapshot CDN file lives under the **snapshot date**, so every
+ * per-snapshot fetch, query key, and date-scoped lookup keys on
+ * `SNAPSHOT_DATE`. The as-of `sourceCsvDate` is display/provenance ONLY and must
+ * never key a fetch.
+ *
+ * These two dates are deliberately NOT equal. Toastmasters' month-end
+ * reconciliation pins the snapshot to the month-end while the dashboard as-of
+ * date advances into the next month — they agree ~340 days a year and diverge
+ * for 1–3 weeks each close. Fixtures that set them equal make the wrong keying
+ * unobservable: that blind spot is why the RegionPage suite missed #1315, the
+ * fourth recurrence of this bug. Every page test therefore runs inside the
+ * closing window by default.
+ *
+ * The +5d offset crosses a month boundary on purpose — that is the real shape
+ * (live 2026-07-06: snapshot 2026-06-30, `sourceCsvDate` 2026-07-05), and it is
+ * what makes `computeFreshness` report `reconciling`. Real year-end lag runs to
+ * ~3 weeks, so +5d is conservative.
+ *
+ * A test asserting equal-date behaviour must opt in EXPLICITLY by overriding
+ * these values in its own mock — never by flattening the default back.
+ *
+ * @see tasks/lessons/lessons/key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate.md
+ */
+export const SNAPSHOT_DATE = '2024-12-31'
+export const SOURCE_CSV_DATE = '2025-01-05'
+
+/**
+ * The snapshot dates this fixture CDN actually has files for.
+ *
+ * Every per-snapshot file lives under `/snapshots/{date}/…`, and the real bucket
+ * has nothing under any other date — a request for one 404s. The mock enforces
+ * that, which is what makes the divergence above a GUARD rather than decoration:
+ * a date-blind mock that matches on `path.includes('competitive-awards.json')`
+ * happily serves the same fixture for `snapshots/2025-01-05/…`, rubber-stamping
+ * the exact keying bug the fixture is meant to expose.
+ */
+export const KNOWN_SNAPSHOT_DATES: readonly string[] = [
+  SNAPSHOT_DATE,
+  '2024-11-30',
+  '2024-06-30',
+  '2023-12-31',
+]
+
 // Sample data schemas based on cdn.ts
 export const cdnMocks = {
   latest: {
-    latestSnapshotDate: '2024-12-31',
+    latestSnapshotDate: SNAPSHOT_DATE,
     generatedAt: '2024-12-31T12:00:00Z',
   },
   dates: {
@@ -45,14 +91,15 @@ export const cdnMocks = {
         overallRank: 8,
       },
     ],
-    date: '2024-12-31',
+    // `v1/rankings.json` carries its AS-OF date as a bare `date` (cdn.ts reads
+    // it out as `asOfDate`). There is no pinned snapshot on the latest path.
+    date: SOURCE_CSV_DATE,
     generatedAt: '2024-12-31T12:00:00Z',
   },
   districtSnapshot: {
     districtId: '61',
     districtName: 'District 61',
     region: 'Region 6',
-    asOfDate: '2024-12-31',
     programYear: '2024-2025',
     clubs: [
       {
@@ -235,6 +282,27 @@ export function setupCdnFetchMock() {
         if (url.startsWith(baseUrl)) {
           const path = url.replace(baseUrl, '')
 
+          // Serve per-snapshot files ONLY under a date the bucket really has
+          // (#1322). The route table below matches on `path.includes(filename)`
+          // and is otherwise date-blind, so without this gate a consumer keying
+          // on the as-of `sourceCsvDate` is handed the snapshot's own fixture
+          // and every test passes — the #1315 blind spot, reproduced in the
+          // harness. Live, that fetch 404s: awards → null → blank UI.
+          const requestedSnapshotDate = /^\/snapshots\/([^/]+)\//.exec(
+            path
+          )?.[1]
+          if (
+            requestedSnapshotDate &&
+            !KNOWN_SNAPSHOT_DATES.includes(requestedSnapshotDate)
+          ) {
+            return {
+              ok: false,
+              status: 404,
+              headers: new Headers(),
+              json: async () => ({}),
+            } as Response
+          }
+
           let data = {}
           if (path === '/v1/latest.json') {
             data = cdnMocks.latest
@@ -247,7 +315,10 @@ export function setupCdnFetchMock() {
           } else if (path.includes('all-districts-rankings.json')) {
             data = {
               metadata: {
-                sourceCsvDate: '2024-12-31',
+                // Diverges from the snapshot date this file is stored under —
+                // see SOURCE_CSV_DATE. A consumer that keys a per-snapshot
+                // fetch on this value 404s during the closing window (#1315).
+                sourceCsvDate: SOURCE_CSV_DATE,
                 calculatedAt: '2025-01-01T00:00:00Z',
               },
               rankings: cdnMocks.rankings.rankings,
@@ -260,8 +331,8 @@ export function setupCdnFetchMock() {
             data = cdnMocks.rankHistory
           } else if (path.includes('/district_61/index-metadata.json')) {
             data = {
-              latestSnapshotDate: '2024-12-31',
-              availableSnapshotDates: ['2024-12-31', '2024-11-30'],
+              latestSnapshotDate: SNAPSHOT_DATE,
+              availableSnapshotDates: [SNAPSHOT_DATE, '2024-11-30'],
               programYear: '2024-2025',
             }
           } else if (path.includes('/club_123456/index-metadata.json')) {

--- a/frontend/src/pages/__tests__/SnapshotDateDivergence.awards.test.tsx
+++ b/frontend/src/pages/__tests__/SnapshotDateDivergence.awards.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * Snapshot-date divergence tests for the three remaining per-snapshot
+ * competitive-awards consumers (#1322, epic #1319 Sprint 3).
+ *
+ * THE RULE these lock in: a per-snapshot CDN file lives under the **snapshot
+ * date**, so `useCompetitiveAwards` must be keyed on the page-owned snapshot
+ * date — never on the as-of `sourceCsvDate` that arrives on the rankings
+ * response. The as-of date is display/provenance only.
+ *
+ * Every test below runs inside the month-end closing window, where the two
+ * dates diverge (live 2026-07-06: snapshot 2026-06-30, sourceCsvDate
+ * 2026-07-05). That divergence is the whole point: the dates are equal ~340
+ * days a year, so a fixture that sets them equal cannot observe the wrong
+ * keying at all — which is exactly why RegionPage's own suite sailed past
+ * #1315, the fourth recurrence of this bug.
+ *
+ * Live, the wrong key fetches `snapshots/2026-07-05/competitive-awards.json`,
+ * which 404s → `fetchCdnCompetitiveAwards` returns null → the awards race /
+ * trophy case / standings render blank, with no error to notice.
+ *
+ * `RegionPage.programYear.test.tsx` already covers RegionPage, and
+ * `SnapshotDateDivergence.test.tsx` (#1321) covers Division/Area visit-round
+ * gating. These three are the consumers that had no divergence test.
+ *
+ * @see tasks/lessons/lessons/key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate.md
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import {
+  fetchCdnCompetitiveAwards,
+  type CompetitiveAwardStandings,
+} from '../../services/cdn'
+import DistrictsPage from '../DistrictsPage'
+import AwardsPage from '../AwardsPage'
+import DistrictDetailPage from '../DistrictDetailPage'
+
+/** The pinned snapshot every per-snapshot file is stored under. */
+const SNAPSHOT_DATE = '2026-06-30'
+/** The dashboard as-of date, advanced past the snapshot by reconciliation. */
+const AS_OF_DATE = '2026-07-05'
+
+const standings: CompetitiveAwardStandings = {
+  metadata: {
+    snapshotId: SNAPSHOT_DATE,
+    calculatedAt: '2026-07-05T00:00:00Z',
+    totalDistricts: 1,
+  },
+  extensionAward: [
+    {
+      districtId: '61',
+      districtName: 'District 61',
+      region: '6',
+      rank: 1,
+      value: 5,
+      isWinner: false,
+    },
+  ],
+  twentyPlusAward: [],
+  retentionAward: [],
+  byDistrict: {},
+}
+
+const ranking = {
+  districtId: '61',
+  districtName: 'District 61',
+  region: '6',
+  paidClubs: 105,
+  paidClubBase: 100,
+  clubGrowthPercent: 5,
+  totalPayments: 4500,
+  paymentBase: 4400,
+  paymentGrowthPercent: 2.27,
+  activeClubs: 105,
+  distinguishedClubs: 50,
+  selectDistinguished: 10,
+  presidentsDistinguished: 5,
+  distinguishedPercent: 61.9,
+  clubsRank: 1,
+  paymentsRank: 1,
+  distinguishedRank: 1,
+  aggregateScore: 250,
+  overallRank: 1,
+}
+
+vi.mock('../../services/cdn', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../services/cdn')>()
+  return {
+    ...actual,
+    fetchCdnSnapshotIndex: vi.fn(),
+    fetchCdnDates: vi.fn(),
+    fetchCdnManifest: vi.fn(),
+    fetchCdnRankings: vi.fn(),
+    fetchCdnRankingsForDate: vi.fn(),
+    fetchCdnCompetitiveAwards: vi.fn(),
+  }
+})
+
+// AwardsPage/DistrictDetailPage source the freshness pill from this shared
+// hook; it is not the subject here.
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: AS_OF_DATE,
+    latestSnapshotDate: SNAPSHOT_DATE,
+    isLatest: true,
+  }),
+}))
+
+vi.mock('../../hooks/useIsMobile', () => ({ useIsMobile: () => false }))
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: vi.fn(() => ({
+    data: { districts: [{ id: '61', name: 'District 61' }] },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+// The district's snapshot index — snapshot dates only. The as-of date is NOT a
+// snapshot date and never appears here; that asymmetry is the bug's shape.
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    data: { dates: [SNAPSHOT_DATE] },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+vi.mock('../../hooks/useDistrictAnalytics', () => ({
+  useDistrictAnalytics: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}))
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+vi.mock('../../hooks/useLeadershipInsights', () => ({
+  useLeadershipInsights: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    error: null,
+  })),
+}))
+vi.mock('../../hooks/useDistinguishedClubAnalytics', () => ({
+  useDistinguishedClubAnalytics: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    error: null,
+  })),
+}))
+vi.mock('../../hooks/usePaymentsTrend', () => ({
+  usePaymentsTrend: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    error: null,
+  })),
+}))
+vi.mock('../../hooks/useTimeSeries', () => ({
+  useTimeSeries: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}))
+vi.mock('../../hooks/useAggregatedAnalytics', () => ({
+  useAggregatedAnalytics: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    usedFallback: false,
+  })),
+}))
+vi.mock('../../hooks/useRankHistory', () => ({
+  useRankHistory: vi.fn(() => ({ data: null, isLoading: false, error: null })),
+}))
+
+// Keep Recharts out of JSDOM.
+vi.mock('../../components/MembershipTrendChart', () => ({
+  MembershipTrendChart: () => <div data-testid="membership-trend-chart" />,
+}))
+vi.mock('../../components/YearOverYearComparison', () => ({
+  YearOverYearComparison: () => <div data-testid="year-over-year-comparison" />,
+}))
+
+const mockedAwards = vi.mocked(fetchCdnCompetitiveAwards)
+
+/**
+ * Assert the awards fetch resolved to the pinned snapshot, not the as-of date.
+ * Both halves matter: `toHaveBeenCalledWith(SNAPSHOT_DATE)` alone would pass a
+ * consumer that fetched BOTH dates.
+ */
+async function expectAwardsKeyedOnSnapshotDate() {
+  await waitFor(() => expect(mockedAwards).toHaveBeenCalled())
+  expect(mockedAwards).toHaveBeenCalledWith(SNAPSHOT_DATE)
+  expect(mockedAwards).not.toHaveBeenCalledWith(AS_OF_DATE)
+}
+
+function renderAt(url: string, path: string, element: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <Routes>
+            <Route path={path} element={element} />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(async () => {
+  localStorage.clear()
+  vi.clearAllMocks()
+  const cdn = await import('../../services/cdn')
+  // Snapshot index / dates carry SNAPSHOT dates only.
+  vi.mocked(cdn.fetchCdnSnapshotIndex).mockResolvedValue({
+    '61': [SNAPSHOT_DATE],
+  })
+  vi.mocked(cdn.fetchCdnDates).mockResolvedValue({
+    dates: [SNAPSHOT_DATE],
+    count: 1,
+    generatedAt: '2026-07-05T00:00:00Z',
+  })
+  vi.mocked(cdn.fetchCdnManifest).mockResolvedValue({
+    latestSnapshotDate: SNAPSHOT_DATE,
+    generatedAt: '2026-07-05T00:00:00Z',
+  })
+  // The rankings response carries the ADVANCED as-of date — the poisoned well.
+  // A consumer that reaches for `asOfDate` to key its awards fetch gets the
+  // closing-window 404. `mockResolvedValue` (not Once): these queries fetch
+  // more than once across a render lifecycle (Lesson 59).
+  vi.mocked(cdn.fetchCdnRankingsForDate).mockResolvedValue({
+    rankings: [ranking],
+    asOfDate: AS_OF_DATE,
+    snapshotDate: SNAPSHOT_DATE,
+    generatedAt: '2026-07-05T00:00:00Z',
+  })
+  vi.mocked(cdn.fetchCdnRankings).mockResolvedValue({
+    rankings: [ranking],
+    asOfDate: AS_OF_DATE,
+    generatedAt: '2026-07-05T00:00:00Z',
+  })
+  // Date-AWARE, mirroring the bucket: the awards file exists only under the
+  // snapshot date, and `fetchCdnCompetitiveAwards` maps the 404 to null. A
+  // date-blind `mockResolvedValue(standings)` would hand the same payload to a
+  // wrongly-keyed consumer and rubber-stamp the bug — the harness must be as
+  // honest as the wire, or the content assertion below proves nothing.
+  mockedAwards.mockImplementation(async (date: string) =>
+    date === SNAPSHOT_DATE ? standings : null
+  )
+})
+
+afterEach(() => cleanup())
+
+describe('snapshot-date divergence — competitive-awards keying (#1322)', () => {
+  it('DistrictsPage keys the awards race on the snapshot date, not the as-of date', async () => {
+    renderAt('/', '/', <DistrictsPage />)
+    await expectAwardsKeyedOnSnapshotDate()
+  })
+
+  it('AwardsPage keys the standings on the snapshot date, not the as-of date', async () => {
+    renderAt('/awards', '/awards', <AwardsPage />)
+    await expectAwardsKeyedOnSnapshotDate()
+  })
+
+  it('DistrictDetailPage keys the trophy case on the snapshot date, not the as-of date', async () => {
+    renderAt('/districts/61', '/districts/:districtId', <DistrictDetailPage />)
+    await expectAwardsKeyedOnSnapshotDate()
+  })
+
+  it('renders awards content in the closing window (the 404 would blank it)', async () => {
+    // The keying assertions above prove the ARGUMENT; this proves the
+    // consequence — that awards data actually reaches the UI while the two
+    // dates diverge. A snapshot-date 404 renders this section empty.
+    renderAt('/awards', '/awards', <AwardsPage />)
+    await waitFor(() => expect(mockedAwards).toHaveBeenCalled())
+    expect(await screen.findByText(/District 61/i)).toBeInTheDocument()
+  })
+})

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -3,6 +3,7 @@
 
 ## lessons (manifest-pinned + session-judged)
 - `a-phantom-field-is-a-live-default-every-read-of-it-silently-becomes-the-fallback.md` — A phantom field (typed but never on the wire) doesn't fail — it silently becomes its fallback, so the default is the real code path; grep the primitive, and a `?? today` default hides it forever  (2026-07-15)
+- `divergence-by-default-fixtures-are-inert-unless-the-mock-routes-on-the-same-key-the-wire-does.md` — Divergence-by-default fixtures are inert unless the mock ROUTES on the same key the wire does — a date-blind router serves the right fixture for the wrong key and rubber-stamps the bug the fixture was written to expose  (2026-07-15)
 - `key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate.md` — During month-end closing the CSV as-of date (sourceCsvDate / data.date) drifts past the pinned snapshot date — key every per-snapshot fetch and date-scoped lookup on the snapshot date, never data.date  (2026-07-06)
 - `renaming-a-typed-field-the-prod-compiler-misses-test-only-typed-fixtures-and-untyped-mocks.md` — When you rename a widely-typed field, the prod `tsc` enumerates prod consumers but is blind to test-only typed fixtures (caught only by non-CI `typecheck:test`) and to untyped mocks (caught by nothing) — sweep both by hand  (2026-07-06)
 - `a-self-heal-hook-that-writes-the-url-on-mount-clobbers-a-consumers-navigation-state.md` — A shared "self-heal" hook that rewrites the URL on mount clobbers a consumer's navigation state; gate the write for pages that receive location.state  (2026-07-04)

--- a/tasks/lessons/lessons/divergence-by-default-fixtures-are-inert-unless-the-mock-routes-on-the-same-key-the-wire-does.md
+++ b/tasks/lessons/lessons/divergence-by-default-fixtures-are-inert-unless-the-mock-routes-on-the-same-key-the-wire-does.md
@@ -1,0 +1,102 @@
+---
+date: 2026-07-15
+tier: principle
+summary: Divergence-by-default fixtures are inert unless the mock ROUTES on the same key the wire does — a date-blind router serves the right fixture for the wrong key and rubber-stamps the bug the fixture was written to expose
+tags:
+  [
+    tests,
+    fixtures,
+    mocks,
+    cdn,
+    snapshot-date,
+    verification,
+    regression-class,
+    test-infra,
+  ]
+---
+
+# Principle — A fixture only guards what its mock ROUTER can get wrong
+
+**Filed:** 2026-07-15 (#1322, epic #1319 Sprint 3 — the systemic guard for the
+`sourceCsvDate` ≠ `snapshotDate` bug class).
+
+## The trap
+
+The epic's layer 2 was "make the divergence the default test world": set
+`sourceCsvDate = snapshotDate + 5d` in every fixture so any consumer keying a
+per-snapshot fetch on the as-of date fails in CI. Landing that change alone
+produced **57/57 integration tests still green** — and it would have shipped as
+a guard that guards nothing.
+
+The reason wasn't the fixture. It was the **router**:
+
+```ts
+} else if (path.includes('competitive-awards.json')) {   // date-blind
+```
+
+The mock matched on filename and ignored the `/snapshots/{date}/` segment
+entirely. So a consumer asking for `snapshots/2026-07-05/competitive-awards.json`
+(the wrong key) was handed the snapshot's own fixture and passed. The fallback
+was worse: an unmatched path returned `{ ok: true, status: 200, json: () => ({}) }`
+with a `console.warn`. **The harness could not 404.** Live, that same request
+404s → `fetchCdnCompetitiveAwards` returns null → blank UI, which is the entire
+#1315 mechanism.
+
+The fixture encoded the divergence. The router erased it. Diverging the *data*
+while the *routing* stays key-blind reproduces the original blind spot one layer
+down — inside the harness written to catch it.
+
+## The rule
+
+**A fixture's values are only observable through the mock's routing. If the mock
+resolves on a looser key than the wire, the fixture's distinctions are
+unreachable and every assertion over them is vacuous.**
+
+Ask, of any mock you rely on as a guard: *what request would the real system
+reject that this mock happily serves?* Each such gap is a bug class the suite is
+structurally blind to. Then close it — mirror the rejection:
+
+```ts
+const requestedSnapshotDate = /^\/snapshots\/([^/]+)\//.exec(path)?.[1]
+if (requestedSnapshotDate && !KNOWN_SNAPSHOT_DATES.includes(requestedSnapshotDate)) {
+  return { ok: false, status: 404, ... } as Response
+}
+```
+
+Same trap at the per-test level: `mockedAwards.mockResolvedValue(standings)`
+returns the payload for **any** date, so a content assertion ("the awards render")
+passes under a wrongly-keyed consumer. `mockImplementation(async date => date === SNAPSHOT_DATE ? standings : null)`
+mirrors the 404→null mapping and makes the assertion bite. A mock's *return
+value* gets scrutiny; its *matching condition* rarely does — that's where this
+hides.
+
+## How to apply
+
+- **A route table keyed on `path.includes(filename)` cannot enforce anything
+  about the path's other segments** (date, district, program year). If a segment
+  carries meaning your code can get wrong, route on it.
+- **A 200-only mock is a rubber stamp.** If the real surface has a rejection
+  path (404, 403, empty), the harness needs one, or "green" only means "the code
+  ran."
+- **Prove the guard bites — never assume it.** These consumers were already
+  correct, so the tests passed on arrival, which says nothing. Mutating the
+  source (re-point each consumer at the as-of date) and the harness (delete the
+  404 gate) is what demonstrated they fail for the right reason. A guard you
+  haven't seen fail is a guard you haven't tested. This is the general form of
+  the mutation check the epic prescribed for one consumer.
+- **Guard the harness itself.** `mockCdnHarness.test.ts` asserts both properties
+  (dates diverge; wrong dates 404), so a future edit can't quietly flatten the
+  divergence back or drop the gate.
+
+## Related
+
+- [[key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate]]
+  — the bug class this guards; this lesson is why its layer-2 recommendation
+  needs a routing change, not just a fixture change.
+- [[a-dated-cdn-snapshot-is-a-perdistrictdata-envelope-mock-the-wrapper-or-the-page-reads-empty-on-live]]
+  — the sibling: there the mock's *shape* was dishonest, here its *routing* is.
+  Same root — the mock is more permissive than the wire.
+- [[a-structural-injection-guard-must-check-value-honesty-not-just-key-presence]]
+  — same shape one level up: presence isn't honesty.
+- [[a-year-end-snapshots-source-date-falls-in-july-so-a-program-year-equality-guard-drops-every-year]]
+  — "green on mocks, broken on live," date-semantics flavour.


### PR DESCRIPTION
Sprint 3 of epic #1319 — part of the systemic guard so a **5th** recurrence of the closing-window date-conflation bug cannot ship. Refs #1322.

## What this does

Sprints 1 & 2 killed the ambiguous field (`date` → `asOfDate` + `snapshotDate`) and the phantom `DistrictStatistics.asOfDate`. This sprint builds **layer 2**: make the divergence the *default* test world, so a future consumer that keys a per-snapshot fetch on the as-of date fails in CI.

- **Divergence-by-default fixtures** (`mockCdnData.ts`) — `SNAPSHOT_DATE` 2024-12-31 / `SOURCE_CSV_DATE` 2025-01-05. Every page + journey test now runs inside the month-end closing window. The +5d offset crosses a month boundary on purpose: that's the live shape (2026-06-30 snapshot, 2026-07-05 as-of), and real year-end lag runs ~3 weeks, so +5d is conservative.
- **A date-aware mock router** — `/snapshots/{date}/…` now resolves only under a date the bucket really has, and 404s otherwise.
- **Per-consumer reconciliation tests** — `DistrictsPage` (awards race), `AwardsPage` (standings), `DistrictDetailPage` (trophy case). RegionPage and Division/Area were already covered by #1315 and #1321.
- **A harness self-test** — guards both properties so a future edit can't quietly flatten the divergence or drop the gate.
- **Fixture honesty** — drops `districtSnapshot.asOfDate`, which Sprint 2 proved a phantom absent from the live envelope.

## The finding that shaped this sprint

Landing the divergent fixtures alone left **57/57 integration tests green** — the guard guarded nothing. The fixture wasn't the problem; the **router** was:

```ts
} else if (path.includes('competitive-awards.json')) {   // date-blind
```

It matched on filename and ignored the `/snapshots/{date}/` segment, so a consumer asking for the *wrong* date was handed the snapshot's own fixture and passed. The fallback was worse: any unmatched path returned `{ok: true, status: 200, json: () => ({})}`. **The harness could not 404** — the exact #1315 mechanism (404 → null → blank UI) was unreachable in tests. Diverging the *data* while the *routing* stays key-blind reproduces the original blind spot one layer down, inside the harness written to catch it.

Same trap per-test: `mockResolvedValue(standings)` answers for *any* date, so a "the awards render" assertion passes under a wrongly-keyed consumer. The awards mock is now date-aware, mirroring the real 404→null mapping.

## Verification — falsified by mutation, not assumed

All three consumers were **already correct**, so these tests passed on arrival, which proves nothing. Each was temporarily re-pointed at the as-of date and the suite confirmed red for the right reason:

| Mutation | Result |
|---|---|
| `DistrictsPage` → `useCompetitiveAwards(data?.asOfDate)` | ❌ `expected vi.fn() to not be called with [ '2026-07-05' ]` |
| `DistrictDetailPage` → keyed on as-of | ❌ `expected vi.fn() to be called with [ '2026-06-30' ]` |
| `AwardsPage` → keyed on as-of | ❌ same, **plus** `Unable to find text /District 61/i` — the literal blank-UI symptom of #1315 |
| Harness: date gate removed | ❌ both 404 self-tests fail |

Sources restored; `git diff origin/main..HEAD` touches no page source.

## Gates

- Full frontend suite: **303 files / 3645 tests passing** (baseline 301/3634 → +2 files, +11 tests), zero regressions.
- `format:check` ✅ · partition guard ✅ (303 = 215 unit + 88 integration, disjoint + exhaustive) · no-page-mounts ✅ · quarantine empty ✅
- No `testTimeout` bumps, no quarantine entries, no assertion pinning.

## Note on preview verification

The diff is test-only, so `pr-preview.yml`'s `frontend/**` filter deploys a preview but there is **no new user-facing surface to drive** — the shipped behaviour is unchanged by design (this sprint locks in Sprints 1–2). Per Lesson 138, the honest verification here is the mutation check above plus the full suite, which is exactly what the epic prescribed for Sprint 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxadvY1tZxeCpMnihJYvK8
