### PR TITLE
perf(fonts): metric-matched swap fallbacks take 375px CLS 0.141 -> 0.002, plus a gate that can see mobile (#1373)

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -188,3 +188,18 @@ jobs:
         env:
           BASE_URL: ${{ steps.deploy.outputs.url }}
         run: npx playwright test --config playwright.config.ts e2e/landing-mobile-cls.smoke.ts
+
+      # 375px CLS budget under real throttling (#1373). The guard above proves
+      # loading→loaded geometry; this one measures the Core Web Vital itself,
+      # which no existing gate can see: lighthouserc.js runs `preset: desktop`
+      # (mobile is never sampled) against localhost:4173, and Chromium does not
+      # throttle loopback — so a `display=swap` font reflow worth 0.151 at
+      # 375px on main read ~0.00 everywhere and shipped. Cold cache + CDP
+      # Fast-3G + a pre-navigation layout-shift observer, on the deployed
+      # channel. Chromium-only by design: the webkit project skips itself,
+      # because layout-shift and CDP throttling are both Chromium-only.
+      - name: Mobile font-swap CLS budget against preview
+        working-directory: frontend
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.url }}
+        run: npx playwright test --config playwright.config.ts e2e/landing-font-swap-cls.smoke.ts

--- a/frontend/e2e/landing-font-swap-cls.smoke.ts
+++ b/frontend/e2e/landing-font-swap-cls.smoke.ts
@@ -1,0 +1,149 @@
+import { test, expect } from '@playwright/test'
+
+/* Mobile CLS budget for the landing page, measured live (#1373).
+ *
+ * ── The blind spot this closes ───────────────────────────────────────────
+ * `lighthouserc.js` asserts `cumulative-layout-shift <= 0.1` and passes, but
+ * it is blind to this failure in two independent ways:
+ *
+ *   1. `preset: 'desktop'` — mobile is never sampled. The worst case is at
+ *      375px; at 1350px the real number genuinely is under budget.
+ *   2. Its fixtures are served from `localhost:4173`, and Chromium does not
+ *      throttle loopback. A naive local run reads ~0.00 at every width
+ *      *including on known-bad builds*, so a clean local table proves
+ *      nothing.
+ *
+ * Consequence: `main` carried CLS 0.151 at 375px — 95% of it the
+ * Google-Fonts `display=swap` reflow — with every gate green. This test is
+ * the missing half of the fix: without it, tokens/font-fallbacks.css can be
+ * deleted, or a stack reordered so system-ui wins, and nothing goes red.
+ *
+ * ── Method ───────────────────────────────────────────────────────────────
+ * The three things that make the number real, all of which the Lighthouse
+ * gate lacks: a **deployed** origin (BASE_URL, the PR preview channel), a
+ * **cold cache with Fast-3G throttling** applied via CDP (so fonts.gstatic
+ * lands after first paint, the way it does for a real phone), and the
+ * `layout-shift` observer installed **before navigation** via
+ * `addInitScript` — an observer attached after load misses the entries that
+ * matter, even with `buffered: true` when the page has already settled.
+ *
+ * Chromium-only: `layout-shift` and CDP network emulation are both
+ * Chromium-only, so the webkit project skips rather than silently passing.
+ *
+ * ── Reading a failure ────────────────────────────────────────────────────
+ * The assertion message prints every entry's value and named sources. Read
+ * those, never the total: the aggregate cannot tell you whether it is one
+ * regression or the sum of two unrelated ones (Lesson: "bisecting a gate
+ * with no headroom finds variance, not a regression").
+ *
+ * A result of exactly 0 with the table missing is a broken run, not a pass —
+ * hence the explicit content assertion before the number is read.
+ */
+
+const VIEWPORT = { width: 375, height: 900 }
+
+// The same budget lighthouserc.js enforces on desktop. Measured on the
+// preview channel after #1373 the landing page sits an order of magnitude
+// below it, so this is a real regression detector and not a coin flip.
+const CLS_BUDGET = 0.1
+
+// DevTools "Fast 3G".
+const FAST_3G = {
+  offline: false,
+  downloadThroughput: (1.6 * 1024 * 1024) / 8,
+  uploadThroughput: (750 * 1024) / 8,
+  latency: 562.5,
+}
+
+interface ShiftEntry {
+  t: number
+  value: number
+  sources: string[]
+}
+
+declare global {
+  interface Window {
+    __clsEntries?: ShiftEntry[]
+  }
+}
+
+const INSTALL_OBSERVER = () => {
+  window.__clsEntries = []
+  new PerformanceObserver(list => {
+    for (const raw of list.getEntries()) {
+      const e = raw as PerformanceEntry & {
+        hadRecentInput: boolean
+        value: number
+        sources?: {
+          node?: Element
+          previousRect?: DOMRect
+          currentRect?: DOMRect
+        }[]
+      }
+      if (e.hadRecentInput) continue
+      const rect = (r?: DOMRect) =>
+        r ? `${Math.round(r.y)}x${Math.round(r.height)}` : '-'
+      window.__clsEntries?.push({
+        t: Math.round(e.startTime),
+        value: Number(e.value.toFixed(5)),
+        sources: (e.sources ?? []).map(s => {
+          const tag = s.node?.tagName ?? 'DETACHED'
+          const cls = (s.node?.className ?? '').toString().split(' ')[0]
+          return `<${tag}.${cls}> ${rect(s.previousRect)} -> ${rect(s.currentRect)}`
+        }),
+      })
+    }
+  }).observe({ type: 'layout-shift', buffered: true })
+}
+
+test.describe('landing CLS at 375px on a cold Fast-3G load (#1373)', () => {
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'layout-shift + CDP network emulation are Chromium-only'
+  )
+
+  test('stays inside the 0.1 CLS budget with fonts loading normally', async ({
+    page,
+  }) => {
+    // A full cold Fast-3G load of the landing page plus a settle window.
+    test.setTimeout(240_000)
+    await page.setViewportSize(VIEWPORT)
+
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Network.enable')
+    await cdp.send('Network.setCacheDisabled', { cacheDisabled: true })
+    await cdp.send('Network.emulateNetworkConditions', FAST_3G)
+
+    await page.addInitScript(INSTALL_OBSERVER)
+    await page.goto('/', { waitUntil: 'load', timeout: 180_000 })
+
+    // Sanity gate before the number is read: an all-zeros CLS almost always
+    // means the page never got past its loading state (or the channel 404'd),
+    // not that the page is perfect.
+    await page
+      .locator('table[aria-label="District rankings"]')
+      .waitFor({ state: 'visible', timeout: 120_000 })
+    await page.evaluate(() => document.fonts.ready.then(() => undefined))
+    // Let any post-swap reflow land before sampling.
+    await page.waitForTimeout(3_000)
+
+    const entries = await page.evaluate(() => window.__clsEntries ?? [])
+    const total = Number(entries.reduce((a, e) => a + e.value, 0).toFixed(5))
+
+    const breakdown = entries
+      .filter(e => e.value > 0.0005)
+      .map(
+        e => `  t=${e.t}ms value=${e.value}\n    ${e.sources.join('\n    ')}`
+      )
+      .join('\n')
+
+    expect(
+      total,
+      `landing CLS at 375px is ${total} (budget ${CLS_BUDGET}) on ${page.url()}\n` +
+        `Largest contributors — read the sources, not the total:\n${breakdown}\n` +
+        `If the sources name text elements that move without changing height, ` +
+        `the metric-matched fallbacks in tokens/font-fallbacks.css have drifted ` +
+        `or been dropped from a font stack (#1373).`
+    ).toBeLessThan(CLS_BUDGET)
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,6 +18,9 @@
 @import "tailwindcss/theme" layer(theme);
 @import "tailwindcss/preflight" layer(base);
 @import "tailwindcss/utilities" layer(utilities);
+/* Metric-matched @font-face fallbacks for the display=swap reflow (#1373).
+   Imported before the token files whose stacks name them. */
+@import './styles/tokens/font-fallbacks.css';
 @import './styles/tokens/colors.css';
 @import './styles/tokens/typography.css';
 @import './styles/tokens/spacing.css';

--- a/frontend/src/styles/__tests__/font-fallbacks.test.ts
+++ b/frontend/src/styles/__tests__/font-fallbacks.test.ts
@@ -112,6 +112,23 @@ describe('metric-matched font fallbacks (#1373)', () => {
       }
     })
 
+    it('is scoped to the web font’s own subsets, so unmatched glyphs pass through', () => {
+      // A face with no unicode-range swallows every codepoint the web font
+      // does not ship. Those glyphs never needed metric-matching and moving
+      // them is pure visual change: U+2192 (the "See Awards" arrow) jumped
+      // from system-ui to size-adjusted Arial.
+      expect(block).toMatch(/unicode-range:/)
+      // latin + latin-ext + vietnamese must be in…
+      expect(block).toMatch(/U\+0000-02CC/)
+      expect(block).toMatch(/U\+1E00-1EFF/)
+      expect(block).toMatch(/U\+2000-206F/)
+      // …and the arrow must be out. U+2191/U+2193 are inside Google's latin
+      // subset and U+2192 is not, so an over-broad range shows up here.
+      expect(block).toMatch(/U\+2191/)
+      expect(block).not.toMatch(/U\+2192/)
+      expect(block).not.toMatch(/U\+2190-/)
+    })
+
     it('declares a bold bucket that resolves to a real bold local face', () => {
       // A single 400-only face would make the browser synthesise bold, which
       // is both wider than the measured ratio and visibly wrong mid-swap.

--- a/frontend/src/styles/__tests__/font-fallbacks.test.ts
+++ b/frontend/src/styles/__tests__/font-fallbacks.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+/* #1373 — metric-matched fallback faces for the Google-Fonts `display=swap`
+   reflow.
+ *
+ * Measured on a deployed preview channel (cold cache, Fast-3G, layout-shift
+ * observer installed pre-navigation), the swap was 95% of the 375px CLS —
+ * 0.151 against a 0.1 budget. A two-state geometry diff (fonts blocked vs
+ * fonts on, both fully loaded) named the mechanism: it is a WIDTH problem,
+ * not a reserve problem. Source Sans 3 is ~6% narrower than the system-ui
+ * fallback, so every rankings row that wrapped to two lines in the fallback
+ * collapses to one when the font swaps in — 28px per row, ~560px of table.
+ *
+ * The fix is the one CLAUDE.md already names: a fallback face built on a
+ * metrically-stable local font (Arial, aliased to Liberation Sans/Roboto
+ * where Arial is absent) with `size-adjust` + ascent/descent overrides, so
+ * the fallback and the web font occupy identical space and the swap reflows
+ * nothing. `local()` sources download nothing, so this needs no new origin
+ * and no CSP change.
+ *
+ * These assertions are load-bearing, in the Lesson 81 sense: dropping the
+ * fallback from a stack, or letting a descriptor drift from the measured
+ * value, silently restores a 0.15 mobile CLS. The live proof is
+ * `frontend/e2e/landing-font-swap-cls.smoke.ts`, which measures the real
+ * number on the deployed preview channel. */
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const read = (rel: string) => readFileSync(resolve(__dirname, rel), 'utf-8')
+
+const fallbacks = read('../tokens/font-fallbacks.css')
+const typography = read('../tokens/typography.css')
+const redesign = read('../tokens/redesign.css')
+const indexCss = read('../../index.css')
+
+/** Grab one `@font-face { ... }` block by its font-family descriptor. */
+function face(css: string, family: string): string {
+  const blocks = css.match(/@font-face\s*\{[^}]*\}/g) ?? []
+  const found = blocks.filter(b =>
+    new RegExp(`font-family:\\s*['"]${family}['"]`).test(b)
+  )
+  expect(
+    found.length,
+    `expected exactly one @font-face for '${family}'`
+  ).toBeGreaterThan(0)
+  return found.join('\n')
+}
+
+/** Every declared value of `prop` inside a block, as numbers (percent). */
+function pct(block: string, prop: string): number[] {
+  return [...block.matchAll(new RegExp(`${prop}:\\s*([\\d.]+)%`, 'g'))].map(m =>
+    Number(m[1])
+  )
+}
+
+describe('metric-matched font fallbacks (#1373)', () => {
+  it('index.css imports font-fallbacks.css', () => {
+    expect(indexCss).toMatch(
+      /@import\s+['"]\.\/styles\/tokens\/font-fallbacks\.css['"]/
+    )
+  })
+
+  describe.each([
+    // family, measured size-adjust range, ascent, descent
+    ['Montserrat Fallback', [108, 116], 1.219],
+    ['Source Sans 3 Fallback', [89, 96], 1.424],
+  ] as const)('%s', (family, sizeAdjustRange, normalLineHeight) => {
+    const block = face(fallbacks, family)
+
+    it('sources only local fonts — no new origin, so no CSP change', () => {
+      expect(block).toMatch(/src:\s*local\(/)
+      expect(block).not.toMatch(/url\(/)
+    })
+
+    it('names Arial first and a Linux/Android-reachable alias after it', () => {
+      // fontconfig aliases Arial -> Liberation Sans, and Android maps it to
+      // Roboto; naming Liberation Sans explicitly covers hosts that do
+      // neither. Without a resolvable local() the whole face is skipped and
+      // the stack quietly falls through to system-ui again.
+      expect(block).toMatch(/local\(['"]Arial/)
+      expect(block).toMatch(/Liberation Sans/)
+    })
+
+    it('carries a measured size-adjust in the expected range', () => {
+      const values = pct(block, 'size-adjust')
+      expect(values.length).toBeGreaterThan(0)
+      for (const v of values) {
+        expect(v).toBeGreaterThanOrEqual(sizeAdjustRange[0])
+        expect(v).toBeLessThanOrEqual(sizeAdjustRange[1])
+      }
+    })
+
+    it('overrides ascent, descent and line-gap so line boxes match', () => {
+      expect(pct(block, 'ascent-override').length).toBeGreaterThan(0)
+      expect(pct(block, 'descent-override').length).toBeGreaterThan(0)
+      expect(block).toMatch(/line-gap-override:\s*0%/)
+    })
+
+    it('reconstructs the web font’s normal line height from its descriptors', () => {
+      // ascent+descent are expressed relative to the size-adjusted em, so
+      // (ascent + descent) * size-adjust must reproduce the measured
+      // line-height:normal of the real font. This is the assertion that
+      // catches a hand-edited descriptor.
+      const s = pct(block, 'size-adjust')
+      const a = pct(block, 'ascent-override')
+      const d = pct(block, 'descent-override')
+      for (let i = 0; i < s.length; i++) {
+        const lh = ((a[i] + d[i]) * s[i]) / 10000
+        expect(lh).toBeCloseTo(normalLineHeight, 2)
+      }
+    })
+
+    it('declares a bold bucket that resolves to a real bold local face', () => {
+      // A single 400-only face would make the browser synthesise bold, which
+      // is both wider than the measured ratio and visibly wrong mid-swap.
+      expect(block).toMatch(/font-weight:\s*[\d]+\s+[\d]+/)
+      expect(block).toMatch(/local\(['"]Arial Bold/)
+    })
+  })
+
+  it('inserts the fallback into the tm-* stacks ahead of system-ui', () => {
+    expect(typography).toMatch(
+      /--tm-font-headline:\s*"Montserrat",\s*"Montserrat Fallback",\s*system-ui/
+    )
+    expect(typography).toMatch(
+      /--tm-font-body:\s*"Source Sans 3",\s*"Source Sans 3 Fallback",\s*system-ui/
+    )
+  })
+
+  it('inserts the fallback into the redesign --serif / --sans stacks', () => {
+    expect(redesign).toMatch(
+      /--serif:\s*'Montserrat',\s*'Montserrat Fallback',\s*system-ui/
+    )
+    expect(redesign).toMatch(
+      /--sans:\s*'Source Sans 3',\s*'Source Sans 3 Fallback',\s*system-ui/
+    )
+  })
+})

--- a/frontend/src/styles/tokens/font-fallbacks.css
+++ b/frontend/src/styles/tokens/font-fallbacks.css
@@ -1,0 +1,140 @@
+/* Metric-matched fallback faces for the Google-Fonts `display=swap` reflow
+ * (#1373).
+ *
+ * ── Why ──────────────────────────────────────────────────────────────────
+ * Measured on a deployed preview channel (cold cache, Fast-3G, layout-shift
+ * observer installed pre-navigation), the font swap was the dominant CLS
+ * term at every width and 95% of it at 375px — 0.151 against a 0.1 budget.
+ *
+ * A two-state geometry diff (fonts blocked vs fonts on, both states pinned
+ * fully-loaded) named the mechanism, and it is a WIDTH problem, not a
+ * reserve problem: Source Sans 3 is ~6% narrower than the system-ui
+ * fallback, so district names in the rankings table wrap to two lines in the
+ * fallback and collapse to one when the font arrives — 28px per row, ~560px
+ * of table height, everything below it jumping up.
+ *
+ *   dh=-28  h 162->134  13px/400 Source Sans 3  TD.px-6.py-4
+ *   dh=-28  h 130->102  13px/400 Source Sans 3  TD.px-6.py-4        (×N rows)
+ *   dy=-19                                      DIV.districts-page-header__actions
+ *
+ * Giving each family a fallback whose average advance width and line-box
+ * metrics equal the web font's makes the swap a pure glyph substitution:
+ * nothing rewraps, nothing moves.
+ *
+ * ── Why local(), not self-hosted woff2 ───────────────────────────────────
+ * `src: local(...)` downloads nothing — no new origin, no bytes, and
+ * critically no `font-src` change in firebase.json's CSP. Arial is
+ * metrically stable across Windows/macOS/iOS; fontconfig aliases it to
+ * Liberation Sans on Linux and Android maps it to Roboto, and Liberation
+ * Sans is also named explicitly for hosts that do neither. A face whose
+ * every local() misses is simply skipped, and the stack falls through to
+ * system-ui exactly as it does today — this can degrade, it cannot break.
+ *
+ * ── Where the numbers come from ──────────────────────────────────────────
+ * Measured in Chromium (the engine that renders them) at font-size 1000px:
+ * `xWidthAvg` is the capsize letter-frequency-weighted average advance
+ * width; ascent/descent are canvas `fontBoundingBox*`; line-gap is the
+ * residual of `line-height: normal` minus ascent+descent (0 for all four).
+ *
+ *   size-adjust       = xWidthAvg(webfont) / xWidthAvg(local base)
+ *   ascent-override   = ascent(webfont)  / size-adjust
+ *   descent-override  = descent(webfont) / size-adjust
+ *
+ * Regular buckets are matched against Arial regular, bold buckets against
+ * Arial Bold — a single 400-only face would leave the browser to synthesise
+ * bold, which is both wider than the measured ratio and visibly wrong.
+ *
+ * Raw measurements (per 1em):
+ *   Arial          400  xWidthAvg 0.42736  ascent 0.9050  descent 0.2120
+ *   Arial          700  xWidthAvg 0.46185  ascent 0.9050  descent 0.2120
+ *   Montserrat          ascent 0.9680  descent 0.2510  normal line-height 1.219
+ *   Source Sans 3       ascent 1.0240  descent 0.4000  normal line-height 1.424
+ *
+ * ── Phase 2 (ops#37 / #339) ──────────────────────────────────────────────
+ * The brand pair is loaded but has zero live consumers today (nothing reads
+ * --rt-font-display / --rt-font-body), so it reflows nothing and needs no
+ * fallback yet. `rt-brand-v1.css` is a copy-on-release of upstream and must
+ * not be hand-edited, so wiring these in belongs in the Phase 2 chrome PR.
+ * The measurements are recorded here so that PR does not have to re-derive
+ * them (same method, same engine):
+ *
+ *   Space Grotesk  w400/500 size-adjust 110.81% · w600/700 102.46%
+ *                  ascent 0.9840  descent 0.2920  (normal line-height 1.276)
+ *   Inter          w400/500 size-adjust 107.30% · w600     100.98%
+ *                  ascent 0.9690  descent 0.2410  (normal line-height 1.210)
+ *
+ * See tasks/lessons/lessons/a-font-swap-reflow-masquerades-as-a-reserve-error.md
+ * and Lesson 81 (`phase-gated-deferral-tests-move-with-the-spec.md`).
+ */
+
+/* ── Montserrat (--tm-font-headline, --serif) ─────────────────────────────
+   Loaded at 500;600;700;800;900. The 400-500 bucket is matched against
+   Arial regular (Montserrat 500 is 115.5% of its average width); the
+   600-900 bucket against Arial Bold (Montserrat 700 is 110.8% of it). */
+@font-face {
+  font-family: 'Montserrat Fallback';
+  font-style: normal;
+  font-weight: 100 500;
+  src:
+    local('Arial'),
+    local('ArialMT'),
+    local('Helvetica'),
+    local('Liberation Sans'),
+    local('Arimo');
+  size-adjust: 115.548%;
+  ascent-override: 83.775%;
+  descent-override: 21.723%;
+  line-gap-override: 0%;
+}
+
+@font-face {
+  font-family: 'Montserrat Fallback';
+  font-style: normal;
+  font-weight: 600 900;
+  src:
+    local('Arial Bold'),
+    local('Arial-BoldMT'),
+    local('Helvetica Bold'),
+    local('Liberation Sans Bold'),
+    local('Arimo Bold');
+  size-adjust: 110.771%;
+  ascent-override: 87.387%;
+  descent-override: 22.659%;
+  line-gap-override: 0%;
+}
+
+/* ── Source Sans 3 (--tm-font-body, --sans) ───────────────────────────────
+   Loaded at 400;500;600;700. This is the family that drives the 375px
+   number: it is *narrower* than Arial (93.97% at 400), which is why the
+   fallback over-wraps and the page shrinks when the swap lands. */
+@font-face {
+  font-family: 'Source Sans 3 Fallback';
+  font-style: normal;
+  font-weight: 100 500;
+  src:
+    local('Arial'),
+    local('ArialMT'),
+    local('Helvetica'),
+    local('Liberation Sans'),
+    local('Arimo');
+  size-adjust: 93.97%;
+  ascent-override: 108.971%;
+  descent-override: 42.567%;
+  line-gap-override: 0%;
+}
+
+@font-face {
+  font-family: 'Source Sans 3 Fallback';
+  font-style: normal;
+  font-weight: 600 900;
+  src:
+    local('Arial Bold'),
+    local('Arial-BoldMT'),
+    local('Helvetica Bold'),
+    local('Liberation Sans Bold'),
+    local('Arimo Bold');
+  size-adjust: 91.951%;
+  ascent-override: 111.364%;
+  descent-override: 43.502%;
+  line-gap-override: 0%;
+}

--- a/frontend/src/styles/tokens/font-fallbacks.css
+++ b/frontend/src/styles/tokens/font-fallbacks.css
@@ -50,6 +50,15 @@
  *   Montserrat          ascent 0.9680  descent 0.2510  normal line-height 1.219
  *   Source Sans 3       ascent 1.0240  descent 0.4000  normal line-height 1.424
  *
+ * ── Why the unicode-range ────────────────────────────────────────────────
+ * The faces are scoped to the same subsets Google serves for these families
+ * (latin + latin-ext + vietnamese, merged; both declare the same ranges).
+ * A fallback face with no unicode-range swallows every codepoint the web
+ * font does not ship, and those never needed matching in the first place —
+ * U+2192, the "See Awards" arrow, silently moved from system-ui to
+ * size-adjusted Arial. 64 pixels of visual change for no CLS benefit.
+ * Scoping keeps this change provably inert once the fonts have loaded.
+ *
  * ── Phase 2 (ops#37 / #339) ──────────────────────────────────────────────
  * The brand pair is loaded but has zero live consumers today (nothing reads
  * --rt-font-display / --rt-font-body), so it reflows nothing and needs no
@@ -85,6 +94,11 @@
   ascent-override: 83.775%;
   descent-override: 21.723%;
   line-gap-override: 0%;
+  /* Coverage-scoped — see the unicode-range note in the file header. */
+  unicode-range: U+0000-02CC, U+02CE-02D7, U+02DA, U+02DC-02FF,
+    U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1D00-1DBF,
+    U+1E00-1EFF, U+2000-206F, U+20A0-20C0, U+2113, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+2C60-2C7F, U+A720-A7FF, U+FEFF, U+FFFD;
 }
 
 @font-face {
@@ -101,6 +115,11 @@
   ascent-override: 87.387%;
   descent-override: 22.659%;
   line-gap-override: 0%;
+  /* Coverage-scoped — see the unicode-range note in the file header. */
+  unicode-range: U+0000-02CC, U+02CE-02D7, U+02DA, U+02DC-02FF,
+    U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1D00-1DBF,
+    U+1E00-1EFF, U+2000-206F, U+20A0-20C0, U+2113, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+2C60-2C7F, U+A720-A7FF, U+FEFF, U+FFFD;
 }
 
 /* ── Source Sans 3 (--tm-font-body, --sans) ───────────────────────────────
@@ -121,6 +140,11 @@
   ascent-override: 108.971%;
   descent-override: 42.567%;
   line-gap-override: 0%;
+  /* Coverage-scoped — see the unicode-range note in the file header. */
+  unicode-range: U+0000-02CC, U+02CE-02D7, U+02DA, U+02DC-02FF,
+    U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1D00-1DBF,
+    U+1E00-1EFF, U+2000-206F, U+20A0-20C0, U+2113, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+2C60-2C7F, U+A720-A7FF, U+FEFF, U+FFFD;
 }
 
 @font-face {
@@ -137,4 +161,9 @@
   ascent-override: 111.364%;
   descent-override: 43.502%;
   line-gap-override: 0%;
+  /* Coverage-scoped — see the unicode-range note in the file header. */
+  unicode-range: U+0000-02CC, U+02CE-02D7, U+02DA, U+02DC-02FF,
+    U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1D00-1DBF,
+    U+1E00-1EFF, U+2000-206F, U+20A0-20C0, U+2113, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+2C60-2C7F, U+A720-A7FF, U+FEFF, U+FFFD;
 }

--- a/frontend/src/styles/tokens/redesign.css
+++ b/frontend/src/styles/tokens/redesign.css
@@ -56,8 +56,11 @@
      brand-token edit (rt-brand-v1.css stays untouched). */
   --rt-stats-focus: #b5651d;
 
-  --serif: 'Montserrat', system-ui, sans-serif;
-  --sans: 'Source Sans 3', system-ui, sans-serif;
+  /* Metric-matched swap fallbacks (#1373) — see tokens/font-fallbacks.css.
+     Must sit between the web font and system-ui. --mono has no fallback
+     face because JetBrains Mono is still not loaded at all (Lesson 81). */
+  --serif: 'Montserrat', 'Montserrat Fallback', system-ui, sans-serif;
+  --sans: 'Source Sans 3', 'Source Sans 3 Fallback', system-ui, sans-serif;
   --mono: 'JetBrains Mono', ui-monospace, monospace;
 
   --rds-radius-sm: 6px;

--- a/frontend/src/styles/tokens/typography.css
+++ b/frontend/src/styles/tokens/typography.css
@@ -1,9 +1,16 @@
 /* Toastmasters Typography System - Design Tokens */
 
 :root {
-  /* Font Families with Comprehensive Fallbacks */
-  --tm-font-headline: "Montserrat", system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --tm-font-body: "Source Sans 3", system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  /* Font Families with Comprehensive Fallbacks.
+     The "* Fallback" entries are metric-matched local faces declared in
+     tokens/font-fallbacks.css (#1373) — same average advance width and line
+     box as the web font, so `display=swap` substitutes glyphs without
+     rewrapping anything. They must stay immediately after the web font and
+     ahead of system-ui: system-ui first would win and reintroduce the
+     0.15 mobile CLS. If no local() resolves, the face is skipped and the
+     stack degrades to system-ui exactly as it did before. */
+  --tm-font-headline: "Montserrat", "Montserrat Fallback", system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --tm-font-body: "Source Sans 3", "Source Sans 3 Fallback", system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   
   /* Font Weights */
   --tm-font-weight-regular: 400;

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -35,6 +35,22 @@ module.exports = {
         // Core Web Vitals
         'largest-contentful-paint': ['error', { maxNumericValue: 2500 }],
         'max-potential-fid': ['error', { maxNumericValue: 100 }],
+        // NOTE (#1373): this assertion is DESKTOP-ONLY and effectively
+        // UNTHROTTLED, and it has already let a 0.151 mobile CLS through
+        // while staying green. Two independent blind spots, neither of them
+        // a bug in #915:
+        //   1. `preset: 'desktop'` above — 375px, the worst case, is never
+        //      sampled. At 1350px the real number genuinely is under budget,
+        //      so this gate is not lying, just narrow.
+        //   2. The fixtures are served from localhost:4173 and Chromium does
+        //      not throttle loopback, so the late `display=swap` font reflow
+        //      that dominates a real cold mobile load barely occurs. A clean
+        //      local table is NOT evidence — known-bad builds also read ~0.00
+        //      at every width.
+        // Mobile is covered by frontend/e2e/landing-font-swap-cls.smoke.ts,
+        // run against the deployed preview channel by pr-preview.yml and
+        // wired-in by scripts/lib/__tests__/mobileClsGate.test.ts. Keep both:
+        // this one still catches desktop regressions cheaply and pre-deploy.
         'cumulative-layout-shift': ['error', { maxNumericValue: 0.1 }],
 
         // Performance score

--- a/scripts/lib/__tests__/mobileClsGate.test.ts
+++ b/scripts/lib/__tests__/mobileClsGate.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+/**
+ * Contract test for the mobile CLS gate (#1373).
+ *
+ * The Lighthouse gate in `lighthouserc.js` asserts `cumulative-layout-shift
+ * <= 0.1` and passes — while `main` carried 0.151 at 375px. It is blind twice
+ * over: `preset: 'desktop'` never samples a mobile viewport, and its fixtures
+ * are served from `localhost:4173`, which Chromium does not throttle, so the
+ * sequencing that produces a `display=swap` reflow largely does not occur.
+ *
+ * `frontend/e2e/landing-font-swap-cls.smoke.ts` closes both holes by measuring
+ * on the deployed preview channel at 375px under CDP Fast-3G. Lesson 082: a
+ * gate that exists but is never invoked protects nothing — so this asserts the
+ * *wiring*, not just the file. Deleting the workflow step, or narrowing the
+ * run to a `--project` that skips it, goes red here.
+ *
+ * Resolve the repo root from this file, not `process.cwd()` (Lesson 082).
+ */
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const read = (rel: string) => readFileSync(join(repoRoot, rel), 'utf8')
+
+const E2E_SPEC = 'frontend/e2e/landing-font-swap-cls.smoke.ts'
+const PR_PREVIEW = '.github/workflows/pr-preview.yml'
+
+describe('mobile CLS gate (#1373)', () => {
+  it('the 375px CLS spec exists', () => {
+    expect(existsSync(join(repoRoot, E2E_SPEC))).toBe(true)
+  })
+
+  describe('the spec measures the thing it claims to', () => {
+    const spec = read(E2E_SPEC)
+
+    it('runs at a 375px viewport', () => {
+      expect(spec).toMatch(/width:\s*375/)
+    })
+
+    it('throttles the network — an unthrottled load hides the swap', () => {
+      expect(spec).toMatch(/Network\.emulateNetworkConditions/)
+      expect(spec).toMatch(/Network\.setCacheDisabled/)
+    })
+
+    it('installs the layout-shift observer before navigation', () => {
+      // addInitScript must precede goto; an observer attached afterwards
+      // misses the entries that matter.
+      const initAt = spec.indexOf('addInitScript')
+      const gotoAt = spec.indexOf('page.goto')
+      expect(initAt).toBeGreaterThan(-1)
+      expect(gotoAt).toBeGreaterThan(initAt)
+      expect(spec).toMatch(/type:\s*'layout-shift'/)
+    })
+
+    it('asserts against the same 0.1 budget lighthouserc.js uses', () => {
+      expect(spec).toMatch(/CLS_BUDGET\s*=\s*0\.1\b/)
+      expect(spec).toMatch(/toBeLessThan\(CLS_BUDGET\)/)
+    })
+
+    it('proves the page actually painted before reading the number', () => {
+      // An all-zeros CLS is usually a page that never left its loading state
+      // (or a 404'd channel), not a perfect page.
+      expect(spec).toMatch(/District rankings/)
+    })
+  })
+
+  describe('the gate is invoked on every frontend PR', () => {
+    const wf = read(PR_PREVIEW)
+
+    it('pr-preview.yml runs the spec', () => {
+      expect(wf).toContain('e2e/landing-font-swap-cls.smoke.ts')
+    })
+
+    it('points the run at the freshly deployed preview channel', () => {
+      // Local numbers are not comparable — loopback is not throttled. The run
+      // must target steps.deploy.outputs.url, not the config default.
+      const step = wf
+        .split(/\n\s*- name: /)
+        .find(s => s.includes('landing-font-swap-cls.smoke.ts'))
+      expect(step).toBeDefined()
+      expect(step).toContain('BASE_URL: ${{ steps.deploy.outputs.url }}')
+    })
+
+    it('does not filter the run to the webkit-only project', () => {
+      const step = wf
+        .split(/\n\s*- name: /)
+        .find(s => s.includes('landing-font-swap-cls.smoke.ts'))
+      expect(step).not.toMatch(/--project[= ]webkit/)
+    })
+  })
+
+  it('lighthouserc.js documents that it cannot see this failure', () => {
+    // The desktop-only blind spot is not obvious from the config. Without a
+    // pointer, the next person to read a green Lighthouse run concludes the
+    // mobile budget is covered.
+    const rc = read('lighthouserc.js')
+    expect(rc).toMatch(/landing-font-swap-cls\.smoke\.ts/)
+    expect(rc).toMatch(/#1373/)
+  })
+})

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,7 +2,9 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `a-geometry-ablation-overstates-the-reflow-arrival-order-decides-what-counts.md` — A fonts-blocked geometry ablation shows every reflow the swap could cause, not the ones it does — arrival order decides which count, so tune against the real cold load  (2026-08-02)
 - `a-new-workflows-own-path-filter-cannot-be-exercised-by-the-pr-that-adds-it.md` — A path-filtered workflow's own filter can never be exercised by the PR that introduces it — the diff always contains the workflow file, so the filtered case reads as "mixed" until after merge; open the probe PR against a scratch base branch that widens only `pull_request.branches`  (2026-08-02)
+- `an-unscoped-fallback-face-restyles-every-glyph-the-web-font-does-not-ship.md` — A metric-matched fallback @font-face with no unicode-range captures every codepoint the web font does not ship, silently restyling glyphs it was never meant to touch  (2026-08-02)
 - `assert-the-echo-field-that-is-invariant-not-the-one-that-looks-semantic.md` — When an upstream echoes your request back, assert the echo field that is invariant across every response shape — not the one that reads most semantically  (2026-08-02)
 - `firebase-hosting-header-precedence-is-last-match-wins-and-globs-run-before-rewrites.md` — Firebase Hosting resolves each header key from the LAST matching rule (the docs say first) and matches `source` globs against the request path BEFORE rewrites — so an SPA cache rule that reads correctly is usually inverted and blind to every deep route  (2026-08-02)
 - `a-font-swap-reflow-masquerades-as-a-reserve-error.md` — A web-font swap reflow masquerades as a reserve error — pin both states instead of racing them, and ablate the font before attributing CLS to your diff  (2026-08-01)

--- a/tasks/lessons/lessons/a-geometry-ablation-overstates-the-reflow-arrival-order-decides-what-counts.md
+++ b/tasks/lessons/lessons/a-geometry-ablation-overstates-the-reflow-arrival-order-decides-what-counts.md
@@ -1,0 +1,91 @@
+---
+date: 2026-08-02
+tier: lesson
+summary: A fonts-blocked geometry ablation shows every reflow the swap could cause, not the ones it does — arrival order decides which count, so tune against the real cold load
+tags: [cls, performance, fonts, debugging, measurement, frontend]
+---
+
+# A geometry ablation overstates the reflow — arrival order decides what counts
+
+**Date:** 2026-08-02
+**Issue:** #1373 · **PR:** #1381
+
+## What happened
+
+Fixing the `display=swap` reflow (375px CLS 0.141), I used the two-pinned-states
+diff from the previous sprint's lesson: load the page twice, once with the font
+hosts blocked, both fully settled, and diff every element's geometry. It named
+the mechanism perfectly — Source Sans 3 is ~6% narrower than `system-ui`, so
+rankings rows collapse from two lines to one, 28px each.
+
+After shipping the metric-matched fallback, I re-ran the ablation. The header
+was fixed (`dy` 0 instead of −19) but **the table still showed 28px per row,
+560px total**. Obvious conclusion: the fix is half done, go tune `size-adjust`.
+
+So I swept it against the true layout and found a clean cliff — the table only
+matched at 85–87.5%, not the 93.97% I had shipped. I was one commit away from
+changing it.
+
+Then I measured the actual cold Fast-3G load instead:
+
+```
+size-adjust   375px CLS
+   93.97%      0.00221      <- shipped
+      88%      0.00249
+      87%      0.00308
+      86%      0.00329
+      85%      0.00349      <- the "geometrically perfect" value
+```
+
+The value the ablation said was wrong was the best one, and the value it
+pointed at was **58% worse**.
+
+## Why the ablation lied
+
+CLS only counts a shift that actually happens. On Fast-3G the fonts land at
+~600ms and the rankings data lands seconds later, so **the table is first
+painted with the web font already installed** — it never reflows, no matter how
+badly the fallback would have wrapped it. The only text that pays the swap is
+what is on screen before the fonts arrive: the header block.
+
+The ablation cannot know this. It compares two *end states* and reports every
+difference the swap is capable of producing. That is exactly the right tool for
+finding the mechanism and exactly the wrong tool for sizing the fix.
+
+## The lesson
+
+- **An ablation answers "what could move", a cold load answers "what does".**
+  Use the first to find the mechanism and the second to choose the parameter.
+  Never tune a number against the ablation.
+- **Arrival order is part of the measurement.** A shift is only a shift if the
+  element was painted before the thing that moves it arrives. When two async
+  inputs race (fonts vs data, data vs layout), the same build produces very
+  different numbers depending on which wins — and on a throttled connection
+  the winner is stable, so this is not flakiness, it is a fact about the page.
+- **A parameter sweep that finds a clean cliff is seductive and often
+  irrelevant.** The cliff was real, reproducible and precisely located. It was
+  also measuring a reflow the user never experiences.
+
+## How to apply
+
+When a CLS fix has a tunable knob, close the loop on the real metric before
+committing to a value. It costs one route interception: fetch the built CSS,
+append an override rule with the candidate, and read the cold-load number.
+
+```js
+await page.route(/\/assets\/index-.*\.css$/, async route => {
+  const res = await route.fetch()
+  await route.fulfill({ response: res, body: (await res.text()) + override(cand) })
+})
+```
+
+Every arm is then the same deployed build, and the comparison is same-run.
+
+## Related
+
+- [[a-font-swap-reflow-masquerades-as-a-reserve-error]] — the pinned-states
+  ablation this builds on. Still the right first move; just not the last one.
+- [[bisecting-a-gate-with-no-headroom-finds-variance-not-a-regression]] — same
+  family: a signal that is not a function of the thing you are changing.
+- `frontend/e2e/landing-font-swap-cls.smoke.ts` — the cold-load measurement,
+  now a gate.

--- a/tasks/lessons/lessons/an-unscoped-fallback-face-restyles-every-glyph-the-web-font-does-not-ship.md
+++ b/tasks/lessons/lessons/an-unscoped-fallback-face-restyles-every-glyph-the-web-font-does-not-ship.md
@@ -1,0 +1,75 @@
+---
+date: 2026-08-02
+tier: lesson
+summary: A metric-matched fallback @font-face with no unicode-range captures every codepoint the web font does not ship, silently restyling glyphs it was never meant to touch
+tags: [css, fonts, performance, frontend, visual-regression]
+---
+
+# An unscoped fallback face restyles every glyph the web font does not ship
+
+**Date:** 2026-08-02
+**Issue:** #1373 · **PR:** #1381
+
+## What happened
+
+Adding metric-matched `@font-face` fallbacks (`src: local('Arial')` plus
+`size-adjust` / ascent / descent overrides) to kill a `display=swap` reflow. The
+CLS work was clean and the type scale was untouched, so I expected the fully
+loaded page to be pixel-identical to `main`.
+
+It was not. 64 pixels differed at 375px, in one 8px band:
+
+```
+See Awards    →        (main: system-ui arrow)
+See Awards    →        (branch: Arial arrow, 6% narrower, longer, thinner)
+```
+
+## Why
+
+The font stack was `'Source Sans 3', 'Source Sans 3 Fallback', system-ui, …`.
+Google serves Source Sans 3 in subsets whose `unicode-range` covers latin,
+latin-ext, vietnamese, cyrillic and greek — and **U+2192 (→) is in none of
+them**. Before the change, `→` fell straight through to `system-ui` and rendered
+identically whether or not the web font had loaded.
+
+My fallback face declared no `unicode-range`, which means *every codepoint*. So
+it inserted itself between the web font and `system-ui` for exactly the glyphs
+the web font never had — and rendered them in Arial at 93.97% scale.
+
+Those glyphs never needed metric-matching. They were not part of the reflow;
+they cannot be, because they never swap. The face restyled them for nothing.
+
+## The lesson
+
+**A fallback face's coverage must equal the coverage of the font it stands in
+for.** `@font-face` with no `unicode-range` is a claim to serve the entire
+codespace, and in a fallback chain that claim is load-bearing — it changes what
+renders the characters the primary font declines.
+
+The general shape: when you insert a layer into an existing resolution chain
+(font stack, module resolver, middleware, `PATH`), scope it to exactly the
+inputs it is meant to handle. A layer that answers everything intercepts cases
+you never considered, and the failures are cosmetic and easy to miss.
+
+## How to apply
+
+Take the `unicode-range` descriptors from the provider's own CSS and merge them:
+
+```bash
+curl -s -A "<a modern Chrome UA>" \
+  "https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;700&display=swap" \
+  | grep -o "unicode-range: [^;]*" | sort -u
+```
+
+Then assert the boundary in a test, not just the presence of the descriptor —
+pick a codepoint that must be **in** and one that must be **out**. U+2191/U+2193
+are inside Google's latin subset while U+2192 is not, which makes them a good
+tripwire pair for an over-broad range.
+
+## Related
+
+- `frontend/src/styles/tokens/font-fallbacks.css` — the scoped faces.
+- `frontend/src/styles/__tests__/font-fallbacks.test.ts` — the in/out assertion.
+- [[phase-gated-deferral-tests-move-with-the-spec]] — Lesson 81, the previous
+  attempt at making the brand fonts cheap, and why metric-matching was the
+  named unblock.


### PR DESCRIPTION
Addresses #1373.

The Google-Fonts `display=swap` reflow was the dominant CLS term at every
width and 95% of it at 375px, where `main` sat at **0.151 against a 0.1
budget**. Every gate was green, because the only CLS gate we have runs
`preset: 'desktop'` against unthrottled loopback.

## What was actually moving

A two-state geometry diff — fonts blocked vs fonts on, **both states pinned
fully-loaded** rather than raced — named it, and it is a **width** problem,
not a reserve problem. Source Sans 3 is ~6% narrower than the `system-ui`
fallback, so text that wraps to two lines in the fallback collapses to one
when the font lands:

```
375px, fonts-blocked -> fonts-on
  dh=-28  h 162->134   13px/400 Source Sans 3  TD.px-6.py-4       (per row)
  dh=-28  h 130->102   13px/400 Source Sans 3  TD.px-6.py-4       (x N)
  dy=-19                                       DIV.districts-page-header__actions
```

## The fix

Metric-matched fallback faces in a new
`frontend/src/styles/tokens/font-fallbacks.css`, inserted into the
`--tm-font-*` and `--serif`/`--sans` stacks between the web font and
`system-ui`. Same average advance width and the same line box, so the swap
becomes a pure glyph substitution.

- **`src: local(...)` only** — Arial, with `Liberation Sans`/`Arimo` named for
  hosts where fontconfig does not alias it. Downloads nothing, so **no CSP
  change is needed** and `firebase.json` is untouched (that file is owned by
  another in-flight PR right now).
- **Per-weight buckets.** A single 400-only face would leave the browser to
  synthesise bold — wider than the measured ratio and visibly wrong mid-swap.
- **Descriptors are measured, not guessed**, in Chromium at 1000px:
  `size-adjust` from the capsize letter-frequency-weighted advance width,
  ascent/descent from canvas `fontBoundingBox*`. Provenance and raw numbers
  are in the file header.
- **Scoped by `unicode-range`** to the web fonts' own Google subsets. Without
  it the face swallows every codepoint the web font does not ship, and U+2192
  (the "See Awards" arrow) quietly moved from system-ui to size-adjusted
  Arial. Scoped, the change is pixel-identical once fonts have loaded.
- The **legacy pair stays** (Phase 2 / `ops#37`), and **no preload was added** —
  PR #595 showed what an unmatched preload does. The brand pair has zero live
  consumers so it reflows nothing; its measured descriptors are recorded in
  the file header for the Phase 2 PR, which is where `rt-brand-v1.css` (a
  copy-on-release file, not hand-editable) gets wired up.

## Measured, on deployed preview channels

Two channels built from `main` and from this branch, then an **interleaved**
A/B — same run, same browser, same moment. Cold cache, CDP Fast-3G,
`layout-shift` observer installed pre-navigation, three reps each. Every rep
returned the identical value (zero run-to-run spread).

| viewport | `main` | this PR | fonts-blocked floor on `main` |
| --- | --- | --- | --- |
| 1350px | 0.04542 | **0.02232** | 0.01538 |
| 900px | 0.08279 | **0.00157** | 0.00028 |
| 600px | 0.03557 | **0.01621** | 0.01350 |
| **375px** | **0.14087** | **0.00221** | 0.00739 |

375px is **64x better** and an order of magnitude inside budget. No width
regressed; every width is now at or near its fonts-blocked floor, i.e. the
font contribution is essentially gone and what remains is pre-existing
structural shift.

Visual: full-page screenshots of both channels, fully loaded, light **and**
dark, at 375px and 1350px. Three of the four are **zero differing pixels**;
light/375px differs on 154 of 1,645,704 pixels with a maximum summed-RGB delta
of **4 out of 765** — antialiasing noise, not a design change. (Before the
`unicode-range` scoping the same comparison showed a real 64-pixel change: the
`→` glyph. That is what the scoping removed.)

## The gate (the half that keeps this fixed)

`frontend/e2e/landing-font-swap-cls.smoke.ts` — 375px, cold cache, CDP
Fast-3G, observer before navigation, asserted against the same 0.1 budget,
run by `pr-preview.yml` against the freshly deployed preview channel.
Chromium-only by design; the webkit project skips itself because
`layout-shift` and CDP throttling are both Chromium-only.

Proof it bites: pointed at the `main` channel it fails at 0.14087 and prints
the named sources; pointed at this branch's channel it passes at 0.00221.

`scripts/lib/__tests__/mobileClsGate.test.ts` asserts the **wiring**, not just
the file (Lesson 82): delete the workflow step, drop the throttling, move the
observer after `goto`, or narrow the run to webkit, and it goes red.
`lighthouserc.js` now documents its own blind spot and points at the e2e gate;
its assertion is unchanged and still runs.

## Not done here

- `preset: 'mobile'` was **not** added to `lighthouserc.js`. It would sample
  375px but still against unthrottled loopback, which reads ~0.00 on
  known-bad builds — coverage in name only.
- A `size-adjust` of 96% measured marginally better at all four widths (best
  delta 0.0008). Not taken: it is curve-fitting to today's district names with
  no derivation behind it, and the residual is already at the fonts-blocked
  floor.

## Verification

- `npm run quality:check` — green
- `npm run test:scripts` — 27 files / 339 tests green
- Live verification on deployed channels; numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoCZn3LeJX495jz4KdTQBh
