### PR TITLE
ci: fast docs-only gate so markdown PRs are not ungated (#1375)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
     # Skip CI when a push touches only non-code artifacts (lessons, docs,
     # markdown, ignore/license). Runs whenever ANY changed file is outside
     # these globs, so mixed code+docs changes are still fully gated.
+    #
+    # SYNC WARNING: what this list skips, .github/workflows/docs.yml picks up
+    # via an identical `paths:` allowlist (#1375) -- it runs the three gates
+    # that DO apply to markdown (lessons INDEX drift, prettier, yamllint). If
+    # the two lists drift, files fall into a gap covered by neither workflow.
+    # Edit both together.
     paths-ignore:
       - '**/*.md'
       - 'tasks/**'
@@ -14,6 +20,7 @@ on:
       - 'LICENSE'
   pull_request:
     branches: [main]
+    # Keep in sync with .github/workflows/docs.yml -- see the note above.
     paths-ignore:
       - '**/*.md'
       - 'tasks/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,87 @@
+name: Docs
+
+# Fast gate for documentation-only changes (#1375).
+#
+# `ci.yml` deliberately skips markdown/docs so a typo does not pay for the
+# 15-minute frontend suite. But three of its gates DO cover markdown:
+#   - lessons INDEX.md drift  (Test Suite -> Run scripts/lib tests)
+#   - prettier --check "**/*.md"  (Quality Gates -> format check)
+#   - yamllint ... docs/  (Quality Gates -> lint:yaml)
+# Without this job a docs-only PR merges completely ungated, and its defect
+# goes red on the NEXT code PR, on files that author never touched (this
+# happened: the INDEX drift gate blocked #1369 and #1371 until #1372).
+#
+# SYNC WARNING: the `paths:` allowlist below MIRRORS the `paths-ignore:` list
+# in .github/workflows/ci.yml. If the two drift, files fall into a gap covered
+# by neither workflow. Edit both together.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'tasks/**'
+      - 'docs/**'
+      - '.gitignore'
+      - 'LICENSE'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'tasks/**'
+      - 'docs/**'
+      - '.gitignore'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    name: Docs Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Deliberately FIRST and dependency-free: the drift gate is pure bash.
+      # Putting it behind `npm ci` would triple this job for no benefit, and
+      # the whole point of this workflow is that it stays fast enough that
+      # nobody wants to path-filter it away again.
+      - name: Check lessons INDEX.md is not stale (#1375)
+        env:
+          LESSONS_DIR: tasks/lessons
+        run: bash scripts/lessons-index.sh --check
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+
+      # Whole-repo markdown, not just the changed files: it is exactly the md
+      # coverage `npm run format:check` has in Quality Gates, it needs no diff
+      # base (so `push` and `pull_request` behave identically), and it costs
+      # ~5s. `.prettierignore` still applies -- note tasks/lessons/ is excluded
+      # there on purpose, so lesson prose is covered by the drift gate only.
+      #
+      # prettier is fetched standalone rather than via `npm ci` (~1 package vs
+      # the full monorepo). The range is read from package.json so this can
+      # never drift from the version Quality Gates uses.
+      - name: Check markdown formatting (#1375)
+        run: |
+          version="$(node -p "require('./package.json').devDependencies.prettier")"
+          echo "Using prettier@${version}"
+          npx --yes "prettier@${version}" --check "**/*.md"
+
+      # Unconditional, not "only when docs/ or .github/ yaml changed": the run
+      # is ~1s, and a conditional here would need an explicit case for every
+      # path combination (R17) to buy nothing. yamllint is preinstalled on the
+      # GitHub-hosted ubuntu image -- ci.yml's Quality Gates relies on the same.
+      - name: Check YAML lint (#1375)
+        run: npm run lint:yaml

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,6 +2,7 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `a-new-workflows-own-path-filter-cannot-be-exercised-by-the-pr-that-adds-it.md` — A path-filtered workflow's own filter can never be exercised by the PR that introduces it — the diff always contains the workflow file, so the filtered case reads as "mixed" until after merge; open the probe PR against a scratch base branch that widens only `pull_request.branches`  (2026-08-02)
 - `assert-the-echo-field-that-is-invariant-not-the-one-that-looks-semantic.md` — When an upstream echoes your request back, assert the echo field that is invariant across every response shape — not the one that reads most semantically  (2026-08-02)
 - `firebase-hosting-header-precedence-is-last-match-wins-and-globs-run-before-rewrites.md` — Firebase Hosting resolves each header key from the LAST matching rule (the docs say first) and matches `source` globs against the request path BEFORE rewrites — so an SPA cache rule that reads correctly is usually inverted and blind to every deep route  (2026-08-02)
 - `a-font-swap-reflow-masquerades-as-a-reserve-error.md` — A web-font swap reflow masquerades as a reserve error — pin both states instead of racing them, and ablate the font before attributing CLS to your diff  (2026-08-01)

--- a/tasks/lessons/lessons/a-new-workflows-own-path-filter-cannot-be-exercised-by-the-pr-that-adds-it.md
+++ b/tasks/lessons/lessons/a-new-workflows-own-path-filter-cannot-be-exercised-by-the-pr-that-adds-it.md
@@ -1,0 +1,57 @@
+---
+date: 2026-08-02
+tier: lesson
+summary: A path-filtered workflow's own filter can never be exercised by the PR that introduces it — the diff always contains the workflow file, so the filtered case reads as "mixed" until after merge; open the probe PR against a scratch base branch that widens only `pull_request.branches`
+tags: [ci, github-actions, verification, workflows, path-filters]
+---
+
+# A new workflow's own path filter cannot be exercised by the PR that adds it
+
+**Date:** 2026-08-02
+**PR:** #1376 (issue #1375)
+
+## What happened
+
+`docs.yml` was added with a `paths:` allowlist (`**/*.md`, `tasks/**`, `docs/**`,
+`.gitignore`, `LICENSE`) mirroring `ci.yml`'s `paths-ignore:`. The acceptance
+criterion was "a docs-only PR runs this job and **nothing else** — confirm by
+inspecting an actual PR's check list, not by reading the YAML."
+
+That is unobservable on the introducing PR, and not for a fixable reason. The PR's
+diff necessarily contains `.github/workflows/docs.yml`, which is:
+
+- **outside** its own allowlist (it is not markdown, `tasks/`, or `docs/`), and
+- **inside** `ci.yml`'s trigger set (`.github/**` is not in its `paths-ignore`).
+
+So every PR that adds a path-filtered workflow is, by construction, a *mixed* PR.
+Adding a docs file to it produces "Docs Gate + CI", never "Docs Gate alone". You
+can argue the extra CI run is attributable only to the workflow file — but that is
+an inference from the YAML, which is exactly what the criterion forbids.
+
+## The trick
+
+Path filters are evaluated against the PR diff; `pull_request.branches` is evaluated
+against the **base**. Decouple them:
+
+1. Push a scratch base branch that changes **only** `pull_request.branches` in the
+   affected workflows (`[main]` -> `[main, scratch-base]`). Nothing else.
+2. Branch off it, commit **only** a file inside the filter under test.
+3. Open the PR with `--base scratch-base`. The diff is now purely the filtered file,
+   because the workflow edits are on both sides.
+4. Read `gh pr diff --name-only` **and** `gh pr checks` together — the diff proves
+   what was actually being filtered.
+5. Close the PR and delete both branches.
+
+This gave the real answer: diff = one `.md`, check list = one entry, `Docs Gate pass 15s`.
+
+## The transferable part
+
+When a verification target is "what does the CI system do with diff shape X", the
+introducing change is never a valid specimen — it perturbs the diff shape it is
+trying to measure. Build the specimen separately. And the same shape recurs beyond
+path filters: any conditional keyed on the diff (changed-files actions, `dorny/paths-filter`,
+Turborepo/Nx affected-graph gates) is unobservable on the commit that installs it.
+
+Corollary for the negative case, which *is* observable: a PR containing only the new
+workflow files is a genuine "code-only" specimen — if the new job is absent from its
+check list, the allowlist correctly excludes `.github/**`.


### PR DESCRIPTION
Adds `.github/workflows/docs.yml` — a fast gate that runs the three checks that
genuinely apply to documentation, on the exact set of paths `ci.yml` skips.

Refs #1375.

## Why

A docs-only PR triggers **zero** checks today (`ci.yml` `paths-ignore`), and branch
protection has no required contexts, so it merges completely ungated. That is mostly
deliberate — nobody wants a 15-minute frontend suite for a typo. But three gates that
*do* cover markdown live inside the skipped workflows:

| gate | lived in | covers |
| --- | --- | --- |
| `scripts/lessons-index.sh --check` | `Test Suite` → `Run scripts/lib tests` | `tasks/lessons/**` drift |
| `prettier --check "**/*.md"` | `Quality Gates` → format check | all markdown |
| `npm run lint:yaml` | `Quality Gates` | `docs/` yaml |

So a docs PR can land a defect that goes red on the **next code PR**, on files that
author never touched. Not hypothetical: the INDEX drift gate blocked #1369 and #1371
until #1372 was root-caused.

## What

- New `Docs` workflow, `pull_request` + `push: [main]`, `paths:` allowlist that
  **mirrors** `ci.yml`'s `paths-ignore` exactly.
- Step order matters: the INDEX drift check is **first and dependency-free** (pure
  bash, no `npm ci`). Prettier is then fetched standalone at the range `package.json`
  pins — one package, not the whole monorepo — so the version can never drift from
  Quality Gates'. `npm run lint:yaml` last; `yamllint` is preinstalled on the runner
  image, same as `ci.yml` already assumes.
- `SYNC WARNING` cross-reference comments in **both** files: if the two path lists
  drift, files fall into a gap covered by neither workflow.

## Deliberate choices

- **Whole-repo `**/*.md`, not only the changed files.** Same md coverage
  `format:check` has, no diff base needed (so `push` and `pull_request` behave
  identically), and ~5s. `.prettierignore` still applies — `tasks/lessons/` is
  excluded there on purpose, so lesson prose is gated by the drift check only.
- **`lint:yaml` runs unconditionally**, not "only when `docs/`/`.github/` yaml
  changed": ~1s, and a conditional would need an explicit case for every path
  combination (R17) to buy nothing.
- **A mixed code+docs PR triggering both this and `ci.yml` is correct** and is not
  suppressed.
- **Not added to branch protection.** There are currently no required contexts;
  adding one changes merge behaviour repo-wide. Owner's call.

## Verification

Failure modes and trigger scenarios were demonstrated on a throwaway PR — run URLs
in the issue thread / review comment.