### PR TITLE
feat(pipeline): allow_subtractive override for a reviewed district consolidation (#1350)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -76,6 +76,11 @@ on:
         required: false
         type: boolean
         default: false
+      allow_subtractive:
+        description: 'Promote even if staging has FEWER districts/dates than prod (review the count diff first). For TI district consolidations.'
+        required: false
+        type: boolean
+        default: false
 
 # Prevent overlapping pipeline runs
 concurrency:
@@ -1488,6 +1493,8 @@ jobs:
       - name: Diff staging vs production
         id: diff
         if: steps.mode.outputs.mode != 'prune'
+        env:
+          ALLOW_SUBTRACTIVE: ${{ inputs.allow_subtractive }}
         run: |
           echo "Comparing staging vs production buckets..."
 
@@ -1514,13 +1521,32 @@ jobs:
 
           # Determine if promotion is safe (additive-only)
           PROMOTE="true"
+          SUBTRACTIVE="false"
           if [ "$STAGING_RANKINGS" -lt "$PROD_RANKINGS" ] 2>/dev/null; then
             echo "::warning::SUBTRACTIVE: staging has fewer ranked districts than production"
             PROMOTE="false"
+            SUBTRACTIVE="true"
           fi
           if [ "$STAGING_DATES" -lt "$PROD_DATES" ] 2>/dev/null; then
             echo "::warning::SUBTRACTIVE: staging has fewer dates than production"
             PROMOTE="false"
+            SUBTRACTIVE="true"
+          fi
+
+          # Operator override for a REVIEWED subtractive change (#1350).
+          # Toastmasters periodically consolidates districts — PY 2026-2027 cut
+          # the roster 128 → 94 — which is a legitimate reduction the count gate
+          # cannot distinguish from data loss. Mirrors allow_value_changes for
+          # the value gate. Overriding is recorded loudly: it must never be
+          # possible to discover after the fact that a gate was bypassed.
+          if [ "$SUBTRACTIVE" = "true" ] && [ "${ALLOW_SUBTRACTIVE:-false}" = "true" ]; then
+            echo "::warning::Count gate OVERRIDDEN by allow_subtractive — operator asserts this reduction is intended"
+            PROMOTE="true"
+            {
+              echo "- **⚠️ Count gate OVERRIDDEN** (\`allow_subtractive=true\`)"
+              echo "  - Ranked districts: ${PROD_RANKINGS} → ${STAGING_RANKINGS} ($((STAGING_RANKINGS - PROD_RANKINGS)))"
+              echo "  - Dates: ${PROD_DATES} → ${STAGING_DATES} ($((STAGING_DATES - PROD_DATES)))"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "promote=${PROMOTE}" >> "$GITHUB_OUTPUT"
@@ -1677,6 +1703,7 @@ jobs:
           echo "- Value gate: **${{ steps.valuediff.outputs.value_promote }}**" >> "$GITHUB_STEP_SUMMARY"
           echo "Production data is **unchanged**. Review the diffs above." >> "$GITHUB_STEP_SUMMARY"
           echo "For a reviewed re-derive, re-run with **allow_value_changes = true**." >> "$GITHUB_STEP_SUMMARY"
+          echo "For a reviewed district/date REDUCTION (e.g. a TI consolidation), re-run with **allow_subtractive = true**." >> "$GITHUB_STEP_SUMMARY"
 
       # ════════════════════════════════════════════════════════
       # PROMOTION-HELD ALERT (#1073, epic #1072)


### PR DESCRIPTION
Fixes #1350. Unblocks the PY 2026-2027 promotion held by run [30643159639](https://github.com/taverns-red/toast-stats/actions/runs/30643159639).

## Context

The force re-run on `76e279ca` (with #1345 + #1347) **successfully ingested PY 2026-2027** — first time ever. Staging holds a real `snapshots/2026-07-30` under the new program year. Promotion was then correctly refused:

```
SUBTRACTIVE: staging has fewer ranked districts than production
Gate outputs — count_promote=false value_promote=true
Decision — blocked=true gate=count
```

TI consolidated districts for the new program year:

| | districts |
|---|---|
| 2025-2026 | 128 |
| 2026-2027 | **94** |
| net | **−34** |

30 new 2xx districts (201–231) appear; 64 old ones retire. **Operator confirmed this reduction is real.**

## Why an override rather than a smarter gate

The count gate cannot distinguish a legitimate consolidation from genuine data loss, and teaching it to try would be worse — it would weaken the check for every future run in order to handle a once-a-decade event. This is an operator judgement, and the system had no way to record one.

The value gate already has `allow_value_changes`. The count gate had no equivalent, so the only way to promote a reviewed reduction was to bypass the workflow entirely with a hand-run `gsutil rsync` — which skips CDN invalidation (#1294) and leaves no trace in the run summary. That's strictly worse than an explicit, logged override.

## Change

`allow_subtractive` (boolean, default `false`), mirroring `allow_value_changes`.

Applied at the **gate's output**, not at the four downstream `if:` conditions. `Promote`, `Invalidate CDN cache`, `Promotion blocked`, and the promotion-held alert (#1073) all read `steps.diff.outputs.promote`, so overriding at the source keeps them consistent — four separately-edited conditions would be a divergence waiting to happen.

Overriding emits a `::warning::` and a step-summary block naming both deltas:

```
- **⚠️ Count gate OVERRIDDEN** (`allow_subtractive=true`)
  - Ranked districts: 128 → 94 (-34)
  - Dates: 39 → 40 (1)
```

It must never be possible to discover after the fact that a gate was bypassed without also seeing why. The `Promotion blocked` message now names the new input too, so the next person hitting this finds the remedy in the summary.

## Testing

This workflow can't be exercised in CI, so I extracted the gate logic and simulated it over 7 cases:

| case | override | result |
|---|---|---|
| 94 vs 128 districts | off | blocks ✓ |
| 94 vs 128 districts | on | promotes ✓ |
| additive run | off / on | promotes ✓ |
| fewer dates only | off | blocks ✓ |
| fewer dates only | on | promotes ✓ |
| scheduled run (inputs empty) | n/a | blocks ✓ |

That last row matters: `inputs.*` is an empty string on `schedule`, so `${ALLOW_SUBTRACTIVE:-false}` must not accidentally enable the override on the nightly cron. It doesn't.

`npm run lint:yaml` clean; the workflow parses and the input is well-formed.

## One decision worth your review

The override is deliberately **general** — it also permits a reduction in *dates*, not just districts. A date reduction means losing history, which is the scarier failure, so there's a fair argument for narrowing this to districts only (`allow_district_reduction`). I kept it general because the gate itself is general and the summary prints both deltas, but I'd rather you make that call than have it decided by my default. Noted in #1350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzS7FV5pH7JMDazPK3T1vn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzS7FV5pH7JMDazPK3T1vn)_