### PR TITLE
SCRATCH (do not merge) — docs-only check-list probe (#1375)

### DIFF
--- a/docs/zzz-demo-docsonly-delete-me.md
+++ b/docs/zzz-demo-docsonly-delete-me.md
@@ -1,0 +1,4 @@
+# Docs-only trigger probe (#1375)
+
+Scratch file. Its only job is to make a PR diff that contains nothing but
+markdown, so the Docs Gate path filter can be observed on a real check list.


### PR DESCRIPTION
Throwaway. Diff is one markdown file and nothing else. Opened against a scratch base branch purely to observe which workflows a docs-only PR triggers. Deleted immediately.