### PR TITLE
Sprint 4 (#1323) — branded SnapshotDate at the service layer

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -62,6 +62,43 @@ export default [
         { allowConstantExport: true },
       ],
       'no-console': 'warn',
+      // Keep the SnapshotDate brand honest (#1323, epic #1319). The brand makes
+      // the #1315 closing-window bug class (as-of date keyed into a
+      // snapshots/{date}/... fetch) unrepresentable — but `raw as SnapshotDate`
+      // re-admits all of it in five characters, and no type-level guard can see
+      // a cast. The mint module below is exempt; everywhere else must go through
+      // toSnapshotDate / snapshotDatesFrom / snapshotDateFromManifest.
+      //
+      // Syntactic by necessity: this config runs tsparser with no `project`, so
+      // type-aware rules are unavailable. Behaviour (not severity) is asserted
+      // by src/__tests__/lint/no-snapshot-date-cast.test.ts — an AST selector is
+      // an unchecked string and silently matches nothing if the ESTree shape
+      // drifts (Lesson 82).
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            'TSAsExpression > TSTypeReference > Identifier[name="SnapshotDate"]',
+          message:
+            'Do not cast to SnapshotDate — it launders an unvalidated date into a per-snapshot fetch and re-admits the #1315 blank-UI bug. Mint it instead: toSnapshotDate(raw) for URL/API input, or snapshotDatesFrom(index) / snapshotDateFromManifest(manifest) when the CDN index is at hand.',
+        },
+        {
+          selector:
+            'TSTypeAssertion > TSTypeReference > Identifier[name="SnapshotDate"]',
+          message:
+            'Do not cast to SnapshotDate — it launders an unvalidated date into a per-snapshot fetch and re-admits the #1315 blank-UI bug. Mint it instead: toSnapshotDate(raw) for URL/API input, or snapshotDatesFrom(index) / snapshotDateFromManifest(manifest) when the CDN index is at hand.',
+        },
+      ],
+    },
+  },
+  {
+    // The mint module is where the brand is CREATED — the casts here are the
+    // one place the nominal type can come into existence, guarded by the
+    // validation in toSnapshotDate. Exempting it is what makes the ban above
+    // enforceable everywhere else rather than impossible to satisfy.
+    files: ['src/types/snapshotDate.ts'],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
   {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,6 +5,10 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import globals from 'globals'
 
+// Shared by both selectors below (the `as` form and the angle-bracket form).
+const SNAPSHOT_DATE_CAST_MESSAGE =
+  'Do not cast to SnapshotDate — it launders an unvalidated date into a per-snapshot fetch and re-admits the #1315 blank-UI bug. Mint it instead: toSnapshotDate(raw) for URL/API input, or snapshotDatesFrom(index) / snapshotDateFromManifest(manifest) when the CDN index is at hand.'
+
 export default [
   js.configs.recommended,
   {
@@ -79,14 +83,12 @@ export default [
         {
           selector:
             'TSAsExpression > TSTypeReference > Identifier[name="SnapshotDate"]',
-          message:
-            'Do not cast to SnapshotDate — it launders an unvalidated date into a per-snapshot fetch and re-admits the #1315 blank-UI bug. Mint it instead: toSnapshotDate(raw) for URL/API input, or snapshotDatesFrom(index) / snapshotDateFromManifest(manifest) when the CDN index is at hand.',
+          message: SNAPSHOT_DATE_CAST_MESSAGE,
         },
         {
           selector:
             'TSTypeAssertion > TSTypeReference > Identifier[name="SnapshotDate"]',
-          message:
-            'Do not cast to SnapshotDate — it launders an unvalidated date into a per-snapshot fetch and re-admits the #1315 blank-UI bug. Mint it instead: toSnapshotDate(raw) for URL/API input, or snapshotDatesFrom(index) / snapshotDateFromManifest(manifest) when the CDN index is at hand.',
+          message: SNAPSHOT_DATE_CAST_MESSAGE,
         },
       ],
     },

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -77,17 +77,26 @@ export default [
       // type-aware rules are unavailable. Behaviour (not severity) is asserted
       // by src/__tests__/lint/no-snapshot-date-cast.test.ts — an AST selector is
       // an unchecked string and silently matches nothing if the ESTree shape
-      // drifts (Lesson 82).
+      // drifts (Lesson 82). It shipped doing exactly that: a `>` combinator here
+      // let `as SnapshotDate[]` / `| undefined` / `Array<SnapshotDate>` through
+      // until review caught it, which is why every variant is now pinned.
+      //
+      // Blind spots, stated rather than papered over (L166): this bans the CAST,
+      // not every route to a lie. `toSnapshotDate(data.asOfDate)` mints the
+      // #1315 bug through the front door (format is checked, provenance cannot
+      // be), and `snapshotDatesFrom({ dates: [asOfDate] })` forges the index
+      // shape. The brand raises the cost of the mistake and makes the honest
+      // path the easy one; it is not a proof.
       'no-restricted-syntax': [
         'error',
         {
           selector:
-            'TSAsExpression > TSTypeReference > Identifier[name="SnapshotDate"]',
+            'TSAsExpression TSTypeReference > Identifier[name="SnapshotDate"]',
           message: SNAPSHOT_DATE_CAST_MESSAGE,
         },
         {
           selector:
-            'TSTypeAssertion > TSTypeReference > Identifier[name="SnapshotDate"]',
+            'TSTypeAssertion TSTypeReference > Identifier[name="SnapshotDate"]',
           message: SNAPSHOT_DATE_CAST_MESSAGE,
         },
       ],

--- a/frontend/src/__tests__/lint/no-snapshot-date-cast.test.ts
+++ b/frontend/src/__tests__/lint/no-snapshot-date-cast.test.ts
@@ -51,6 +51,42 @@ export function launderTheAsOfDate(data: { asOfDate: string }) {
 }
 `
 
+/** Double-casting through `unknown` is the classic brand-defeat move. */
+const UNKNOWN_DOUBLE_CAST = `import type { SnapshotDate } from '../types/snapshotDate'
+
+export function launderViaUnknown(raw: string) {
+  return raw as unknown as SnapshotDate
+}
+`
+
+/**
+ * The array form. This is the shape the mint module itself uses, so it is the
+ * likeliest to be copied out of it — and a whole INDEX laundered in one cast is
+ * strictly worse than one date.
+ */
+const ARRAY_CAST = `import type { SnapshotDate } from '../types/snapshotDate'
+
+export function launderAWholeIndex(raw: string[]) {
+  return raw as SnapshotDate[]
+}
+`
+
+/** The union form — what you reach for when the value might be absent. */
+const UNION_CAST = `import type { SnapshotDate } from '../types/snapshotDate'
+
+export function launderAnOptionalDate(raw: string | undefined) {
+  return raw as SnapshotDate | undefined
+}
+`
+
+/** The generic form — same laundering, wearing Array<>. */
+const GENERIC_CAST = `import type { SnapshotDate } from '../types/snapshotDate'
+
+export function launderViaGeneric(raw: string[]) {
+  return raw as Array<SnapshotDate>
+}
+`
+
 /** Casting to an unrelated type must stay legal — the rule must be narrow. */
 const UNRELATED_CAST = `export function castToSomethingElse(raw: unknown): string {
   return raw as string
@@ -72,6 +108,10 @@ describe('as-SnapshotDate cast ban (#1323)', () => {
     ['an `as SnapshotDate` cast', AS_CAST],
     ['an angle-bracket `<SnapshotDate>` cast', ANGLE_BRACKET_CAST],
     ['a cast that launders an as-of date', AS_CAST_ON_AS_OF_DATE],
+    ['an `as unknown as SnapshotDate` double cast', UNKNOWN_DOUBLE_CAST],
+    ['an `as SnapshotDate[]` array cast', ARRAY_CAST],
+    ['an `as SnapshotDate | undefined` union cast', UNION_CAST],
+    ['an `as Array<SnapshotDate>` generic cast', GENERIC_CAST],
   ])(
     'flags %s outside the mint module',
     async (_label, source) => {

--- a/frontend/src/__tests__/lint/no-snapshot-date-cast.test.ts
+++ b/frontend/src/__tests__/lint/no-snapshot-date-cast.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Lint sentinel — proves the `as SnapshotDate` cast ban actually fires
+ * (#1323, epic #1319).
+ *
+ * The brand is only as strong as the ban on minting it by hand: `raw as
+ * SnapshotDate` re-admits the entire #1315 bug class in five characters, and a
+ * type-level guard cannot see it (a cast is, by definition, the escape hatch).
+ * The ESLint rule is the backstop for that bypass — the same factory-plus-guard
+ * pairing as L166 (`toSnapshotDate` is the blessed mint; this is the bypass
+ * catcher).
+ *
+ * Per Lesson 82 this lints a known-bad snippet through the project's REAL
+ * config and asserts the rule FIRES. A `calculateConfigForFile` severity
+ * assertion would pass against a rule that is configured but matching nothing —
+ * and an AST selector that silently stops matching (a `no-restricted-syntax`
+ * selector is a string; nothing typechecks it against the ESTree shape) is
+ * exactly that failure mode.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { ESLint } from 'eslint'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const frontendDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..'
+)
+
+const RULE = 'no-restricted-syntax'
+
+const AS_CAST = `import type { SnapshotDate } from '../types/snapshotDate'
+
+export function launderTheBrand(raw: string): SnapshotDate {
+  return raw as SnapshotDate
+}
+`
+
+const ANGLE_BRACKET_CAST = `import type { SnapshotDate } from '../types/snapshotDate'
+
+export function launderTheBrandTheOldWay(raw: string) {
+  return <SnapshotDate>raw
+}
+`
+
+/** The as-of date laundered through a cast — #1315 re-admitted verbatim. */
+const AS_CAST_ON_AS_OF_DATE = `import type { SnapshotDate } from '../types/snapshotDate'
+
+export function launderTheAsOfDate(data: { asOfDate: string }) {
+  return data.asOfDate as SnapshotDate
+}
+`
+
+/** Casting to an unrelated type must stay legal — the rule must be narrow. */
+const UNRELATED_CAST = `export function castToSomethingElse(raw: unknown): string {
+  return raw as string
+}
+`
+
+const lintAt = async (source: string, relativePath: string) => {
+  const eslint = new ESLint({ cwd: frontendDir })
+  const [result] = await eslint.lintText(source, {
+    filePath: path.join(frontendDir, relativePath),
+  })
+  return (result?.messages ?? []).filter(
+    m => m.ruleId === RULE && m.severity === 2
+  )
+}
+
+describe('as-SnapshotDate cast ban (#1323)', () => {
+  it.each([
+    ['an `as SnapshotDate` cast', AS_CAST],
+    ['an angle-bracket `<SnapshotDate>` cast', ANGLE_BRACKET_CAST],
+    ['a cast that launders an as-of date', AS_CAST_ON_AS_OF_DATE],
+  ])(
+    'flags %s outside the mint module',
+    async (_label, source) => {
+      const errors = await lintAt(source, 'src/__sentinel__/launder.ts')
+
+      expect(
+        errors.length,
+        'the cast ban did not fire — the brand is bypassable'
+      ).toBeGreaterThan(0)
+      expect(errors[0]?.message).toMatch(/snapshotDate|toSnapshotDate|mint/i)
+    },
+    20000
+  )
+
+  it('does NOT flag a cast to an unrelated type', async () => {
+    const errors = await lintAt(UNRELATED_CAST, 'src/__sentinel__/unrelated.ts')
+    expect(errors).toEqual([])
+  }, 20000)
+
+  it('does NOT flag the mint module itself — it is where the brand is created', async () => {
+    const errors = await lintAt(AS_CAST, 'src/types/snapshotDate.ts')
+    expect(
+      errors,
+      'the mint module must be exempt, or the brand cannot be created at all'
+    ).toEqual([])
+  }, 20000)
+})

--- a/frontend/src/components/DataControlsBar.tsx
+++ b/frontend/src/components/DataControlsBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { ProgramYear } from '../utils/programYear'
+import type { SnapshotDate } from '../types/snapshotDate'
 import { formatDisplayDate } from '../utils/dateFormatting'
 import { computeFreshness } from '../utils/dataFreshness'
 
@@ -22,9 +23,9 @@ export interface DataControlsBarProps {
   availableProgramYears: ProgramYear[]
   selectedProgramYear: ProgramYear
   onProgramYearChange: (py: ProgramYear) => void
-  availableDates: string[]
-  selectedDate: string | undefined
-  onDateChange: (date: string | undefined) => void
+  availableDates: SnapshotDate[]
+  selectedDate: SnapshotDate | undefined
+  onDateChange: (date: SnapshotDate | undefined) => void
   /** #922 — true while the query feeding latestSnapshotDate is still in
    * flight. On a cold load the rankings query usually resolves first, so
    * without this the toolbar paints 2-chip and rewraps (one row shorter on
@@ -195,7 +196,7 @@ export const DataControlsBar: React.FC<DataControlsBarProps> = ({
         testId="date-chip"
         ariaLabel="Snapshot date"
         value={selectedDate ?? ''}
-        onChange={v => onDateChange(v === '' ? undefined : v)}
+        onChange={v => onDateChange(sortedDates.find(d => d === v))}
         display={
           selectedDate ? formatDisplayDate(selectedDate) : 'Latest in PY'
         }

--- a/frontend/src/components/DatePairPicker.tsx
+++ b/frontend/src/components/DatePairPicker.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { formatDisplayDate } from '../utils/dateFormatting'
 
 /* From/To date-pair picker for the "What Changed" digest (#794, epic #797
@@ -9,13 +8,18 @@ import { formatDisplayDate } from '../utils/dateFormatting'
    district actually recorded; selections are reported up (the page owns the
    pair, R3). */
 
-export interface DatePairPickerProps {
+/**
+ * Generic in the date type so a branded `SnapshotDate[]` round-trips through the
+ * picker still branded (#1323): every value it emits is an ELEMENT of `dates`,
+ * narrowed from the offered options rather than re-read off the <select>.
+ */
+export interface DatePairPickerProps<T extends string = string> {
   /** Ascending list of the district's recorded snapshot dates. */
-  dates: string[]
-  from: string | undefined
-  to: string | undefined
-  onFromChange: (date: string) => void
-  onToChange: (date: string) => void
+  dates: readonly T[]
+  from: T | undefined
+  to: T | undefined
+  onFromChange: (date: T) => void
+  onToChange: (date: T) => void
 }
 
 // min-h-[44px]: the WCAG 2.5.5 / handoff 44px touch-target floor (#886, epic
@@ -25,52 +29,63 @@ export interface DatePairPickerProps {
 const CHIP_BASE =
   'inline-flex items-center gap-1.5 min-h-[44px] px-3 py-2 rounded-full text-xs font-medium border bg-white border-gray-200 text-gray-700 theme-dark:bg-gray-800 theme-dark:border-gray-700 theme-dark:text-gray-200'
 
-const DateChipSelect: React.FC<{
+function DateChipSelect<T extends string>({
+  testId,
+  label,
+  value,
+  options,
+  onChange,
+}: {
   testId: string
   label: string
-  value: string | undefined
-  options: string[]
-  onChange: (value: string) => void
-}> = ({ testId, label, value, options, onChange }) => (
-  <label
-    data-testid={testId}
-    className={`${CHIP_BASE} relative cursor-pointer hover:bg-gray-50 theme-dark:hover:bg-gray-700 focus-within:ring-2 focus-within:ring-tm-loyal-blue focus-within:ring-offset-1`}
-  >
-    <span className="text-gray-400 theme-dark:text-gray-500">{label}</span>
-    <span>{value ? formatDisplayDate(value) : '—'}</span>
-    <span aria-hidden="true" className="text-gray-400">
-      ▾
-    </span>
-    <select
-      data-testid={`${testId}-select`}
-      aria-label={
-        value ? `${label} date: ${formatDisplayDate(value)}` : `${label} date`
-      }
-      value={value ?? ''}
-      onChange={e => onChange(e.target.value)}
-      // appearance-none + min-h-[44px]: the <select> IS the touch target, and
-      // inset-0 sizes it to the label's PADDING box (44px − 2px border = 42px,
-      // measured in both engines on PR #943). The floor must live on the
-      // select; appearance-none opts out of native sizing so WebKit honours
-      // min-height (Lesson 111). opacity-0 keeps it invisible.
-      className="absolute inset-0 opacity-0 cursor-pointer appearance-none min-h-[44px]"
+  value: T | undefined
+  options: readonly T[]
+  onChange: (value: T) => void
+}) {
+  return (
+    <label
+      data-testid={testId}
+      className={`${CHIP_BASE} relative cursor-pointer hover:bg-gray-50 theme-dark:hover:bg-gray-700 focus-within:ring-2 focus-within:ring-tm-loyal-blue focus-within:ring-offset-1`}
     >
-      {options.map(d => (
-        <option key={d} value={d}>
-          {formatDisplayDate(d)}
-        </option>
-      ))}
-    </select>
-  </label>
-)
+      <span className="text-gray-400 theme-dark:text-gray-500">{label}</span>
+      <span>{value ? formatDisplayDate(value) : '—'}</span>
+      <span aria-hidden="true" className="text-gray-400">
+        ▾
+      </span>
+      <select
+        data-testid={`${testId}-select`}
+        aria-label={
+          value ? `${label} date: ${formatDisplayDate(value)}` : `${label} date`
+        }
+        value={value ?? ''}
+        onChange={e => {
+          const picked = options.find(o => o === e.target.value)
+          if (picked !== undefined) onChange(picked)
+        }}
+        // appearance-none + min-h-[44px]: the <select> IS the touch target, and
+        // inset-0 sizes it to the label's PADDING box (44px − 2px border = 42px,
+        // measured in both engines on PR #943). The floor must live on the
+        // select; appearance-none opts out of native sizing so WebKit honours
+        // min-height (Lesson 111). opacity-0 keeps it invisible.
+        className="absolute inset-0 opacity-0 cursor-pointer appearance-none min-h-[44px]"
+      >
+        {options.map(d => (
+          <option key={d} value={d}>
+            {formatDisplayDate(d)}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
 
-export const DatePairPicker: React.FC<DatePairPickerProps> = ({
+export function DatePairPicker<T extends string>({
   dates,
   from,
   to,
   onFromChange,
   onToChange,
-}) => {
+}: DatePairPickerProps<T>) {
   // Newest first in the dropdown — the recent dates are the common pick.
   const sorted = [...dates].sort((a, b) => b.localeCompare(a))
   return (

--- a/frontend/src/components/DistrictDetailHeader.tsx
+++ b/frontend/src/components/DistrictDetailHeader.tsx
@@ -4,6 +4,7 @@ import { HeaderActionsMenu } from './HeaderActionsMenu'
 import { ProgramYearTitleSuffix } from './ProgramYearTitleSuffix'
 import { useLatestAsOfDate } from '../hooks/useLatestAsOfDate'
 import type { ProgramYear } from '../utils/programYear'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 /* District detail page header (#358). Extracted from DistrictDetailPage so
    redesign tests can mount this small component (~50 DOM nodes) instead
@@ -20,9 +21,9 @@ interface DistrictDetailHeaderProps {
   selectedProgramYear: ProgramYear
   setSelectedProgramYear: (py: ProgramYear) => void
   availableProgramYears: ProgramYear[]
-  selectedDate: string | undefined
-  onDateChange: (date: string | undefined) => void
-  availableDates: string[]
+  selectedDate: SnapshotDate | undefined
+  onDateChange: (date: SnapshotDate | undefined) => void
+  availableDates: SnapshotDate[]
   latestSnapshotDate: string | undefined
 }
 

--- a/frontend/src/components/DistrictOverview.tsx
+++ b/frontend/src/components/DistrictOverview.tsx
@@ -6,10 +6,11 @@ import { LoadingSkeleton } from './LoadingSkeleton'
 import { ErrorDisplay, EmptyState } from './ErrorDisplay'
 import DistinguishedCompositionBar from './DistinguishedCompositionBar'
 import PaymentComposition from './PaymentComposition'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 interface DistrictOverviewProps {
   districtId: string
-  selectedDate?: string
+  selectedDate?: SnapshotDate
   programYearStartDate?: string
   /**
    * Pre-fetched performance targets from the usePerformanceTargets hook.

--- a/frontend/src/hooks/__tests__/useAggregatedAnalytics.test.tsx
+++ b/frontend/src/hooks/__tests__/useAggregatedAnalytics.test.tsx
@@ -17,15 +17,16 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactNode } from 'react'
 import { useAggregatedAnalytics } from '../useAggregatedAnalytics'
 import {
-  fetchCdnManifest,
+  fetchLatestSnapshotDate,
   cdnAnalyticsUrl,
   fetchFromCdn,
 } from '../../services/cdn'
+import { toSnapshotDate } from '../../types/snapshotDate'
 import type { DistrictAnalytics } from '../useDistrictAnalytics'
 
 // Mock the CDN client — CDN fetch resolves with test data.
 vi.mock('../../services/cdn', () => ({
-  fetchCdnManifest: vi.fn(),
+  fetchLatestSnapshotDate: vi.fn(),
   cdnAnalyticsUrl: vi.fn(),
   fetchFromCdn: vi.fn(),
 }))
@@ -124,10 +125,11 @@ describe('useAggregatedAnalytics', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Set up CDN mocks for each test
-    vi.mocked(fetchCdnManifest).mockResolvedValue({
-      latestSnapshotDate: '2024-12-15',
-      generatedAt: '2024-12-15T10:00:00Z',
-    })
+    // The hook resolves "latest" via the branded mint helper now, not the raw
+    // manifest (#1323).
+    vi.mocked(fetchLatestSnapshotDate).mockResolvedValue(
+      toSnapshotDate('2024-12-15')!
+    )
     vi.mocked(cdnAnalyticsUrl).mockReturnValue(
       'https://cdn.taverns.red/snapshots/2024-12-15/analytics/district_42_analytics.json'
     )
@@ -222,7 +224,7 @@ describe('useAggregatedAnalytics', () => {
      * Test that hook reports error when CDN fails
      */
     it('should report error when CDN fails', async () => {
-      vi.mocked(fetchCdnManifest).mockRejectedValue(
+      vi.mocked(fetchLatestSnapshotDate).mockRejectedValue(
         new Error('CDN unavailable')
       )
 

--- a/frontend/src/hooks/__tests__/useMembershipData.test.tsx
+++ b/frontend/src/hooks/__tests__/useMembershipData.test.tsx
@@ -16,17 +16,21 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactNode } from 'react'
 import { useDistrictStatistics } from '../useMembershipData'
-import { fetchCdnManifest, fetchCdnDistrictSnapshot } from '../../services/cdn'
+import {
+  fetchLatestSnapshotDate,
+  fetchCdnDistrictSnapshot,
+} from '../../services/cdn'
+import { toSnapshotDate } from '../../types/snapshotDate'
 import type { DistrictStatistics } from '../../types/districts'
 
 // Mock the CDN service
 vi.mock('../../services/cdn', () => ({
-  fetchCdnManifest: vi.fn(),
+  fetchLatestSnapshotDate: vi.fn(),
   fetchCdnDistrictSnapshot: vi.fn(),
   fetchCdnDistrictAnalytics: vi.fn(),
 }))
 
-const mockedFetchCdnManifest = vi.mocked(fetchCdnManifest)
+const mockedFetchLatestSnapshotDate = vi.mocked(fetchLatestSnapshotDate)
 const mockedFetchCdnDistrictSnapshot = vi.mocked(fetchCdnDistrictSnapshot)
 
 // Create a mock DistrictStatistics response
@@ -82,11 +86,12 @@ const createWrapper = () => {
 describe('useDistrictStatistics', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Default manifest mock
-    mockedFetchCdnManifest.mockResolvedValue({
-      latestSnapshotDate: '2022-12-05',
-      generatedAt: '2022-12-05T00:00:00Z',
-    })
+    // Default "latest snapshot" mock. The hook no longer reads the raw
+    // manifest — fetchLatestSnapshotDate is the blessed mint that validates it
+    // and hands back a branded SnapshotDate (#1323).
+    mockedFetchLatestSnapshotDate.mockResolvedValue(
+      toSnapshotDate('2022-12-05')!
+    )
   })
 
   afterEach(() => {
@@ -144,8 +149,8 @@ describe('useDistrictStatistics', () => {
         expect(result.current.isSuccess).toBe(true)
       })
 
-      // Should use manifest date when no selectedDate
-      expect(mockedFetchCdnManifest).toHaveBeenCalled()
+      // Should use the latest snapshot date when no selectedDate
+      expect(mockedFetchLatestSnapshotDate).toHaveBeenCalled()
       expect(mockedFetchCdnDistrictSnapshot).toHaveBeenCalledWith(
         '2022-12-05',
         districtId
@@ -281,7 +286,7 @@ describe('useDistrictStatistics', () => {
       })
 
       // Empty string is falsy, so manifest date should be used
-      expect(mockedFetchCdnManifest).toHaveBeenCalled()
+      expect(mockedFetchLatestSnapshotDate).toHaveBeenCalled()
     })
   })
 
@@ -396,7 +401,7 @@ describe('useDistrictStatistics', () => {
     it('should handle manifest fetch errors', async () => {
       const districtId = 'D101'
 
-      mockedFetchCdnManifest.mockRejectedValue(
+      mockedFetchLatestSnapshotDate.mockRejectedValue(
         new Error('CDN manifest fetch failed: 500')
       )
 

--- a/frontend/src/hooks/aggregatedAnalytics/helpers.ts
+++ b/frontend/src/hooks/aggregatedAnalytics/helpers.ts
@@ -7,12 +7,13 @@
  */
 
 import {
-  fetchCdnManifest,
+  fetchLatestSnapshotDate,
   cdnAnalyticsUrl,
   fetchFromCdn,
 } from '../../services/cdn'
 import type { DistrictAnalytics } from '../useDistrictAnalytics'
 import type { AggregatedAnalyticsResponse, TrendData } from './types'
+import type { SnapshotDate } from '../../types/snapshotDate'
 
 /**
  * Fetch district analytics from Cloud CDN.
@@ -23,9 +24,9 @@ import type { AggregatedAnalyticsResponse, TrendData } from './types'
  */
 export async function fetchIndividualAnalytics(
   districtId: string,
-  snapshotDate?: string
+  snapshotDate?: SnapshotDate
 ): Promise<DistrictAnalytics> {
-  const date = snapshotDate || (await fetchCdnManifest()).latestSnapshotDate
+  const date = snapshotDate || (await fetchLatestSnapshotDate())
   const url = cdnAnalyticsUrl(date, districtId, 'analytics')
   const file = await fetchFromCdn<{ data: DistrictAnalytics }>(url)
   return file.data

--- a/frontend/src/hooks/useAggregatedAnalytics.ts
+++ b/frontend/src/hooks/useAggregatedAnalytics.ts
@@ -32,6 +32,7 @@ import {
   fetchIndividualAnalytics,
   convertToAggregatedFormat,
 } from './aggregatedAnalytics/helpers'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 // ============================================================================
 // Hook Implementation
@@ -52,7 +53,7 @@ import {
  */
 export function useAggregatedAnalytics(
   districtId: string | null,
-  snapshotDate?: string
+  snapshotDate?: SnapshotDate
 ): {
   data: AggregatedAnalyticsResponse | null
   isLoading: boolean

--- a/frontend/src/hooks/useClubHistory.ts
+++ b/frontend/src/hooks/useClubHistory.ts
@@ -26,6 +26,7 @@ import {
 import type { PerDistrictData } from '@taverns-red/shared-contracts'
 import { getProgramYearForDate } from '../utils/programYear'
 import { buildClubHistoryRow, type ClubHistoryRow } from '../utils/clubHistory'
+import { snapshotDatesFrom } from '../types/snapshotDate'
 
 export const clubHistoryQueryKey = (
   districtId: string,
@@ -48,9 +49,17 @@ export interface UseClubHistoryResult {
   error: Error | null
 }
 
-/** Latest snapshot date within each program year, for one district. */
-function latestDateByProgramYear(dates: string[]): Map<number, string> {
-  const latestByYear = new Map<number, string>()
+/**
+ * Latest snapshot date within each program year, for one district.
+ *
+ * Generic in the date type so a branded `SnapshotDate[]` yields branded values:
+ * every entry is an ELEMENT of `dates`, so it carries the caller's provenance
+ * straight through to the per-snapshot fetch below (#1323).
+ */
+function latestDateByProgramYear<T extends string>(
+  dates: readonly T[]
+): Map<number, T> {
+  const latestByYear = new Map<number, T>()
   for (const d of dates) {
     // getProgramYearForDate parses the ISO string via calendarParts (regex,
     // timezone-safe) — not new Date() — so the Jul-1 boundary is exact.
@@ -72,7 +81,7 @@ export function useClubHistory(
     enabled,
     queryFn: async (): Promise<ClubHistoryData> => {
       const index = await fetchCdnSnapshotIndex()
-      const dates = index[districtId!] ?? []
+      const dates = snapshotDatesFrom({ dates: index[districtId!] ?? [] })
 
       // Latest date per program year → keep only COMPLETED years, newest first.
       const now = new Date()

--- a/frontend/src/hooks/useClubTrends.ts
+++ b/frontend/src/hooks/useClubTrends.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import type { ClubHealthStatus } from '@taverns-red/shared-contracts'
 import {
-  fetchCdnManifest,
+  fetchLatestSnapshotDate,
   cdnAnalyticsUrl,
   fetchFromCdn,
 } from '../services/cdn'
@@ -91,9 +91,8 @@ export const useVulnerableClubs = (
       }
 
       // CDN-only: fetch pre-computed vulnerable-clubs.json (#173)
-      const manifest = await fetchCdnManifest()
       const url = cdnAnalyticsUrl(
-        manifest.latestSnapshotDate,
+        await fetchLatestSnapshotDate(),
         districtId,
         'vulnerable-clubs'
       )

--- a/frontend/src/hooks/useClubs.ts
+++ b/frontend/src/hooks/useClubs.ts
@@ -1,5 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchCdnManifest, fetchCdnDistrictSnapshot } from '../services/cdn'
+import {
+  fetchLatestSnapshotDate,
+  fetchCdnDistrictSnapshot,
+} from '../services/cdn'
 import type { ClubsResponse, DistrictStatistics } from '../types/districts'
 
 /**
@@ -13,9 +16,8 @@ export const useClubs = (districtId: string | null) => {
       if (!districtId) {
         throw new Error('District ID is required')
       }
-      const { latestSnapshotDate } = await fetchCdnManifest()
       const snapshot = await fetchCdnDistrictSnapshot<DistrictStatistics>(
-        latestSnapshotDate,
+        await fetchLatestSnapshotDate(),
         districtId
       )
       return {

--- a/frontend/src/hooks/useCompetitiveAwards.ts
+++ b/frontend/src/hooks/useCompetitiveAwards.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
 import {
   fetchCdnCompetitiveAwards,
-  fetchCdnManifest,
+  fetchLatestSnapshotDate,
   type CompetitiveAwardStandings,
 } from '../services/cdn'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 /**
  * React Query hook for fetching competitive award standings (#330).
@@ -16,12 +17,13 @@ import {
  * (Pre-fix the hook returned null for undefined date — the AwardsPage
  * surfaced this as an empty state.)
  */
-export function useCompetitiveAwards(date: string | undefined) {
+export function useCompetitiveAwards(date: SnapshotDate | undefined) {
   return useQuery<CompetitiveAwardStandings | null>({
     queryKey: ['competitive-awards', date ?? 'latest'],
     queryFn: async () => {
-      const resolvedDate = date ?? (await fetchCdnManifest()).latestSnapshotDate
-      return fetchCdnCompetitiveAwards(resolvedDate)
+      return fetchCdnCompetitiveAwards(
+        date ?? (await fetchLatestSnapshotDate())
+      )
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes

--- a/frontend/src/hooks/useDistinguishedClubAnalytics.ts
+++ b/frontend/src/hooks/useDistinguishedClubAnalytics.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import {
-  fetchCdnManifest,
+  fetchLatestSnapshotDate,
   cdnAnalyticsUrl,
   fetchFromCdn,
 } from '../services/cdn'
@@ -75,9 +75,8 @@ export const useDistinguishedClubAnalytics = (
       }
 
       // Fetch from CDN — pre-computed JSON
-      const manifest = await fetchCdnManifest()
       const url = cdnAnalyticsUrl(
-        manifest.latestSnapshotDate,
+        await fetchLatestSnapshotDate(),
         districtId,
         'distinguished-analytics'
       )

--- a/frontend/src/hooks/useDistrictAnalytics.ts
+++ b/frontend/src/hooks/useDistrictAnalytics.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import {
-  fetchCdnManifest,
+  fetchLatestSnapshotDate,
   cdnAnalyticsUrl,
   fetchFromCdn,
   fetchCdnDistrictReports,
@@ -14,6 +14,7 @@ import {
   buildDuesRenewalLookup,
   type ClubStatusOverlay,
 } from '../utils/clubStatusOverlay'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 // Re-export for backward compatibility with existing imports
 export type { ClubHealthStatus, ProspectiveClub }
@@ -229,7 +230,7 @@ export interface DistrictPerformanceTargets {
 export const useDistrictAnalytics = (
   districtId: string | null,
   startDate?: string,
-  endDate?: string
+  endDate?: SnapshotDate
 ) => {
   // Validate date range - don't make request if startDate > endDate
   const hasValidDateRange = !startDate || !endDate || startDate <= endDate
@@ -242,8 +243,7 @@ export const useDistrictAnalytics = (
       }
 
       // Use the selected date for CDN URL; fall back to manifest latest
-      const snapshotDate =
-        endDate || (await fetchCdnManifest()).latestSnapshotDate
+      const snapshotDate = endDate || (await fetchLatestSnapshotDate())
       const url = cdnAnalyticsUrl(snapshotDate, districtId, 'analytics')
       // Read-time club-status overlay (epic #1062 Sprint 4 #1069): fetch the
       // base analytics and the daily Dues Renewal report in parallel (they are

--- a/frontend/src/hooks/useDistrictData.ts
+++ b/frontend/src/hooks/useDistrictData.ts
@@ -38,9 +38,9 @@ export const useDistrictCachedDates = (
       // snapshots it wrote for this district — the district-side mint for the
       // brand (#1323), the sibling of useProgramYearControls' dates-index mint.
       const index = await fetchCdnSnapshotIndex()
-      const dates = [
-        ...snapshotDatesFrom({ dates: index[districtId] ?? [] }),
-      ].sort()
+      const dates = snapshotDatesFrom({
+        dates: index[districtId] ?? [],
+      }).sort()
 
       return {
         districtId,

--- a/frontend/src/hooks/useDistrictData.ts
+++ b/frontend/src/hooks/useDistrictData.ts
@@ -1,16 +1,17 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchCdnSnapshotIndex } from '../services/cdn'
+import { snapshotDatesFrom, type SnapshotDate } from '../types/snapshotDate'
 
 /**
  * Interface for cached dates response (CDN-compatible shape)
  */
 export interface CachedDatesResponse {
   districtId: string
-  dates: string[]
+  dates: SnapshotDate[]
   count: number
   dateRange: {
-    startDate: string
-    endDate: string
+    startDate: SnapshotDate
+    endDate: SnapshotDate
   } | null
 }
 
@@ -33,8 +34,13 @@ export const useDistrictCachedDates = (
         throw new Error('District ID is required')
       }
 
+      // The per-district snapshot index is the pipeline's own enumeration of the
+      // snapshots it wrote for this district — the district-side mint for the
+      // brand (#1323), the sibling of useProgramYearControls' dates-index mint.
       const index = await fetchCdnSnapshotIndex()
-      const dates = (index[districtId] ?? []).sort()
+      const dates = [
+        ...snapshotDatesFrom({ dates: index[districtId] ?? [] }),
+      ].sort()
 
       return {
         districtId,

--- a/frontend/src/hooks/useDistrictExport.ts
+++ b/frontend/src/hooks/useDistrictExport.ts
@@ -1,6 +1,10 @@
 import { useState, useCallback } from 'react'
-import { fetchCdnManifest, fetchCdnDistrictSnapshot } from '../services/cdn'
+import {
+  fetchLatestSnapshotDate,
+  fetchCdnDistrictSnapshot,
+} from '../services/cdn'
 import { arrayToCSV, downloadCSV, generateFilename } from '../utils/csvExport'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 interface ExportState {
   isExporting: boolean
@@ -8,7 +12,10 @@ interface ExportState {
 }
 
 interface UseDistrictExportResult extends ExportState {
-  exportToCSV: (startDate?: string, endDate?: string) => Promise<void>
+  exportToCSV: (
+    startDate?: SnapshotDate,
+    endDate?: SnapshotDate
+  ) => Promise<void>
   clearError: () => void
 }
 
@@ -29,7 +36,7 @@ export const useDistrictExport = (
   }, [])
 
   const exportToCSV = useCallback(
-    async (startDate?: string, _endDate?: string) => {
+    async (startDate?: SnapshotDate, _endDate?: SnapshotDate) => {
       if (!districtId) {
         setState(prev => ({
           ...prev,
@@ -42,7 +49,7 @@ export const useDistrictExport = (
 
       try {
         // Determine the date for snapshot lookup
-        const date = startDate || (await fetchCdnManifest()).latestSnapshotDate
+        const date = startDate || (await fetchLatestSnapshotDate())
 
         // Fetch snapshot data from CDN
         const snapshot = await fetchCdnDistrictSnapshot<{

--- a/frontend/src/hooks/useDistrictProgramYearControls.ts
+++ b/frontend/src/hooks/useDistrictProgramYearControls.ts
@@ -40,26 +40,27 @@ import {
   isDateInProgramYear,
 } from '../utils/programYear'
 import type { ProgramYear } from '../utils/programYear'
+import type { SnapshotDate } from '../types/snapshotDate'
 
-const EMPTY_DATES: string[] = []
+const EMPTY_DATES: SnapshotDate[] = []
 
 export interface DistrictProgramYearControls {
   selectedProgramYear: ProgramYear
   setSelectedProgramYear: (py: ProgramYear) => void
-  selectedDate: string | undefined
-  setSelectedDate: (date: string | undefined) => void
+  selectedDate: SnapshotDate | undefined
+  setSelectedDate: (date: SnapshotDate | undefined) => void
   /** Program years that actually have snapshots for this district, newest first. */
   availableProgramYears: ProgramYear[]
   /** Snapshot dates within the selected PY — feeds the date chip (which sorts). */
-  availableDates: string[]
+  availableDates: SnapshotDate[]
   /** The selected PY reconciled to one with data (self-heal); null until dates load. */
   effectiveProgramYear: ProgramYear | null
   /** The date the page should fetch: `?date=` when in-PY, else the PY's latest. */
-  effectiveEndDate: string | null
+  effectiveEndDate: SnapshotDate | null
   /** True once a program year AND an end date have resolved. */
   hasValidDates: boolean
   /** The district's overall most-recent snapshot date (for the freshness pill). */
-  latestSnapshotDate: string | undefined
+  latestSnapshotDate: SnapshotDate | undefined
   /** True when the effective end date is the district's newest snapshot — the
    * signal computeFreshness needs to flag month-end reconciliation only on the
    * live snapshot, never a finalized historical date (#1310). */
@@ -137,10 +138,14 @@ export function useDistrictProgramYearControls(
     ) {
       return selectedDate
     }
-    return (
-      getMostRecentDateInProgramYear(allCachedDates, effectiveProgramYear) ||
-      effectiveProgramYear.endDate
-    )
+    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound
+    // (`${year + 1}-06-30`) is a calendar edge, not a snapshot that exists, and
+    // it is also unreachable. effectiveProgramYear is always an element of
+    // availableProgramYears = getAvailableProgramYears(allCachedDates), and that
+    // derivation keeps a PY iff filterDatesByProgramYear keeps one of its dates
+    // (identical July-boundary predicate), so getMostRecentDateInProgramYear
+    // cannot return null here. The brand made the dead branch visible (#1323).
+    return getMostRecentDateInProgramYear(allCachedDates, effectiveProgramYear)
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 
   const hasValidDates =

--- a/frontend/src/hooks/useDistrictProgramYearControls.ts
+++ b/frontend/src/hooks/useDistrictProgramYearControls.ts
@@ -138,13 +138,9 @@ export function useDistrictProgramYearControls(
     ) {
       return selectedDate
     }
-    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound
-    // (`${year + 1}-06-30`) is a calendar edge, not a snapshot that exists, and
-    // it is also unreachable. effectiveProgramYear is always an element of
-    // availableProgramYears = getAvailableProgramYears(allCachedDates), and that
-    // derivation keeps a PY iff filterDatesByProgramYear keeps one of its dates
-    // (identical July-boundary predicate), so getMostRecentDateInProgramYear
-    // cannot return null here. The brand made the dead branch visible (#1323).
+    // null is unreachable here — effectiveProgramYear comes from
+    // getAvailableProgramYears(allCachedDates). See getMostRecentDateInProgramYear
+    // for why, and why a `|| endDate` fallback must not come back (#1323).
     return getMostRecentDateInProgramYear(allCachedDates, effectiveProgramYear)
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 

--- a/frontend/src/hooks/useEducationalAwards.ts
+++ b/frontend/src/hooks/useEducationalAwards.ts
@@ -1,5 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchCdnManifest, fetchCdnDistrictAnalytics } from '../services/cdn'
+import {
+  fetchLatestSnapshotDate,
+  fetchCdnDistrictAnalytics,
+} from '../services/cdn'
 import type { EducationalAwardsResponse } from '../types/districts'
 
 /**
@@ -16,9 +19,8 @@ export const useEducationalAwards = (
       if (!districtId) {
         throw new Error('District ID is required')
       }
-      const { latestSnapshotDate } = await fetchCdnManifest()
       return fetchCdnDistrictAnalytics<EducationalAwardsResponse>(
-        latestSnapshotDate,
+        await fetchLatestSnapshotDate(),
         districtId,
         'distinguished-analytics'
       )

--- a/frontend/src/hooks/useLatestAsOfDate.ts
+++ b/frontend/src/hooks/useLatestAsOfDate.ts
@@ -29,12 +29,16 @@
  */
 import { useQuery } from '@tanstack/react-query'
 import { fetchCdnRankings, fetchCdnManifest } from '../services/cdn'
+import {
+  snapshotDateFromManifest,
+  type SnapshotDate,
+} from '../types/snapshotDate'
 
 export interface LatestAsOfDate {
   /** Global dashboard "as of" date (sourceCsvDate) — undefined until loaded. */
   asOfDate: string | undefined
   /** Global pinned latest-snapshot (month-end) date — undefined until loaded. */
-  latestSnapshotDate: string | undefined
+  latestSnapshotDate: SnapshotDate | undefined
 }
 
 export function useLatestAsOfDate(): LatestAsOfDate {
@@ -53,7 +57,7 @@ export function useLatestAsOfDate(): LatestAsOfDate {
 
   return {
     asOfDate: rankings?.asOfDate,
-    latestSnapshotDate: manifest?.latestSnapshotDate,
+    latestSnapshotDate: snapshotDateFromManifest(manifest),
   }
 }
 
@@ -83,7 +87,7 @@ export interface GlobalFreshness {
  * @param isLatestSnapshot - whether the page is viewing that newest snapshot.
  */
 export function useGlobalFreshness(params: {
-  districtLatestSnapshotDate: string | undefined
+  districtLatestSnapshotDate: SnapshotDate | undefined
   isLatestSnapshot: boolean
 }): GlobalFreshness {
   const { asOfDate, latestSnapshotDate: globalLatestSnapshot } =

--- a/frontend/src/hooks/useLeadershipInsights.ts
+++ b/frontend/src/hooks/useLeadershipInsights.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import {
-  fetchCdnManifest,
+  fetchLatestSnapshotDate,
   cdnAnalyticsUrl,
   fetchFromCdn,
 } from '../services/cdn'
@@ -90,9 +90,8 @@ export const useLeadershipInsights = (
       }
 
       // Fetch from CDN — pre-computed JSON
-      const manifest = await fetchCdnManifest()
       const url = cdnAnalyticsUrl(
-        manifest.latestSnapshotDate,
+        await fetchLatestSnapshotDate(),
         districtId,
         'leadership-insights'
       )

--- a/frontend/src/hooks/useMembershipData.ts
+++ b/frontend/src/hooks/useMembershipData.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import {
-  fetchCdnManifest,
+  fetchLatestSnapshotDate,
   fetchCdnDistrictSnapshot,
   fetchCdnDistrictAnalytics,
 } from '../services/cdn'
@@ -8,6 +8,7 @@ import type {
   DistrictStatistics,
   MembershipHistoryResponse,
 } from '../types/districts'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 /**
  * React Query hook to fetch district statistics from CDN (#173).
@@ -21,7 +22,7 @@ import type {
  */
 export const useDistrictStatistics = (
   districtId: string | null,
-  selectedDate?: string,
+  selectedDate?: SnapshotDate,
   fields?: 'divisions' | 'clubs' | 'all'
 ) => {
   return useQuery<DistrictStatistics, Error>({
@@ -30,7 +31,7 @@ export const useDistrictStatistics = (
       if (!districtId) {
         throw new Error('District ID is required')
       }
-      const date = selectedDate || (await fetchCdnManifest()).latestSnapshotDate
+      const date = selectedDate || (await fetchLatestSnapshotDate())
       return fetchCdnDistrictSnapshot<DistrictStatistics>(date, districtId)
     },
     enabled: !!districtId,
@@ -53,9 +54,8 @@ export const useMembershipHistory = (
       if (!districtId) {
         throw new Error('District ID is required')
       }
-      const { latestSnapshotDate } = await fetchCdnManifest()
       return fetchCdnDistrictAnalytics<MembershipHistoryResponse>(
-        latestSnapshotDate,
+        await fetchLatestSnapshotDate(),
         districtId,
         'membership'
       )

--- a/frontend/src/hooks/usePaymentsTrend.ts
+++ b/frontend/src/hooks/usePaymentsTrend.ts
@@ -18,6 +18,7 @@ import {
   getProgramYearForDate,
   ProgramYear,
 } from '../utils/programYear'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 /**
  * Multi-year payment data structure for chart rendering
@@ -235,7 +236,7 @@ export function findComparablePayment(
 export function usePaymentsTrend(
   districtId: string | null,
   programYearStartDate?: string,
-  endDate?: string,
+  endDate?: SnapshotDate,
   selectedProgramYear?: ProgramYear,
   performanceTargets?: DistrictPerformanceTargets | null
 ): UsePaymentsTrendResult {
@@ -245,14 +246,17 @@ export function usePaymentsTrend(
   const startDate =
     programYearStartDate ??
     getProgramYear(currentProgramYear.year - 2).startDate
-  const queryEndDate = endDate ?? new Date().toISOString().split('T')[0]
-
-  // Fetch analytics data using existing hook
+  // No wall-clock fallback for endDate (#1323): today's date is never a
+  // snapshot date, so `?? new Date()...` keyed cdnAnalyticsUrl on a path that
+  // cannot exist and always 404'd. It survived only because the sole caller
+  // always passes effectiveEndDate behind a hasValidDates gate. Passing
+  // undefined through is both honest and better: useDistrictAnalytics falls
+  // back to the manifest's latest snapshot, which is a snapshot that exists.
   const {
     data: analyticsData,
     isLoading,
     error,
-  } = useDistrictAnalytics(districtId, startDate, queryEndDate)
+  } = useDistrictAnalytics(districtId, startDate, endDate)
 
   // Transform the data
   const result = useMemo(() => {

--- a/frontend/src/hooks/usePerformanceTargets.ts
+++ b/frontend/src/hooks/usePerformanceTargets.ts
@@ -12,7 +12,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import {
-  fetchCdnManifest,
+  fetchLatestSnapshotDate,
   cdnAnalyticsUrl,
   fetchFromCdn,
 } from '../services/cdn'
@@ -23,6 +23,7 @@ import type {
   RecognitionTargets,
   RecognitionLevel,
 } from './useDistrictAnalytics'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 /**
  * CDN performance-targets.json shape
@@ -158,7 +159,7 @@ function convertToPerformanceTargets(
  */
 export function usePerformanceTargets(
   districtId: string | null,
-  snapshotDate?: string
+  snapshotDate?: SnapshotDate
 ) {
   return useQuery<DistrictPerformanceTargets, Error>({
     queryKey: ['performanceTargets', districtId, snapshotDate],
@@ -167,7 +168,7 @@ export function usePerformanceTargets(
         throw new Error('District ID is required')
       }
 
-      const date = snapshotDate || (await fetchCdnManifest()).latestSnapshotDate
+      const date = snapshotDate || (await fetchLatestSnapshotDate())
       const url = cdnAnalyticsUrl(date, districtId, 'performance-targets')
       const file = await fetchFromCdn<{
         data: CdnPerformanceTargetsData

--- a/frontend/src/hooks/useProgramYearControls.ts
+++ b/frontend/src/hooks/useProgramYearControls.ts
@@ -35,20 +35,19 @@ import {
   getMostRecentDateInProgramYear,
 } from '../utils/programYear'
 import type { ProgramYear } from '../utils/programYear'
-
-const EMPTY_DATES: string[] = []
+import { snapshotDatesFrom, type SnapshotDate } from '../types/snapshotDate'
 
 export interface ProgramYearControls {
   selectedProgramYear: ProgramYear
   setSelectedProgramYear: (py: ProgramYear) => void
-  selectedDate: string | undefined
-  setSelectedDate: (date: string | undefined) => void
+  selectedDate: SnapshotDate | undefined
+  setSelectedDate: (date: SnapshotDate | undefined) => void
   /** Program years that actually have snapshots, newest first. */
   availableProgramYears: ProgramYear[]
   /** Snapshot dates within the selected program year. */
-  cachedDates: string[]
+  cachedDates: SnapshotDate[]
   /** The date the page should fetch: `?date=` if set, else the PY's latest. */
-  effectiveDate: string | undefined
+  effectiveDate: SnapshotDate | undefined
   /** True when the selected date is the most recent snapshot in the PY (or no
    * explicit date is chosen). Drives the freshness pill's reconciliation axis
    * (#1296) — memoized here so each consuming page doesn't re-sort per render. */
@@ -74,7 +73,11 @@ export function useProgramYearControls(): ProgramYearControls {
     retry: false,
   })
 
-  const allCachedDates = data?.dates ?? EMPTY_DATES
+  // The dates index is the pipeline's own enumeration of what it wrote, so this
+  // is the primary mint for the brand (#1323). Everything downstream —
+  // cachedDates, effectiveDate, and every per-snapshot fetch keyed on them —
+  // inherits its provenance from this one call.
+  const allCachedDates = useMemo(() => snapshotDatesFrom(data), [data])
 
   const availableProgramYears = useMemo(
     () => getAvailableProgramYears(allCachedDates),

--- a/frontend/src/hooks/useProgramYearSummaries.ts
+++ b/frontend/src/hooks/useProgramYearSummaries.ts
@@ -18,6 +18,7 @@ import {
   buildProgramYearSummary,
   type ProgramYearSummary,
 } from '../utils/programYearSummary'
+import { snapshotDatesFrom, type SnapshotDate } from '../types/snapshotDate'
 
 export const programYearSummariesQueryKey = ['program-year-summaries'] as const
 
@@ -56,10 +57,10 @@ export function useProgramYearSummaries(): UseProgramYearSummariesResult {
   const query = useQuery({
     queryKey: programYearSummariesQueryKey,
     queryFn: async (): Promise<ProgramYearSummary[]> => {
-      const { dates } = await fetchCdnDates()
+      const dates = snapshotDatesFrom(await fetchCdnDates())
 
       // Group snapshot dates by program year, tracking each year's latest date.
-      const latestByYear = new Map<number, string>()
+      const latestByYear = new Map<number, SnapshotDate>()
       for (const d of dates) {
         const sy = startYearOf(d)
         const cur = latestByYear.get(sy)

--- a/frontend/src/hooks/useSnapshotDiff.ts
+++ b/frontend/src/hooks/useSnapshotDiff.ts
@@ -7,6 +7,7 @@ import type {
 } from '@taverns-red/shared-contracts'
 import { diffAreaDivisionStatus } from '../utils/diffAreaDivisionStatus'
 import { diffClubStatus } from '../utils/diffClubStatus'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 /**
  * Resolve the default "since the previous recorded date" pair from a district's
@@ -20,9 +21,9 @@ import { diffClubStatus } from '../utils/diffClubStatus'
  *
  * @see docs/design/what-changed-feature.md §5
  */
-export function previousRecordedDate(
-  dates: string[]
-): { from: string; to: string } | null {
+export function previousRecordedDate<T extends string>(
+  dates: readonly T[]
+): { from: T; to: T } | null {
   if (dates.length < 2) return null
   return {
     from: dates[dates.length - 2]!,
@@ -39,8 +40,8 @@ export function previousRecordedDate(
  */
 export function useSnapshotDiff(
   districtId: string | undefined,
-  from: string | undefined,
-  to: string | undefined
+  from: SnapshotDate | undefined,
+  to: SnapshotDate | undefined
 ) {
   return useQuery<SnapshotDiff, Error>({
     queryKey: ['snapshot-diff', districtId, from, to],

--- a/frontend/src/hooks/useUrlDatePair.ts
+++ b/frontend/src/hooks/useUrlDatePair.ts
@@ -23,11 +23,13 @@ import { previousRecordedDate } from './useSnapshotDiff'
  * @param dates Ascending list of the district's recorded snapshot dates.
  * @see docs/design/what-changed-feature.md §5, §4
  */
-export function useUrlDatePair(dates: string[]): {
-  from: string | undefined
-  to: string | undefined
-  setFrom: (date: string) => void
-  setTo: (date: string) => void
+export function useUrlDatePair<T extends string>(
+  dates: readonly T[]
+): {
+  from: T | undefined
+  to: T | undefined
+  setFrom: (date: T) => void
+  setTo: (date: T) => void
 } {
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -38,11 +40,11 @@ export function useUrlDatePair(dates: string[]): {
 
   // A URL value wins only if it's a date this district actually recorded;
   // otherwise fall back to the Phase-1 default for that side.
-  const from = urlFrom && dates.includes(urlFrom) ? urlFrom : defaultPair?.from
-  const to = urlTo && dates.includes(urlTo) ? urlTo : defaultPair?.to
+  const from = dates.find(d => d === urlFrom) ?? defaultPair?.from
+  const to = dates.find(d => d === urlTo) ?? defaultPair?.to
 
   const setParam = useCallback(
-    (key: 'from' | 'to', date: string, current: string | undefined) => {
+    (key: 'from' | 'to', date: T, current: T | undefined) => {
       if (date === current) return // no-op — don't churn history (Lesson 070)
       const isDefault = defaultPair
         ? date === (key === 'from' ? defaultPair.from : defaultPair.to)
@@ -61,11 +63,11 @@ export function useUrlDatePair(dates: string[]): {
   )
 
   const setFrom = useCallback(
-    (date: string) => setParam('from', date, from),
+    (date: T) => setParam('from', date, from),
     [setParam, from]
   )
   const setTo = useCallback(
-    (date: string) => setParam('to', date, to),
+    (date: T) => setParam('to', date, to),
     [setParam, to]
   )
 

--- a/frontend/src/hooks/useUrlProgramYear.ts
+++ b/frontend/src/hooks/useUrlProgramYear.ts
@@ -52,7 +52,7 @@ export function useUrlProgramYear() {
   // malformed value resolves to undefined and the caller falls back to the PY's
   // latest snapshot, rather than keying a fetch on garbage and rendering blank.
   const urlDate = searchParams.get('date')
-  const selectedDate = useMemo(() => toSnapshotDate(urlDate), [urlDate])
+  const selectedDate = toSnapshotDate(urlDate)
 
   // Sync program year to context when URL differs
   useEffect(() => {

--- a/frontend/src/hooks/useUrlProgramYear.ts
+++ b/frontend/src/hooks/useUrlProgramYear.ts
@@ -17,6 +17,7 @@ import { useProgramYear } from '../contexts/ProgramYearContext'
 import { getProgramYear } from '../utils/programYear'
 import type { ProgramYear } from '../utils/programYear'
 import { useDefaultProgramYear } from './useDefaultProgramYear'
+import { toSnapshotDate, type SnapshotDate } from '../types/snapshotDate'
 
 export function useUrlProgramYear() {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -46,9 +47,12 @@ export function useUrlProgramYear() {
     [effectivePyYear]
   )
 
-  // Read date from URL
+  // Read date from URL. `?date=` is untrusted input — a hand-edited or stale
+  // shared link can carry anything — so it is MINTED, not trusted (#1323). A
+  // malformed value resolves to undefined and the caller falls back to the PY's
+  // latest snapshot, rather than keying a fetch on garbage and rendering blank.
   const urlDate = searchParams.get('date')
-  const selectedDate = urlDate || undefined
+  const selectedDate = useMemo(() => toSnapshotDate(urlDate), [urlDate])
 
   // Sync program year to context when URL differs
   useEffect(() => {
@@ -89,7 +93,7 @@ export function useUrlProgramYear() {
   )
 
   const setSelectedDate = useCallback(
-    (date: string | undefined) => {
+    (date: SnapshotDate | undefined) => {
       setSearchParams(
         prev => {
           const next = new URLSearchParams(prev)

--- a/frontend/src/pages/DistrictActionListPage.tsx
+++ b/frontend/src/pages/DistrictActionListPage.tsx
@@ -165,7 +165,14 @@ const DistrictActionListPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    return mostRecent || effectiveProgramYear.endDate
+    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
+    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
+    // effectiveProgramYear is always an element of availableProgramYears =
+    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
+    // filterDatesByProgramYear keeps one of its dates (same July-boundary
+    // predicate), so mostRecent cannot be null here. The brand surfaced the
+    // dead branch (#1323).
+    return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 
   const hasValidDates =

--- a/frontend/src/pages/DistrictActionListPage.tsx
+++ b/frontend/src/pages/DistrictActionListPage.tsx
@@ -165,13 +165,9 @@ const DistrictActionListPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
-    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
-    // effectiveProgramYear is always an element of availableProgramYears =
-    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
-    // filterDatesByProgramYear keeps one of its dates (same July-boundary
-    // predicate), so mostRecent cannot be null here. The brand surfaced the
-    // dead branch (#1323).
+    // null is unreachable here — effectiveProgramYear comes from
+    // getAvailableProgramYears(allCachedDates). See getMostRecentDateInProgramYear
+    // for why, and why a `|| endDate` fallback must not come back (#1323).
     return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 

--- a/frontend/src/pages/DistrictAnalyticsPage.tsx
+++ b/frontend/src/pages/DistrictAnalyticsPage.tsx
@@ -93,7 +93,14 @@ const DistrictAnalyticsPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    return mostRecent || effectiveProgramYear.endDate
+    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
+    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
+    // effectiveProgramYear is always an element of availableProgramYears =
+    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
+    // filterDatesByProgramYear keeps one of its dates (same July-boundary
+    // predicate), so mostRecent cannot be null here. The brand surfaced the
+    // dead branch (#1323).
+    return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 
   const hasValidDates =

--- a/frontend/src/pages/DistrictAnalyticsPage.tsx
+++ b/frontend/src/pages/DistrictAnalyticsPage.tsx
@@ -93,13 +93,9 @@ const DistrictAnalyticsPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
-    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
-    // effectiveProgramYear is always an element of availableProgramYears =
-    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
-    // filterDatesByProgramYear keeps one of its dates (same July-boundary
-    // predicate), so mostRecent cannot be null here. The brand surfaced the
-    // dead branch (#1323).
+    // null is unreachable here — effectiveProgramYear comes from
+    // getAvailableProgramYears(allCachedDates). See getMostRecentDateInProgramYear
+    // for why, and why a `|| endDate` fallback must not come back (#1323).
     return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -205,13 +205,9 @@ const DistrictClubsPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
-    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
-    // effectiveProgramYear is always an element of availableProgramYears =
-    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
-    // filterDatesByProgramYear keeps one of its dates (same July-boundary
-    // predicate), so mostRecent cannot be null here. The brand surfaced the
-    // dead branch (#1323).
+    // null is unreachable here — effectiveProgramYear comes from
+    // getAvailableProgramYears(allCachedDates). See getMostRecentDateInProgramYear
+    // for why, and why a `|| endDate` fallback must not come back (#1323).
     return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 

--- a/frontend/src/pages/DistrictClubsPage.tsx
+++ b/frontend/src/pages/DistrictClubsPage.tsx
@@ -205,7 +205,14 @@ const DistrictClubsPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    return mostRecent || effectiveProgramYear.endDate
+    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
+    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
+    // effectiveProgramYear is always an element of availableProgramYears =
+    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
+    // filterDatesByProgramYear keeps one of its dates (same July-boundary
+    // predicate), so mostRecent cannot be null here. The brand surfaced the
+    // dead branch (#1323).
+    return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 
   const hasValidDates =

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -140,13 +140,9 @@ const DistrictDetailPageInner: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
-    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
-    // effectiveProgramYear is always an element of availableProgramYears =
-    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
-    // filterDatesByProgramYear keeps one of its dates (same July-boundary
-    // predicate), so mostRecent cannot be null here. The brand surfaced the
-    // dead branch (#1323).
+    // null is unreachable here — effectiveProgramYear comes from
+    // getAvailableProgramYears(allCachedDates). See getMostRecentDateInProgramYear
+    // for why, and why a `|| endDate` fallback must not come back (#1323).
     return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -140,7 +140,14 @@ const DistrictDetailPageInner: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    return mostRecent || effectiveProgramYear.endDate
+    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
+    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
+    // effectiveProgramYear is always an element of availableProgramYears =
+    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
+    // filterDatesByProgramYear keeps one of its dates (same July-boundary
+    // predicate), so mostRecent cannot be null here. The brand surfaced the
+    // dead branch (#1323).
+    return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 
   // Determine if we have valid dates for API calls

--- a/frontend/src/pages/DistrictDivisionsPage.tsx
+++ b/frontend/src/pages/DistrictDivisionsPage.tsx
@@ -89,7 +89,14 @@ const DistrictDivisionsPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    return mostRecent || effectiveProgramYear.endDate
+    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
+    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
+    // effectiveProgramYear is always an element of availableProgramYears =
+    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
+    // filterDatesByProgramYear keeps one of its dates (same July-boundary
+    // predicate), so mostRecent cannot be null here. The brand surfaced the
+    // dead branch (#1323).
+    return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 
   const hasValidDates =

--- a/frontend/src/pages/DistrictDivisionsPage.tsx
+++ b/frontend/src/pages/DistrictDivisionsPage.tsx
@@ -89,13 +89,9 @@ const DistrictDivisionsPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
-    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
-    // effectiveProgramYear is always an element of availableProgramYears =
-    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
-    // filterDatesByProgramYear keeps one of its dates (same July-boundary
-    // predicate), so mostRecent cannot be null here. The brand surfaced the
-    // dead branch (#1323).
+    // null is unreachable here — effectiveProgramYear comes from
+    // getAvailableProgramYears(allCachedDates). See getMostRecentDateInProgramYear
+    // for why, and why a `|| endDate` fallback must not come back (#1323).
     return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 

--- a/frontend/src/pages/DistrictGridPage.tsx
+++ b/frontend/src/pages/DistrictGridPage.tsx
@@ -176,13 +176,9 @@ const DistrictGridPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
-    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
-    // effectiveProgramYear is always an element of availableProgramYears =
-    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
-    // filterDatesByProgramYear keeps one of its dates (same July-boundary
-    // predicate), so mostRecent cannot be null here. The brand surfaced the
-    // dead branch (#1323).
+    // null is unreachable here — effectiveProgramYear comes from
+    // getAvailableProgramYears(allCachedDates). See getMostRecentDateInProgramYear
+    // for why, and why a `|| endDate` fallback must not come back (#1323).
     return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 

--- a/frontend/src/pages/DistrictGridPage.tsx
+++ b/frontend/src/pages/DistrictGridPage.tsx
@@ -176,7 +176,14 @@ const DistrictGridPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    return mostRecent || effectiveProgramYear.endDate
+    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
+    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
+    // effectiveProgramYear is always an element of availableProgramYears =
+    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
+    // filterDatesByProgramYear keeps one of its dates (same July-boundary
+    // predicate), so mostRecent cannot be null here. The brand surfaced the
+    // dead branch (#1323).
+    return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 
   const hasValidDates =

--- a/frontend/src/pages/DistrictRankingsPage.tsx
+++ b/frontend/src/pages/DistrictRankingsPage.tsx
@@ -84,7 +84,14 @@ const DistrictRankingsPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    return mostRecent || effectiveProgramYear.endDate
+    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
+    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
+    // effectiveProgramYear is always an element of availableProgramYears =
+    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
+    // filterDatesByProgramYear keeps one of its dates (same July-boundary
+    // predicate), so mostRecent cannot be null here. The brand surfaced the
+    // dead branch (#1323).
+    return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 
   const rawName = selectedDistrict?.name || districtId || ''

--- a/frontend/src/pages/DistrictRankingsPage.tsx
+++ b/frontend/src/pages/DistrictRankingsPage.tsx
@@ -84,13 +84,9 @@ const DistrictRankingsPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
-    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
-    // effectiveProgramYear is always an element of availableProgramYears =
-    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
-    // filterDatesByProgramYear keeps one of its dates (same July-boundary
-    // predicate), so mostRecent cannot be null here. The brand surfaced the
-    // dead branch (#1323).
+    // null is unreachable here — effectiveProgramYear comes from
+    // getAvailableProgramYears(allCachedDates). See getMostRecentDateInProgramYear
+    // for why, and why a `|| endDate` fallback must not come back (#1323).
     return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 

--- a/frontend/src/pages/DistrictTrendsPage.tsx
+++ b/frontend/src/pages/DistrictTrendsPage.tsx
@@ -104,13 +104,9 @@ const DistrictTrendsPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
-    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
-    // effectiveProgramYear is always an element of availableProgramYears =
-    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
-    // filterDatesByProgramYear keeps one of its dates (same July-boundary
-    // predicate), so mostRecent cannot be null here. The brand surfaced the
-    // dead branch (#1323).
+    // null is unreachable here — effectiveProgramYear comes from
+    // getAvailableProgramYears(allCachedDates). See getMostRecentDateInProgramYear
+    // for why, and why a `|| endDate` fallback must not come back (#1323).
     return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 

--- a/frontend/src/pages/DistrictTrendsPage.tsx
+++ b/frontend/src/pages/DistrictTrendsPage.tsx
@@ -104,7 +104,14 @@ const DistrictTrendsPage: React.FC = () => {
       allCachedDates,
       effectiveProgramYear
     )
-    return mostRecent || effectiveProgramYear.endDate
+    // No `|| effectiveProgramYear.endDate` fallback: that synthesized bound is a
+    // calendar edge, not a snapshot that exists — and it is unreachable anyway.
+    // effectiveProgramYear is always an element of availableProgramYears =
+    // getAvailableProgramYears(allCachedDates), which keeps a PY iff
+    // filterDatesByProgramYear keeps one of its dates (same July-boundary
+    // predicate), so mostRecent cannot be null here. The brand surfaced the
+    // dead branch (#1323).
+    return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
 
   const hasValidDates =

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -37,6 +37,7 @@ import { ProgramYearTitleSuffix } from '../components/ProgramYearTitleSuffix'
 import { DistrictRanking } from '../types/districts'
 import { arrayToCSV, downloadCSV } from '../utils/csvExport'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { snapshotDatesFrom } from '../types/snapshotDate'
 
 // On mobile (<768px) the rankings render only the top slice by default,
 // followed by a "Show all <n>" disclosure. The user landed on `/` to find
@@ -203,9 +204,13 @@ const DistrictsPage: React.FC = () => {
     },
   })
 
-  const allCachedDates: string[] = React.useMemo(
-    () => cachedDatesData?.dates || [],
-    [cachedDatesData?.dates]
+  // The union of every district's snapshot dates, drawn from the pipeline's own
+  // snapshot index — this page's mint for the brand (#1323). It hand-rolls the
+  // PY derivation that useProgramYearControls packages for the other aggregate
+  // pages, so it mints here rather than inheriting one.
+  const allCachedDates = React.useMemo(
+    () => snapshotDatesFrom(cachedDatesData),
+    [cachedDatesData]
   )
 
   // Get available program years from cached dates

--- a/frontend/src/pages/__tests__/DistrictsPage.tierChipDensity.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.tierChipDensity.test.tsx
@@ -24,10 +24,8 @@ vi.mock('../../services/cdn', () => ({
   fetchCdnSnapshotIndex: vi.fn().mockResolvedValue({}),
   fetchCdnRankings: vi.fn(),
   fetchCdnRankingsForDate: vi.fn(),
-  fetchCdnManifest: vi.fn().mockResolvedValue({
-    latestSnapshotDate: '2026-05-18',
-    generatedAt: '2026-05-18T00:00:00Z',
-  }),
+  // The "latest snapshot" seam is the branded mint helper now (#1323).
+  fetchLatestSnapshotDate: vi.fn().mockResolvedValue('2026-05-18'),
   fetchCdnCompetitiveAwards: vi.fn(),
   cdnAnalyticsUrl: vi.fn().mockReturnValue('https://cdn.taverns.red/test'),
   fetchFromCdn: vi.fn(),

--- a/frontend/src/pages/__tests__/RegionPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegionPage.test.tsx
@@ -24,9 +24,9 @@ vi.mock('../../services/cdn', () => ({
   fetchCdnRankings: vi.fn(),
   fetchCdnRankingsForDate: vi.fn(),
   fetchCdnCompetitiveAwards: vi.fn().mockResolvedValue(null),
-  fetchCdnManifest: vi
-    .fn()
-    .mockResolvedValue({ latestSnapshotDate: '2026-05-12', generatedAt: 'x' }),
+  // useCompetitiveAwards resolves "latest" through the branded mint helper
+  // rather than reading the raw manifest itself (#1323).
+  fetchLatestSnapshotDate: vi.fn().mockResolvedValue('2026-05-12'),
 }))
 
 const mockedFetchCdnRankings = vi.mocked(fetchCdnRankings)

--- a/frontend/src/services/cdn.ts
+++ b/frontend/src/services/cdn.ts
@@ -19,6 +19,11 @@ import {
   type DistrictReportsDataset,
 } from '@taverns-red/shared-contracts'
 
+import {
+  snapshotDateFromManifest,
+  type SnapshotDate,
+} from '../types/snapshotDate'
+
 import { recordCdnResponse } from './cdnCacheTracker'
 
 // CDN base URL — set via VITE_CDN_BASE_URL at build time (#316)
@@ -81,6 +86,29 @@ export async function fetchCdnManifest(): Promise<CdnManifest> {
 }
 
 /**
+ * Fetch the pipeline's newest snapshot date, branded (#1323).
+ *
+ * The blessed mint for every "just give me the latest" read. `CdnManifest`
+ * itself stays unbranded — it is a raw remote payload, and branding a field on
+ * arrival would be laundering — so this is where the manifest's claim gets
+ * validated exactly once instead of at each of its ~8 call sites.
+ *
+ * Throws if the manifest carries no usable date: a manifest we cannot trust is
+ * a pipeline failure, and fetching `snapshots/undefined/…` would only turn it
+ * into a confusing 404.
+ */
+export async function fetchLatestSnapshotDate(): Promise<SnapshotDate> {
+  const manifest = await fetchCdnManifest()
+  const latest = snapshotDateFromManifest(manifest)
+  if (!latest) {
+    throw new Error(
+      `CDN manifest has no valid latestSnapshotDate: ${JSON.stringify(manifest.latestSnapshotDate)}`
+    )
+  }
+  return latest
+}
+
+/**
  * Fetch all available snapshot dates from CDN.
  */
 export async function fetchCdnDates(): Promise<CdnDatesIndex> {
@@ -130,7 +158,7 @@ export interface CdnRankingsData {
    * by `fetchCdnRankingsForDate`; `undefined` on the `fetchCdnRankings()` latest
    * path and whenever the per-date file 404s and we fall back to latest.
    */
-  snapshotDate?: string
+  snapshotDate?: SnapshotDate
   generatedAt: string
 }
 
@@ -164,7 +192,7 @@ export async function fetchCdnRankings(): Promise<CdnRankingsData> {
  * Falls back to v1/rankings.json if the per-date file doesn't exist.
  */
 export async function fetchCdnRankingsForDate(
-  date: string
+  date: SnapshotDate
 ): Promise<CdnRankingsData> {
   const url = `${cdnBaseUrl()}/snapshots/${date}/all-districts-rankings.json`
   const res = await fetch(url)
@@ -355,7 +383,7 @@ export interface CompetitiveAwardStandings {
  * Returns null if the file does not exist (legacy snapshots).
  */
 export async function fetchCdnCompetitiveAwards(
-  date: string
+  date: SnapshotDate
 ): Promise<CompetitiveAwardStandings | null> {
   const url = `${cdnBaseUrl()}/snapshots/${date}/competitive-awards.json`
   const res = await fetch(url)
@@ -375,7 +403,7 @@ export async function fetchCdnCompetitiveAwards(
  * @returns Full CDN URL
  */
 export function cdnAnalyticsUrl(
-  date: string,
+  date: SnapshotDate,
   districtId: string,
   type: string
 ): string {
@@ -385,7 +413,7 @@ export function cdnAnalyticsUrl(
 /**
  * Construct a CDN URL for a district snapshot file.
  */
-export function cdnSnapshotUrl(date: string, districtId: string): string {
+export function cdnSnapshotUrl(date: SnapshotDate, districtId: string): string {
   return `${cdnBaseUrl()}/snapshots/${date}/district_${districtId}.json`
 }
 
@@ -416,7 +444,7 @@ export async function fetchFromCdn<T>(url: string): Promise<T> {
  * distinct and the read-time overlay (Sprint 4 #1069) never touches the base.
  */
 export function cdnDistrictReportsUrl(
-  date: string,
+  date: SnapshotDate,
   districtId: string
 ): string {
   return `${cdnBaseUrl()}/snapshots/${date}/district_${districtId}_reports.json`
@@ -430,7 +458,7 @@ export function cdnDistrictReportsUrl(
  * schema-validation failure, or network error; only a valid dataset resolves.
  */
 export async function fetchCdnDistrictReports(
-  date: string,
+  date: SnapshotDate,
   districtId: string
 ): Promise<DistrictReportsDataset | null> {
   try {
@@ -457,7 +485,7 @@ export function resetCdnManifestCache(): void {
  * Returns the full snapshot JSON (DistrictStatistics shape).
  */
 export async function fetchCdnDistrictSnapshot<T>(
-  date: string,
+  date: SnapshotDate,
   districtId: string
 ): Promise<T> {
   return fetchFromCdn<T>(cdnSnapshotUrl(date, districtId))
@@ -470,7 +498,7 @@ export async function fetchCdnDistrictSnapshot<T>(
  *   'leadership-insights', 'year-over-year', 'performance-targets', 'club-trends-index'
  */
 export async function fetchCdnDistrictAnalytics<T>(
-  date: string,
+  date: SnapshotDate,
   districtId: string,
   type: string
 ): Promise<T> {

--- a/frontend/src/types/__tests__/snapshotDate.brand.sentinel.test.ts
+++ b/frontend/src/types/__tests__/snapshotDate.brand.sentinel.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Type sentinel — proves the `SnapshotDate` brand actually REJECTS the #1315
+ * bug class at compile time (#1323, epic #1319).
+ *
+ * Why a compiler-API sentinel instead of the two obvious guards? Both are inert
+ * here, and inertness is invisible (Lesson 82 — assert behaviour, not
+ * declaration):
+ *
+ *   1. `@ts-expect-error` in a normal type-test file asserts NOTHING, because
+ *      `tsconfig.json` excludes `src/**\/__tests__/**\/*` and `src/**\/*.test.ts`
+ *      from the program — `npm run typecheck` never reads this directory.
+ *   2. A `*.test-d.ts` + `vitest --typecheck` file matches NEITHER vitest
+ *      project's include (the `unit` project inherits the default
+ *      `**\/*.{test,spec}.?(c|m)[jt]s?(x)`, which does not match `.test-d.ts`),
+ *      so it would silently run in no project at all — the R20/#482 partition
+ *      hazard.
+ *
+ * So instead we compile known-bad snippets through the project's REAL
+ * `tsconfig.json` and assert the specific diagnostic fires. This is the direct
+ * analogue of the ESLint sentinel in `src/__tests__/lint/set-state-in-effect.test.ts`,
+ * which lints a known-bad snippet at a virtual `src/__sentinel__/…` path — same
+ * virtual-path trick, same discipline.
+ *
+ * Every negative case is paired with a POSITIVE CONTROL (a minted date compiles
+ * clean). Without it a sentinel can false-pass on an unrelated compile error —
+ * "an error fired" is not the same claim as "the brand fired".
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest'
+import ts from 'typescript'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Resolve the frontend workspace root from this file's own location so the test
+// is cwd-independent (root `npm run test` launches from the repo root; the
+// workspace run launches from frontend/).
+const frontendDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..'
+)
+
+/** Virtual directory — these paths never exist on disk. Imports resolve
+ *  relative to them, so `../types/snapshotDate` hits the real module. */
+const SENTINEL_DIR = path.join(frontendDir, 'src/__sentinel__')
+
+const MINT = `import { toSnapshotDate } from '../types/snapshotDate'
+const minted = toSnapshotDate('2026-06-30')!
+`
+
+/**
+ * A minted snapshot date flows into every per-snapshot entry point cleanly.
+ * If this control ever goes red the negative cases below are meaningless —
+ * they would be "passing" on some unrelated compile error.
+ */
+const POSITIVE_CONTROL = `${MINT}
+import {
+  fetchCdnRankingsForDate,
+  fetchCdnCompetitiveAwards,
+  cdnAnalyticsUrl,
+  cdnSnapshotUrl,
+  cdnDistrictReportsUrl,
+  fetchCdnDistrictSnapshot,
+  fetchCdnDistrictAnalytics,
+} from '../services/cdn'
+
+export async function allSevenEntryPointsAcceptAMintedDate() {
+  await fetchCdnRankingsForDate(minted)
+  await fetchCdnCompetitiveAwards(minted)
+  cdnAnalyticsUrl(minted, '61', 'analytics')
+  cdnSnapshotUrl(minted, '61')
+  cdnDistrictReportsUrl(minted, '61')
+  await fetchCdnDistrictSnapshot<unknown>(minted, '61')
+  await fetchCdnDistrictAnalytics<unknown>(minted, '61', 'analytics')
+}
+`
+
+/**
+ * The #1315 bug verbatim: the rankings payload's as-of date (which advances
+ * past the pinned snapshot during month-end closing) keyed into a per-snapshot
+ * fetch. This is the single case the whole epic exists to make unrepresentable.
+ */
+const AS_OF_DATE_INTO_AWARDS_FETCH = `${MINT}
+import { fetchCdnRankingsForDate, fetchCdnCompetitiveAwards } from '../services/cdn'
+
+export async function theBugFromIssue1315() {
+  const data = await fetchCdnRankingsForDate(minted)
+  // data.asOfDate is metadata.sourceCsvDate — NOT the snapshot key.
+  await fetchCdnCompetitiveAwards(data.asOfDate)
+}
+`
+
+/** An unvalidated raw string — the shape every laundering path collapses to. */
+const RAW_STRING_INTO_AWARDS_FETCH = `import { fetchCdnCompetitiveAwards } from '../services/cdn'
+
+export async function rawStringIsNotASnapshotDate(date: string) {
+  await fetchCdnCompetitiveAwards(date)
+}
+`
+
+/** Even a correctly-shaped literal must not be trusted — it bypassed the mint. */
+const RAW_LITERAL_INTO_ANALYTICS_URL = `import { cdnAnalyticsUrl } from '../services/cdn'
+
+export function aWellShapedLiteralStillBypassesTheMint() {
+  return cdnAnalyticsUrl('2026-06-30', '61', 'analytics')
+}
+`
+
+/**
+ * A synthesized program-year boundary (`${year + 1}-06-30`) is a calendar
+ * bound, not a snapshot that exists — the F3 laundering shape.
+ */
+const PROGRAM_YEAR_END_DATE_INTO_FETCH = `import { getProgramYear } from '../utils/programYear'
+import { fetchCdnCompetitiveAwards } from '../services/cdn'
+
+export async function aSynthesizedPyBoundIsNotASnapshot() {
+  await fetchCdnCompetitiveAwards(getProgramYear(2025).endDate)
+}
+`
+
+/** Today's wall-clock date is never a snapshot date — the F1 laundering shape. */
+const WALL_CLOCK_INTO_FETCH = `import { fetchCdnCompetitiveAwards } from '../services/cdn'
+
+export async function todayIsNotASnapshot() {
+  await fetchCdnCompetitiveAwards(new Date().toISOString().split('T')[0]!)
+}
+`
+
+const SENTINELS: Record<string, string> = {
+  'positiveControl.ts': POSITIVE_CONTROL,
+  'asOfDateIntoAwardsFetch.ts': AS_OF_DATE_INTO_AWARDS_FETCH,
+  'rawStringIntoAwardsFetch.ts': RAW_STRING_INTO_AWARDS_FETCH,
+  'rawLiteralIntoAnalyticsUrl.ts': RAW_LITERAL_INTO_ANALYTICS_URL,
+  'programYearEndDateIntoFetch.ts': PROGRAM_YEAR_END_DATE_INTO_FETCH,
+  'wallClockIntoFetch.ts': WALL_CLOCK_INTO_FETCH,
+}
+
+/** TS2345: Argument of type 'X' is not assignable to parameter of type 'Y'. */
+const ARGUMENT_NOT_ASSIGNABLE = 2345
+
+const virtualPath = (name: string) => path.join(SENTINEL_DIR, name)
+
+let diagnosticsByFile: Map<string, readonly ts.Diagnostic[]>
+
+/**
+ * One program over every sentinel at once — the lib/node_modules type graph is
+ * loaded once rather than per-case, which is the whole cost here.
+ */
+function compileSentinels(): Map<string, readonly ts.Diagnostic[]> {
+  const configPath = path.join(frontendDir, 'tsconfig.json')
+  const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile)
+  if (error)
+    throw new Error(ts.flattenDiagnosticMessageText(error.messageText, '\n'))
+
+  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, frontendDir)
+  const options: ts.CompilerOptions = {
+    ...parsed.options,
+    noEmit: true,
+    skipLibCheck: true,
+    // The sentinels are deliberately un-referenced by the real program.
+    noUnusedLocals: false,
+    noUnusedParameters: false,
+  }
+
+  const sources = new Map(
+    Object.entries(SENTINELS).map(([name, source]) => [
+      virtualPath(name),
+      source,
+    ])
+  )
+  const isVirtual = (fileName: string) => sources.has(path.resolve(fileName))
+
+  const host = ts.createCompilerHost(options, true)
+  const realGetSourceFile = host.getSourceFile.bind(host)
+  const realFileExists = host.fileExists.bind(host)
+  const realReadFile = host.readFile.bind(host)
+
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
+    const source = sources.get(path.resolve(fileName))
+    return source === undefined
+      ? realGetSourceFile(fileName, languageVersion, onError, shouldCreate)
+      : ts.createSourceFile(
+          fileName,
+          source,
+          languageVersion,
+          true,
+          ts.ScriptKind.TS
+        )
+  }
+  host.fileExists = fileName => isVirtual(fileName) || realFileExists(fileName)
+  host.readFile = fileName =>
+    sources.get(path.resolve(fileName)) ?? realReadFile(fileName)
+
+  const program = ts.createProgram([...sources.keys()], options, host)
+
+  return new Map(
+    [...sources.keys()].map(filePath => {
+      const sourceFile = program.getSourceFile(filePath)
+      if (!sourceFile) throw new Error(`sentinel not in program: ${filePath}`)
+      return [
+        filePath,
+        [
+          ...program.getSyntacticDiagnostics(sourceFile),
+          ...program.getSemanticDiagnostics(sourceFile),
+        ],
+      ]
+    })
+  )
+}
+
+const diagnosticsFor = (name: string): readonly ts.Diagnostic[] => {
+  const found = diagnosticsByFile.get(virtualPath(name))
+  if (!found) throw new Error(`no diagnostics captured for ${name}`)
+  return found
+}
+
+const describeDiagnostics = (diagnostics: readonly ts.Diagnostic[]): string =>
+  diagnostics
+    .map(
+      d => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, ' ')}`
+    )
+    .join('\n') || '(none)'
+
+describe('SnapshotDate brand enforcement (#1323)', () => {
+  beforeAll(() => {
+    diagnosticsByFile = compileSentinels()
+  }, 120000)
+
+  it('POSITIVE CONTROL: a minted date is accepted by all seven entry points', () => {
+    const diagnostics = diagnosticsFor('positiveControl.ts')
+    expect(
+      describeDiagnostics(diagnostics),
+      'The control must compile clean, or every rejection below is meaningless'
+    ).toBe('(none)')
+  })
+
+  it.each([
+    [
+      'the #1315 bug — asOfDate keyed into a per-snapshot fetch',
+      'asOfDateIntoAwardsFetch.ts',
+    ],
+    ['an unvalidated raw string', 'rawStringIntoAwardsFetch.ts'],
+    [
+      'a well-shaped literal that bypassed the mint',
+      'rawLiteralIntoAnalyticsUrl.ts',
+    ],
+    ['a synthesized program-year end bound', 'programYearEndDateIntoFetch.ts'],
+    ["today's wall-clock date", 'wallClockIntoFetch.ts'],
+  ])('rejects %s', (_label, name) => {
+    const diagnostics = diagnosticsFor(name)
+    const brandErrors = diagnostics.filter(
+      d => d.code === ARGUMENT_NOT_ASSIGNABLE
+    )
+
+    expect(
+      brandErrors.length,
+      `expected a TS${ARGUMENT_NOT_ASSIGNABLE} brand rejection, got:\n${describeDiagnostics(diagnostics)}`
+    ).toBeGreaterThan(0)
+
+    // Assert it is the BRAND rejecting it, not some incidental mismatch.
+    expect(
+      brandErrors
+        .map(d => ts.flattenDiagnosticMessageText(d.messageText, ' '))
+        .join('\n')
+    ).toContain('SnapshotDate')
+  })
+})

--- a/frontend/src/types/__tests__/snapshotDate.brand.sentinel.test.ts
+++ b/frontend/src/types/__tests__/snapshotDate.brand.sentinel.test.ts
@@ -167,12 +167,10 @@ function compileSentinels(): Map<string, readonly ts.Diagnostic[]> {
       source,
     ])
   )
-  const isVirtual = (fileName: string) => sources.has(path.resolve(fileName))
-
+  // Only getSourceFile needs overriding: the sentinels are program rootNames and
+  // never import each other, so the host is never asked to resolve or stat them.
   const host = ts.createCompilerHost(options, true)
   const realGetSourceFile = host.getSourceFile.bind(host)
-  const realFileExists = host.fileExists.bind(host)
-  const realReadFile = host.readFile.bind(host)
 
   host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
     const source = sources.get(path.resolve(fileName))
@@ -186,9 +184,6 @@ function compileSentinels(): Map<string, readonly ts.Diagnostic[]> {
           ts.ScriptKind.TS
         )
   }
-  host.fileExists = fileName => isVirtual(fileName) || realFileExists(fileName)
-  host.readFile = fileName =>
-    sources.get(path.resolve(fileName)) ?? realReadFile(fileName)
 
   const program = ts.createProgram([...sources.keys()], options, host)
 

--- a/frontend/src/types/__tests__/snapshotDate.test.ts
+++ b/frontend/src/types/__tests__/snapshotDate.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Runtime behaviour of the SnapshotDate mint points (#1323, epic #1319).
+ *
+ * The brand is a compile-time nominal type, but its mints are the runtime
+ * boundary where an unvalidated string becomes a trusted snapshot key. A brand
+ * minted from an unvalidated source is laundering, not validation (L166 —
+ * check value-honesty, not just shape), so these assert what each mint REJECTS
+ * at least as hard as what it accepts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  toSnapshotDate,
+  snapshotDatesFrom,
+  snapshotDateFromManifest,
+} from '../snapshotDate'
+
+describe('toSnapshotDate — the validating mint for URL/API-sourced dates', () => {
+  it('mints a well-formed ISO date, preserving the value', () => {
+    expect(toSnapshotDate('2026-06-30')).toBe('2026-06-30')
+  })
+
+  it.each([
+    ['a zero-padding-free month', '2026-6-30'],
+    ['a zero-padding-free day', '2026-06-3'],
+    ['a full ISO timestamp', '2026-06-30T00:00:00Z'],
+    ['a slash-separated date', '2026/06/30'],
+    ['free text', 'garbage'],
+    ['an empty string', ''],
+    ['whitespace padding', ' 2026-06-30 '],
+  ])('rejects %s', (_label, raw) => {
+    expect(toSnapshotDate(raw)).toBeUndefined()
+  })
+
+  it.each([
+    ['a 13th month', '2026-13-01'],
+    ['a zero month', '2026-00-10'],
+    ['a 32nd day', '2026-06-32'],
+    ['a zero day', '2026-06-00'],
+    ['a non-leap Feb 29', '2026-02-29'],
+  ])('rejects %s — shape alone is not a real date', (_label, raw) => {
+    expect(toSnapshotDate(raw)).toBeUndefined()
+  })
+
+  it('accepts a real leap day', () => {
+    expect(toSnapshotDate('2024-02-29')).toBe('2024-02-29')
+  })
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+  ])('rejects %s without throwing', (_label, raw) => {
+    expect(toSnapshotDate(raw)).toBeUndefined()
+  })
+})
+
+describe('snapshotDatesFrom — the mint for the CDN dates index', () => {
+  it('mints every well-formed date in the index', () => {
+    expect(snapshotDatesFrom({ dates: ['2026-06-30', '2026-05-31'] })).toEqual([
+      '2026-06-30',
+      '2026-05-31',
+    ])
+  })
+
+  it('drops malformed entries rather than trusting the index wholesale', () => {
+    expect(
+      snapshotDatesFrom({ dates: ['2026-06-30', 'not-a-date', '2026-13-01'] })
+    ).toEqual(['2026-06-30'])
+  })
+
+  it('preserves index order (callers sort for themselves)', () => {
+    expect(snapshotDatesFrom({ dates: ['2026-01-31', '2026-06-30'] })).toEqual([
+      '2026-01-31',
+      '2026-06-30',
+    ])
+  })
+
+  it.each([
+    ['an undefined index (query in flight)', undefined],
+    ['an index with no dates', { dates: [] }],
+  ])('returns an empty array for %s', (_label, index) => {
+    expect(snapshotDatesFrom(index)).toEqual([])
+  })
+
+  it('returns a stable empty array so it is safe as a hook dep', () => {
+    expect(snapshotDatesFrom(undefined)).toBe(snapshotDatesFrom(undefined))
+  })
+})
+
+describe('snapshotDateFromManifest — the mint for v1/latest.json', () => {
+  it('mints a well-formed latestSnapshotDate', () => {
+    expect(snapshotDateFromManifest({ latestSnapshotDate: '2026-06-30' })).toBe(
+      '2026-06-30'
+    )
+  })
+
+  it('rejects a malformed latestSnapshotDate', () => {
+    expect(
+      snapshotDateFromManifest({ latestSnapshotDate: 'unknown' })
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for an undefined manifest (query in flight)', () => {
+    expect(snapshotDateFromManifest(undefined)).toBeUndefined()
+  })
+})

--- a/frontend/src/types/__tests__/snapshotDate.test.ts
+++ b/frontend/src/types/__tests__/snapshotDate.test.ts
@@ -81,10 +81,6 @@ describe('snapshotDatesFrom — the mint for the CDN dates index', () => {
   ])('returns an empty array for %s', (_label, index) => {
     expect(snapshotDatesFrom(index)).toEqual([])
   })
-
-  it('returns a stable empty array so it is safe as a hook dep', () => {
-    expect(snapshotDatesFrom(undefined)).toBe(snapshotDatesFrom(undefined))
-  })
 })
 
 describe('snapshotDateFromManifest — the mint for v1/latest.json', () => {

--- a/frontend/src/types/snapshotDate.ts
+++ b/frontend/src/types/snapshotDate.ts
@@ -57,40 +57,20 @@ interface ManifestLike {
   latestSnapshotDate: string
 }
 
-const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/
-
-/**
- * Frozen so callers can use it as a stable hook dependency without a `useMemo`
- * (an array literal would be a fresh reference every render).
- */
-const NO_DATES: readonly SnapshotDate[] = Object.freeze([])
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
 
 /**
  * True when `raw` is a well-formed, real calendar date in `YYYY-MM-DD`.
  *
  * Shape alone is not enough: `2026-13-01` and `2026-02-29` match the regex but
- * name no day, so the round-trip through `Date` rejects the overflow that
- * `Date.UTC` would otherwise silently roll forward into March.
+ * name no day. `Date` silently rolls those forward (Feb 29 → Mar 1), so the
+ * round-trip back through `toISOString` is what actually rejects them — if the
+ * date were real it would serialize to the same string it parsed from.
  */
 function isIsoCalendarDate(raw: string): boolean {
-  const match = ISO_DATE.exec(raw)
-  if (!match) return false
-
-  const [, year, month, day] = match as unknown as [
-    string,
-    string,
-    string,
-    string,
-  ]
-  const asDate = new Date(`${year}-${month}-${day}T00:00:00Z`)
-  if (Number.isNaN(asDate.getTime())) return false
-
-  // Reject rolled-over overflows (2026-02-29 → 2026-03-01).
-  return (
-    asDate.getUTCFullYear() === Number(year) &&
-    asDate.getUTCMonth() + 1 === Number(month) &&
-    asDate.getUTCDate() === Number(day)
-  )
+  if (!ISO_DATE.test(raw)) return false
+  const parsed = new Date(`${raw}T00:00:00Z`)
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(raw)
 }
 
 /**
@@ -129,10 +109,7 @@ export function toSnapshotDate(
 export function snapshotDatesFrom(
   index: DatesIndexLike | null | undefined
 ): SnapshotDate[] {
-  if (!index?.dates?.length) return NO_DATES as SnapshotDate[]
-
-  const minted = index.dates.filter(isIsoCalendarDate) as SnapshotDate[]
-  return minted.length > 0 ? minted : (NO_DATES as SnapshotDate[])
+  return (index?.dates ?? []).filter(isIsoCalendarDate) as SnapshotDate[]
 }
 
 /**

--- a/frontend/src/types/snapshotDate.ts
+++ b/frontend/src/types/snapshotDate.ts
@@ -1,0 +1,149 @@
+/**
+ * `SnapshotDate` — a nominal brand for the PINNED snapshot date (#1323, epic
+ * #1319).
+ *
+ * ## Why this exists
+ *
+ * Toastmasters' month-end reconciliation pins a snapshot to the month-end
+ * (`2026-06-30`) while the dashboard **as-of** date keeps advancing
+ * (`sourceCsvDate = 2026-07-05`). The two are equal ~340 days a year and
+ * diverge for ~1–3 weeks each close. Per-snapshot CDN files live under the
+ * *pinned* date, so keying a fetch on the *as-of* date 404s → null → blank UI,
+ * with no error. It passes every test and every mid-month check.
+ *
+ * That bug shipped four times (#1289, #1292, #1296, #1315) because one field
+ * name — `date` — carried two divergent meanings and nothing distinguished
+ * them. Sprints 1–3 of epic #1319 renamed the field (`asOfDate` vs
+ * `snapshotDate`) and made the divergence the default in test fixtures. Those
+ * catch the mistake. This makes it **unrepresentable**: a `string` no longer
+ * satisfies a `snapshots/{date}/…` entry point, so recurrence #5 cannot compile.
+ *
+ * ## The contract
+ *
+ * A value is a `SnapshotDate` only if it came from a source that actually
+ * enumerates snapshots — the CDN dates index, the manifest, or a date validated
+ * against them. The brand is a *provenance* claim, not a format claim, so the
+ * mints below are the ONLY way to make one. `as SnapshotDate` re-admits the
+ * whole bug class in five characters and is banned by ESLint outside this
+ * module (`no-restricted-syntax`, guarded by
+ * `src/__tests__/lint/no-snapshot-date-cast.test.ts`).
+ *
+ * ## What is deliberately NOT a SnapshotDate
+ *
+ * - `asOfDate` / `metadata.sourceCsvDate` — the advancing as-of date. Display
+ *   and provenance only. This is the #1315 bug.
+ * - `ProgramYear.startDate` / `.endDate` — synthesized calendar bounds
+ *   (`${year + 1}-06-30`), not dates any snapshot was written under.
+ * - `new Date()` / `todayIso()` — the wall clock never names a snapshot.
+ *
+ * @see tasks/lessons/lessons/key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate.md
+ */
+
+/**
+ * A date string known to name a real, pinned CDN snapshot.
+ *
+ * Assignable TO `string` (so display/formatting helpers need no change) but not
+ * FROM one — that asymmetry is the entire guard.
+ */
+export type SnapshotDate = string & { readonly __brand: 'SnapshotDate' }
+
+/** Shape of the CDN dates index (`v1/dates.json`) this module mints from. */
+interface DatesIndexLike {
+  dates: string[]
+}
+
+/** Shape of the CDN manifest (`v1/latest.json`) this module mints from. */
+interface ManifestLike {
+  latestSnapshotDate: string
+}
+
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/
+
+/**
+ * Frozen so callers can use it as a stable hook dependency without a `useMemo`
+ * (an array literal would be a fresh reference every render).
+ */
+const NO_DATES: readonly SnapshotDate[] = Object.freeze([])
+
+/**
+ * True when `raw` is a well-formed, real calendar date in `YYYY-MM-DD`.
+ *
+ * Shape alone is not enough: `2026-13-01` and `2026-02-29` match the regex but
+ * name no day, so the round-trip through `Date` rejects the overflow that
+ * `Date.UTC` would otherwise silently roll forward into March.
+ */
+function isIsoCalendarDate(raw: string): boolean {
+  const match = ISO_DATE.exec(raw)
+  if (!match) return false
+
+  const [, year, month, day] = match as unknown as [
+    string,
+    string,
+    string,
+    string,
+  ]
+  const asDate = new Date(`${year}-${month}-${day}T00:00:00Z`)
+  if (Number.isNaN(asDate.getTime())) return false
+
+  // Reject rolled-over overflows (2026-02-29 → 2026-03-01).
+  return (
+    asDate.getUTCFullYear() === Number(year) &&
+    asDate.getUTCMonth() + 1 === Number(month) &&
+    asDate.getUTCDate() === Number(day)
+  )
+}
+
+/**
+ * Mint a `SnapshotDate` from an untrusted string — a URL `?date=` / `?from=` /
+ * `?to=` value, or a public API parameter.
+ *
+ * This validates FORMAT, which is weaker than the brand's provenance promise:
+ * it cannot know whether a snapshot was actually written under this date. It is
+ * the right mint only where the value is a user-supplied *selection* from dates
+ * the app already offered (the picker's options come from the index) and where
+ * a wrong date degrades to a 404-and-fallback rather than silently wrong data.
+ * Prefer {@link snapshotDatesFrom} whenever the index is at hand — narrowing an
+ * element of the real list carries the provenance this cannot.
+ *
+ * @returns the branded date, or `undefined` if `raw` is absent or not a real
+ *   `YYYY-MM-DD` calendar date.
+ */
+export function toSnapshotDate(
+  raw: string | null | undefined
+): SnapshotDate | undefined {
+  if (!raw) return undefined
+  return isIsoCalendarDate(raw) ? (raw as SnapshotDate) : undefined
+}
+
+/**
+ * Mint every snapshot date in a CDN dates index — the primary mint. These dates
+ * come from the pipeline's own enumeration of what it wrote, which is exactly
+ * the provenance the brand claims.
+ *
+ * Malformed entries are dropped rather than trusted wholesale: an index is a
+ * remote JSON payload, and a brand minted from an unvalidated source is
+ * laundering, not validation.
+ *
+ * Order is preserved — callers sort for themselves.
+ */
+export function snapshotDatesFrom(
+  index: DatesIndexLike | null | undefined
+): SnapshotDate[] {
+  if (!index?.dates?.length) return NO_DATES as SnapshotDate[]
+
+  const minted = index.dates.filter(isIsoCalendarDate) as SnapshotDate[]
+  return minted.length > 0 ? minted : (NO_DATES as SnapshotDate[])
+}
+
+/**
+ * Mint the latest snapshot date from the CDN manifest (`v1/latest.json`) — the
+ * pipeline's own statement of the newest snapshot it wrote.
+ *
+ * @returns `undefined` while the manifest query is in flight, or if the
+ *   manifest's date is malformed.
+ */
+export function snapshotDateFromManifest(
+  manifest: ManifestLike | null | undefined
+): SnapshotDate | undefined {
+  return toSnapshotDate(manifest?.latestSnapshotDate)
+}

--- a/frontend/src/utils/csvExport.ts
+++ b/frontend/src/utils/csvExport.ts
@@ -6,6 +6,7 @@ import type { SnapshotDiff } from '@taverns-red/shared-contracts'
 import { distinguishedTierName } from './distinguishedTier'
 import { toClubHistoryCsvRows, type ClubHistoryRow } from './clubHistory'
 import { logger } from './logger'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 /**
  * Converts a 2D array to CSV string
@@ -500,15 +501,15 @@ export const exportHistoricalRankData = (
  */
 export const exportDistrictAnalytics = async (
   districtId: string,
-  startDate?: string,
-  _endDate?: string
+  startDate?: SnapshotDate,
+  _endDate?: SnapshotDate
 ): Promise<void> => {
   try {
     // Dynamically import CDN services to avoid circular dependencies
-    const { fetchCdnManifest, fetchCdnDistrictSnapshot } =
+    const { fetchLatestSnapshotDate, fetchCdnDistrictSnapshot } =
       await import('../services/cdn')
 
-    const date = startDate || (await fetchCdnManifest()).latestSnapshotDate
+    const date = startDate || (await fetchLatestSnapshotDate())
 
     const snapshot = await fetchCdnDistrictSnapshot<{
       districtId: string

--- a/frontend/src/utils/programYear.ts
+++ b/frontend/src/utils/programYear.ts
@@ -131,12 +131,24 @@ export function isDateInProgramYear(
  * (useProgramYearControls) and `effectiveEndDate` (useDistrictProgramYearControls),
  * which is how the brand reaches the per-snapshot fetches (#1323).
  *
- * ## The null case is unreachable when `programYear` came from these `dates`
+ * ## The null case is unreachable for STRICT-ISO dates from `getAvailableProgramYears`
  *
- * Callers that pass a PY drawn from `getAvailableProgramYears(dates)` can never
- * see `null` back: that derivation admits a PY iff `filterDatesByProgramYear`
- * keeps one of its dates — both use the identical `month >= 7 ? year : year - 1`
- * July-boundary rule. Such callers must NOT add a `|| programYear.endDate`
+ * Callers that pass a PY drawn from `getAvailableProgramYears(dates)` cannot see
+ * `null` back — *provided every element of `dates` is a strict `YYYY-MM-DD`*.
+ * That proviso is load-bearing, and it is NOT free: the two predicates are not
+ * the same code. `getAvailableProgramYears` derives the PY via `calendarParts`,
+ * whose regex is unanchored at the end; `filterDatesByProgramYear` compares
+ * lexicographically against the PY bounds. They agree on strict ISO and diverge
+ * off it — `'2026-06-30T00:00:00Z'` derives PY 2025 but sorts ABOVE the
+ * `'2026-06-30'` bound, so it would be admitted as a year yet filtered out of
+ * it, and this function would return `null` after all.
+ *
+ * What actually guarantees the proviso is the mint: `snapshotDatesFrom`
+ * (`types/snapshotDate.ts`) drops every entry that is not a real strict-ISO
+ * calendar date, so a branded `SnapshotDate[]` cannot contain the divergent
+ * shapes. **If that filter is ever loosened, re-check every caller here.**
+ *
+ * Such callers must NOT "fix" the null case with a `|| programYear.endDate`
  * fallback: `endDate` is a synthesized `${year + 1}-06-30` calendar bound, not a
  * date any snapshot was written under, so feeding it to a `snapshots/{date}/…`
  * fetch is the #1315 laundering bug wearing a plausible disguise. The

--- a/frontend/src/utils/programYear.ts
+++ b/frontend/src/utils/programYear.ts
@@ -65,7 +65,9 @@ export function getProgramYear(year: number): ProgramYear {
 /**
  * Get all available program years from a list of dates
  */
-export function getAvailableProgramYears(dates: string[]): ProgramYear[] {
+export function getAvailableProgramYears(
+  dates: readonly string[]
+): ProgramYear[] {
   if (dates.length === 0) return []
 
   const programYears = new Set<number>()
@@ -85,12 +87,16 @@ export function getAvailableProgramYears(dates: string[]): ProgramYear[] {
 }
 
 /**
- * Filter dates to only include those within a specific program year
+ * Filter dates to only include those within a specific program year.
+ *
+ * Generic in the date type so a branded `SnapshotDate[]` survives the filter —
+ * this is a narrowing of the caller's own list, so every element it returns
+ * already carries whatever provenance went in (#1323).
  */
-export function filterDatesByProgramYear(
-  dates: string[],
+export function filterDatesByProgramYear<T extends string>(
+  dates: readonly T[],
   programYear: ProgramYear
-): string[] {
+): T[] {
   return dates.filter(dateStr => {
     return dateStr >= programYear.startDate && dateStr <= programYear.endDate
   })
@@ -117,12 +123,18 @@ export function isDateInProgramYear(
 }
 
 /**
- * Get the most recent date within a program year from a list of dates
+ * Get the most recent date within a program year from a list of dates.
+ *
+ * Generic for the same reason as `filterDatesByProgramYear`: it returns an
+ * ELEMENT of `dates`, so a branded `SnapshotDate[]` yields a `SnapshotDate`.
+ * This is the hot path — it is the direct source of both `effectiveDate`
+ * (useProgramYearControls) and `effectiveEndDate` (useDistrictProgramYearControls),
+ * which is how the brand reaches the per-snapshot fetches (#1323).
  */
-export function getMostRecentDateInProgramYear(
-  dates: string[],
+export function getMostRecentDateInProgramYear<T extends string>(
+  dates: readonly T[],
   programYear: ProgramYear
-): string | null {
+): T | null {
   const filteredDates = filterDatesByProgramYear(dates, programYear)
   if (filteredDates.length === 0) return null
 

--- a/frontend/src/utils/programYear.ts
+++ b/frontend/src/utils/programYear.ts
@@ -130,6 +130,17 @@ export function isDateInProgramYear(
  * This is the hot path — it is the direct source of both `effectiveDate`
  * (useProgramYearControls) and `effectiveEndDate` (useDistrictProgramYearControls),
  * which is how the brand reaches the per-snapshot fetches (#1323).
+ *
+ * ## The null case is unreachable when `programYear` came from these `dates`
+ *
+ * Callers that pass a PY drawn from `getAvailableProgramYears(dates)` can never
+ * see `null` back: that derivation admits a PY iff `filterDatesByProgramYear`
+ * keeps one of its dates — both use the identical `month >= 7 ? year : year - 1`
+ * July-boundary rule. Such callers must NOT add a `|| programYear.endDate`
+ * fallback: `endDate` is a synthesized `${year + 1}-06-30` calendar bound, not a
+ * date any snapshot was written under, so feeding it to a `snapshots/{date}/…`
+ * fetch is the #1315 laundering bug wearing a plausible disguise. The
+ * `SnapshotDate` brand is what made those eight dead fallbacks visible (#1323).
  */
 export function getMostRecentDateInProgramYear<T extends string>(
   dates: readonly T[],

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,6 +2,7 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `a-nominal-brand-is-only-as-honest-as-the-mint-and-the-cast-ban-behind-it.md` — A nominal brand's guarantee lives in its mints and its cast-ban selector, not the type — and both fail silently, so pin every laundering variant with a behaviour sentinel and name the premise the proof actually rests on  (2026-07-15)
 - `a-phantom-field-is-a-live-default-every-read-of-it-silently-becomes-the-fallback.md` — A phantom field (typed but never on the wire) doesn't fail — it silently becomes its fallback, so the default is the real code path; grep the primitive, and a `?? today` default hides it forever  (2026-07-15)
 - `divergence-by-default-fixtures-are-inert-unless-the-mock-routes-on-the-same-key-the-wire-does.md` — Divergence-by-default fixtures are inert unless the mock ROUTES on the same key the wire does — a date-blind router serves the right fixture for the wrong key and rubber-stamps the bug the fixture was written to expose  (2026-07-15)
 - `key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate.md` — During month-end closing the CSV as-of date (sourceCsvDate / data.date) drifts past the pinned snapshot date — key every per-snapshot fetch and date-scoped lookup on the snapshot date, never data.date  (2026-07-06)

--- a/tasks/lessons/lessons/a-nominal-brand-is-only-as-honest-as-the-mint-and-the-cast-ban-behind-it.md
+++ b/tasks/lessons/lessons/a-nominal-brand-is-only-as-honest-as-the-mint-and-the-cast-ban-behind-it.md
@@ -1,0 +1,118 @@
+---
+date: 2026-07-15
+tier: principle
+summary: A nominal brand's guarantee lives in its mints and its cast-ban selector, not the type — and both fail silently, so pin every laundering variant with a behaviour sentinel and name the premise the proof actually rests on
+tags:
+  [
+    types,
+    frontend,
+    tdd,
+    lint,
+    guard,
+    snapshot-date,
+    source-csv-date,
+    regression-class,
+    eslint,
+  ]
+---
+
+# Principle — A nominal brand is only as honest as its mint and its cast-ban
+
+**Issue:** #1323 (epic #1319, Sprint 4 — the snapshot-date guard).
+**PR:** [#1330](https://github.com/taverns-red/toast-stats/pull/1330)
+
+## Context
+
+Epic #1319 closed a bug that shipped **four times** (#1289/#1292/#1296/#1315):
+during month-end closing the as-of `sourceCsvDate` advances past the pinned
+snapshot date, so keying a `snapshots/{date}/…` fetch on `data.date` 404s → blank
+UI. Sprints 1–3 renamed the field and made divergence the fixture default —
+those *catch* the mistake. Sprint 4 made it **unrepresentable**:
+`SnapshotDate = string & { __brand }`, required at all seven CDN entry points.
+
+It worked: the compiler enumerated 21 laundering sites, and three of them were
+real defects the types had been hiding (a wall-clock `?? new Date()` feeding a
+URL that cannot exist; a synthesized `${year+1}-06-30` PY bound; an unvalidated
+public export param). Zero casts were needed to thread it.
+
+But **both halves of the guard shipped subtly false**, and fresh-context review —
+not the compiler, not 3,684 green tests — is what caught them.
+
+## The trap
+
+**1. The cast ban had holes exactly where they mattered.** The obvious selector
+
+```js
+'TSAsExpression > TSTypeReference > Identifier[name="SnapshotDate"]'
+```
+
+only matches when the type reference is a **direct child** of the cast. So
+`as SnapshotDate` was caught while `as SnapshotDate[]`,
+`as SnapshotDate | undefined`, and `as Array<SnapshotDate>` sailed through — a
+`TSArrayType` / `TSUnionType` / `TSTypeReference` intervenes. The array form is
+the shape the *mint module itself* uses, i.e. the likeliest to be copy-pasted
+out of it, and it launders a whole index in one cast. The sentinel was green
+because it only tested the two variants that already passed — **Lesson 82's
+failure mode, one level up**: I asserted behaviour, but only the behaviour I'd
+already assumed worked. An AST selector is an unchecked string; nothing
+typechecks it against the ESTree shape.
+
+**2. The proof of a deletion named the wrong premise.** The brand exposed a
+`getMostRecentDateInProgramYear(dates, py) || py.endDate` fallback duplicated
+across 8 pages + 1 hook. I deleted all nine, documenting them as provably dead
+because `getAvailableProgramYears` and `filterDatesByProgramYear` "use the
+identical July-boundary predicate." **They don't.** The former derives the PY via
+`calendarParts`, whose regex is *unanchored at the end*; the latter compares
+lexicographically against the PY bounds. `2026-06-30T00:00:00Z` derives PY 2025
+but sorts **above** the `'2026-06-30'` bound — admitted as a year, filtered out
+of it, `null` after all.
+
+The fallbacks were still dead — but because `snapshotDatesFrom` filters to strict
+ISO first. **The mint was the load-bearing premise, and my comment credited
+something else.** A maintainer trusting that comment could loosen the mint's
+filter and silently resurrect the bug the epic exists to kill.
+
+## The rule
+
+- **A brand's guarantee lives in its mints and its cast-ban, not in the type.**
+  The nominal type is just the enforcement surface. Ask "what can still produce
+  one?" — the mints (do they *validate*, or merely assert?) and the cast ban (does
+  its selector cover the variants?). `toSnapshotDate(data.asOfDate)` still mints
+  the original bug through the front door: format is checkable, provenance isn't.
+  **Say that in the module** (L166) instead of implying the brand is a proof.
+- **Pin every laundering VARIANT, not just the canonical one.** For a cast ban
+  that means the array, union, generic, and `as unknown as` forms — write them
+  as failing tests first and watch them fail. A guard tested only on the shape
+  you had in mind is a guard tested on nothing.
+- **When you delete code as "provably dead," name the premise the proof actually
+  rests on — and verify it against the code, not against the two functions'
+  names.** Two predicates that agree on your data are not the same predicate. If
+  the real premise is an upstream filter, say so and say what breaks if it's
+  loosened; that sentence is the whole value of the comment.
+- **Corollary — prefer narrowing to minting.** Every branded value in this sprint
+  reached its fetch by narrowing an element of a list the pipeline enumerated
+  (`dates.find(d => d === urlValue)`, `getMostRecentDateInProgramYear`, generic
+  `<T extends string>` helpers). Narrowing carries provenance a format check
+  cannot. That's why the diff needed zero casts — and a brand that needs casts to
+  thread is telling you the mints are in the wrong place.
+
+## Also worth keeping
+
+- **The two obvious type-test mechanisms were inert here.** `@ts-expect-error` in
+  a test asserts nothing (`tsconfig.json` excludes `__tests__` from the program),
+  and `*.test-d.ts` matches neither vitest project's include (the R20/#482
+  partition hazard). What works: compile known-bad snippets through the real
+  `tsconfig` via the **TS compiler API** at a virtual `src/__sentinel__/…` path —
+  the direct analogue of the repo's ESLint `lintText` sentinel. Fast (~1.5s), no
+  CI wiring, no new project. Give it a **positive control** (a minted date
+  compiles clean) or it can false-pass on an unrelated compile error.
+- **Don't smuggle behaviour into a type change.** I reflexively "modernised"
+  `selectedDate || (await latest())` to `??` in six hooks; a test caught that it
+  changes empty-string handling. Reverted — the brand makes `''` unrepresentable
+  from typed callers anyway, so `??` bought nothing and risked something.
+
+Related: [[key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate]]
+(the bug class this closes), [[a-lint-rule-can-be-present-but-inert-assert-behavior-not-severity]]
+(L82 — whose lesson I re-learned one level up), and
+[[a-structural-injection-guard-must-check-value-honesty-not-just-key-presence]]
+(L166 — document the guard's blind spots rather than overclaiming).

--- a/tasks/sprint-1323-plan.md
+++ b/tasks/sprint-1323-plan.md
@@ -1,0 +1,133 @@
+# Sprint 4 (#1323) — Branded `SnapshotDate` at the service layer
+
+Epic #1319. Predecessor #1322 (Sprint 3) shipped divergence-by-default fixtures.
+Sprint 1 already killed the ambiguous `date` field on the rankings fetch
+(`asOfDate` + `snapshotDate?` now exist separately), so the brand lands on a
+service layer that already names the two dates apart.
+
+## Hypothesis
+
+If `SnapshotDate` is nominal and minted **only** from validated snapshot
+sources, then every current path that launders an _as-of_ / _synthesized_ /
+_wall-clock_ date into a `snapshots/{date}/…` fetch stops compiling. The
+compiler — not a reviewer, not a test — becomes the guard. Recurrence #5 of the
+#1289/#1292/#1296/#1315 class becomes unrepresentable.
+
+## Blast-radius survey (Explore agent, full map in session)
+
+**Good news:** all five `snapshots/{date}/…` URL builders already live in
+`services/cdn.ts`. The URL surface is fully centralized — nothing to corral.
+
+Three mint sources feed the 7 entry points through exactly two hub shapes:
+`effectiveDate` / `effectiveEndDate` (PY-control hooks) and `latestSnapshotDate`
+(manifest, resolved inline in ~10 fetch hooks).
+
+### Mints (the only places the brand is created)
+
+| Mint                          | Source                                                                                          | Validates                  |
+| ----------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------- |
+| `snapshotDatesFrom(index)`    | `fetchCdnDates()` → `{ dates: string[] }`, and the per-district `fetchCdnSnapshotIndex()` lists | format, per element        |
+| `snapshotDateFromManifest(m)` | `v1/latest.json` → `latestSnapshotDate`                                                         | format                     |
+| `toSnapshotDate(raw)`         | URL `?date=` / `?from=` / `?to=`, export API params                                             | format, real calendar date |
+
+`asOfDate` stays plain `string` — passing one no longer compiles. That is the
+whole point.
+
+### Three call sites the brand rejects (the payoff)
+
+- **F1 — `usePaymentsTrend.ts:248` (live latent bug).**
+  `const queryEndDate = endDate ?? new Date().toISOString().split('T')[0]`
+  → `useDistrictAnalytics` → `cdnAnalyticsUrl`. Today's wall-clock date is
+  **never** a snapshot date, so this branch always 404s. Masked only because the
+  sole caller (`DistrictTrendsPage:136`) always passes `effectiveEndDate` behind
+  a `hasValidDates` gate. Same family as the epic's named `todayIso()` fallback.
+  **Fix: delete the fallback, require the date.** Not a cast.
+
+- **F2 — `csvExport.ts:511` / `useDistrictExport.ts:45`.**
+  `const date = startDate || (await fetchCdnManifest()).latestSnapshotDate`.
+  Manifest branch is a legitimate mint; `startDate` is a free `string` from a
+  public export API with no validation. **Fix: brand the param.** (Both then read
+  `snapshot.metadata?.sourceCsvDate || date` for display — correct, stays
+  `string`.)
+
+- **F3 — `useDistrictProgramYearControls.ts:140-143` — provably dead laundering.**
+
+  ```ts
+  return (
+    getMostRecentDateInProgramYear(allCachedDates, effectiveProgramYear) ||
+    effectiveProgramYear.endDate // ← synthesized `${year+1}-06-30`, not a snapshot
+  )
+  ```
+
+  `effectiveProgramYear` is only ever an element of `availableProgramYears`, and
+  `getAvailableProgramYears(dates)` derives a PY from a date iff
+  `filterDatesByProgramYear` would keep that date (both use the identical
+  July-boundary predicate — verified against `programYear.ts:68-97`). So when
+  `effectiveProgramYear !== null`, `getMostRecentDateInProgramYear` **cannot**
+  return null: the `||` branch is unreachable.
+  **Fix: delete the dead fallback.** Zero behavior change.
+
+  Deliberately NOT changed to "return null when the PY is empty" — that would be
+  a real regression: a null end date makes the fetch hooks fall back to the
+  manifest's latest snapshot, silently rendering the _wrong_ PY's data for a PY
+  the user explicitly selected. The unreachability argument is what makes this
+  safe. Same dead fallback duplicated at `DistrictTrendsPage.tsx:107`.
+
+### Brand-preserving generics (`utils/programYear.ts`)
+
+`filterDatesByProgramYear` and `getMostRecentDateInProgramYear` become
+`<T extends string>(dates: T[], py) => T[] | T | null` so a branded array stays
+branded through them. Zero-runtime. `getAvailableProgramYears`,
+`isDateInProgramYear`, `getProgramYearForDate` need no change (they return
+`ProgramYear` / `boolean`).
+
+`ProgramYear.startDate` / `.endDate` stay plain `string` — they are synthesized
+calendar bounds, deliberately **not** snapshot dates (that's what makes F3 fail
+to compile).
+
+## Guard mechanism — why not the obvious ones
+
+Two obvious guards are **inert here**, both instances of Lesson 82
+("present-but-inert; assert behavior, not declaration"):
+
+1. **`@ts-expect-error` type-tests are never checked.** `tsconfig.json:43-49`
+   excludes `src/**/__tests__/**/*` and `src/**/*.test.ts*` from the program, so
+   `npm run typecheck` never reads a type-test file. A `@ts-expect-error` there
+   asserts nothing.
+2. **`*.test-d.ts` + vitest typecheck falls outside both projects.** The `unit`
+   project inherits vitest's default include (`**/*.{test,spec}.?(c|m)[jt]s?(x)`),
+   which does not match `.test-d.ts` — the file would silently run in no project
+   (the exact R20/#482 partition hazard).
+
+**Chosen: a type sentinel that compiles a known-bad snippet through the real
+`tsconfig.json` via the TypeScript compiler API**, asserting the specific
+diagnostic fires — the direct analogue of the repo's existing ESLint sentinel
+(`src/__tests__/lint/set-state-in-effect.test.ts`), which lints a known-bad
+snippet at a virtual `src/__sentinel__/…` path. Same virtual-path trick, same
+"assert behavior" discipline, no CI wiring, no new vitest project.
+
+Each sentinel carries a **positive control** (a minted date compiles clean), so
+it cannot false-pass on an unrelated compile error — the type-level twin of
+L166's value-honesty point.
+
+## ESLint `no-restricted-syntax`
+
+Bans `as SnapshotDate` / `<SnapshotDate>` outside `types/snapshotDate.ts`.
+Note `eslint.config.js:17-20` runs `tsparser` with **no** `project`/
+`projectService`, so this must be syntactic (AST selector on the type-annotation
+name), not type-aware. Guarded by a `lintText` sentinel per L82 — plus a negative
+control proving the mint module itself is exempt.
+
+## TDD
+
+1. **Red** — `snapshotDate.test.ts` (runtime mint behavior), the type sentinel
+   (brand rejects `asOfDate` / raw string), the lint sentinel (cast ban fires).
+2. **Green** — brand + mints; cdn.ts signatures; programYear generics; thread
+   through hooks/pages; delete F1/F3 fallbacks; brand F2's param.
+3. **Refactor** — `/simplify` + fresh-context `review`.
+
+## Acceptance criteria (#1323)
+
+- [ ] All seven `cdn.ts` per-snapshot entry points require `SnapshotDate`.
+- [ ] `grep -rn "as SnapshotDate" frontend/src --include="*.ts*" | grep -v types/snapshotDate` → 0, lint-enforced.
+- [ ] Type-tests + full suite + `npm run quality:check` green.


### PR DESCRIPTION
Sprint 4 of epic #1319. Closes the loop on the closing-window date-conflation bug that shipped **four times** (#1289 / #1292 / #1296 / #1315) by making recurrence #5 **fail to compile**.

Sprints 1–3 renamed the ambiguous field (`asOfDate` vs `snapshotDate`) and made divergence the fixture default — those *catch* the mistake. This makes it **unrepresentable**.

## What landed

`SnapshotDate = string & { readonly __brand: 'SnapshotDate' }`, required at all **seven** `snapshots/{date}/…` entry points in `services/cdn.ts` (plus `fetchCdnDistrictReports`, which builds the same URL). `asOfDate` stays a plain `string` — passing one no longer compiles. That is the whole point.

Minted **only** in `types/snapshotDate.ts`, from sources that actually enumerate snapshots:

| Mint | Source |
|---|---|
| `snapshotDatesFrom(index)` | the CDN dates index / per-district snapshot index |
| `snapshotDateFromManifest(m)` | `v1/latest.json` |
| `toSnapshotDate(raw)` | URL `?date=` / `?from=` / `?to=`, export-API params |

Plus `fetchLatestSnapshotDate()` in `cdn.ts` — the blessed mint replacing a hand-rolled manifest read at ~11 sites.

**Zero `as SnapshotDate` casts outside the mint module.** Every value threads from a real mint, because the helpers became generic (`<T extends string>`) and the pickers narrow the `<select>`'s raw string back to an offered option (`options.find`) instead of re-emitting it — narrowing carries provenance a format check can't.

## The brand paid for itself immediately

The compiler enumerated 21 laundering sites. Three were **real defects the types had been hiding**:

- **F1 — live latent bug.** `usePaymentsTrend` fed `cdnAnalyticsUrl` a wall-clock date (`endDate ?? new Date()…`). Today's date is never a snapshot date, so that branch **always 404'd**. Deleted; undefined now falls through to the manifest's real latest snapshot.
- **F3 — dead laundering ×9.** `mostRecent || effectiveProgramYear.endDate` (a synthesized `${year+1}-06-30` calendar bound) duplicated across 8 pages + the district hub hook. Deleted, zero behavior change — see the caveat below.
- **F2** — unvalidated public `startDate` on the CSV export path, now branded.

Also: `?date=` is now **minted, not trusted** — a hand-edited URL falls back to the PY's latest instead of keying a fetch on garbage.

Falsy-handling deliberately **preserved** (`||`, not `??`) at every pre-existing fallback. This is a type change; it must not quietly alter runtime semantics. (A test caught me doing exactly that — reverted.)

## Fresh-context review caught two things worth reading

Both halves of the guard shipped subtly false. Neither could ship, because "a guard that claims more than it delivers" is the exact failure mode this epic exists to end.

1. **The cast ban didn't enforce its own acceptance criterion.** The `>` child combinator missed `as SnapshotDate[]`, `as SnapshotDate | undefined`, and `as Array<SnapshotDate>` — and the array form is the shape the mint module itself uses. The sentinel was green because it only tested the two variants that already passed: **Lesson 82's failure mode, one level up.** Now a descendant combinator, with all seven variants pinned red-first.
2. **The "provably dead" proof named the wrong premise.** I documented the nine deleted fallbacks as dead because the two PY predicates are "identical". They aren't — `calendarParts`' regex is *unanchored*, `filterDatesByProgramYear` compares lexicographically, and `2026-06-30T00:00:00Z` splits them. The fallbacks *are* dead, but because **`snapshotDatesFrom` filters to strict ISO first**. The mint is load-bearing; a maintainer trusting the old comment could loosen that filter and silently resurrect #1315. Corrected at the source.

The blind spots are now **stated rather than papered over** (L166): `toSnapshotDate(data.asOfDate)` still mints the bug through the front door — format is checkable, provenance isn't. The brand raises the cost of the mistake and makes the honest path the easy one; it is not a proof.

## How this is guarded (both assert behaviour, per L82)

The two obvious mechanisms are **inert here**, invisibly: `@ts-expect-error` type-tests are never read (`tsconfig` excludes `__tests__` from the program), and `*.test-d.ts` matches **neither** vitest project's include (the R20/#482 partition hazard).

So instead:
- **`snapshotDate.brand.sentinel.test.ts`** — compiles known-bad snippets through the real `tsconfig` via the TS compiler API at a virtual `src/__sentinel__/…` path (the analogue of the repo's ESLint `lintText` sentinel). Carries a **positive control** so it can't false-pass on an unrelated error. ~1.5s.
- **`no-snapshot-date-cast.test.ts`** — lints all seven cast variants through the real config, with negative controls for an unrelated cast and for the mint module's exemption.

## Verification

- `npm run quality:check` — **exit 0**. 5,801 tests green across all workspaces (frontend 3,684 / 306 files), 0 lint errors, prettier clean, typecheck clean.
- Live verification on the PR preview channel (Chromium + WebKit) to follow on this PR before merge.

Acceptance criteria: all seven entry points require `SnapshotDate` ✅ · zero casts outside the mint, lint-enforced ✅ · type-tests + full suite + quality:check green ✅

## Follow-up (not this sprint)

Eight District pages hand-roll the full body of `useDistrictProgramYearControls` (which `AreaPage` / `ClubDetailPage` / `DivisionPage` simply call). Pre-existing, but this diff made it measurable: the same edit had to land 9×. Worth its own issue.

Lesson filed: `tasks/lessons/lessons/a-nominal-brand-is-only-as-honest-as-the-mint-and-the-cast-ban-behind-it.md`.

Part of epic #1319 · sub-issue #1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzKwUSiiT97DGXTjPV6qLo