### PR TITLE
fix(frontend): NaN program year (#1353), year-driven DD checklist (#1354), contact path (#1356), 640px column dead zone (#1358), landing CLS 0.265 → 0.004 (#1359)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Report a bug
+description: Something on ts.taverns.red is wrong, broken, or showing data you don't expect.
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. The most useful thing you can give us is the
+        **page URL** — it encodes the program year, the as-of date and any
+        region filters, which is usually enough to reproduce straight away.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you see, and what did you expect instead?
+      placeholder: |
+        District 61's paid clubs showed 0, but the Toastmasters dashboard
+        shows 147 for the same date.
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: Page URL
+      description: Copy it from the address bar — the query string matters.
+      placeholder: https://ts.taverns.red/?date=2026-07-30&py=2026
+    validations:
+      required: true
+
+  - type: input
+    id: district
+    attributes:
+      label: District (if the problem is specific to one)
+      placeholder: '61'
+
+  - type: textarea
+    id: dashboard
+    attributes:
+      label: What does the Toastmasters dashboard show?
+      description: |
+        Optional, but it settles things fast. If the numbers differ from
+        dashboards.toastmasters.org, say what that shows for the same date —
+        that tells us whether the bug is in our pipeline or upstream.
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser / device
+      placeholder: Chrome 148 on macOS, or Safari on iPhone

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# Keep the chooser to the two curated forms (#1356). blank_issues_enabled
+# stays true so maintainers can still open a free-form issue without going
+# through a form — most of this repo's issues are written that way.
+blank_issues_enabled: true
+
+contact_links:
+  - name: How the numbers are calculated
+    url: https://ts.taverns.red/methodology
+    about: >-
+      Distinguished tiers, DCP goals and award formulas are documented
+      here — worth a look before filing a data bug.
+  - name: Toastmasters International dashboards
+    url: https://dashboards.toastmasters.org
+    about: Toast Stats mirrors TI's published data. If a number is wrong at the source, it will be wrong here too.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Request a feature
+description: Suggest a metric, view, or capability you'd like Toast Stats to have.
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ideas are welcome. It helps most to hear what you're trying to *find
+        out* — the underlying question often has a better answer than the
+        feature it first suggests.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The question you're trying to answer, or the task you're stuck on.
+      placeholder: |
+        I'm a Division Director and I want to see which of my clubs are at
+        risk of dropping below 12 members before the September renewal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would help?
+      description: Your suggested feature, if you have one in mind.
+
+  - type: input
+    id: role
+    attributes:
+      label: Your Toastmasters role (optional)
+      description: Helps us judge who a feature would serve.
+      placeholder: Area Director, D61
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: How do you do this today?
+      description: |
+        Optional. If you're exporting CSV and pivoting it in a spreadsheet,
+        that's useful signal about what's missing.

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ logs.txt
 
 # Data (local-only)
 data/
+
+# Ephemeral per-agent git worktrees (Claude Code `isolation: worktree`).
+# Live scratch checkouts with their own node_modules — never committable.
+.claude/worktrees/

--- a/frontend/src/__tests__/rankingsColumnPriority.guard.test.ts
+++ b/frontend/src/__tests__/rankingsColumnPriority.guard.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Static guard for the rankings table's responsive column ladder (#1358).
+ *
+ * Reads the CSS and the page source as TEXT rather than mounting
+ * DistrictsPage: jsdom has no layout engine, so a mount could not prove a
+ * media query anyway, and mounting this page is the exact contention cost
+ * Lesson 51 warns about. Reading by `fs` also keeps this out of R22's
+ * page-mount check, which keys on importing `pages/*Page`.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const css = readFileSync(
+  join(__dirname, '../styles/components/app-shell.css'),
+  'utf-8'
+)
+const page = readFileSync(
+  join(__dirname, '../pages/DistrictsPage.tsx'),
+  'utf-8'
+)
+
+describe('rankings column priority ladder (#1358)', () => {
+  // The dead zone: a 360x640 phone in LANDSCAPE is 640px — 70% wider than the
+  // 375px design target, yet below the 768px tablet breakpoint, so it was
+  // served the bare District/Rank/Score set with no orientation or zoom that
+  // could reveal a metric.
+  it('reveals the compact columns at 600px, closing the 640px landscape gap', () => {
+    expect(css).toMatch(
+      /@media\s*\(min-width:\s*600px\)\s*\{\s*\.districts-rankings-table__col--compact\s*\{\s*display:\s*table-cell/
+    )
+  })
+
+  it('keeps compact columns hidden by default (mobile-first)', () => {
+    expect(css).toMatch(
+      /\.districts-rankings-table__col--compact[\s\S]{0,120}?display:\s*none/
+    )
+  })
+
+  it('leaves the existing 768 / 1280 rungs intact', () => {
+    expect(css).toMatch(
+      /@media\s*\(min-width:\s*768px\)\s*\{\s*\.districts-rankings-table__col--tablet/
+    )
+    expect(css).toMatch(
+      /@media\s*\(min-width:\s*1280px\)\s*\{\s*\.districts-rankings-table__col--desktop/
+    )
+  })
+
+  // Paid Clubs and Total Payments dominate the Borda score, so they are the
+  // two worth surfacing first on a narrow screen. Distinguished stays at 768.
+  // Counts MARKUP only — the ` px-` suffix is the utility-class run that
+  // follows in a real class attribute, which keeps prose mentions of these
+  // class names in the surrounding code comments from inflating the count.
+  it('promotes Paid Clubs and Total Payments to the compact tier', () => {
+    const compactCells = page.match(
+      /districts-rankings-table__col--compact px-/g
+    )
+    // 2 headers + 2 body cells
+    expect(compactCells?.length).toBe(4)
+  })
+
+  it('leaves Distinguished on the tablet tier', () => {
+    const tabletCells = page.match(/districts-rankings-table__col--tablet px-/g)
+    // 1 header + 1 body cell
+    expect(tabletCells?.length).toBe(2)
+  })
+})

--- a/frontend/src/__tests__/rankingsColumnPriority.guard.test.ts
+++ b/frontend/src/__tests__/rankingsColumnPriority.guard.test.ts
@@ -48,20 +48,63 @@ describe('rankings column priority ladder (#1358)', () => {
 
   // Paid Clubs and Total Payments dominate the Borda score, so they are the
   // two worth surfacing first on a narrow screen. Distinguished stays at 768.
-  // Counts MARKUP only — the ` px-` suffix is the utility-class run that
-  // follows in a real class attribute, which keeps prose mentions of these
-  // class names in the surrounding code comments from inflating the count.
+  // Counts MARKUP only — matched inside a class attribute so prose mentions
+  // of these class names in surrounding code comments can't inflate the
+  // count. (Deliberately not keyed on a trailing utility class: the padding
+  // utilities were removed in the density pass, #1358.)
+  const cellsWith = (cls: string) =>
+    page.match(
+      new RegExp(`(?:className|thClassName)="[^"]*${cls}(?:[ "])`, 'g')
+    ) ?? []
+
   it('promotes Paid Clubs and Total Payments to the compact tier', () => {
-    const compactCells = page.match(
-      /districts-rankings-table__col--compact px-/g
-    )
     // 2 headers + 2 body cells
-    expect(compactCells?.length).toBe(4)
+    expect(cellsWith('districts-rankings-table__col--compact').length).toBe(4)
   })
 
   it('leaves Distinguished on the tablet tier', () => {
-    const tabletCells = page.match(/districts-rankings-table__col--tablet px-/g)
     // 1 header + 1 body cell
-    expect(tabletCells?.length).toBe(2)
+    expect(cellsWith('districts-rankings-table__col--tablet').length).toBe(2)
+  })
+})
+
+describe('rankings table density (#1358 follow-up)', () => {
+  // Layer order in index.css is `base, brand, utilities` — utilities LAST, so
+  // Tailwind's px-*/py-* beat the `.districts-rankings-table td` rule in the
+  // brand layer regardless of specificity. Cells carrying padding utilities
+  // therefore silently override the table's own density, and the two sources
+  // drift. CSS is the single source of truth; markup carries none.
+  it('leaves cell padding to CSS — no padding utilities on table cells', () => {
+    const padded = page.match(
+      /(?:className|thClassName)="[^"]*districts-rankings-table__(?:col--|sticky-col)[^"]*p[xy]-\d/g
+    )
+    expect(padded).toBeNull()
+  })
+
+  // The sticky identity column is subtracted from EVERY viewport before a
+  // metric renders, so an award-decorated district must not set the width for
+  // the whole table on a phone.
+  it('caps the sticky District column on small screens', () => {
+    expect(css).toMatch(
+      /\.districts-rankings-table__sticky-col[\s\S]{0,200}?max-width/
+    )
+  })
+
+  // Award chips were icon + text label. Below the compact breakpoint the label
+  // is visually hidden but kept for assistive tech (sr-only, not display:none)
+  // — a trophy alone is meaningless to a screen reader.
+  it('renders award chip labels icon-only on narrow screens', () => {
+    const srOnlyLabels = page.match(/className="sr-only sm:not-sr-only[^"]*"/g)
+    // Extension, 20-Plus, Retention
+    expect(srOnlyLabels?.length).toBe(3)
+  })
+
+  // The td said `whitespace-nowrap` while its inner flex said `flex-wrap` —
+  // contradictory. The chips are meant to wrap rather than widen the column.
+  it('does not force the District cell to a single line', () => {
+    const stickyCell = page.match(
+      /className="[^"]*districts-rankings-table__sticky-col[^"]*"/g
+    )
+    expect(stickyCell?.some(c => c.includes('whitespace-nowrap'))).toBe(false)
   })
 })

--- a/frontend/src/components/AppShell/AppMeta.tsx
+++ b/frontend/src/components/AppShell/AppMeta.tsx
@@ -47,6 +47,21 @@ const AppMeta: React.FC = () => {
             MCP server
           </Link>
           {' · '}
+          {/* The only contact path in the app (#1356). There is no backend to
+              POST a form to, so this goes to the GitHub issue chooser, whose
+              bug/feature templates live in .github/ISSUE_TEMPLATE/. Same
+              placement reasoning as the /mcp link above: it sits BEFORE the
+              license so the "MIT License · <version>" pairing stays adjacent
+              for the version guard. */}
+          <a
+            href="https://github.com/taverns-red/toast-stats/issues/new/choose"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="app-shell-footer__link"
+          >
+            Report an issue
+          </a>
+          {' · '}
           <a
             href="https://github.com/taverns-red/toast-stats/blob/main/LICENSE"
             target="_blank"

--- a/frontend/src/components/AppShell/__tests__/AppMeta.test.tsx
+++ b/frontend/src/components/AppShell/__tests__/AppMeta.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import AppMeta from '../AppMeta'
+
+const ISSUES_URL =
+  'https://github.com/taverns-red/toast-stats/issues/new/choose'
+
+function renderMeta() {
+  return render(
+    <MemoryRouter>
+      <AppMeta />
+    </MemoryRouter>
+  )
+}
+
+describe('AppMeta — report an issue (#1356)', () => {
+  it('exposes a "Report an issue" link to the issue chooser', () => {
+    renderMeta()
+
+    const link = screen.getByRole('link', { name: /report an issue/i })
+    expect(link).toHaveAttribute('href', ISSUES_URL)
+  })
+
+  // Every other external link here opens in a new tab; this one must not
+  // navigate the user away from the data they are trying to report on.
+  it('opens in a new tab with a safe rel', () => {
+    renderMeta()
+
+    const link = screen.getByRole('link', { name: /report an issue/i })
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  // AppMeta renders in BOTH the desktop footer and the mobile "About ▾"
+  // disclosure (#889). Asserting on AppMeta itself is what makes the link
+  // reachable at every breakpoint rather than desktop-only.
+  it('renders the link as part of the shared meta strip', () => {
+    renderMeta()
+
+    const link = screen.getByRole('link', { name: /report an issue/i })
+    expect(link).toHaveClass('app-shell-footer__link')
+  })
+
+  // AppMeta's own comment warns that the "MIT License · <version>" pairing
+  // must stay adjacent — AppShellTopBar.about.test.tsx:74 asserts it. A new
+  // link inserted between them would break that guard, so pin it here too:
+  // this file is where someone adding the NEXT link will look.
+  it('keeps "MIT License · <version>" adjacent', () => {
+    renderMeta()
+
+    const text = screen.getByTestId('app-version').textContent ?? ''
+    expect(text).toMatch(/MIT License\s*·\s*(?:v?\d|dev)/i)
+  })
+})

--- a/frontend/src/components/AwardsRaceSection.tsx
+++ b/frontend/src/components/AwardsRaceSection.tsx
@@ -146,7 +146,15 @@ const AwardsRaceSkeleton: React.FC = () => (
     data-testid="awards-race-skeleton"
   >
     <header className="awards-race__header">
-      <span className="awards-race-skeleton__bar awards-race-skeleton__bar--heading" />
+      {/* Wrapped in the real __title so the heading's own metrics apply, and
+          carrying a .tooltip-reserve for the InfoTooltip the loaded heading
+          renders — its trigger is a <button>, floored at 44px by
+          styles/layers/base.css, which is 45px more than a bare bar reserves
+          (#1359). */}
+      <span className="awards-race__title">
+        <span className="awards-race-skeleton__bar awards-race-skeleton__bar--heading" />
+        <span className="tooltip-reserve" aria-hidden="true" />
+      </span>
     </header>
     <div className="awards-race__grid">
       {AWARD_CARDS.map(({ key, spec }) => (

--- a/frontend/src/components/AwardsRaceSection.tsx
+++ b/frontend/src/components/AwardsRaceSection.tsx
@@ -88,13 +88,16 @@ export const AwardsRaceSection: React.FC<AwardsRaceSectionProps> = ({
     return { spec, entries }
   })
 
-  // Settled with data but every award array empty → collapse (same rare path
-  // as the null/legacy-snapshot case above; on populated snapshots all three
-  // arrays carry contenders, so the reserved skeleton fills in place). The
-  // minor collapse shift here is bounded to snapshots that genuinely have no
-  // competitive-award standings.
-  const allEmpty = cardData.every(({ entries }) => entries.length === 0)
-  if (allEmpty) return null
+  // Settled with data but every award array empty → the slot is HELD, not
+  // vacated (#1359). This used to `return null`, described as a rare path
+  // "bounded to snapshots that genuinely have no competitive-award
+  // standings" — but at the start of a program year that is every snapshot,
+  // because no district has contended for anything yet. So the reserved #750
+  // skeleton mounted and then unmounted on every load for the first months
+  // of each year: a measured 196px collapse, CLS 0.083 on the landing page.
+  // `AwardCard` renders its own no-leader state, and that state is
+  // structurally identical to a populated card, so skeleton → empty →
+  // populated are all the same box and no swap shifts the page below.
 
   const updatedAt = (() => {
     const raw = standings.metadata?.calculatedAt
@@ -177,6 +180,13 @@ const AwardCard: React.FC<AwardCardProps> = ({ spec, entries }) => {
   const winners = entries.filter(e => e.isWinner)
   const isAchieved = leader?.isWinner ?? false
 
+  // No contenders yet — the normal state for the first months of a program
+  // year, not an exotic one (#1359). Mirrors the populated card's rows
+  // (leader → progress → status) exactly, so this card occupies the same box
+  // as the #750 skeleton it replaces and as the populated card that replaces
+  // it once standings appear. Matching structurally rather than pinning a
+  // min-height means the reserve holds at every breakpoint and cannot drift
+  // away from the content it is reserving for.
   if (!leader) {
     return (
       <article className="awards-race-card">
@@ -184,7 +194,24 @@ const AwardCard: React.FC<AwardCardProps> = ({ spec, entries }) => {
           <h3 className="awards-race-card__title">{spec.title}</h3>
           <p className="awards-race-card__threshold">{spec.threshold}</p>
         </header>
-        <p className="awards-race-card__empty">No standings yet.</p>
+        <div className="awards-race-card__row">
+          <span
+            className="awards-race-card__leader-placeholder"
+            aria-hidden="true"
+          >
+            —
+          </span>
+          <span className="awards-race-card__leader-value" aria-hidden="true">
+            —
+          </span>
+        </div>
+        {/* Unfilled track, and deliberately no role="progressbar": a bar
+            announcing 0% would imply a measurement nobody has taken yet. */}
+        <div className="awards-race-card__progress-track" />
+        <footer className="awards-race-card__status">
+          <span aria-hidden="true" className="awards-race-card__status-dot" />
+          <span className="awards-race-card__empty">No standings yet.</span>
+        </footer>
       </article>
     )
   }

--- a/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
+++ b/frontend/src/components/DistinguishedDistrictTrophyCase.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { requiredPrerequisitesForProgramYear } from '@taverns-red/analytics-core'
 import {
   deriveRemainingToTier,
   type RemainingInputs,
@@ -59,6 +60,15 @@ interface DistinguishedDistrictTrophyCaseProps {
    * slot in place.
    */
   isLoading?: boolean
+  /**
+   * Program year ("YYYY-YYYY") the status belongs to. Drives which
+   * prerequisite rows the checklist renders — TI's required gates change
+   * by year (e.g. Region Advisor Visit retired for 2026-27, #1344) while
+   * `status.prerequisites` deliberately keeps emitting the legacy
+   * 5-boolean shape for every era (#1354). Omitted callers keep the
+   * pre-#1354 behavior of showing all 5 rows.
+   */
+  programYear?: string
   /** Optional rankings row used to derive the absolute remaining counts
       when the canonical fields are absent or the next tier is above
       Distinguished. Matches the region page's data source. */
@@ -242,6 +252,7 @@ export const DistinguishedDistrictTrophyCase: React.FC<
 > = ({
   status,
   isLoading = false,
+  programYear,
   ranking,
   clubStrengthQualifies,
   clubStrengthGrowth,
@@ -259,8 +270,16 @@ export const DistinguishedDistrictTrophyCase: React.FC<
 
   const { currentTier, allPrerequisitesMet, prerequisites, nextTierGap } =
     status
-  const metCount = PREREQUISITE_KEYS.filter(k => prerequisites[k]).length
-  const totalCount = PREREQUISITE_KEYS.length
+  // Drive the visible checklist rows from the program year's required
+  // gate set (#1354) rather than the fixed PREREQUISITE_LABELS map — so a
+  // retired requirement (e.g. Region Advisor Visit for 2026-27, #1344)
+  // stops rendering as a permanently-unmet row. No `programYear` keeps
+  // the pre-#1354 behavior of showing every legacy key.
+  const visibleKeys = programYear
+    ? requiredPrerequisitesForProgramYear(programYear)
+    : PREREQUISITE_KEYS
+  const metCount = visibleKeys.filter(k => prerequisites[k]).length
+  const totalCount = visibleKeys.length
   // Unmet prereqs are the whole point of the panel — never let the user
   // collapse the list when something needs attention.
   const expanded = !allPrerequisitesMet || userExpanded
@@ -353,7 +372,7 @@ export const DistinguishedDistrictTrophyCase: React.FC<
             id="prerequisite-list"
             className="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-1"
           >
-            {PREREQUISITE_KEYS.map(key => {
+            {visibleKeys.map(key => {
               const met = prerequisites[key]
               return (
                 <li

--- a/frontend/src/components/__tests__/AwardsRaceSection.test.tsx
+++ b/frontend/src/components/__tests__/AwardsRaceSection.test.tsx
@@ -171,6 +171,33 @@ describe('AwardsRaceSection — 3-card redesign (#357)', () => {
     expect(container.querySelector('.awards-race-card__leader-link')).toBeNull()
   })
 
+  // #1359 — the loaded section heading carries an InfoTooltip, whose trigger
+  // is a <button>, and styles/layers/base.css floors every button at 44px
+  // (WCAG 2.5.5). That inflates the heading's line box far beyond its text,
+  // so a skeleton heading rendered as a bare bar under-reserves by ~45px and
+  // the swap expands the section — measured as a residual CLS 0.0105 after
+  // the collapse in this same issue was fixed. The reserve is structural
+  // (a .tooltip-reserve box, same 44px floor) rather than a pinned height.
+  it('reserves the heading tooltip the loaded section renders (#1359)', () => {
+    const { container } = renderWithRouter(
+      <AwardsRaceSection standings={null} isLoading />
+    )
+    const heading = container.querySelector('.awards-race__header')
+    expect(heading).not.toBeNull()
+    expect(heading!.querySelector('.tooltip-reserve')).not.toBeNull()
+  })
+
+  it('renders that heading tooltip in the loaded section', () => {
+    // Guards the premise of the reserve above: if the loaded heading ever
+    // stops carrying a tooltip, the reserve becomes an over-reserve and this
+    // test — not a mystery CLS number — is what should fail.
+    const { container } = renderWithRouter(
+      <AwardsRaceSection standings={mockStandings} />
+    )
+    const heading = container.querySelector('.awards-race__header')
+    expect(heading!.querySelector('button')).not.toBeNull()
+  })
+
   it('still renders nothing once the query settles with no data (not loading)', () => {
     const { container } = renderWithRouter(
       <AwardsRaceSection standings={null} isLoading={false} />

--- a/frontend/src/components/__tests__/AwardsRaceSection.test.tsx
+++ b/frontend/src/components/__tests__/AwardsRaceSection.test.tsx
@@ -178,17 +178,63 @@ describe('AwardsRaceSection — 3-card redesign (#357)', () => {
     expect(container.querySelector('.awards-race')).toBeNull()
   })
 
-  it('does not render when all award arrays are empty', () => {
+  // #1359 — this used to collapse to null, which the code called a "rare"
+  // path "bounded to snapshots that genuinely have no competitive-award
+  // standings". At the START of a program year that is EVERY snapshot: no
+  // district has contended for anything yet. So the reserved 196px skeleton
+  // mounted and then unmounted on every single load for the first months of
+  // each year — a guaranteed CLS 0.083 collapse, measured on the landing page.
+  // Settled-with-no-contenders now holds the slot instead of vacating it.
+  describe('a program year with no contenders yet (#1359)', () => {
     const empty: CompetitiveAwardStandings = {
       ...mockStandings,
       extensionAward: [],
       twentyPlusAward: [],
       retentionAward: [],
     }
-    const { container } = renderWithRouter(
-      <AwardsRaceSection standings={empty} />
-    )
-    expect(container.querySelector('.awards-race-card')).toBeNull()
+
+    it('holds the slot rather than collapsing it', () => {
+      const { container } = renderWithRouter(
+        <AwardsRaceSection standings={empty} />
+      )
+      expect(container.querySelector('.awards-race')).not.toBeNull()
+      expect(container.querySelectorAll('.awards-race-card').length).toBe(3)
+    })
+
+    // Same box as the skeleton it replaces and as the populated card that
+    // replaces IT later in the year — matched structurally (same rows) rather
+    // than by a hardcoded min-height, so every breakpoint is covered and the
+    // reserve cannot drift from the content.
+    it('keeps the populated card structure so the swap is shift-free', () => {
+      const { container } = renderWithRouter(
+        <AwardsRaceSection standings={empty} />
+      )
+      expect(container.querySelectorAll('.awards-race-card__row').length).toBe(
+        3
+      )
+      expect(
+        container.querySelectorAll('.awards-race-card__progress-track').length
+      ).toBe(3)
+      expect(
+        container.querySelectorAll('.awards-race-card__status').length
+      ).toBe(3)
+    })
+
+    it('says so in words rather than showing a fake leader', () => {
+      renderWithRouter(<AwardsRaceSection standings={empty} />)
+      expect(screen.getAllByText(/no standings yet/i).length).toBe(3)
+      expect(
+        document.querySelector('.awards-race-card__leader-link')
+      ).toBeNull()
+    })
+
+    // The dark-mode contrast sweep enumerates this selector by name.
+    it('keeps the __empty class the contrast sweep enumerates', () => {
+      const { container } = renderWithRouter(
+        <AwardsRaceSection standings={empty} />
+      )
+      expect(container.querySelector('.awards-race-card__empty')).not.toBeNull()
+    })
   })
 
   it('renders a progress bar on each card with a sensible width %', () => {

--- a/frontend/src/components/__tests__/DistinguishedDistrictTrophyCase.test.tsx
+++ b/frontend/src/components/__tests__/DistinguishedDistrictTrophyCase.test.tsx
@@ -117,6 +117,74 @@ describe('DistinguishedDistrictTrophyCase', () => {
     })
   })
 
+  // #1354 — TM retired the Region Advisor Visit requirement for 2026-27
+  // and dropped the column from the export. The calculator still emits
+  // all 5 booleans on `prerequisites` (legacy display shape), so the
+  // checklist must drive its rows from the program year's REQUIRED set
+  // rather than a fixed label map, or a legitimately-Distinguished
+  // 2026-27 district shows a permanently-unmet Region Advisor row.
+  describe('prerequisite checklist — driven by program year ruleset (#1354)', () => {
+    it('renders four rows and no Region Advisor row for 2026-27', async () => {
+      const user = userEvent.setup()
+      const status2026: DistinguishedDistrictStatus = {
+        ...baseStatus,
+        allPrerequisitesMet: true,
+        prerequisites: {
+          dspSubmitted: true,
+          trainingMet: true,
+          marketAnalysisSubmitted: true,
+          communicationPlanSubmitted: true,
+          // Column dropped for 2026-27 — always coerced false, but it must
+          // not render as an unmet row for a district that otherwise
+          // earned its tier.
+          regionAdvisorVisitMet: false,
+        },
+      }
+      render(
+        <DistinguishedDistrictTrophyCase
+          status={status2026}
+          programYear="2026-2027"
+        />
+      )
+      const toggle = screen.getByRole('button', {
+        name: /4 of 4 prerequisites met/i,
+      })
+      await user.click(toggle)
+      expect(
+        screen.getByText(/District Success Plan submitted/i)
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(/85% Director training complete/i)
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(/Market Analysis Plan submitted/i)
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(/Communication Plan submitted/i)
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(/2\+ Region Advisor meetings/i)
+      ).not.toBeInTheDocument()
+    })
+
+    it('still renders all five rows, including Region Advisor, for 2025-26', async () => {
+      const user = userEvent.setup()
+      render(
+        <DistinguishedDistrictTrophyCase
+          status={baseStatus}
+          programYear="2025-2026"
+        />
+      )
+      const toggle = screen.getByRole('button', {
+        name: /5 of 5 prerequisites met/i,
+      })
+      await user.click(toggle)
+      expect(
+        screen.getByText(/2\+ Region Advisor meetings/i)
+      ).toBeInTheDocument()
+    })
+  })
+
   describe('gap to next tier — canonical countdown tiles (#840)', () => {
     /* The district tiles must consume the SAME integers the region row's
        "Remaining to Distinguished" cells consume — never a value derived

--- a/frontend/src/hooks/__tests__/useDefaultProgramYear.test.ts
+++ b/frontend/src/hooks/__tests__/useDefaultProgramYear.test.ts
@@ -79,4 +79,29 @@ describe('useDefaultProgramYear (#1300)', () => {
       expect(result.current.year).toBe(getCurrentProgramYear().year)
     )
   })
+
+  it('never derives a NaN program year from a malformed dates payload (#1353)', async () => {
+    // The raw CDN payload is untrusted: an empty string, a non-date, and a
+    // non-ISO-suffixed timestamp must not reach getAvailableProgramYears
+    // unfiltered — this hook must mint (snapshotDatesFrom) exactly like
+    // useProgramYearControls does, not read `data.dates` raw.
+    //
+    // Deliberately uses a PY (2020-2021) far from the current calendar PY —
+    // the loading-state calendar fallback would coincidentally equal the
+    // target year if this used the current PY, making the assertion pass
+    // vacuously on the pre-resolve render instead of the resolved value.
+    vi.mocked(fetchCdnDates).mockResolvedValue({
+      dates: ['', 'not-a-date', '2020-07-30T00:00:00Z', '2020-07-30'],
+      count: 4,
+      generatedAt: '2020-07-30T00:00:00Z',
+    })
+
+    const { result } = renderHook(() => useDefaultProgramYear(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.year).toBe(2020))
+    expect(Number.isNaN(result.current.year)).toBe(false)
+    expect(result.current.label).toBe('2020-2021')
+  })
 })

--- a/frontend/src/hooks/useDefaultProgramYear.ts
+++ b/frontend/src/hooks/useDefaultProgramYear.ts
@@ -17,6 +17,7 @@
  * derived newest PY advances to it automatically — no calendar flag day.
  */
 
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { fetchCdnDates } from '../services/cdn'
 import {
@@ -24,6 +25,7 @@ import {
   getCurrentProgramYear,
 } from '../utils/programYear'
 import type { ProgramYear } from '../utils/programYear'
+import { snapshotDatesFrom } from '../types/snapshotDate'
 
 export function useDefaultProgramYear(): ProgramYear {
   // Shares the cache with DateSelector's identical dates query.
@@ -34,9 +36,18 @@ export function useDefaultProgramYear(): ProgramYear {
     retry: false,
   })
 
-  const availableProgramYears = data?.dates
-    ? getAvailableProgramYears(data.dates)
-    : []
+  // Mint before deriving (#1353) — the same strict-ISO filter
+  // useProgramYearControls applies to this identical ['available-dates']
+  // query. Without it, a malformed entry in the raw CDN payload (an empty
+  // string, a non-date, a non-ISO-suffixed timestamp) reaches
+  // getAvailableProgramYears unfiltered and can seed the app's default
+  // program year with a NaN year.
+  const mintedDates = useMemo(() => snapshotDatesFrom(data), [data])
+
+  const availableProgramYears = useMemo(
+    () => getAvailableProgramYears(mintedDates),
+    [mintedDates]
+  )
 
   // getAvailableProgramYears sorts newest first; [0] is the latest PY-with-data.
   return availableProgramYears[0] ?? getCurrentProgramYear()

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -520,6 +520,9 @@ const DistrictDetailPageInner: React.FC = () => {
                 <DistinguishedDistrictTrophyCase
                   status={distinguishedDistrictStatus}
                   isLoading={isLoadingCompetitiveAwards}
+                  {...(effectiveProgramYear && {
+                    programYear: effectiveProgramYear.label,
+                  })}
                   ranking={distinguishedRankingInputs}
                   clubStrengthQualifies={clubStrengthResult?.qualifies}
                   clubStrengthGrowth={clubStrengthResult?.growthPercent}

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -1294,13 +1294,13 @@ const DistrictsPage: React.FC = () => {
                 </caption>
                 <thead>
                   <tr>
-                    <th className="districts-rankings-table__sticky-col px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="districts-rankings-table__sticky-col text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                       District
                     </th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                       Rank
                     </th>
-                    <th className="districts-rankings-table__col--desktop px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="districts-rankings-table__col--desktop text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                       Tier
                     </th>
                     <SortableHeader<SortFieldT>
@@ -1308,7 +1308,7 @@ const DistrictsPage: React.FC = () => {
                       label="Paid Clubs"
                       currentSort={sort}
                       onSort={toggleSort}
-                      thClassName="districts-rankings-table__col--compact px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      thClassName="districts-rankings-table__col--compact text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
                       numeric
                     />
                     <SortableHeader<SortFieldT>
@@ -1316,7 +1316,7 @@ const DistrictsPage: React.FC = () => {
                       label="Total Payments"
                       currentSort={sort}
                       onSort={toggleSort}
-                      thClassName="districts-rankings-table__col--compact px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      thClassName="districts-rankings-table__col--compact text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
                       numeric
                     />
                     <SortableHeader<SortFieldT>
@@ -1324,7 +1324,7 @@ const DistrictsPage: React.FC = () => {
                       label="Distinguished"
                       currentSort={sort}
                       onSort={toggleSort}
-                      thClassName="districts-rankings-table__col--tablet px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      thClassName="districts-rankings-table__col--tablet text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
                       numeric
                     />
                     <SortableHeader<SortFieldT>
@@ -1382,7 +1382,7 @@ const DistrictsPage: React.FC = () => {
                           data-row-tint={
                             isMine ? 'mine' : isPinned ? 'pinned' : 'none'
                           }
-                          className="districts-rankings-table__sticky-col px-6 py-4 whitespace-nowrap"
+                          className="districts-rankings-table__sticky-col"
                         >
                           <div className="flex items-center gap-3 flex-wrap">
                             <button
@@ -1440,7 +1440,9 @@ const DistrictsPage: React.FC = () => {
                                 className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-800 border border-yellow-200"
                               >
                                 <span aria-hidden="true">🏆</span>
-                                <span className="ml-1">Extension</span>
+                                <span className="sr-only sm:not-sr-only sm:ml-1">
+                                  Extension
+                                </span>
                               </span>
                             )}
                             {competitiveAwards?.byDistrict?.[
@@ -1451,7 +1453,9 @@ const DistrictsPage: React.FC = () => {
                                 className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-800 border border-yellow-200"
                               >
                                 <span aria-hidden="true">🏆</span>
-                                <span className="ml-1">20-Plus</span>
+                                <span className="sr-only sm:not-sr-only sm:ml-1">
+                                  20-Plus
+                                </span>
                               </span>
                             )}
                             {competitiveAwards?.byDistrict?.[
@@ -1462,7 +1466,9 @@ const DistrictsPage: React.FC = () => {
                                 className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-800 border border-yellow-200"
                               >
                                 <span aria-hidden="true">🏆</span>
-                                <span className="ml-1">Retention</span>
+                                <span className="sr-only sm:not-sr-only sm:ml-1">
+                                  Retention
+                                </span>
                               </span>
                             )}
                             {/* Region collapses into the District cell as
@@ -1530,7 +1536,7 @@ const DistrictsPage: React.FC = () => {
                             </span>
                           </div>
                         </td>
-                        <td className="districts-rankings-table__col--desktop px-4 py-4 whitespace-nowrap">
+                        <td className="districts-rankings-table__col--desktop">
                           {ddpTier ? (
                             <DistrictTierChip
                               districtId={district.districtId}
@@ -1549,7 +1555,7 @@ const DistrictsPage: React.FC = () => {
                             </span>
                           )}
                         </td>
-                        <td className="districts-rankings-table__col--compact px-6 py-4 whitespace-nowrap text-right">
+                        <td className="districts-rankings-table__col--compact text-right">
                           <div className="text-sm font-medium text-gray-900">
                             {formatNumber(district.paidClubs)}
                           </div>
@@ -1571,7 +1577,7 @@ const DistrictsPage: React.FC = () => {
                             </span>
                           </div>
                         </td>
-                        <td className="districts-rankings-table__col--compact px-6 py-4 whitespace-nowrap text-right">
+                        <td className="districts-rankings-table__col--compact text-right">
                           <div className="text-sm font-medium text-gray-900">
                             {formatNumber(district.totalPayments)}
                           </div>
@@ -1593,7 +1599,7 @@ const DistrictsPage: React.FC = () => {
                             </span>
                           </div>
                         </td>
-                        <td className="districts-rankings-table__col--tablet px-6 py-4 whitespace-nowrap text-right">
+                        <td className="districts-rankings-table__col--tablet text-right">
                           <div className="text-sm font-medium text-gray-900">
                             {formatNumber(district.distinguishedClubs)}
                           </div>

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -601,7 +601,15 @@ const DistrictsPage: React.FC = () => {
   // Holding the upper chrome (header text + KPI strip) constant across
   // all three states means only the lower content area transitions —
   // no upper geometry collapse like the 0.198 swap on PR #825.
-  const renderShell = (body: React.ReactNode) => (
+  //
+  // `reserveHeroSlots` (#1359) additionally holds the data-dependent hero
+  // slots — Awards Race, region toolbar, hero search. Loading-only on
+  // purpose: those slots pulse, and a permanently pulsing panel above an
+  // error card reads as broken. The cost is that loading → error now
+  // collapses the reserve, but that transition already swaps a 748px table
+  // pulse for an error card of unrelated height, so it was never shift-free
+  // and no user reaches a *loaded* page through it.
+  const renderShell = (body: React.ReactNode, reserveHeroSlots = false) => (
     <div className="districts-page-root">
       <div className="districts-page">
         <div className="districts-page-header">
@@ -668,28 +676,83 @@ const DistrictsPage: React.FC = () => {
             />
           </div>
         </div>
-        {/* #861 — reserve the mobile-hoisted hero-search slot so the
-            skeleton/error → loaded swap is shift-free (CLS, #826/#488,
-            Lesson 125). Rendered only <768px via CSS. */}
-        <div className="districts-hero-search-skeleton" aria-hidden="true" />
-        <div className="districts-kpi-strip" aria-hidden="true">
-          {[
-            'Paid Clubs · Global',
-            'Total Payments',
-            'Distinguished Clubs',
-            'Districts Tracked',
-          ].map((label, i) => (
-            <div
-              key={label}
-              className={`districts-kpi-card${i > 0 ? ' districts-kpi-card--secondary' : ''}`}
-            >
-              <p className="districts-kpi-card__label">{label}</p>
+        {/* #1359 — the shell's reserved slots now live in a real
+            .districts-hero-stack, in the loaded tree's order, so the stack's
+            own rules (the <768px `order: -1` search hoist, the 640–767px
+            single-column step) apply to the reserve exactly as they apply to
+            the thing reserved for. Previously the shell reserved only the
+            KPI strip and the mobile search, leaving the Awards Race, the
+            toolbar and the desktop search unreserved — a measured 452px jump
+            at 1350px and 328px at 375px when the data landed. */}
+        <div className="districts-hero-stack">
+          <div className="districts-kpi-strip" aria-hidden="true">
+            {[
+              'Paid Clubs · Global',
+              'Total Payments',
+              'Distinguished Clubs',
+              'Districts Tracked',
+            ].map((label, i) => (
               <div
-                className="districts-kpi-card__value animate-pulse bg-gray-200 rounded-sm"
-                style={{ height: 30, width: '60%' }}
-              />
-            </div>
-          ))}
+                key={label}
+                className={`districts-kpi-card${i > 0 ? ' districts-kpi-card--secondary' : ''}`}
+              >
+                <p className="districts-kpi-card__label">
+                  {label}
+                  {/* The loaded label carries an InfoTooltip whose trigger is a
+                    <button>, floored at 44px by styles/layers/base.css — so
+                    the loaded label box is 50px against this one's 17px, and
+                    every card under-reserved by 33px (#1359). */}
+                  <span className="tooltip-reserve" aria-hidden="true" />
+                </p>
+                <div
+                  className="districts-kpi-card__value animate-pulse bg-gray-200 rounded-sm"
+                  style={{ height: 30, width: '60%' }}
+                />
+              </div>
+            ))}
+          </div>
+          {reserveHeroSlots && (
+            <>
+              {/* The section's own #750 skeleton — same component, so the
+                  reserve cannot drift from what it reserves for. Hidden
+                  <768px by .awards-race, where the mobile link takes over. */}
+              <AwardsRaceSection standings={null} isLoading />
+              {/* Static destination, so render the real link rather than a
+                  placeholder: it needs no data and works while loading. */}
+              <Link to="/awards" className="awards-race-mobile-link">
+                See Awards
+                <span aria-hidden="true"> →</span>
+              </Link>
+              {/* Region toolbar. One chip row — exact at ≥768px where the
+                  chips fit on a single line. Below that the loaded row wraps
+                  to as many lines as there are regions, which the shell
+                  cannot know before the data arrives, so this under-reserves
+                  on a phone rather than guessing a region count that would
+                  silently drift. */}
+              <div className="districts-toolbar" aria-hidden="true">
+                <div className="districts-toolbar__row">
+                  <span className="districts-toolbar__label">Regions:</span>
+                  <span
+                    className="districts-actions-skeleton__chip"
+                    style={{ width: 52 }}
+                  />
+                  <span
+                    className="districts-actions-skeleton__chip"
+                    style={{ width: 44 }}
+                  />
+                </div>
+              </div>
+            </>
+          )}
+          {/* #861 — hero-search reserve, held in EVERY shell state (loading
+              and both error branches), unlike the data-dependent slots
+              above. Carries the real --hero modifier, so the stack's <768px
+              `order: -1` rule hoists this reserve above the KPI strip
+              exactly as it hoists the loaded search. */}
+          <div
+            className="districts-hero-search-skeleton districts-toolbar__search--hero"
+            aria-hidden="true"
+          />
         </div>
         {body}
       </div>
@@ -710,7 +773,8 @@ const DistrictsPage: React.FC = () => {
             <div key={i} className="h-16 bg-gray-200 rounded-sm" />
           ))}
         </div>
-      </div>
+      </div>,
+      true
     )
   }
 

--- a/frontend/src/pages/DistrictsPage.tsx
+++ b/frontend/src/pages/DistrictsPage.tsx
@@ -34,6 +34,7 @@ import {
   getMostRecentDateInProgramYear,
 } from '../utils/programYear'
 import { ProgramYearTitleSuffix } from '../components/ProgramYearTitleSuffix'
+import { rankingsScrollLabel } from '../utils/rankingsScrollLabel'
 import { DistrictRanking } from '../types/districts'
 import { arrayToCSV, downloadCSV } from '../utils/csvExport'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -503,6 +504,16 @@ const DistrictsPage: React.FC = () => {
       el.parentElement?.setAttribute(
         'data-scrollable-right',
         String(moreToRight)
+      )
+      // Keep the region's accessible name honest (#1358). Derived from total
+      // overflow, NOT moreToRight: the latter goes false once the user hits
+      // the right edge, which would strip the affordance mid-scroll. Below the
+      // priority breakpoints nothing overflows because the shed columns are
+      // `display: none`, so the label must stop telling people to scroll for
+      // metrics that scrolling cannot reach.
+      el.setAttribute(
+        'aria-label',
+        rankingsScrollLabel(el.scrollWidth - el.clientWidth > 1)
       )
     }
     update()
@@ -1258,16 +1269,20 @@ const DistrictsPage: React.FC = () => {
               scrollable-region-focusable); (2) the District identity column is
               the single sticky key column (no hardcoded second-sticky px seam);
               (3) the right-edge scroll-cue signals more columns. Low-priority
-              columns hide at tablet/mobile via the __col--tablet/--desktop
+              columns hide at mobile via the __col--compact/--tablet/--desktop
               priority classes so a phone shows a sensible set. Don't "fix" this
-              into a card collapse. */}
+              into a card collapse.
+              The --compact rung (≥600px) exists because 375/768/1280 left a
+              dead zone: a 360x640 phone is 640px in LANDSCAPE, so it got the
+              375px treatment and no orientation could reveal a metric
+              (#1358). */}
           <div className="districts-rankings-table__scroll-wrap">
             <div
               ref={rankingsScrollRef}
               className="overflow-x-auto"
               role="region"
               tabIndex={0}
-              aria-label="District rankings — scroll horizontally to see all metrics"
+              aria-label={rankingsScrollLabel(false)}
             >
               <table
                 className="districts-rankings-table"
@@ -1293,7 +1308,7 @@ const DistrictsPage: React.FC = () => {
                       label="Paid Clubs"
                       currentSort={sort}
                       onSort={toggleSort}
-                      thClassName="districts-rankings-table__col--tablet px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      thClassName="districts-rankings-table__col--compact px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
                       numeric
                     />
                     <SortableHeader<SortFieldT>
@@ -1301,7 +1316,7 @@ const DistrictsPage: React.FC = () => {
                       label="Total Payments"
                       currentSort={sort}
                       onSort={toggleSort}
-                      thClassName="districts-rankings-table__col--tablet px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      thClassName="districts-rankings-table__col--compact px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
                       numeric
                     />
                     <SortableHeader<SortFieldT>
@@ -1534,7 +1549,7 @@ const DistrictsPage: React.FC = () => {
                             </span>
                           )}
                         </td>
-                        <td className="districts-rankings-table__col--tablet px-6 py-4 whitespace-nowrap text-right">
+                        <td className="districts-rankings-table__col--compact px-6 py-4 whitespace-nowrap text-right">
                           <div className="text-sm font-medium text-gray-900">
                             {formatNumber(district.paidClubs)}
                           </div>
@@ -1556,7 +1571,7 @@ const DistrictsPage: React.FC = () => {
                             </span>
                           </div>
                         </td>
-                        <td className="districts-rankings-table__col--tablet px-6 py-4 whitespace-nowrap text-right">
+                        <td className="districts-rankings-table__col--compact px-6 py-4 whitespace-nowrap text-right">
                           <div className="text-sm font-medium text-gray-900">
                             {formatNumber(district.totalPayments)}
                           </div>

--- a/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
@@ -135,7 +135,12 @@ describe('DistrictsPage rankings table — responsive + sticky (#811)', () => {
     const { container } = renderWithProviders(<DistrictsPage />)
     await screen.findByText('District 7')
 
-    const scroller = screen.getByRole('region', { name: /scroll/i })
+    // Matched on the region's stable name, not on the word "scroll": the
+    // label is now derived from real overflow (#1358), and jsdom has no
+    // layout engine, so scrollWidth/clientWidth are both 0 and nothing
+    // "scrolls" here. The assertion under test is that the region is
+    // focusable and LABELLED, which still holds either way.
+    const scroller = screen.getByRole('region', { name: /district rankings/i })
     expect(scroller).toHaveAttribute('tabindex', '0')
     expect(scroller.className).toMatch(/overflow-x-auto/)
 
@@ -184,13 +189,19 @@ describe('DistrictsPage rankings table — responsive + sticky (#811)', () => {
     // Always-visible (mobile 375): District (sticky), Rank, Score.
     for (const re of [/^rank$/i, /^score$/i]) {
       const th = headerByText(re)
+      expect(th.className).not.toMatch(/__col--compact/)
       expect(th.className).not.toMatch(/__col--tablet/)
       expect(th.className).not.toMatch(/__col--desktop/)
     }
-    // Tablet+ (≥768): the three metric columns.
-    for (const re of [/paid clubs/i, /total payments/i, /distinguished/i]) {
-      expect(headerByText(re).className).toMatch(/__col--tablet/)
+    // Compact+ (≥600): Paid Clubs / Payments. Promoted from the tablet rung
+    // in #1358 — a 360x640 phone is 640px in landscape, so the old 768
+    // threshold left that whole device class with no metric columns at any
+    // orientation.
+    for (const re of [/paid clubs/i, /total payments/i]) {
+      expect(headerByText(re).className).toMatch(/__col--compact/)
     }
+    // Tablet+ (≥768): Distinguished.
+    expect(headerByText(/distinguished/i).className).toMatch(/__col--tablet/)
     // Desktop-only (≥1280): Tier.
     expect(headerByText(/^tier$/i).className).toMatch(/__col--desktop/)
   })

--- a/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictsPage.responsive.test.tsx
@@ -104,8 +104,16 @@ const expectReservedShell = (container: HTMLElement) => {
   const strip = container.querySelector('.districts-kpi-strip')
   expect(skel).not.toBeNull()
   expect(strip).not.toBeNull()
-  // Hero-search slot precedes the KPI strip in DOM so it sits above on mobile.
-  expect(precedesInDom(skel!, strip!)).toBe(true)
+  // #1359 — the hoist is no longer DOM order. The reserve now sits inside a
+  // real .districts-hero-stack in the LOADED tree's position (after the KPI
+  // strip) and carries the real --hero modifier, so the stack's own
+  // `.districts-hero-stack .districts-toolbar__search--hero { order: -1 }`
+  // rule lifts it above the strip below 768px — the identical mechanism, and
+  // the identical rule, that positions the loaded search. Asserting DOM order
+  // would now assert the OPPOSITE of the loaded page it is reserving for.
+  expect(skel!.closest('.districts-hero-stack')).not.toBeNull()
+  expect(skel!.classList.contains('districts-toolbar__search--hero')).toBe(true)
+  expect(strip!.closest('.districts-hero-stack')).not.toBeNull()
   // 3 secondary KPI cards → the strip's mobile height matches across states.
   expect(
     container.querySelectorAll('.districts-kpi-card--secondary').length
@@ -290,6 +298,48 @@ describe('DistrictsPage landing hero hoist + KPI demotion (#861)', () => {
 
     // Lesson 125: the loading shell reserves the same slot as loaded + error.
     expectReservedShell(container)
+  })
+
+  /**
+   * #1359 — the shell reserved the KPI strip and the mobile search but not the
+   * data-dependent hero slots, so when the rankings landed the Awards Race,
+   * region toolbar and desktop search all appeared at once and pushed the
+   * rankings table down 452px at 1350px (328px at 375px). CLS 0.179 of a 0.1
+   * budget, on the landing page, on every first visit.
+   *
+   * jsdom has no layout engine, so these assert the STRUCTURE that produces
+   * the geometry (Lesson 66) — each reserve is the real element the loaded
+   * tree renders, inside the same stack, so it cannot drift from what it
+   * reserves for. The heights themselves were verified in a real browser
+   * against the committed Lighthouse fixtures.
+   */
+  it('reserves the data-dependent hero slots in the loading shell (#1359)', async () => {
+    mockedFetchCdnRankings.mockReturnValue(new Promise(() => {}) as never)
+    const { container } = renderWithProviders(<DistrictsPage />)
+    await screen.findByRole('status', { name: /loading district rankings/i })
+
+    const stack = container.querySelector('.districts-hero-stack')
+    expect(stack).not.toBeNull()
+    // The Awards Race section's own skeleton — same component the loaded page
+    // renders, not a look-alike placeholder.
+    expect(stack!.querySelector('.awards-race')).not.toBeNull()
+    // Its <768px counterpart, where .awards-race is display:none.
+    expect(stack!.querySelector('.awards-race-mobile-link')).not.toBeNull()
+    // Region toolbar + its chip row.
+    expect(stack!.querySelector('.districts-toolbar')).not.toBeNull()
+    expect(stack!.querySelector('.districts-toolbar__row')).not.toBeNull()
+  })
+
+  it('does not reserve the pulsing slots in a terminal error state (#1359)', async () => {
+    // Those slots animate. A skeleton that pulses forever above an error card
+    // reads as broken, and no user reaches a *loaded* page through this
+    // branch, so there is no swap left to protect.
+    mockedFetchCdnRankings.mockRejectedValue(new Error('CDN boom') as never)
+    const { container } = renderWithProviders(<DistrictsPage />)
+    await screen.findByText(/unable to load|error/i)
+
+    expect(container.querySelector('.awards-race')).toBeNull()
+    expect(container.querySelector('.districts-toolbar')).toBeNull()
   })
 })
 

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -1276,12 +1276,26 @@
   /* Per-column responsive priority (ADR-006 §3). Mobile-first: low-priority
      columns are hidden by default and revealed at each breakpoint. Always-on
      at 375px: District (sticky), Rank, Score. */
+  .districts-rankings-table__col--compact,
   .districts-rankings-table__col--tablet,
   .districts-rankings-table__col--desktop {
     display: none;
   }
-  /* Tablet (≥768): + the three metric columns (Paid Clubs / Payments /
-     Distinguished). */
+  /* Compact (≥600): + Paid Clubs / Payments (#1358).
+     The 375/768/1280 ladder left a DEAD ZONE that a whole device class lives
+     in: a 360x640 phone is 640px in LANDSCAPE — 70% wider than the 375px
+     design target, yet still under 768 — so it was served the bare
+     District/Rank/Score set, and no orientation or zoom could reveal a metric.
+     Android's Display-size setting shrinks the CSS viewport further. Reported
+     from South Asia, where that device class is common.
+     These two carry most of the Borda score, so they are what a narrow screen
+     needs first; Distinguished stays at 768 to bound the row width. */
+  @media (min-width: 600px) {
+    .districts-rankings-table__col--compact {
+      display: table-cell;
+    }
+  }
+  /* Tablet (≥768): + Distinguished. */
   @media (min-width: 768px) {
     .districts-rankings-table__col--tablet {
       display: table-cell;

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -1223,6 +1223,19 @@
       inset 0 -1px 0 var(--line-2);
   }
 
+  /* Cap the identity column on small screens (#1358). Because it is sticky,
+     its width is subtracted from EVERY viewport before a single metric can
+     render — so one award-decorated district (up to three chips) was free to
+     set the width for the whole table and squeeze the numbers off a phone.
+     55vw guarantees the metrics keep almost half the screen; the inner
+     flex-wrap lets the chips take a second line instead of widening. Lifted
+     at the compact rung, where there is room for the full identity again. */
+  @media (max-width: 599px) {
+    .districts-rankings-table__sticky-col {
+      max-width: 55vw;
+    }
+  }
+
   /* The last row zeroes its real border-bottom; do the same for the sticky
      cell's box-shadow-drawn rule so it doesn't leave a stray hairline under
      the first column. Keep only the right (sticky/scroll seam) inset. */

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -790,6 +790,24 @@
     color: var(--ink-3);
   }
 
+  /* #1359 — reserves an InfoTooltip trigger's box in a skeleton that renders
+     the label text but not the tooltip. The trigger is a <button>, and
+     styles/layers/base.css floors EVERY button at 44px/44px (WCAG 2.5.5), so
+     a tooltip inflates the line box it sits in to roughly 3x an 11px label:
+     the loaded .districts-kpi-card__label measures 50px against the
+     skeleton's 17px, and the Awards Race heading 45px more than a bare
+     skeleton bar. Both under-reserves shifted the whole page below them.
+     Structural, not a pinned height — it carries the same 44px floor, so if
+     that floor ever moves, the reserve and the thing it reserves for move
+     together. Shared by the KPI skeleton and the Awards Race skeleton. */
+  .tooltip-reserve {
+    display: inline-flex;
+    min-width: 44px;
+    min-height: 44px;
+    /* Matches InfoTooltip's own `ml-1`. */
+    margin-left: 4px;
+  }
+
   .districts-kpi-card__value {
     font-family: var(--serif);
     font-weight: 800;
@@ -886,9 +904,12 @@
     .districts-kpi-card--secondary {
       display: block;
     }
-    .districts-hero-search-skeleton {
-      display: none;
-    }
+    /* #1359 — the hero-search reserve stays visible at ≥768px. It used to be
+       mobile-only because the shell rendered it above the KPI strip, where a
+       desktop reserve would have sat in the wrong place; it now lives inside
+       .districts-hero-stack in the loaded tree's position, so at ≥768px it
+       reserves the desktop search's 56px in situ. Without it the loaded
+       search appeared from nowhere and pushed the rankings table down. */
     .districts-page-header__actions--skeleton {
       display: none;
     }

--- a/frontend/src/styles/components/app-shell.css
+++ b/frontend/src/styles/components/app-shell.css
@@ -2996,6 +2996,16 @@
     text-decoration: underline;
   }
 
+  /* #1359 — stands in for the leader link on a card with no contenders yet,
+     so the row keeps its geometry. Same metrics as the link, muted colour:
+     it is not a destination and must not read as one. */
+  .awards-race-card__leader-placeholder {
+    font-family: var(--serif);
+    font-weight: 700;
+    font-size: 14px;
+    color: var(--ink-3);
+  }
+
   .awards-race-card__leader-value {
     font-family: var(--serif);
     font-weight: 800;

--- a/frontend/src/utils/__tests__/programYear.malformedDates.test.ts
+++ b/frontend/src/utils/__tests__/programYear.malformedDates.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { getAvailableProgramYears } from '../programYear'
+
+/**
+ * Malformed-date robustness regression (#1353).
+ *
+ * `getAvailableProgramYears` derives a program year per date with no guard
+ * against an unparseable one: `calendarParts` returns `NaN` for a non-ISO
+ * string, `NaN >= 7` is `false`, so `programYearStart = NaN - 1 = NaN`, and
+ * the dedup Set gains a `NaN` entry. `getProgramYear(NaN)` then yields a
+ * `label: "NaN-NaN"` program year that renders as a selectable dropdown
+ * option (`DataControlsBar.tsx`).
+ *
+ * The two derivation paths (`useProgramYearControls` vs
+ * `useDefaultProgramYear`) disagree about filtering malformed dates before
+ * calling this function — see `useDefaultProgramYear.ts`. Regardless of
+ * which caller is at fault, this function must be defensive at the source:
+ * it must never emit a program year whose `year` is `NaN`.
+ */
+describe('getAvailableProgramYears malformed-date robustness (#1353)', () => {
+  it('skips empty, non-date, and non-ISO-suffixed entries and yields exactly one program year', () => {
+    const dates = ['', 'not-a-date', '2026-07-30T00:00:00Z', '2026-07-30']
+    const result = getAvailableProgramYears(dates)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.year).toBe(2026)
+    expect(result[0]?.label).toBe('2026-2027')
+  })
+
+  it('never emits a program year whose year is NaN', () => {
+    const dates = ['', 'not-a-date', 'garbage', '2026-07-30']
+    const result = getAvailableProgramYears(dates)
+
+    expect(result.every(py => !Number.isNaN(py.year))).toBe(true)
+  })
+
+  it('returns an empty list when every date is malformed', () => {
+    const dates = ['', 'not-a-date', 'garbage']
+    const result = getAvailableProgramYears(dates)
+
+    expect(result).toEqual([])
+  })
+
+  it('still derives every program year correctly when all dates are well-formed', () => {
+    // Behaviour for well-formed input must be unchanged by the guard.
+    const dates = ['2024-08-15', '2025-01-15', '2025-09-30', '2026-06-30']
+    const result = getAvailableProgramYears(dates)
+
+    expect(result.map(py => py.year)).toEqual([2025, 2024])
+  })
+})

--- a/frontend/src/utils/__tests__/rankingsScrollLabel.test.ts
+++ b/frontend/src/utils/__tests__/rankingsScrollLabel.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { rankingsScrollLabel } from '../rankingsScrollLabel'
+
+describe('rankingsScrollLabel (#1358)', () => {
+  it('offers the scroll hint when the table actually overflows', () => {
+    expect(rankingsScrollLabel(true)).toMatch(/scroll horizontally/i)
+  })
+
+  // Below 768px the shed columns are `display: none`, not off-screen — no
+  // amount of scrolling reveals them. Telling a screen-reader user to scroll
+  // is an instruction that cannot succeed.
+  it('does NOT promise scrolling when nothing can scroll', () => {
+    const label = rankingsScrollLabel(false)
+
+    expect(label).not.toMatch(/scroll/i)
+    expect(label).toMatch(/district rankings/i)
+  })
+
+  it('always names the region, so the landmark stays labelled', () => {
+    expect(rankingsScrollLabel(true)).toMatch(/district rankings/i)
+    expect(rankingsScrollLabel(false)).toMatch(/district rankings/i)
+  })
+})

--- a/frontend/src/utils/programYear.ts
+++ b/frontend/src/utils/programYear.ts
@@ -77,6 +77,14 @@ export function getAvailableProgramYears(
 
     // Determine which program year this date belongs to
     const programYearStart = month >= 7 ? year : year - 1
+
+    // Defensive at the source (#1353): an unparseable dateStr makes
+    // calendarParts return NaN, which propagates to programYearStart. A
+    // NaN start year must never enter the Set — getProgramYear(NaN) mints a
+    // "NaN-NaN" label that DataControlsBar renders as a selectable option.
+    // Callers SHOULD pass only minted (snapshotDatesFrom) dates so this
+    // never triggers, but this guard holds even if a caller doesn't.
+    if (Number.isNaN(programYearStart)) return
     programYears.add(programYearStart)
   })
 

--- a/frontend/src/utils/rankingsScrollLabel.ts
+++ b/frontend/src/utils/rankingsScrollLabel.ts
@@ -1,0 +1,25 @@
+/**
+ * Accessible name for the rankings table's scroll region (#1358).
+ *
+ * The label used to promise "scroll horizontally to see all metrics"
+ * unconditionally. Below the column-priority breakpoints the shed columns are
+ * `display: none`, NOT off-screen — so on the very screens where a user most
+ * needs those metrics, the label instructed them to perform an action that
+ * cannot possibly work. A mislabelled `role="region"` is an accessibility
+ * defect, not just a cosmetic one.
+ *
+ * Kept as a pure function rather than inlined in DistrictsPage so it can be
+ * unit-tested without mounting the page (R22, and the Lesson 51 contention
+ * cost of a full DistrictsPage mount).
+ *
+ * @param isScrollable Whether the region's content actually overflows
+ *   horizontally. Note this must be derived from `scrollWidth > clientWidth`,
+ *   NOT from the "more content to the right" flag that drives the fade cue —
+ *   that one goes false once the user scrolls to the end, which would strip
+ *   the affordance from the label mid-interaction.
+ */
+export function rankingsScrollLabel(isScrollable: boolean): string {
+  return isScrollable
+    ? 'District rankings — scroll horizontally to see all metrics'
+    : 'District rankings'
+}

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -222,6 +222,7 @@ export {
   type CompetitiveAwardsByDistrict,
   type CompetitiveAwardStandings,
   DistinguishedDistrictCalculator,
+  requiredPrerequisitesForProgramYear,
   type DistinguishedDistrictTier,
   type DistinguishedDistrictPrerequisites,
   type DistinguishedDistrictGap,

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.test.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.test.ts
@@ -6,7 +6,10 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
-import { DistinguishedDistrictCalculator } from './DistinguishedDistrictCalculator.js'
+import {
+  DistinguishedDistrictCalculator,
+  requiredPrerequisitesForProgramYear,
+} from './DistinguishedDistrictCalculator.js'
 import type { DistrictRanking } from '@taverns-red/shared-contracts'
 
 function buildRanking(overrides: Partial<DistrictRanking>): DistrictRanking {
@@ -112,6 +115,39 @@ describe('DistinguishedDistrictCalculator', () => {
       expect(calculator.calculate(ranking, '2026-2027').currentTier).toBe(
         'Distinguished'
       )
+    })
+  })
+
+  // #1354 — the checklist UI needs the per-year REQUIRED set (not the
+  // legacy 5-boolean `prerequisites` shape) so it stops rendering a
+  // permanently-false "Region Advisor" row for 2026-27.
+  describe('requiredPrerequisitesForProgramYear (#1354)', () => {
+    it('returns the 4 surviving gates for 2026-27', () => {
+      expect(requiredPrerequisitesForProgramYear('2026-2027')).toEqual([
+        'dspSubmitted',
+        'trainingMet',
+        'marketAnalysisSubmitted',
+        'communicationPlanSubmitted',
+      ])
+    })
+
+    it('returns all 5 gates, including Region Advisor, for 2025-26', () => {
+      expect(requiredPrerequisitesForProgramYear('2025-2026')).toEqual([
+        'dspSubmitted',
+        'trainingMet',
+        'marketAnalysisSubmitted',
+        'communicationPlanSubmitted',
+        'regionAdvisorVisitMet',
+      ])
+    })
+
+    it('defaults to the current (2026-27) ruleset when no year is given', () => {
+      expect(requiredPrerequisitesForProgramYear()).toEqual([
+        'dspSubmitted',
+        'trainingMet',
+        'marketAnalysisSubmitted',
+        'communicationPlanSubmitted',
+      ])
     })
   })
 

--- a/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
+++ b/packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.ts
@@ -350,6 +350,24 @@ function rulesetForProgramYear(programYear?: string): YearRuleset {
   return ERA_2016_RULESET
 }
 
+/**
+ * The prerequisite gates a given program year actually requires (#1354).
+ *
+ * `DistinguishedDistrictStatus.prerequisites` deliberately keeps emitting
+ * all 5 booleans for every era (display breakdown, see `calculate()`), so
+ * a checklist UI that renders every key verbatim shows a permanently-false
+ * "2+ Region Advisor meetings" row for 2026-27 even on districts that
+ * legitimately earned a tier — the column is gone, not unmet. Consumers
+ * that render a per-prerequisite checklist should intersect
+ * `prerequisites` with this set rather than iterating every key, so the
+ * displayed rows track the ruleset instead of the legacy fixed shape.
+ */
+export function requiredPrerequisitesForProgramYear(
+  programYear?: string
+): ReadonlyArray<keyof DistinguishedDistrictPrerequisites> {
+  return rulesetForProgramYear(programYear).requiredPrerequisites
+}
+
 export class DistinguishedDistrictCalculator {
   /**
    * Calculate Distinguished District status for a single district.

--- a/packages/analytics-core/src/rankings/index.ts
+++ b/packages/analytics-core/src/rankings/index.ts
@@ -31,6 +31,7 @@ export {
 
 export {
   DistinguishedDistrictCalculator,
+  requiredPrerequisitesForProgramYear,
   type DistinguishedDistrictTier,
   type DistinguishedDistrictPrerequisites,
   type DistinguishedDistrictGap,

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,6 +2,8 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `a-skeleton-that-omits-a-button-under-reserves-by-the-touch-target-floor.md` — A skeleton that omits an interactive element under-reserves by the touch-target floor, not by the element's visual size  (2026-08-01)
+- `bisecting-a-gate-with-no-headroom-finds-variance-not-a-regression.md` — Bisecting a threshold gate that has no headroom identifies variance, not a culprit — measure the baseline before believing the bisect  (2026-08-01)
 - `a-nominal-brand-is-only-as-honest-as-the-mint-and-the-cast-ban-behind-it.md` — A nominal brand's guarantee lives in its mints and its cast-ban selector, not the type — and both fail silently, so pin every laundering variant with a behaviour sentinel and name the premise the proof actually rests on  (2026-07-15)
 - `a-phantom-field-is-a-live-default-every-read-of-it-silently-becomes-the-fallback.md` — A phantom field (typed but never on the wire) doesn't fail — it silently becomes its fallback, so the default is the real code path; grep the primitive, and a `?? today` default hides it forever  (2026-07-15)
 - `divergence-by-default-fixtures-are-inert-unless-the-mock-routes-on-the-same-key-the-wire-does.md` — Divergence-by-default fixtures are inert unless the mock ROUTES on the same key the wire does — a date-blind router serves the right fixture for the wrong key and rubber-stamps the bug the fixture was written to expose  (2026-07-15)

--- a/tasks/lessons/lessons/a-skeleton-that-omits-a-button-under-reserves-by-the-touch-target-floor.md
+++ b/tasks/lessons/lessons/a-skeleton-that-omits-a-button-under-reserves-by-the-touch-target-floor.md
@@ -1,0 +1,60 @@
+---
+date: 2026-08-01
+tier: lesson
+summary: A skeleton that omits an interactive element under-reserves by the touch-target floor, not by the element's visual size
+tags: [cls, skeleton, accessibility, css, frontend, performance]
+---
+
+# A skeleton that omits a button under-reserves by the touch-target floor
+
+**Date:** 2026-08-01
+**PR:** #1357 (issue #1359)
+
+## What happened
+
+The landing page measured CLS 0.265 against a 0.1 budget. Two of the
+contributing under-reserves had the same cause, and it was not the one the
+skeletons were written against.
+
+`InfoTooltip` renders a 14px info icon — `w-3.5 h-3.5`. Every skeleton that
+reproduced a label carrying one reproduced the *text* and skipped the
+tooltip, on the reasonable assumption that a 14px inline icon is noise.
+
+But `styles/layers/base.css` floors **every** `button` at `min-height: 44px;
+min-width: 44px` for WCAG 2.5.5. The tooltip trigger is a `<button>`. So a
+14px icon occupies a 44px box, and because it is inline, it inflates the
+line box it sits in:
+
+| element | skeleton | loaded |
+| --- | --- | --- |
+| `.districts-kpi-card__label` (11px uppercase text) | 17px | **50px** |
+| `.awards-race__header` | 43px | **88px** |
+
+Three times the text height, from an element the skeleton's author was right
+to think of as tiny. Multiplied across four KPI cards plus a section heading,
+that alone was ~170px of unreserved vertical space.
+
+## The lesson
+
+**When reserving space for an element you are not rendering, its reserved
+size is whatever the cascade gives it — not what it looks like.** A global
+accessibility floor, a `min-height` on a base-layer element selector, a
+flex `align-items` rule: any of these can make a component occupy far more
+box than its content. Reasoning from the visual is how you get it wrong.
+
+Two practical consequences:
+
+- Reserve **structurally**, carrying the same rule. A `.tooltip-reserve` with
+  the same `min-height: 44px` tracks the floor if the floor ever moves. A
+  pinned `min-height: 50px` is a number that silently goes stale.
+- The premise deserves its own test. If the loaded heading ever stops
+  carrying a tooltip, the reserve becomes an over-reserve — and what should
+  fail is a named test, not a mystery CLS number three sprints later.
+
+## Where to look
+
+Anywhere a skeleton reproduces a label: `button`, `a[href]`, `[role=button]`
+and `[tabindex]:not([tabindex='-1'])` all carry the 44px floor from
+`styles/layers/base.css`. An inline one inside a small-font label is the
+dangerous shape, because the ratio is worst exactly where the text is
+smallest.

--- a/tasks/lessons/lessons/bisecting-a-gate-with-no-headroom-finds-variance-not-a-regression.md
+++ b/tasks/lessons/lessons/bisecting-a-gate-with-no-headroom-finds-variance-not-a-regression.md
@@ -1,0 +1,76 @@
+---
+date: 2026-08-01
+tier: lesson
+summary: Bisecting a threshold gate that has no headroom identifies variance, not a culprit — measure the baseline before believing the bisect
+tags: [ci, lighthouse, debugging, flakiness, performance]
+---
+
+# Bisecting a gate with no headroom finds variance, not a regression
+
+**Date:** 2026-08-01
+**PR:** #1357 (issue #1359)
+
+## What happened
+
+The Lighthouse CLS gate (`<= 0.1`) went red on a PR. A bisect across the
+branch looked textbook:
+
+```
+dbbed9da  ->  pass
+a964d30d  ->  pass
+1c25f1cc  ->  FAIL (0.271)
+```
+
+Three commits, one clean transition. I concluded — and said out loud — that
+the density commit caused it, and started reverting its four changes to find
+which one.
+
+Then I measured the **parent** commit locally against the same fixtures:
+`0.265`. Identical. The commit the bisect blamed had changed nothing about
+CLS at all.
+
+## Why the bisect lied
+
+The page had two independent layout shifts:
+
+- **0.083** — deterministic, on every single run.
+- **0.179** — only counted when the loading skeleton painted before the data
+  arrived, which depends on runner timing.
+
+So the gate's real state was "0.083 of a 0.1 budget spent unconditionally,
+with a coin flip that adds 0.179." Every green run was green by luck. A
+bisect over that samples a Bernoulli trial and hands back a boundary, and the
+boundary looks exactly like a regression because that is the shape bisect
+always produces.
+
+## The lesson
+
+**A bisect assumes the signal is a function of the commit. On a threshold
+gate with no headroom, it is a function of the commit *and* the roll.**
+Before believing a bisect result on a numeric gate:
+
+1. Measure the "good" side and confirm it is actually good — not merely
+   under the line by less than the run-to-run spread.
+2. Look at the spread. Three local runs of the current tree gave
+   `0.265, 0.265, 0.000` — a bimodal distribution, which is the tell. A
+   metric that flips between two values is not measuring your diff.
+3. Only then attribute it.
+
+The corollary is the more useful half: **a gate passing at 83% of budget is
+already broken**, it just hasn't reported yet. The 0.083 shift had been
+there since the fixtures were committed, and the first change to nudge the
+timing would take the blame for it.
+
+## What actually found it
+
+Not the aggregate score. A `PerformanceObserver('layout-shift')` probe
+printing each entry's `value`, `startTime` and `sources` named both shifting
+elements and the exact millisecond, in one run:
+
+```
+t=331ms value=0.1789  <DIV.districts-rankings-table-wrap> y 386 -> 791
+t=371ms value=0.0832  <DIV.districts-rankings-table-wrap> y 791 -> 575
+```
+
+Two causes, immediately separable. Reach for the per-entry data before the
+scalar; a single number cannot tell you it is the sum of two unrelated bugs.


### PR DESCRIPTION
Fixes #1353. Fixes #1356. Fixes #1358.

Advances #1354 and #1359 — both deliberately left open:
- **#1354** — the reviewer judgement call below was resolved as *yes, make `programYear` required*. That change is in flight on `feat/rankings-table-pass` and is not in this PR.
- **#1359** — gaps (a) the 900px intro reflow and (b) the growing orientation sentence are still open. Live measurement on the preview put 900px at CLS 0.244, above the 0.1 budget. Both are being fixed on `feat/rankings-table-pass`.

Five independent frontend issues, developed in parallel where possible and grouped here because they are **file-disjoint** — the first three were cherry-picked from separate worktrees with zero conflicts. Reviewable commit-by-commit.

| commit | issue | area |
| --- | --- | --- |
| `1ac3acc6` | — | gitignore ephemeral agent worktrees |
| `c2cc6f34` | #1356 | `AppMeta` + `.github/ISSUE_TEMPLATE/` |
| `e0222e8b` `b59347e7` | #1353 | `utils/programYear.ts`, `hooks/useDefaultProgramYear.ts` |
| `8f433fd5` `dbbed9da` | #1354 | `DistinguishedDistrictTrophyCase`, analytics-core |
| `a964d30d` `1c25f1cc` | #1358 | rankings column ladder, scroll-region label, table density |
| `ddbdc7b2` `422eb4a5` | #1359 | Awards Race empty state, hero-stack reserve |

---

## #1359 — the landing page jumped 452px on every first visit

**This started as "my own commit reddened the CLS gate." It wasn't.** A bisect looked textbook — `dbbed9da` pass, `a964d30d` pass, `1c25f1cc` fail at 0.271 — and I said so. Then I measured the *parent* locally against the same committed fixtures: **0.265, identical**. The commit the bisect blamed had changed nothing about CLS.

The gate had two independent shifts underneath it: one **deterministic at 0.083**, and one **timing-dependent at 0.179** that only counts when the loading skeleton paints before the data lands. So every green run was green by luck, with 17% of budget left. A bisect over that samples a coin flip and returns a boundary, and a boundary always looks like a regression.

What actually found it was a `PerformanceObserver('layout-shift')` probe printing per-entry `value` / `startTime` / `sources`, which named both causes in one run. The scalar score cannot tell you it is the sum of two unrelated bugs.

### Cause 1 — the Awards Race vacated a slot it had reserved (0.083)

`AwardsRaceSection` reserves a 196px skeleton while the competitive-awards query is in flight (#750, Lesson 107), then collapsed to `null` if every award array came back empty. The code called that rare, "bounded to snapshots that genuinely have no competitive-award standings."

**At the start of a program year that is every snapshot.** No district has contended for anything yet. So the reserved slot mounted at t=261ms and was gone by t=276ms on every load, for the first months of every year. PY 2026-27 is in exactly that state now, and the committed fixture has all three award arrays empty, so LHCI hit it every run.

It now holds the slot. `AwardCard` already had a no-leader state; it grew the populated card's rows so skeleton → empty → populated are all the same box. Saying "no standings yet" at a rollover is also just better than the section silently vanishing.

### Cause 2 — the shell reserved three of six hero slots (0.179)

#826 reserved the KPI strip, #861 the mobile search, #922 the mobile header actions. Nobody reserved the Awards Race, the region toolbar, or the desktop search. Measured against the fixtures, `contentTop` loading → loaded:

| width | before | after |
| --- | --- | --- |
| 1350px | 386 → 838 (**452px**) | **9px** |
| 900px | 481 → 1217 (736px) | 260px |
| 600px | 543 → 813 (270px) | 72px |
| 375px | 654 → 982 (328px) | 130px |

The reserves now sit inside a real `.districts-hero-stack` in the loaded tree's order, built from the real elements: the Awards Race renders **its own** skeleton component, the mobile "See Awards" link is the real `Link` (it needs no data), and the search reserve carries the real `--hero` modifier so the stack's existing `order: -1` rule hoists it below 768px — the same rule, not a parallel one. A reserve made of the thing it reserves for cannot drift from it.

### The bit worth stealing

Two under-reserves had the same overlooked cause. `InfoTooltip` is a 14px icon — but its trigger is a `<button>`, and `styles/layers/base.css` floors every button at **44px** for WCAG 2.5.5. Inline, that inflates the line box it sits in to ~3× an 11px label: `.districts-kpi-card__label` measures **17px in the skeleton against 50px loaded**, and the Awards Race heading 45px more than a bare bar. Both now carry a shared `.tooltip-reserve` holding that same 44px floor, and there's a test on the *premise* — if the loaded heading ever stops carrying a tooltip, a named test fails rather than a mystery CLS number three sprints later.

### Result

Same fixtures, 3/3 runs identical (it was 0.265 and *varying* before):

**CLS 0.265 → 0.0036. Performance 0.86 → 0.99.**

### Left undone, deliberately, tracked on #1359

- **900px still moves 260px.** Different root cause: the header-actions reserve is `display: none` at ≥768px on the assumption the loaded actions "lay out inline beside the intro (no vertical shift to reserve)". They do lay out inline — and consume horizontal space, so the intro reflows from 172px to 398px. That's a #922 assumption, not a hero-stack one.
- **The orientation sentence grows with the data** ("a Toastmasters district" → "one of the 12 Toastmasters districts"). No reserve fixes that; it needs stable phrasing or a reserved inline width.
- **Below 768px the toolbar's chip row wraps** to as many lines as there are regions, which the shell cannot know before the data arrives. It reserves one row rather than guessing a region count that would silently drift — 130px of the 328px, and an under-reserve, never an over-reserve.
- **The error branches keep today's chrome.** Those slots pulse, and a skeleton pulsing forever above an error card reads as broken. No user reaches a loaded page through that branch, and it already swaps a 748px table pulse for an error card of unrelated height.

---

## #1358 — a user could see the ranking but none of the metrics

**Reported from South Asia:** "can only rank" on the landing page — position and score, none of the numbers the ranking is derived from. They said neither a browser nor landscape helped, which initially read as implausible.

It isn't. Column priority ran on a **375 / 768 / 1280** ladder, and a whole device class lives in the gap: many budget Android handsets are **360×640 CSS px**, so *landscape is 640px* — 70% wider than the design target, still under the 768 tablet breakpoint. No orientation and no zoom reveals a metric, and Android's Display-size setting shrinks the viewport further. In that market this is not an edge case.

**Fix:** a new `--compact` rung at **≥600px** carrying **Paid Clubs** and **Total Payments**, the two columns that dominate the Borda score. Distinguished stays at 768 to bound row width; Tier stays at 1280. No card collapse — ADR-006 §3 and the existing code comment rule that out, and the comparison table is the point of the page.

**Second, independent bug fixed here.** The scroll region advertised *"scroll horizontally to see all metrics"* unconditionally. Below the breakpoints the shed columns are `display: none`, **not** off-screen — so that instruction cannot succeed. A mislabelled `role="region"` is an accessibility defect, not a cosmetic one. The label is now derived from real overflow, reusing the measurement that already drove the fade cue.

Subtlety worth a look: it derives from *total* overflow, not the cue's "more content to the right" flag — that one goes false when the user reaches the right edge, which would strip the affordance from the label mid-scroll.

**Density follow-up (`1c25f1cc`).** `index.css` declares `@layer base, brand, utilities` — utilities **last** — so Tailwind's `px-*`/`py-*` beat `.districts-rankings-table td` regardless of specificity. Cells carried padding utilities that silently overrode the table's own density, and the two sources had drifted; the existing comment claiming the `td` rule "wins over Tailwind px-6" was backwards. (I asserted the same backwards thing mid-review before checking the layer order.) Padding is now single-sourced in CSS, award chip labels go icon-only below the compact rung via `sr-only sm:not-sr-only` — **not** `display: none`, so a screen reader still hears "Extension" rather than a bare trophy — and the sticky column is capped at 55vw below 600px so one award-heavy district can't set the width for the whole table.

**Two pre-existing tests changed, both by intent, neither pinned.** One asserted the old class ladder; one queried the scroll region by `name: /scroll/i`, which no longer matches because jsdom has no layout engine so nothing overflows. Updated to the new ladder and to the region's stable name.

**Explicitly out of scope:** making shed columns *reachable at any width* (a column-groups menu like `ClubsTable` has). No breakpoint can guarantee every column on a 360px portrait screen, so that's the real long-term answer — worth its own issue.

---

## #1353 — phantom `PY NaN–aN`

`getAvailableProgramYears` had no guard against an unparseable date: `calendarParts` returns `NaN`, `NaN >= 7` is false, so `programYearStart = NaN - 1` lands in the dedup `Set`, and `formatProgramYearShort(NaN)` renders literally `NaN-aN` as a selectable option.

Two layers: the deriver now skips dates whose start year is `NaN`, and `useDefaultProgramYear` mints its input through `snapshotDatesFrom` to match `useProgramYearControls`.

**The sighting is not fully explained and this PR does not claim otherwise.** `snapshotDatesFrom` reached `DistrictsPage` on 2026-07-15 (#1329) — *before* the sighting — so that dropdown should already have been protected. The leading hypothesis was also ruled out: `isIsoCalendarDate` and `calendarParts` agree on anything passing the mint. A stale cached bundle is the remaining candidate. Treat the root cause as open.

An earlier draft of one test passed **vacuously** — the hook's loading fallback happens to equal PY 2026 today — so the fixture moved to 2020-21 where it can actually fail.

## #1354 — checklist showed a retired requirement

The trophy case hardcoded five prerequisite labels including Region Advisor Visit, retired for 2026-27 in #1344. Its column is gone and `parseYesNo(undefined)` is `false`, so a district earning a tier would render Distinguished with a permanently-unmet row.

Now driven by the year's required set via a new additive `requiredPrerequisitesForProgramYear()` export. No exported type changed shape; analytics-core's 886 tests pass with no assertion edits, which is the proof tier calculation is untouched.

**Reviewer judgement call, deliberately unresolved:** `programYear` is optional and omitting it falls back to five legacy rows, while the new export defaults to the current four. `DistrictDetailPage` is the only caller and does pass it, so the fallback is unreachable in production and survives only to keep 21 test render sites green. Making it required closes the footgun but churns ~19 sites and 7 assertions that legitimately cover the five-gate era. Left for your call — a future caller forgetting the prop resurrects this bug.

## #1356 — no way to report anything

No contact path existed. With no backend to POST to, this uses the GitHub issue tracker; three templates added since the repo had none and `/issues/new/choose` offered nothing.

The link lives in `AppMeta` because it renders in **both** the desktop footer and the mobile "About ▾" disclosure (#889) — footer-only would be invisible on phones, which is precisely the audience #1358 is about. It sits **before** the licence: `MIT License · ` must stay adjacent for `AppShellTopBar.about.test.tsx:74`, and that adjacency is now asserted in `AppMeta`'s own test too, where the next person adding a link will look.

**Not done, deliberately:** GitHub Issues needs an account most Toastmasters members won't have. `config.yml` supports a `contact_links` email entry, but publishing an address invites scraping — operator's call.

---

## Testing

TDD throughout; every fix has its failing test committed before the implementation.

Full suite green: **frontend 3,714 across 310 files**, analytics-core 886 across 41, typecheck clean, `test:no-page-mounts:check` (R22) passing.

The #1358 guard reads the CSS and page as **text** rather than mounting `DistrictsPage` — jsdom has no layout engine so a mount cannot prove a media query, and that mount is the exact contention cost Lesson 51 warns about. It matches inside class attributes so prose mentions of the class names in code comments can't inflate the count.

The #1359 geometry was verified in a real browser (LHCI + a Playwright layout-shift probe) against the committed fixtures, because jsdom cannot measure it (Lesson 66). The committed tests assert the *structure* that produces the geometry — each reserve is the real element the loaded tree renders, inside the same stack.

**On flakiness.** `DistrictClubsPage > renders the ClubsTable` failed while two agents ran suites concurrently, and I twice reached a confident wrong conclusion — first "contention", then "I caused it" after a stash test showed clean-pass/dirty-fail. That experiment was invalid: an agent finished between the two runs, changing code *and* load together. Repeat runs and a clean suite once the agents finished settle it as the known Lesson 51 / epic #917 contention flake.

## Lessons filed

- *A skeleton that omits a button under-reserves by the touch-target floor* — reserve structurally, carrying the same rule, and test the premise.
- *Bisecting a gate with no headroom finds variance, not a regression* — measure the good side before believing the boundary; a gate passing at 83% of budget is already broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzS7FV5pH7JMDazPK3T1vn
