### PR TITLE
fix(collector): fetch the live program year from the root export path (#1342)

### DIFF
--- a/packages/collector-cli/src/CollectorOrchestrator.ts
+++ b/packages/collector-cli/src/CollectorOrchestrator.ts
@@ -25,6 +25,7 @@ import {
   parseClosingPeriodFromCsv,
   type ReportType as HttpReportType,
   type CsvClosingPeriodInfo,
+  type ExportPathStyle,
 } from './services/HttpCsvDownloader.js'
 import type {
   CollectorOrchestratorConfig,
@@ -278,7 +279,8 @@ export class CollectorOrchestrator {
     downloader: HttpCsvDownloader,
     date: string,
     force: boolean,
-    programYear: string
+    programYear: string,
+    pathStyle: ExportPathStyle
   ): Promise<DistrictScrapeResult> {
     const startTime = Date.now()
     const timestamp = new Date().toISOString()
@@ -312,6 +314,7 @@ export class CollectorOrchestrator {
             programYear,
             reportType: 'districtsummary',
             date: new Date(date + 'T00:00:00'),
+            pathStyle,
           })
 
           const filePath = await this.writeCsvToCache(
@@ -385,7 +388,8 @@ export class CollectorOrchestrator {
     districtId: string,
     date: string,
     force: boolean,
-    programYear: string
+    programYear: string,
+    pathStyle: ExportPathStyle
   ): Promise<DistrictScrapeResult> {
     const startTime = Date.now()
     const timestamp = new Date().toISOString()
@@ -432,6 +436,7 @@ export class CollectorOrchestrator {
               reportType: report,
               districtId,
               date: new Date(date + 'T00:00:00'),
+              pathStyle,
             })
 
             const filePath = await this.writeCsvToCache(
@@ -602,15 +607,19 @@ export class CollectorOrchestrator {
     // June's close is still live under the prior year. Resolving once here and
     // threading it means every fetch (all-districts + per-district) and the
     // stored metadata agree on the year we actually scraped.
-    const { programYear: activeProgramYear, fellBack } =
-      await resolveActiveProgramYear(date, async programYear => {
-        const result = await downloader.downloadCsv({
-          programYear,
-          reportType: 'districtsummary',
-          date: new Date(date + 'T00:00:00'),
-        })
-        return result.content
+    const {
+      programYear: activeProgramYear,
+      pathStyle: activePathStyle,
+      fellBack,
+    } = await resolveActiveProgramYear(date, async (programYear, pathStyle) => {
+      const result = await downloader.downloadCsv({
+        programYear,
+        reportType: 'districtsummary',
+        date: new Date(date + 'T00:00:00'),
+        pathStyle,
       })
+      return result.content
+    })
     if (fellBack) {
       logger.warn(
         'Scraping the prior program year — new program year not yet published (#1284)',
@@ -636,7 +645,8 @@ export class CollectorOrchestrator {
       downloader,
       date,
       force,
-      activeProgramYear
+      activeProgramYear,
+      activePathStyle
     )
     if (allDistrictsResult.success) {
       allCacheLocations.push(...allDistrictsResult.cacheLocations)
@@ -677,7 +687,8 @@ export class CollectorOrchestrator {
               districtId,
               date,
               force,
-              activeProgramYear
+              activeProgramYear,
+              activePathStyle
             ),
           { districtId, date }
         )

--- a/packages/collector-cli/src/__tests__/CollectorOrchestrator.test.ts
+++ b/packages/collector-cli/src/__tests__/CollectorOrchestrator.test.ts
@@ -28,6 +28,7 @@ let capturedDownloadSpecs: Array<{
   reportType: string
   programYear: string
   districtId?: string
+  pathStyle?: 'live' | 'archive'
 }> = []
 
 vi.mock('../services/HttpCsvDownloader.js', () => {
@@ -89,12 +90,14 @@ vi.mock('../services/HttpCsvDownloader.js', () => {
         districtId?: string
         date: Date
         programYear: string
+        pathStyle?: 'live' | 'archive'
       }) {
         this.requestCount++
         capturedDownloadSpecs.push({
           reportType: spec.reportType,
           programYear: spec.programYear,
           districtId: spec.districtId,
+          pathStyle: spec.pathStyle,
         })
 
         if (spec.districtId && failingDistricts.has(spec.districtId)) {
@@ -288,6 +291,45 @@ describe('CollectorOrchestrator - Partial Failure Resilience (#124)', () => {
     expect(csvFiles['allDistricts']).toBe(true)
     const districts = csvFiles['districts'] as Record<string, unknown>
     expect(districts['09']).toBeDefined()
+  })
+
+  // #1342 — the live program year is reachable ONLY at the bare /export.aspx.
+  // Resolving it is useless unless the resolved pathStyle reaches every
+  // subsequent fetch: an un-threaded pathStyle silently falls back to the
+  // archive path, which 500s for the live year. TypeScript cannot catch that,
+  // so it is pinned here.
+  it('threads the resolved live pathStyle into every per-district fetch (#1342)', async () => {
+    const liveCsv = `"REGION","DISTRICT","Paid Clubs"
+"01","02","192"
+Month of July, As of 07/30/2026`
+    mockCsvByProgramYear = { '2026-2027': liveCsv }
+
+    await createDistrictConfig(['09'])
+    const orchestrator = new CollectorOrchestrator(createConfig())
+    const result = await orchestrator.scrape({
+      date: '2026-07-30',
+      force: true,
+    })
+    await orchestrator.close()
+
+    expect(result.success).toBe(true)
+
+    // One probe resolves the year; everything after it must ride the same path.
+    const realFetches = capturedDownloadSpecs.filter(
+      s => s.reportType !== 'districtsummary' || s.districtId !== undefined
+    )
+    expect(realFetches.length).toBeGreaterThan(0)
+    for (const spec of realFetches) {
+      expect(spec.pathStyle).toBe('live')
+      expect(spec.programYear).toBe('2026-2027')
+    }
+
+    // No fetch may use the archive path for the live year — that is the 500.
+    expect(
+      capturedDownloadSpecs.some(
+        s => s.programYear === '2026-2027' && s.pathStyle === 'archive'
+      )
+    ).toBe(false)
   })
 
   it('scrapes the prior program year at the July rollover when the new year is unpublished (#1284)', async () => {

--- a/packages/collector-cli/src/__tests__/HttpCsvDownloader.test.ts
+++ b/packages/collector-cli/src/__tests__/HttpCsvDownloader.test.ts
@@ -27,6 +27,69 @@ describe('HttpCsvDownloader URL Construction (#123)', () => {
       )
     })
 
+    // #1342 — TM moved the live program year to the bare /export.aspx path.
+    // /{PY}/export.aspx now 500s ("URL Rewrite Module Error.") for the live
+    // year and serves ARCHIVED years only. Verified against the dashboard
+    // 2026-07-31; the working URL was captured from the browser's own export.
+    describe('program-year path style (#1342)', () => {
+      it('omits the /{programYear}/ prefix for the LIVE program year', () => {
+        const url = buildExportUrl({
+          programYear: '2026-2027',
+          reportType: 'districtsummary',
+          date: new Date(2026, 6, 30), // July 30, 2026
+          pathStyle: 'live',
+        })
+
+        expect(url).toBe(
+          'https://dashboards.toastmasters.org/export.aspx?type=CSV&report=districtsummary~~7/30/2026~2026-2027'
+        )
+      })
+
+      it('keeps the /{programYear}/ prefix for an ARCHIVED program year', () => {
+        const url = buildExportUrl({
+          programYear: '2025-2026',
+          reportType: 'districtsummary',
+          date: new Date(2026, 5, 30), // June 30, 2026
+          pathStyle: 'archive',
+        })
+
+        expect(url).toBe(
+          'https://dashboards.toastmasters.org/2025-2026/export.aspx?type=CSV&report=districtsummary~~6/30/2026~2025-2026'
+        )
+      })
+
+      // The default MUST stay 'archive': every historical caller
+      // (BackfillOrchestrator, rescrape-historical, backfill-raw-csv-for-dates)
+      // relies on the prefix to pin the year. The root path ignores the
+      // ~{programYear} token and would silently return CURRENT-year data.
+      it('defaults to the archive path when pathStyle is omitted', () => {
+        const url = buildExportUrl({
+          programYear: '2019-2020',
+          reportType: 'clubperformance',
+          districtId: '61',
+          date: new Date(2020, 0, 15),
+        })
+
+        expect(url).toBe(
+          'https://dashboards.toastmasters.org/2019-2020/export.aspx?type=CSV&report=clubperformance~61~~1/15/2020~2019-2020'
+        )
+      })
+
+      it('applies the live path to per-district reports too', () => {
+        const url = buildExportUrl({
+          programYear: '2026-2027',
+          reportType: 'clubperformance',
+          districtId: '61',
+          date: new Date(2026, 6, 30),
+          pathStyle: 'live',
+        })
+
+        expect(url).toBe(
+          'https://dashboards.toastmasters.org/export.aspx?type=CSV&report=clubperformance~61~~7/30/2026~2026-2027'
+        )
+      })
+    })
+
     it('should construct districtsummary URL with monthEndDate (#204)', () => {
       const url = buildExportUrl({
         programYear: '2024-2025',

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -375,11 +375,12 @@ export function createCLI(): Command {
       })
       const resolution = await resolveActiveProgramYear(
         targetDate,
-        async programYear => {
+        async (programYear, pathStyle) => {
           const result = await downloader.downloadCsv({
             programYear,
             reportType: 'districtsummary',
             date: new Date(targetDate + 'T00:00:00'),
+            pathStyle,
           })
           return result.content
         }

--- a/packages/collector-cli/src/services/HttpCsvDownloader.ts
+++ b/packages/collector-cli/src/services/HttpCsvDownloader.ts
@@ -4,8 +4,13 @@
  * Downloads CSV exports directly via HTTP GET requests to the dashboard's
  * export.aspx endpoint, bypassing the need for Playwright browser automation.
  *
- * URL pattern:
- *   https://dashboards.toastmasters.org/{programYear}/export.aspx?type=CSV&report={reportName}
+ * URL pattern (#1342):
+ *   live PY:      https://dashboards.toastmasters.org/export.aspx?type=CSV&report={reportName}
+ *   archived PY:  https://dashboards.toastmasters.org/{programYear}/export.aspx?type=CSV&report={reportName}
+ *
+ * The live year has no /{programYear}/ path (HTTP 500), and the bare path
+ * ignores the ~{programYear} token and always serves the live year — so the
+ * two are not interchangeable. See BackfillDateSpec.pathStyle.
  *
  * Report name patterns:
  *   - districtsummary~{date}~~{programYear}
@@ -46,7 +51,24 @@ export interface BackfillDateSpec {
    * Without it, the dashboard returns only the latest closing period.
    */
   monthEndDate?: Date
+  /**
+   * Which endpoint shape to use (#1342).
+   *
+   * - `'archive'` (default) — `/{programYear}/export.aspx`, which serves that
+   *   specific, already-archived program year.
+   * - `'live'` — the bare `/export.aspx`, which serves whatever program year is
+   *   currently live. The live year has no archive path (TM returns HTTP 500
+   *   "URL Rewrite Module Error."), so it can ONLY be fetched this way.
+   *
+   * The default must stay `'archive'`: the live endpoint **ignores** the
+   * trailing `~{programYear}` token, so pointing a historical fetch at it
+   * silently returns current-year data under a historical date.
+   */
+  pathStyle?: ExportPathStyle
 }
+
+/** @see BackfillDateSpec.pathStyle (#1342) */
+export type ExportPathStyle = 'live' | 'archive'
 
 export interface HttpCsvDownloaderConfig {
   ratePerSecond: number
@@ -118,7 +140,11 @@ export function buildExportUrl(spec: BackfillDateSpec): string {
     reportName = `${spec.reportType}~${spec.districtId}~${monthEndStr}~${dateStr}~${spec.programYear}`
   }
 
-  return `${BASE_URL}/${spec.programYear}/export.aspx?type=CSV&report=${reportName}`
+  // The live program year lives at the bare /export.aspx; archived years live
+  // under /{programYear}/. Defaults to the archive path (#1342).
+  const prefix = spec.pathStyle === 'live' ? '' : `/${spec.programYear}`
+
+  return `${BASE_URL}${prefix}/export.aspx?type=CSV&report=${reportName}`
 }
 
 /**

--- a/packages/collector-cli/src/utils/__tests__/programYearResolver.test.ts
+++ b/packages/collector-cli/src/utils/__tests__/programYearResolver.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   isValidDistrictSummaryCsv,
   parseDistrictIdsFromSummaryCsv,
+  programYearFromCsvFooter,
   resolveActiveProgramYear,
 } from '../programYearResolver.js'
 
@@ -53,54 +54,102 @@ describe('parseDistrictIdsFromSummaryCsv', () => {
   })
 })
 
-describe('resolveActiveProgramYear', () => {
-  it('uses the calendar program year when its dashboard has data', async () => {
-    const fetchSummary = vi.fn(async () => REAL_CSV)
-    const res = await resolveActiveProgramYear('2026-01-15', fetchSummary)
+// Real captured header row from the 2026-2027 districtsummary CSV
+// (downloaded from the dashboard 2026-07-31). Note "Region Advisor Visit" is
+// GONE — TM retired the requirement for this program year (#1344) — and the
+// footer reads "Month of Jul", which is what identifies the year (#1342).
+const CSV_2026_27 = `"REGION","DISTRICT","DSP","Training","Market Analysis","Communication Plan","New Payments","April Payments","October Payments","Late Payments","Charter Payments","Total YTD Payments","Payment Base","% Payment Growth","Paid Club Base","Paid Clubs","% Club Growth","Active Clubs","Distinguished Clubs","Select Distinguished Clubs","Presidents Distinguished Clubs","Smedley Distinguished Clubs","Total Distinguished Clubs","% Distinguished Clubs"
+"01","02","N","N","N","N","71","326","735","7","0","1139","6290","-81.89%","193","193","0%","203","0","0","0","0","0","0%"
+Month of Jul, As of 07/30/2026`
 
-    expect(res.programYear).toBe('2025-2026')
-    expect(res.fellBack).toBe(false)
-    expect(res.content).toBe(REAL_CSV)
-    expect(fetchSummary).toHaveBeenCalledTimes(1)
-    expect(fetchSummary).toHaveBeenCalledWith('2025-2026')
+describe('programYearFromCsvFooter (#1342)', () => {
+  it('derives the program year from a July footer (new PY)', () => {
+    expect(programYearFromCsvFooter(CSV_2026_27, '2026-07-30')).toBe(
+      '2026-2027'
+    )
   })
 
-  it('falls back to the prior program year at the July rollover (#1284)', async () => {
-    // 2026-07-01: calendar PY 2026-2027 not published (HTML error), June close
-    // still live under prior PY 2025-2026.
-    const fetchSummary = vi.fn(async (py: string) =>
-      py === '2026-2027' ? HTML_ERROR : REAL_CSV
+  it('derives the PRIOR program year from a June-close footer', () => {
+    // "Month of Jun, As of 07/01/2026" — June belongs to PY 2025-2026 even
+    // though it was collected in July. This is the rollover discriminator.
+    expect(programYearFromCsvFooter(REAL_CSV, '2026-07-01')).toBe('2025-2026')
+  })
+
+  it('handles the December/January year boundary', () => {
+    const csv = `"REGION","DISTRICT"\n"01","02"\nMonth of Dec, As of 01/05/2027`
+    expect(programYearFromCsvFooter(csv, '2027-01-05')).toBe('2026-2027')
+  })
+
+  it('returns undefined when no footer is present (undecided, #1129)', () => {
+    expect(
+      programYearFromCsvFooter('"REGION","DISTRICT"\n"01","02"', '2026-07-30')
+    ).toBeUndefined()
+    expect(programYearFromCsvFooter(HTML_ERROR, '2026-07-30')).toBeUndefined()
+  })
+})
+
+describe('resolveActiveProgramYear', () => {
+  it('reads the LIVE endpoint and trusts its footer for the active year', async () => {
+    const fetchSummary = vi.fn(async () => CSV_2026_27)
+    const res = await resolveActiveProgramYear('2026-07-30', fetchSummary)
+
+    expect(res.programYear).toBe('2026-2027')
+    expect(res.pathStyle).toBe('live')
+    expect(res.fellBack).toBe(false)
+    expect(res.content).toBe(CSV_2026_27)
+    expect(fetchSummary).toHaveBeenCalledTimes(1)
+    expect(fetchSummary).toHaveBeenCalledWith('2026-2027', 'live')
+  })
+
+  // The rollover case, now decided by CONTENT rather than by probing a path
+  // that may not exist. During Jul 1-29 2026 the live endpoint still served
+  // June's close: one request, correctly labelled 2025-2026 instead of being
+  // ingested as the new year.
+  it('labels the live endpoint by its footer when TM has not rolled over yet', async () => {
+    const fetchSummary = vi.fn(async () => REAL_CSV) // still June's close
+    const res = await resolveActiveProgramYear('2026-07-15', fetchSummary)
+
+    expect(res.programYear).toBe('2025-2026')
+    expect(res.pathStyle).toBe('live')
+    expect(res.fellBack).toBe(true)
+    expect(fetchSummary).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the archive path when the live endpoint throws', async () => {
+    const fetchSummary = vi.fn(
+      async (py: string, pathStyle: 'live' | 'archive') => {
+        if (pathStyle === 'live') throw new Error('HTTP 500')
+        if (py === '2026-2027') return HTML_ERROR
+        return REAL_CSV
+      }
     )
     const res = await resolveActiveProgramYear('2026-07-01', fetchSummary)
 
     expect(res.programYear).toBe('2025-2026')
+    expect(res.pathStyle).toBe('archive')
     expect(res.fellBack).toBe(true)
-    expect(res.content).toBe(REAL_CSV)
-    expect(fetchSummary).toHaveBeenCalledWith('2026-2027')
-    expect(fetchSummary).toHaveBeenCalledWith('2025-2026')
+    expect(fetchSummary).toHaveBeenCalledWith('2025-2026', 'archive')
   })
 
-  it('falls back when the calendar-year fetch throws', async () => {
-    const fetchSummary = vi.fn(async (py: string) => {
-      if (py === '2026-2027') throw new Error('HTTP 500')
-      return REAL_CSV
-    })
-    const res = await resolveActiveProgramYear('2026-07-01', fetchSummary)
+  // The corruption guard: the root path IGNORES the ~{programYear} token and
+  // serves whatever year is live, so a response must be rejected when its
+  // footer disagrees with the year we asked for (#1342).
+  it('rejects content whose footer disagrees with the requested year', async () => {
+    const fetchSummary = vi.fn(
+      async (_py: string, pathStyle: 'live' | 'archive') => {
+        if (pathStyle === 'live') throw new Error('HTTP 500')
+        return CSV_2026_27 // wrong year for every archive probe below
+      }
+    )
+    // Calendar PY here is 2025-2026; the archive probes return 2026-2027 data.
+    const res = await resolveActiveProgramYear('2026-06-15', fetchSummary)
 
+    expect(res.content).toBeUndefined()
     expect(res.programYear).toBe('2025-2026')
-    expect(res.fellBack).toBe(true)
-  })
-
-  it('self-heals: once the new year publishes, the calendar PY wins', async () => {
-    const fetchSummary = vi.fn(async () => REAL_CSV) // new year now returns CSV
-    const res = await resolveActiveProgramYear('2026-07-15', fetchSummary)
-
-    expect(res.programYear).toBe('2026-2027')
     expect(res.fellBack).toBe(false)
-    expect(fetchSummary).toHaveBeenCalledTimes(1)
   })
 
-  it('returns the calendar year (no false fallback) when neither year validates', async () => {
+  it('returns the calendar year (no false fallback) when nothing validates', async () => {
     const fetchSummary = vi.fn(async () => HTML_ERROR)
     const res = await resolveActiveProgramYear('2026-07-01', fetchSummary)
 

--- a/packages/collector-cli/src/utils/__tests__/programYearResolver.test.ts
+++ b/packages/collector-cli/src/utils/__tests__/programYearResolver.test.ts
@@ -135,17 +135,22 @@ describe('resolveActiveProgramYear', () => {
   // serves whatever year is live, so a response must be rejected when its
   // footer disagrees with the year we asked for (#1342).
   it('rejects content whose footer disagrees with the requested year', async () => {
+    // The prior-year archive probe is answered with CURRENT-year content. That
+    // is exactly what the root path does when handed an archived year, so it
+    // must never be accepted as 2025-2026 — doing so writes this year's numbers
+    // under last year's label.
     const fetchSummary = vi.fn(
-      async (_py: string, pathStyle: 'live' | 'archive') => {
+      async (py: string, pathStyle: 'live' | 'archive') => {
         if (pathStyle === 'live') throw new Error('HTTP 500')
-        return CSV_2026_27 // wrong year for every archive probe below
+        if (py === '2026-2027') return HTML_ERROR
+        return CSV_2026_27 // wrong year for the 2025-2026 probe
       }
     )
-    // Calendar PY here is 2025-2026; the archive probes return 2026-2027 data.
-    const res = await resolveActiveProgramYear('2026-06-15', fetchSummary)
+    const res = await resolveActiveProgramYear('2026-07-28', fetchSummary)
 
+    expect(fetchSummary).toHaveBeenCalledWith('2025-2026', 'archive')
     expect(res.content).toBeUndefined()
-    expect(res.programYear).toBe('2025-2026')
+    expect(res.programYear).toBe('2026-2027')
     expect(res.fellBack).toBe(false)
   })
 

--- a/packages/collector-cli/src/utils/csvFooterParser.ts
+++ b/packages/collector-cli/src/utils/csvFooterParser.ts
@@ -28,6 +28,64 @@ const MONTHS: Record<string, string> = {
   dec: '12',
 }
 
+/** The calendar month a CSV's data belongs to, per its footer. */
+export interface FooterDataMonth {
+  year: number
+  /** 1-12. */
+  month: number
+}
+
+/**
+ * Parse the data month from a CSV's "Month of X, As of Y" footer.
+ *
+ * Returns the month **unconditionally** — unlike `parseClosingPeriodFromCsv`,
+ * whose `dataMonth` is populated only for closing periods. Callers that need to
+ * know *which* period the data is for (e.g. deriving its program year, #1342)
+ * need the month even when it matches the collection month.
+ *
+ * @returns undefined when no parseable footer is present — UNDECIDED, never a
+ *          verdict (#1129).
+ */
+export function parseFooterDataMonth(
+  csvContent: string,
+  requestedDate: string
+): FooterDataMonth | undefined {
+  if (!csvContent) return undefined
+
+  const lines = csvContent.split(/\r?\n/).slice(-20) // Search the end of the file
+  for (const line of lines) {
+    // Match e.g. "Month of March, As of 04/01/2026" — TM emits both full and
+    // 3-letter month names ("Month of Jul, As of 07/30/2026").
+    const match = line.match(
+      /^"?Month of\s+([A-Za-z]+),\s*As of\s+([0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4})"?$/i
+    )
+    if (!match) continue
+
+    const monthName = match[1]!.toLowerCase()
+    // e.g. match[2] "04/01/2026" - ignored for now as we only need the month name
+
+    const dataMonthNumStr = MONTHS[monthName]
+    if (!dataMonthNumStr) continue
+
+    // The requestedDate is in YYYY-MM-DD
+    const requestedDateObj = new Date(requestedDate)
+    const referenceYear = requestedDateObj.getUTCFullYear()
+    const referenceMonth = requestedDateObj.getUTCMonth() + 1
+
+    // parseDataMonth takes ("03", 2026, 4) -> { year: 2026, month: 3 }
+    const parsedDataMonth = closingPeriodDetector.parseDataMonth(
+      dataMonthNumStr,
+      referenceYear,
+      referenceMonth
+    )
+    if (!parsedDataMonth) continue
+
+    return parsedDataMonth
+  }
+
+  return undefined
+}
+
 export function parseClosingPeriodFromCsv(
   csvContent: string,
   requestedDate: string
@@ -36,49 +94,23 @@ export function parseClosingPeriodFromCsv(
   // "As of" footer says nothing about its data month. Callers needing
   // fail-closed semantics (#1129) must consult the next authority instead of
   // treating the default isClosingPeriod:false as a decision.
-  if (!csvContent) return { isClosingPeriod: false, footerFound: false }
+  const parsedDataMonth = parseFooterDataMonth(csvContent, requestedDate)
+  if (!parsedDataMonth) return { isClosingPeriod: false, footerFound: false }
 
-  const lines = csvContent.split(/\r?\n/).slice(-20) // Search the end of the file
-  for (const line of lines) {
-    // Match e.g. "Month of March, As of 04/01/2026"
-    const match = line.match(
-      /^"?Month of\s+([A-Za-z]+),\s*As of\s+([0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4})"?$/i
-    )
-    if (match) {
-      const monthName = match[1]!.toLowerCase()
-      // e.g. match[2] "04/01/2026" - ignored for now as we only need the month name
+  const requestedDateObj = new Date(requestedDate)
+  const referenceYear = requestedDateObj.getUTCFullYear()
+  const referenceMonth = requestedDateObj.getUTCMonth() + 1
 
-      const dataMonthNumStr = MONTHS[monthName]
-      if (!dataMonthNumStr) continue
+  // If the parsed month differs from the requested month, it's a closing period
+  const isClosingPeriod =
+    parsedDataMonth.month !== referenceMonth ||
+    parsedDataMonth.year !== referenceYear
 
-      // The requestedDate is in YYYY-MM-DD
-      const requestedDateObj = new Date(requestedDate)
-      const referenceYear = requestedDateObj.getUTCFullYear()
-      const referenceMonth = requestedDateObj.getUTCMonth() + 1
+  const formattedDataMonth = `${parsedDataMonth.year}-${parsedDataMonth.month.toString().padStart(2, '0')}`
 
-      // parseDataMonth takes ("03", 2026, 4) -> { year: 2026, month: 3 }
-      const parsedDataMonth = closingPeriodDetector.parseDataMonth(
-        dataMonthNumStr,
-        referenceYear,
-        referenceMonth
-      )
-
-      if (!parsedDataMonth) continue
-
-      // If the parsed month differs from the requested month, it's a closing period
-      const isClosingPeriod =
-        parsedDataMonth.month !== referenceMonth ||
-        parsedDataMonth.year !== referenceYear
-
-      const formattedDataMonth = `${parsedDataMonth.year}-${parsedDataMonth.month.toString().padStart(2, '0')}`
-
-      return {
-        isClosingPeriod,
-        dataMonth: isClosingPeriod ? formattedDataMonth : undefined,
-        footerFound: true,
-      }
-    }
+  return {
+    isClosingPeriod,
+    dataMonth: isClosingPeriod ? formattedDataMonth : undefined,
+    footerFound: true,
   }
-
-  return { isClosingPeriod: false, footerFound: false }
 }

--- a/packages/collector-cli/src/utils/programYearResolver.ts
+++ b/packages/collector-cli/src/utils/programYearResolver.ts
@@ -14,7 +14,11 @@
  * change.
  */
 import { calculateProgramYear, getPriorProgramYear } from './CachePaths.js'
+import { parseFooterDataMonth } from './csvFooterParser.js'
+import type { ExportPathStyle } from '../services/HttpCsvDownloader.js'
 import { logger } from './logger.js'
+
+export type { ExportPathStyle }
 
 /**
  * A districtsummary CSV always starts with a header row containing the
@@ -35,13 +39,75 @@ export function isValidDistrictSummaryCsv(
 export interface ProgramYearResolution {
   /** The program year whose dashboard actually has data for this date. */
   programYear: string
-  /** True when the calendar year was empty and we fell back to the prior year. */
+  /**
+   * Which endpoint shape served `programYear`. Callers MUST thread this into
+   * every subsequent fetch for the same run — the live year is reachable only
+   * at the bare path, archived years only under `/{programYear}/` (#1342).
+   */
+  pathStyle: ExportPathStyle
+  /** True when the resolved year is not the calendar program year. */
   fellBack: boolean
   /**
    * The validated districtsummary CSV body for `programYear`, or undefined when
-   * neither year returned valid data (callers must then fail loudly).
+   * nothing returned valid data (callers must then fail loudly).
    */
   content?: string
+}
+
+/**
+ * Derive the program year a districtsummary CSV actually contains, from its
+ * "Month of X, As of MM/DD/YYYY" footer (#1342).
+ *
+ * This is the only trustworthy year signal. The live `/export.aspx` endpoint
+ * ignores the `~{programYear}` token in the request, so the URL we asked for
+ * says nothing about the year we got back.
+ *
+ * June is the case that matters: "Month of Jun, As of 07/01/2026" is collected
+ * in July but belongs to PY 2025-2026. Keying off the *data* month rather than
+ * the as-of date is what makes the rollover unambiguous.
+ *
+ * @returns The `YYYY-YYYY` program year, or undefined when no footer is present
+ *          (undecided — never a verdict, cf. #1129).
+ */
+export function programYearFromCsvFooter(
+  content: string | undefined | null,
+  collectionDate: string
+): string | undefined {
+  if (!content) return undefined
+
+  const dataMonth = parseFooterDataMonth(content, collectionDate)
+  if (!dataMonth) return undefined
+
+  // The Toastmasters program year runs July 1 - June 30.
+  const startYear = dataMonth.month >= 7 ? dataMonth.year : dataMonth.year - 1
+  return `${startYear}-${startYear + 1}`
+}
+
+/**
+ * Accept content only when it is a valid districtsummary AND its footer does
+ * not contradict the program year we asked for.
+ *
+ * A missing footer is *undecided*, not a failure: some historical exports have
+ * no footer row, and rejecting those would break backfill. We only reject an
+ * explicit disagreement — which is precisely the wrong-year hazard the live
+ * endpoint introduces (#1342).
+ */
+function isValidForProgramYear(
+  content: string | undefined,
+  expectedProgramYear: string,
+  date: string
+): boolean {
+  if (!isValidDistrictSummaryCsv(content)) return false
+
+  const actual = programYearFromCsvFooter(content, date)
+  if (actual && actual !== expectedProgramYear) {
+    logger.warn(
+      'districtsummary content is for a different program year — rejecting (#1342)',
+      { date, expectedProgramYear, actualProgramYear: actual }
+    )
+    return false
+  }
+  return true
 }
 
 /**
@@ -89,27 +155,68 @@ export function parseDistrictIdsFromSummaryCsv(
  */
 export async function resolveActiveProgramYear(
   date: string,
-  fetchSummary: (programYear: string) => Promise<string>
+  fetchSummary: (
+    programYear: string,
+    pathStyle: ExportPathStyle
+  ) => Promise<string>
 ): Promise<ProgramYearResolution> {
   const calendarPY = calculateProgramYear(date)
 
-  const calendarContent = await tryFetch(fetchSummary, calendarPY, date)
-  if (isValidDistrictSummaryCsv(calendarContent)) {
+  // 1. Ask the LIVE endpoint what it has. It is authoritative about the current
+  //    program year, so its footer answers the rollover question outright —
+  //    no calendar guess, and no probing a /{PY}/ path that may not exist yet.
+  const liveContent = await tryFetch(fetchSummary, calendarPY, 'live', date)
+  if (isValidDistrictSummaryCsv(liveContent)) {
+    const livePY = programYearFromCsvFooter(liveContent, date)
+    if (livePY) {
+      if (livePY !== calendarPY) {
+        logger.info(
+          'Live dashboard is still serving the prior program year (rollover window)',
+          { date, calendarPY, programYear: livePY }
+        )
+      }
+      return {
+        programYear: livePY,
+        pathStyle: 'live',
+        fellBack: livePY !== calendarPY,
+        content: liveContent,
+      }
+    }
+    // Valid CSV but no footer: we cannot tell which year it is, and the live
+    // endpoint ignores the year token — so labelling it would be a guess. Fall
+    // through to the archive path, where the URL does pin the year.
+    logger.warn(
+      'Live districtsummary has no "Month of" footer — cannot confirm its program year (#1342)',
+      { date, calendarPY }
+    )
+  }
+
+  // 2. Archive path for the calendar year. Reachable once TM archives it, and
+  //    the only path whose URL actually constrains the year.
+  const calendarContent = await tryFetch(
+    fetchSummary,
+    calendarPY,
+    'archive',
+    date
+  )
+  if (isValidForProgramYear(calendarContent, calendarPY, date)) {
     return {
       programYear: calendarPY,
+      pathStyle: 'archive',
       fellBack: false,
       content: calendarContent,
     }
   }
 
+  // 3. Archive path for the prior year (the original #1284 rollover fallback).
   const priorPY = getPriorProgramYear(calendarPY)
   logger.warn(
     'Calendar program-year dashboard unavailable — trying prior program year (#1284)',
     { date, calendarPY, priorPY }
   )
 
-  const priorContent = await tryFetch(fetchSummary, priorPY, date)
-  if (isValidDistrictSummaryCsv(priorContent)) {
+  const priorContent = await tryFetch(fetchSummary, priorPY, 'archive', date)
+  if (isValidForProgramYear(priorContent, priorPY, date)) {
     logger.info(
       'Resolved active program year to prior year (rollover window)',
       {
@@ -117,25 +224,35 @@ export async function resolveActiveProgramYear(
         programYear: priorPY,
       }
     )
-    return { programYear: priorPY, fellBack: true, content: priorContent }
+    return {
+      programYear: priorPY,
+      pathStyle: 'archive',
+      fellBack: true,
+      content: priorContent,
+    }
   }
 
-  // Neither validated: return the calendar year so downstream fails loudly with
+  // Nothing validated: return the calendar year so downstream fails loudly with
   // the real (calendar-year) error rather than silently ingesting stale data.
-  return { programYear: calendarPY, fellBack: false }
+  return { programYear: calendarPY, pathStyle: 'archive', fellBack: false }
 }
 
 async function tryFetch(
-  fetchSummary: (programYear: string) => Promise<string>,
+  fetchSummary: (
+    programYear: string,
+    pathStyle: ExportPathStyle
+  ) => Promise<string>,
   programYear: string,
+  pathStyle: ExportPathStyle,
   date: string
 ): Promise<string | undefined> {
   try {
-    return await fetchSummary(programYear)
+    return await fetchSummary(programYear, pathStyle)
   } catch (err) {
     logger.warn('districtsummary fetch failed during program-year resolution', {
       date,
       programYear,
+      pathStyle,
       error: err instanceof Error ? err.message : String(err),
     })
     return undefined


### PR DESCRIPTION
Fixes #1342.

## Problem

The daily pipeline has run green every day since Toastmasters published PY 2026-2027 — and ingested none of it. Every run threw on the program-year probe, fell back to 2025-2026, promoted staging → production, and reported `success`. The only trace was a `warn` in a job log.

`buildExportUrl` hardcoded a `/{programYear}/` path prefix. That path no longer exists for the **live** year.

## Root cause

The endpoint changed shape:

| endpoint | serves |
| --- | --- |
| `/export.aspx` | whatever program year is **currently live** — the `~{programYear}` token is **ignored** |
| `/{PY}/export.aspx` | that specific **archived** year |

2026-2027 is live, so it has no archive path (HTTP 500 `URL Rewrite Module Error.`). 2025-2026 was archived when the new year went live, so its prefix started working. Both are consequences of the same TM-side promotion — which is why this looks like a rollover bug but is really a URL-scheme change that merely *surfaces* at rollover.

Verified against the live dashboard on 2026-07-31:

| URL | Result |
| --- | --- |
| `/2026-2027/export.aspx?…~~7/28/2026~2026-2027` | **500** |
| `/export.aspx?…~~7/30/2026~2026-2027` | 200, correct 2026-2027 data |
| `/2025-2026/export.aspx?…~~6/30/2026~2025-2026` | 200, correct 2025-2026 data |
| `/export.aspx?…~~6/30/2026~2025-2026` | 200, **wrong year — 2026-2027 data** |

The working URL is ground truth, captured from the browser's own export via `mdls -name kMDItemWhereFroms`.

## Why this isn't a one-line fix

Simply dropping the prefix would have been **worse than the 500**. Because the root path ignores the year token, every historical caller — `BackfillOrchestrator`, `scripts/rescrape-historical.ts`, `scripts/backfill-raw-csv-for-dates.ts` — would fetch current-year data and write it under historical dates. All 200s, all with a valid `DISTRICT` header, so `isValidDistrictSummaryCsv` would accept every one. A 500 fails loudly; that would rewrite history silently.

So the URL can no longer be trusted to say what year came back, and the fix has to validate by **content**.

## Changes

- **`buildExportUrl`** — new `pathStyle` on `BackfillDateSpec`. `'live'` omits the prefix; the default stays `'archive'`, so every historical caller's URL is byte-identical.
- **`programYearFromCsvFooter`** — derive the year a CSV actually contains from its `Month of X, As of Y` footer. June collected in July is PY 2025-2026, not 2026-2027; that distinction is what makes the rollover unambiguous.
- **`resolveActiveProgramYear`** — read the live endpoint first and trust its footer. Root is authoritative about the current year, so the rollover needs no calendar guess at all. Reject any response whose footer contradicts the requested year. Returns `pathStyle` for callers to thread.
- **`CollectorOrchestrator` / `cli`** — resolve once per run and thread `pathStyle` into every fetch, per the existing resolve-once-and-thread tripwire.
- **`csvFooterParser`** — extracted `parseFooterDataMonth` so the data month is available regardless of closing-period status (`parseClosingPeriodFromCsv` only exposed it for closing periods). `parseClosingPeriodFromCsv` now delegates to it; behavior unchanged.

## Testing

TDD throughout — failing tests committed first (`4e5eafd`), implementation second (`fdbd262`).

- Exact-URL regression tests for live vs. archive, both districtsummary and per-district reports, plus a test pinning that **omitting** `pathStyle` still yields the archive URL.
- Footer→program-year derivation, including the June-close case and the Dec/Jan boundary.
- The corruption guard: a response whose footer disagrees with the requested year is rejected rather than ingested.
- **Threading guard** — an un-threaded `pathStyle` still type-checks and silently reverts to the 500, so a test pins that every per-district fetch carries the resolved style. Mutation-verified: removing `pathStyle` from one call site fails it.

Full suite green, zero regressions: **5,810 tests across 419 files** (frontend 3684, collector-cli 1018, analytics-core 879, shared-contracts 162, mcp-server 67).

## Follow-ups filed

- **#1343** — the fallback is silent and conflates *not published* with *upstream error*. That ambiguity is why this hid for a month behind a green pipeline. Depends on this PR.
- **#1344** — TM retired `Region Advisor Visit` for 2026-2027 (confirmed by operator). `parseYesNo(undefined) → false` will fail every district's Smedley prerequisite gate **the moment this PR makes ingestion work**. Worth landing close behind.

## Verification note

The pipeline's next daily run should flip to 2026-2027 on its own once this merges. Worth confirming that run ingests a 2026-2027 snapshot rather than assuming it — and #1344 lands before anyone reads the Distinguished standings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzS7FV5pH7JMDazPK3T1vn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzS7FV5pH7JMDazPK3T1vn)_