### PR TITLE
fix(hosting): revalidate the entry document instead of caching it for an hour (#1365)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -62,6 +62,24 @@
               "value": "public, max-age=31536000, immutable"
             }
           ]
+        },
+        {
+          "source": "**/*.html",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "no-cache"
+            }
+          ]
+        },
+        {
+          "source": "**",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "no-cache"
+            }
+          ]
         }
       ]
     },
@@ -107,6 +125,42 @@
             {
               "key": "Cache-Control",
               "value": "public, max-age=31536000, immutable"
+            }
+          ]
+        },
+        {
+          "source": "**/*.@(jpg|jpeg|gif|png|svg|webp|ico)",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "public, max-age=31536000, immutable"
+            }
+          ]
+        },
+        {
+          "source": "**/*.@(woff|woff2|ttf|otf|eot)",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "public, max-age=31536000, immutable"
+            }
+          ]
+        },
+        {
+          "source": "**/*.html",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "no-cache"
+            }
+          ]
+        },
+        {
+          "source": "**",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "no-cache"
             }
           ]
         }

--- a/firebase.json
+++ b/firebase.json
@@ -37,6 +37,15 @@
           ]
         },
         {
+          "source": "**",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "no-cache"
+            }
+          ]
+        },
+        {
           "source": "**/*.@(js|css)",
           "headers": [
             {
@@ -65,15 +74,6 @@
         },
         {
           "source": "**/*.html",
-          "headers": [
-            {
-              "key": "Cache-Control",
-              "value": "no-cache"
-            }
-          ]
-        },
-        {
-          "source": "**",
           "headers": [
             {
               "key": "Cache-Control",
@@ -120,6 +120,15 @@
           ]
         },
         {
+          "source": "**",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "no-cache"
+            }
+          ]
+        },
+        {
           "source": "**/*.@(js|css)",
           "headers": [
             {
@@ -148,15 +157,6 @@
         },
         {
           "source": "**/*.html",
-          "headers": [
-            {
-              "key": "Cache-Control",
-              "value": "no-cache"
-            }
-          ]
-        },
-        {
-          "source": "**",
           "headers": [
             {
               "key": "Cache-Control",

--- a/firebase.json
+++ b/firebase.json
@@ -80,6 +80,15 @@
               "value": "no-cache"
             }
           ]
+        },
+        {
+          "source": "/index.html",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "max-age=0, must-revalidate"
+            }
+          ]
         }
       ]
     },
@@ -161,6 +170,15 @@
             {
               "key": "Cache-Control",
               "value": "no-cache"
+            }
+          ]
+        },
+        {
+          "source": "/index.html",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "max-age=0, must-revalidate"
             }
           ]
         }

--- a/scripts/lib/__tests__/firebaseHeaders.test.ts
+++ b/scripts/lib/__tests__/firebaseHeaders.test.ts
@@ -35,16 +35,50 @@ function loadHosting(): HostingTarget[] {
   return JSON.parse(raw).hosting as HostingTarget[]
 }
 
