### PR TITLE
fix(analytics): retire the Region Advisor Visit prerequisite for 2026-27 (#1344)

### DIFF
--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.test.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.test.ts
@@ -47,16 +47,87 @@ describe('DistinguishedDistrictCalculator', () => {
     calculator = new DistinguishedDistrictCalculator()
   })
 
+  // #1344 — TM retired the Region Advisor Visit requirement for 2026-2027 and
+  // dropped the column from the districtsummary export. The extractor's
+  // parseYesNo(undefined) yields `false`, so without a 2026-27 ruleset EVERY
+  // district trips `anyRequiredNo` and collapses to NotDistinguished for the
+  // whole program year.
+  describe('2026-27 prerequisites (Region Advisor Visit retired, #1344)', () => {
+    const smedleyMetrics = {
+      paidClubs: 110,
+      paidClubBase: 100,
+      clubGrowthPercent: 10,
+      paymentGrowthPercent: 10,
+      distinguishedPercent: 65,
+    }
+
+    it('awards the earned tier when the four surviving prerequisites are met', () => {
+      const ranking = buildRanking({
+        ...smedleyMetrics,
+        regionAdvisorVisitMet: false, // column absent → coerced to false
+      })
+
+      const result = calculator.calculate(ranking, '2026-2027')
+
+      expect(result.currentTier).toBe('Smedley')
+      expect(result.allPrerequisitesMet).toBe(true)
+    })
+
+    it('still gates on the four prerequisites that survive', () => {
+      const ranking = buildRanking({
+        ...smedleyMetrics,
+        communicationPlanSubmitted: false,
+        regionAdvisorVisitMet: false,
+      })
+
+      const result = calculator.calculate(ranking, '2026-2027')
+
+      expect(result.currentTier).toBe('NotDistinguished')
+      expect(result.allPrerequisitesMet).toBe(false)
+    })
+
+    it('keeps the five-gate rule for 2025-2026 (regression)', () => {
+      const ranking = buildRanking({
+        ...smedleyMetrics,
+        regionAdvisorVisitMet: false,
+      })
+
+      const result = calculator.calculate(ranking, '2025-2026')
+
+      expect(result.currentTier).toBe('NotDistinguished')
+      expect(result.allPrerequisitesMet).toBe(false)
+    })
+
+    it('leaves the 2026-27 tier thresholds identical to 2025-26', () => {
+      // Distinguished floor: 1% growth both metrics, 45% distinguished.
+      const ranking = buildRanking({
+        paidClubs: 101,
+        paidClubBase: 100,
+        clubGrowthPercent: 1,
+        paymentGrowthPercent: 1,
+        distinguishedPercent: 45,
+        regionAdvisorVisitMet: false,
+      })
+
+      expect(calculator.calculate(ranking, '2026-2027').currentTier).toBe(
+        'Distinguished'
+      )
+    })
+  })
+
   describe('Prerequisite gating', () => {
     it('should return NotDistinguished when any prerequisite is missing', () => {
-      // District meeting Smedley criteria but missing Region Advisor Visit
+      // District meeting Smedley criteria but missing the Communication Plan.
+      // Uses a prerequisite that survives into the CURRENT ruleset — Region
+      // Advisor Visit was retired for 2026-27 (#1344), so gating on it is now
+      // only meaningful for 2025-26 (covered by its own regression test above).
       const ranking = buildRanking({
         paidClubs: 110,
         paidClubBase: 100,
         clubGrowthPercent: 10,
         paymentGrowthPercent: 10,
         distinguishedPercent: 65,
-        regionAdvisorVisitMet: false,
+        communicationPlanSubmitted: false,
       })
 
       const result = calculator.calculate(ranking)

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
@@ -158,7 +158,10 @@ interface TierThreshold {
  * Prerequisites: exactly DSP + Training (85%, Sep 30) for every year
  * 2016-17..2024-25 (matches the only prerequisite columns in TI's
  * pre-2025-26 all-districts CSVs); 2025-26 adds Market Analysis,
- * Communication Plan, and 2+ Region Advisor meetings (5 gates).
+ * Communication Plan, and 2+ Region Advisor meetings (5 gates); 2026-27
+ * retires Region Advisor Visit and drops its column, leaving 4 gates
+ * (#1344). Tier thresholds are unchanged across the 2025-26/2026-27
+ * boundary — only the prerequisite set moved.
  */
 interface YearRuleset {
   requiredPrerequisites: ReadonlyArray<keyof DistinguishedDistrictPrerequisites>
@@ -196,7 +199,27 @@ const TIER_THRESHOLDS: TierThreshold[] = [
   },
 ]
 
+/**
+ * 2026-27+ (current): Region Advisor Visit retired (#1344).
+ *
+ * TI dropped the "Region Advisor Visit" column from the districtsummary
+ * export for this program year. Leaving it in the required set would be
+ * worse than a no-op: the ranking extractor coerces the absent column to
+ * `false`, so every district would trip `anyRequiredNo` and sit at
+ * NotDistinguished all year. Tier thresholds are unchanged from 2025-26.
+ */
 const CURRENT_RULESET: YearRuleset = {
+  requiredPrerequisites: [
+    'dspSubmitted',
+    'trainingMet',
+    'marketAnalysisSubmitted',
+    'communicationPlanSubmitted',
+  ],
+  tiers: TIER_THRESHOLDS,
+}
+
+/** 2025-26 only: the five-gate era, including 2+ Region Advisor meetings. */
+const ERA_2025_RULESET: YearRuleset = {
   requiredPrerequisites: [
     'dspSubmitted',
     'trainingMet',
@@ -320,7 +343,8 @@ function rulesetForProgramYear(programYear?: string): YearRuleset {
   if (!programYear) return CURRENT_RULESET
   const startYear = Number.parseInt(programYear.slice(0, 4), 10)
   if (Number.isNaN(startYear)) return CURRENT_RULESET
-  if (startYear >= 2025) return CURRENT_RULESET
+  if (startYear >= 2026) return CURRENT_RULESET
+  if (startYear >= 2025) return ERA_2025_RULESET
   if (startYear >= 2022) return ERA_2022_RULESET
   if (startYear >= 2018) return ERA_2018_RULESET
   return ERA_2016_RULESET


### PR DESCRIPTION
Fixes #1344. Follows #1345 (merged).

## Why this is urgent

#1345 made 2026-2027 ingestion work. The next daily pipeline run is the first that will actually write new-year data — and without this change it will publish **every district at NotDistinguished**, for the whole program year.

## Problem

TI retired the Region Advisor Visit requirement for 2026-2027 and dropped the column from the districtsummary export (24 columns vs 25 — confirmed by the operator and by diffing the live 2025-26 and 2026-27 CSVs on 2026-07-31).

Nothing crashes, which is exactly why this is dangerous. The extractor reads by column name and the field is optional, so `parseYesNo(undefined)` quietly returns `false`:

```ts
private parseYesNo(value: string | number | null | undefined): boolean {
  if (typeof value !== 'string') return false
  return value.trim().toUpperCase() === 'Y'
}
```

Every district gets `regionAdvisorVisitMet: false`. The five-gate `CURRENT_RULESET` then hits `anyRequiredNo` and pins the tier to `NotDistinguished`:

```ts
const allPrerequisitesMet = required.every(k => raw[k] === true)
const anyRequiredNo = required.some(k => raw[k] === false)
```

Uniform, silent, and it reads as "nobody has qualified yet" rather than as a bug.

Worth noting: the calculator's tri-state design already anticipated an absent column — `undefined` yields `Unknown`, not `NotDistinguished`. That safeguard is defeated *upstream* by the extractor's coercion to `false`. Fixing the coercion instead would produce `Unknown`, which is also wrong: the requirement doesn't exist, so districts should simply be eligible on the four that remain.

## Changes

The ruleset is already era-keyed, so this is a new era rather than an edit to the old one:

- **`CURRENT_RULESET`** drops `regionAdvisorVisitMet` (4 gates) and applies to `startYear >= 2026`. It remains the default for an absent or unparseable program year — that is the "current rules" semantic the name carries.
- **`ERA_2025_RULESET`** preserves the five-gate rule for 2025-26 so history still evaluates correctly.
- **Tier thresholds untouched** — only the prerequisite set moved.
- `regionAdvisorVisitMet` stays on the type and is still populated; the display breakdown keeps its legacy 5-boolean shape for the checklist UI.

## Testing

TDD — the failing test reproduced the exact collapse first (`expected 'NotDistinguished' to be 'Smedley'`).

- A 2026-27 district meeting the four surviving prerequisites earns its tier, even with `regionAdvisorVisitMet: false`.
- 2026-27 still gates on the four that survive.
- 2025-26 still requires all five (regression pinned).
- Tier thresholds unchanged across the boundary.

**One pre-existing test changed, and it deserves scrutiny rather than a rubber stamp.** `should return NotDistinguished when any prerequisite is missing` used Region Advisor Visit as its example of a missing prerequisite, and passed no program year — so it exercised the *current* ruleset. Its premise went stale, not its intent. I switched it to `communicationPlanSubmitted` so it still proves "any missing prerequisite → NotDistinguished" under current rules, and Region Advisor gating is now covered by the dedicated 2025-26 regression test. No assertion was pinned to a new value.

Full suite green: **5,814 tests across 419 files**.

One flake surfaced on the first full run — `DistrictClubsPage > renders the ClubsTable` — which re-ran clean and is unrelated: `DistrictClubsPage` never imports the calculator, and the frontend references `regionAdvisorVisitMet` only as a display field. That's the known contention surface from epic #917 / Lesson 51, not a regression from this change.

## Follow-up worth filing

`DistinguishedDistrictTrophyCase.tsx:110` hardcodes `regionAdvisorVisitMet: '2+ Region Advisor meetings'` in its checklist label map. After this change a 2026-27 district will correctly show as Distinguished while its checklist still renders that row unmet — cosmetically contradictory. The checklist should be driven by the year's required set rather than a fixed list. Out of scope here; happy to take it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzS7FV5pH7JMDazPK3T1vn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzS7FV5pH7JMDazPK3T1vn)_