-/** The catch-all (`source: "**"`) header rule for a named target. */
-function catchAllHeaders(targetName: string): HeaderKV[] {
+/** Every header rule for a named target, in declaration order. */
+function rulesFor(targetName: string): HeaderRule[] {
   const target = loadHosting().find(t => t.target === targetName)
   expect(target, `hosting target "${targetName}" must exist`).toBeDefined()
-  const rule = target!.headers?.find(r => r.source === '**')
+  expect(
+    target!.headers,
+    `target "${targetName}" must declare header rules`
+  ).toBeDefined()
+  return target!.headers!
+}
+
+/** The catch-all (`source: "**"`) header rule for a named target. */
+function catchAllHeaders(targetName: string): HeaderKV[] {
+  const rule = rulesFor(targetName).find(r => r.source === '**')
   expect(
     rule,
     `target "${targetName}" must have a catch-all (source "**") header rule`
   ).toBeDefined()
   return rule!.headers
+}
+
+/** Index of the first rule whose `source` matches, or -1. */
+function ruleIndex(targetName: string, source: string): number {
+  return rulesFor(targetName).findIndex(r => r.source === source)
+}
+
+/**
+ * Cache-Control resolved for a `source`, using Firebase's documented
+ * precedence: "Hosting applies the header defined by the FIRST rule with a
+ * URL pattern that matches the requested path" — per header key. Rules are
+ * merged across matches (empirically: a hashed `/assets/*.js` on prod carries
+ * BOTH the catch-all's CSP and the js/css rule's Cache-Control), so a later
+ * rule can only supply a key no earlier matching rule defined.
+ */
+function firstCacheControlAmong(
+  targetName: string,
+  sources: string[]
+): string | undefined {
+  for (const rule of rulesFor(targetName)) {
+    if (!sources.includes(rule.source)) continue
+    const cc = headerValue(rule.headers, 'Cache-Control')
+    if (cc !== undefined) return cc
+  }
+  return undefined
 }
 
 function headerValue(headers: HeaderKV[], key: string): string | undefined {
@@ -131,6 +165,113 @@ describe('firebase.json security headers (#783)', () => {
             /connect-src[^;]*https:\/\/www\.google-analytics\.com/
           )
         })
+      })
+    })
+  }
+})
+
+/**
+ * Contract test for #1365 — the entry document must revalidate.
+ *
+ * The hashed bundles are correctly `immutable`, but `index.html` is the only
+ * document mapping a URL to those hashed names. With no HTML rule it fell
+ * through to Firebase's default `max-age=3600` and no validator directive, so
+ * a returning visitor inside the hour got the previous deploy's HTML and
+ * therefore — because the bundles really are immutable — the previous
+ * deploy's JavaScript, with the ETag never consulted.
+ *
+ * Two things this pins that are easy to get wrong:
+ *
+ * 1. `**​/*.html` alone is NOT enough. Firebase matches header `source` globs
+ *    against the REQUEST path, before rewrites are applied. `/` and every SPA
+ *    deep route (`/districts`, `/district/61/clubs`) are extensionless, so they
+ *    never match `*.html` even though they all serve index.html via the `**`
+ *    rewrite. The document default has to be a `**` rule.
+ * 2. That `**` rule must come AFTER the hashed-asset rules. Firebase applies
+ *    the first matching rule per header key, so a no-cache `**` placed ahead
+ *    of them would strip `immutable` off every bundle.
+ */
+const IMMUTABLE = 'public, max-age=31536000, immutable'
+
+const ASSET_SOURCES = [
+  '**/*.@(js|css)',
+  '**/*.@(jpg|jpeg|gif|png|svg|webp|ico)',
+  '**/*.@(woff|woff2|ttf|otf|eot)',
+]
+
+describe('firebase.json cache headers (#1365)', () => {
+  it('keeps the production and staging header rules identical (no drift)', () => {
+    // The two targets are copy-paste twins with no variable mechanism, and
+    // per-PR preview channels deploy the STAGING target — so a rule that
+    // exists only on production is unverifiable on a preview. Assert whole-
+    // array equality rather than re-listing each rule: this catches the next
+    // one-sided edit too. If the targets ever need to diverge on purpose,
+    // that divergence should be a deliberate edit to this expectation.
+    expect(rulesFor('staging')).toEqual(rulesFor('production'))
+  })
+
+  for (const targetName of ['production', 'staging']) {
+    describe(`target: ${targetName}`, () => {
+      it('revalidates the entry document instead of caching it for an hour', () => {
+        // `no-cache`, not `no-store`: the response is still stored, but must
+        // be revalidated against the ETag before reuse. Unchanged deploy =>
+        // a cheap 304; changed deploy => the new bundle immediately.
+        expect(firstCacheControlAmong(targetName, ['**'])).toBe('no-cache')
+      })
+
+      it('revalidates literal .html paths too', () => {
+        expect(firstCacheControlAmong(targetName, ['**/*.html'])).toBe(
+          'no-cache'
+        )
+      })
+
+      it('declares every hashed-asset rule as immutable', () => {
+        for (const source of ASSET_SOURCES) {
+          expect(
+            firstCacheControlAmong(targetName, [source]),
+            `${targetName} rule "${source}" must be immutable`
+          ).toBe(IMMUTABLE)
+        }
+      })
+
+      it('orders every asset rule ahead of the no-cache document default', () => {
+        // Firebase resolves each header key from the FIRST matching rule.
+        // `**` matches hashed assets too, so if the no-cache catch-all came
+        // first the bundles would lose `immutable` and re-download forever.
+        const docDefault = rulesFor(targetName).findIndex(
+          r =>
+            r.source === '**' &&
+            headerValue(r.headers, 'Cache-Control') !== undefined
+        )
+        expect(
+          docDefault,
+          'a `**` rule carrying Cache-Control must exist'
+        ).toBeGreaterThan(-1)
+
+        for (const source of ASSET_SOURCES) {
+          const assetIdx = ruleIndex(targetName, source)
+          expect(
+            assetIdx,
+            `${targetName} must declare "${source}"`
+          ).toBeGreaterThan(-1)
+          expect(
+            assetIdx,
+            `"${source}" must precede the no-cache "**" rule`
+          ).toBeLessThan(docDefault)
+        }
+      })
+
+      it('keeps the security catch-all free of Cache-Control', () => {
+        // The security `**` rule is FIRST, so any Cache-Control added to it
+        // would win over the asset rules for every request. Cache policy
+        // belongs to the trailing `**` rule only.
+        const securityRule = rulesFor(targetName).find(
+          r => r.source === '**' && headerValue(r.headers, 'X-Frame-Options')
+        )
+        expect(securityRule).toBeDefined()
+        expect(
+          headerValue(securityRule!.headers, 'Cache-Control')
+        ).toBeUndefined()
       })
     })
   }

--- a/scripts/lib/__tests__/firebaseHeaders.test.ts
+++ b/scripts/lib/__tests__/firebaseHeaders.test.ts
@@ -56,29 +56,46 @@ function catchAllHeaders(targetName: string): HeaderKV[] {
   return rule!.headers
 }
 
-/** Index of the first rule whose `source` matches, or -1. */
+/** Index of the first rule declaring `source`, or -1. */
 function ruleIndex(targetName: string, source: string): number {
   return rulesFor(targetName).findIndex(r => r.source === source)
 }
 
 /**
- * Cache-Control resolved for a `source`, using Firebase's documented
- * precedence: "Hosting applies the header defined by the FIRST rule with a
- * URL pattern that matches the requested path" — per header key. Rules are
- * merged across matches (empirically: a hashed `/assets/*.js` on prod carries
- * BOTH the catch-all's CSP and the js/css rule's Cache-Control), so a later
- * rule can only supply a key no earlier matching rule defined.
+ * Cache-Control that Hosting will actually serve for a request matching
+ * `sources` — the value from the LAST matching rule that declares the key.
+ *
+ * The precedence is LAST-match-wins, not first. The public docs say the
+ * opposite ("Hosting applies the header defined by the first rule with a URL
+ * pattern that matches the requested path"), and that wording is what makes
+ * this the easiest thing in the file to get backwards. Measured against the
+ * Firebase Hosting emulator, which runs superstatic — the same config engine
+ * Hosting itself uses:
+ *
+ *   rules: ** (security) | js/css immutable | img | font | *.html no-cache | ** no-cache
+ *   GET /assets/index-B5NVCpKe.js  ->  cache-control: no-cache      <- immutable LOST
+ *
+ * Moving the bare-`**` no-cache rule ahead of the asset rules restored it:
+ *
+ *   rules: ** (security) | ** no-cache | js/css immutable | img | font | *.html no-cache
+ *   GET /                          ->  no-cache
+ *   GET /districts                 ->  no-cache
+ *   GET /assets/index-B5NVCpKe.js  ->  public, max-age=31536000, immutable
+ *
+ * Rules are merged per key, so the leading security rule's CSP/XFO still
+ * reach every response either way (5/5 security headers on all paths above).
  */
-function firstCacheControlAmong(
+function resolveCacheControl(
   targetName: string,
   sources: string[]
 ): string | undefined {
+  let resolved: string | undefined
   for (const rule of rulesFor(targetName)) {
     if (!sources.includes(rule.source)) continue
     const cc = headerValue(rule.headers, 'Cache-Control')
-    if (cc !== undefined) return cc
+    if (cc !== undefined) resolved = cc
   }
-  return undefined
+  return resolved
 }
 
 function headerValue(headers: HeaderKV[], key: string): string | undefined {
@@ -186,10 +203,11 @@ describe('firebase.json security headers (#783)', () => {
  *    against the REQUEST path, before rewrites are applied. `/` and every SPA
  *    deep route (`/districts`, `/district/61/clubs`) are extensionless, so they
  *    never match `*.html` even though they all serve index.html via the `**`
- *    rewrite. The document default has to be a `**` rule.
- * 2. That `**` rule must come AFTER the hashed-asset rules. Firebase applies
- *    the first matching rule per header key, so a no-cache `**` placed ahead
- *    of them would strip `immutable` off every bundle.
+ *    rewrite. The document default has to be a bare `**` rule.
+ * 2. That `**` rule must come BEFORE the hashed-asset rules — see
+ *    `resolveCacheControl` above for the measurement. Last match wins, so a
+ *    no-cache `**` placed after them strips `immutable` off every bundle and
+ *    turns the whole app into a re-download on each navigation.
  */
 const IMMUTABLE = 'public, max-age=31536000, immutable'
 
@@ -212,32 +230,35 @@ describe('firebase.json cache headers (#1365)', () => {
 
   for (const targetName of ['production', 'staging']) {
     describe(`target: ${targetName}`, () => {
+      // `/`, `/districts`, `/district/61/clubs` — everything the SPA rewrite
+      // turns into index.html — matches only the bare `**` rules.
       it('revalidates the entry document instead of caching it for an hour', () => {
         // `no-cache`, not `no-store`: the response is still stored, but must
-        // be revalidated against the ETag before reuse. Unchanged deploy =>
-        // a cheap 304; changed deploy => the new bundle immediately.
-        expect(firstCacheControlAmong(targetName, ['**'])).toBe('no-cache')
+        // be revalidated against the ETag before reuse. Verified against prod:
+        // a conditional GET with the current ETag returns 304, a stale one 200.
+        expect(resolveCacheControl(targetName, ['**'])).toBe('no-cache')
       })
 
       it('revalidates literal .html paths too', () => {
-        expect(firstCacheControlAmong(targetName, ['**/*.html'])).toBe(
+        expect(resolveCacheControl(targetName, ['**', '**/*.html'])).toBe(
           'no-cache'
         )
       })
 
-      it('declares every hashed-asset rule as immutable', () => {
+      it('keeps every hashed asset immutable despite the no-cache catch-all', () => {
+        // A hashed asset matches BOTH `**` and its own extension rule. This is
+        // the assertion that would have caught the first attempt at this fix.
         for (const source of ASSET_SOURCES) {
           expect(
-            firstCacheControlAmong(targetName, [source]),
-            `${targetName} rule "${source}" must be immutable`
+            resolveCacheControl(targetName, ['**', source]),
+            `${targetName}: a request matching "${source}" must resolve immutable`
           ).toBe(IMMUTABLE)
         }
       })
 
-      it('orders every asset rule ahead of the no-cache document default', () => {
-        // Firebase resolves each header key from the FIRST matching rule.
-        // `**` matches hashed assets too, so if the no-cache catch-all came
-        // first the bundles would lose `immutable` and re-download forever.
+      it('orders the no-cache document default ahead of every asset rule', () => {
+        // The structural invariant behind the assertion above. Stated
+        // separately so a reordering failure names the cause, not a symptom.
         const docDefault = rulesFor(targetName).findIndex(
           r =>
             r.source === '**' &&
@@ -245,7 +266,7 @@ describe('firebase.json cache headers (#1365)', () => {
         )
         expect(
           docDefault,
-          'a `**` rule carrying Cache-Control must exist'
+          'a bare `**` rule carrying Cache-Control must exist'
         ).toBeGreaterThan(-1)
 
         for (const source of ASSET_SOURCES) {
@@ -256,15 +277,15 @@ describe('firebase.json cache headers (#1365)', () => {
           ).toBeGreaterThan(-1)
           expect(
             assetIdx,
-            `"${source}" must precede the no-cache "**" rule`
-          ).toBeLessThan(docDefault)
+            `"${source}" must come AFTER the no-cache "**" rule to win`
+          ).toBeGreaterThan(docDefault)
         }
       })
 
-      it('keeps the security catch-all free of Cache-Control', () => {
-        // The security `**` rule is FIRST, so any Cache-Control added to it
-        // would win over the asset rules for every request. Cache policy
-        // belongs to the trailing `**` rule only.
+      it('keeps cache policy out of the security catch-all rule', () => {
+        // The #783 helper resolves the security headers via the FIRST `**`
+        // rule. Keeping Cache-Control in its own sibling rule means neither
+        // contract can be broken by an edit aimed at the other.
         const securityRule = rulesFor(targetName).find(
           r => r.source === '**' && headerValue(r.headers, 'X-Frame-Options')
         )

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -3,6 +3,7 @@
 
 ## lessons (manifest-pinned + session-judged)
 - `assert-the-echo-field-that-is-invariant-not-the-one-that-looks-semantic.md` — When an upstream echoes your request back, assert the echo field that is invariant across every response shape — not the one that reads most semantically  (2026-08-02)
+- `firebase-hosting-header-precedence-is-last-match-wins-and-globs-run-before-rewrites.md` — Firebase Hosting resolves each header key from the LAST matching rule (the docs say first) and matches `source` globs against the request path BEFORE rewrites — so an SPA cache rule that reads correctly is usually inverted and blind to every deep route  (2026-08-02)
 - `a-font-swap-reflow-masquerades-as-a-reserve-error.md` — A web-font swap reflow masquerades as a reserve error — pin both states instead of racing them, and ablate the font before attributing CLS to your diff  (2026-08-01)
 - `a-skeleton-that-omits-a-button-under-reserves-by-the-touch-target-floor.md` — A skeleton that omits an interactive element under-reserves by the touch-target floor, not by the element's visual size  (2026-08-01)
 - `an-override-must-match-the-same-element-set-the-utility-it-overrides-paints.md` — A CSS override must match the same element SET the utility it overrides paints — restate that set by hand and you get a silent off-by-one; derive it from the tool instead  (2026-08-01)

--- a/tasks/lessons/lessons/firebase-hosting-header-precedence-is-last-match-wins-and-globs-run-before-rewrites.md
+++ b/tasks/lessons/lessons/firebase-hosting-header-precedence-is-last-match-wins-and-globs-run-before-rewrites.md
@@ -1,0 +1,102 @@
+---
+date: 2026-08-02
+tier: lesson
+summary: Firebase Hosting resolves each header key from the LAST matching rule (the docs say first) and matches `source` globs against the request path BEFORE rewrites — so an SPA cache rule that reads correctly is usually inverted and blind to every deep route
+tags: [firebase, hosting, caching, deployment, config, spa, testing, infrastructure]
+---
+
+# Firebase Hosting header precedence is last-match-wins, and globs run before rewrites
+
+**Date:** 2026-08-02
+**Issue:** #1365 — `index.html` served `max-age=3600` with no revalidation
+**PR:** #1380
+
+## What happened
+
+`firebase.json` set `immutable` on the hashed bundles but had no rule for
+HTML, so `index.html` fell through to Firebase's default `max-age=3600` with
+no validator directive. A returning visitor inside the hour got the previous
+deploy's HTML, and therefore — because the bundles really are immutable —
+the previous deploy's JavaScript.
+
+The obvious fix is four lines:
+
+```json
+{ "source": "**/*.html", "headers": [{ "key": "Cache-Control", "value": "no-cache" }] }
+```
+
+It reads correctly, it is what the issue proposed, and it is wrong twice.
+
+## Trap 1 — header globs match the request path, before rewrites
+
+Every route in this SPA is served by the `"source": "**" → "/index.html"`
+rewrite. But Hosting matches header `source` globs against the **request**
+path, not the rewrite destination. `/`, `/districts`, `/district/61/clubs`
+are all extensionless, so none of them match `*.html`:
+
+```
+minimatch('/', '**/*.html')  ->  false
+```
+
+An `*.html` rule fixes only the one URL nobody navigates to directly. The
+document default has to be a bare `**` rule. This generalises: for any
+rewrite-driven app, a header rule keyed on the *served file's* extension
+covers almost none of the traffic that file actually serves.
+
+## Trap 2 — last match wins, and the docs say the opposite
+
+The public docs state Hosting "applies the header defined by the **first**
+rule with a URL pattern that matches the requested path." Acting on that
+sentence produces a config that is exactly backwards.
+
+The existing file could not disambiguate: the catch-all carried only security
+headers and the asset rules only `Cache-Control`, so no key was ever
+contested, and both precedence models predicted the observed production
+behaviour. The first commit on the branch added the contested key and shipped
+the inversion — a bare `**` no-cache placed *after* the asset rules, which
+silently strips `immutable` from every bundle.
+
+## How it was settled without a deploy
+
+`firebase emulators:start --only hosting` runs **superstatic**, the same
+config engine Hosting itself uses. Point it at a throwaway fixture — a few
+files with realistic hashed names — and replay the real rule array:
+
+```
+** (security) | js/css | img | font | *.html no-cache | ** no-cache
+GET /assets/index-B5NVCpKe.js  ->  cache-control: no-cache      # immutable LOST
+
+** (security) | ** no-cache | js/css | img | font | *.html no-cache
+GET /                          ->  no-cache
+GET /districts                 ->  no-cache
+GET /assets/index-B5NVCpKe.js  ->  public, max-age=31536000, immutable
+```
+
+Last match wins, per key. Rules still *merge* across matches, so the leading
+security rule's CSP and `X-Frame-Options` reach every response either way —
+which is why the merge behaviour looks like "first wins" until two rules
+contest the same key.
+
+Two things made the measurement trustworthy, and both are the reusable part:
+
+- **A control run.** Replaying `origin/main`'s unmodified config through the
+  same harness reproduced production exactly (no `Cache-Control` on `/`,
+  `immutable` on assets). Without it, "everything is `no-cache`" is equally
+  explained by the emulator overriding the header, and the whole experiment
+  proves nothing.
+- **Restarting the emulator between variants.** It does not hot-reload
+  `firebase.json`. Two variants edited in place returned byte-identical
+  results and briefly suggested the config was being ignored entirely.
+
+## Takeaway
+
+Config whose semantics you have only read about is unverified config. When a
+platform's ordering rule is load-bearing, find the engine it actually runs
+(here: superstatic, shipped inside the CLI you already have) and measure —
+with a control, and with the process restarted between variants. Then encode
+the *measured* model in the test, not the documented one, and prove the guard
+fails against the broken ordering.
+
+Corollary for any rewrite-driven site: a header rule matching on file
+extension is a rule about URLs that end in that extension, which for an SPA
+is nearly none of them.


### PR DESCRIPTION
Closes the stale-bundle window described in #1365. `firebase.json` only —
no `frontend/` or `packages/` files touched.

## Problem

`index.html` had no header rule, so it fell through to Firebase's default
`max-age=3600` with no validator directive. The hashed bundles really are
`immutable`, and `index.html` is the only document mapping a URL to their
hashed names — so a returning visitor inside the hour got the previous
deploy's HTML *and therefore its JavaScript*, with the ETag never consulted.

## What changed

Resulting rule order, identical on both targets:

| # | `source` | `Cache-Control` |
|---|---|---|
| 1 | `**` | — (CSP + security headers, untouched) |
| 2 | `**` | `max-age=0, must-revalidate` |
| 3 | `**/*.@(js\|css)` | `public, max-age=31536000, immutable` |
| 4 | `**/*.@(jpg\|jpeg\|gif\|png\|svg\|webp\|ico)` | `public, max-age=31536000, immutable` |
| 5 | `**/*.@(woff\|woff2\|ttf\|otf\|eot)` | `public, max-age=31536000, immutable` |
| 6 | `**/*.html` | `max-age=0, must-revalidate` |

Rules 4 and 5 were previously missing from `staging` — the drift the issue
flagged. Fixed here, and it matters beyond tidiness: per-PR previews deploy
the **staging** target, so without them the image/font criterion could not be
verified on a preview at all.

## Three things the issue's proposed patch got wrong

All three were found by measurement, not review. Each is a commit on this
branch, so the history shows the wrong version and the evidence that killed
it.

**1. `**/*.html` alone does not cover the entry document.** Firebase matches
header `source` globs against the **request path, before rewrites**. `/` and
every SPA deep route (`/districts`, `/district/61/clubs`) are extensionless,
so none of them match `*.html` even though all of them serve `index.html`.
Only a bare `**` rule closes the hole; rule 6 is kept as the explicit
statement for literal `.html` paths.

**2. Precedence is LAST match wins — the docs say the opposite.** The docs
state Hosting "applies the header defined by the *first* rule with a URL
pattern that matches the requested path." Replaying both targets through the
Firebase Hosting emulator (superstatic, the same config engine Hosting runs)
against a fixture of hashed assets and SPA routes, with the revalidate
catch-all placed *after* the asset rules:

```
GET /assets/index-B5NVCpKe.js  ->  cache-control: no-cache      # immutable LOST
```

Commit 00054c17 shipped exactly that regression; 0b9a1f4b fixes it. A control
run of `origin/main`'s config through the same harness reproduced today's
production behaviour exactly, confirming the emulator was not overriding the
header.

**3. `no-cache` closes the hole but costs the 304 (issue AC #5).** It stops
Firebase's edge storing the document, so every revalidation is a full origin
round-trip returning the whole body. A/B'd on one preview channel — same
file, same ETag, `/` vs `/index.html` given different directives in a single
deploy:

```
no-cache                     conditional GET -> 200, x-cache: MISS   (x3)
max-age=0, must-revalidate   conditional GET -> 304, x-cache: HIT    (x3)
```

Control: an `immutable` asset on the *same* channel returns 304, so the
origin does honour `If-None-Match` and the directive was the only variable.
`max-age=0, must-revalidate` gives the browser the identical guarantee —
stale immediately, no reuse without successful revalidation — while keeping
the document at the edge. Firebase purges its own edge on deploy, so a new
deploy still reaches an already-open browser on the next navigation.

## Verification — measured on the live preview channel

`https://staging-toast-stats--pr-1380-xccxba5q.web.app`

```
=== DOCUMENTS        status  cache-control                 security  conditional GET
  /                    200   max-age=0, must-revalidate      5/5      304 HIT
  /index.html          200   max-age=0, must-revalidate      5/5      304 HIT
  /districts           200   max-age=0, must-revalidate      5/5      304 HIT
  /district/61/clubs   200   max-age=0, must-revalidate      5/5      304 HIT
  /regions             200   max-age=0, must-revalidate      5/5      304 HIT
  /robots.txt          200   max-age=0, must-revalidate      5/5      304 HIT

=== HASHED ASSETS
  /assets/cdn-Cj3t2XVW.js           200   public, max-age=31536000, immutable
  /assets/charts-B3cQKfIF.js        200   public, max-age=31536000, immutable
  /assets/ChartSkeleton-36Zi-9cz.js 200   public, max-age=31536000, immutable
  /favicon.ico                      200   public, max-age=31536000, immutable
  /vite.svg                         200   public, max-age=31536000, immutable
```

`security 5/5` = CSP + `X-Frame-Options` + `X-Content-Type-Options` +
`Referrer-Policy` + `Permissions-Policy`, all still present — rules merge per
key, so the leading security rule is unaffected.

Issue acceptance criteria: cache-control on both targets ✅ (staging measured
directly; production is the same rule array, pinned byte-identical by test) ·
assets unchanged ✅ · deploy picked up on next navigation ✅ (implied by
`max-age=0` + a 304/200 revalidation on every document fetch) · revalidation
returns 304 ✅ (measured, not assumed).

Falsifiability: reordering the rules back to the broken layout fails 4
assertions, naming both the symptom and the cause.

Gates: `npm run quality:check` exit 0 (51 pre-existing warnings, 0 errors) ·
`npm run test:scripts` 340/340.

**Still unproven:** production. `firebase.json` only takes effect at deploy
time and `deploy.yml` deploys `hosting:production` on release, so the final
confirmation is `curl -sSI https://ts.taverns.red/` after the next prod
deploy. The preview exercises the staging target of this same config, and a
test pins the two arrays equal, so the remaining risk is the deploy itself.

## Note for a follow-up (not fixed here)

`staging-toast-stats.web.app` serves **no** security headers at all — no CSP,
no `X-Frame-Options`. The staging *site* is never redeployed: `deploy.yml`
only targets `hosting:production`, and `pr-preview.yml` creates per-PR
*channels*, not the live site. So it is a stale artifact predating #783. Out
of scope for #1365, but worth its own issue.

Refs #1365
