### PR TITLE
fix(collector): reach the live program year from backfill, and verify every body against its request (#1384)

### DIFF
--- a/packages/collector-cli/src/__tests__/BackfillOrchestrator.livePath.test.ts
+++ b/packages/collector-cli/src/__tests__/BackfillOrchestrator.livePath.test.ts
@@ -188,6 +188,70 @@ describe('BackfillOrchestrator — live program year (#1384)', () => {
     ).toBe(true)
   })
 
+  it('backfills an explicit list of dates — the #1384 recovery set', async () => {
+    const storage = createSpyStorage()
+    const orchestrator = new BackfillOrchestrator(
+      baseConfig({
+        storage,
+        liveProgramYear: SIM_LIVE_PROGRAM_YEAR,
+        dates: ['2026-07-26', '2026-07-27', '2026-07-28', '2026-07-29'].map(
+          d => new Date(`${d}T00:00:00`)
+        ),
+      })
+    )
+    const sim = createSimulatedDownloader()
+    orchestrator.downloader.downloadCsv = sim.downloadCsv
+
+    const result = await orchestrator.runPhase1Discovery()
+
+    // Exactly the four dates, each on the root path, each with the month-end
+    // slot populated — the empty slot is what makes the endpoint serve today.
+    expect(sim.requestedUrls).toEqual([
+      'https://dashboards.toastmasters.org/export.aspx?type=CSV&report=districtsummary~6/30/2026~7/26/2026~2026-2027',
+      'https://dashboards.toastmasters.org/export.aspx?type=CSV&report=districtsummary~6/30/2026~7/27/2026~2026-2027',
+      'https://dashboards.toastmasters.org/export.aspx?type=CSV&report=districtsummary~6/30/2026~7/28/2026~2026-2027',
+      'https://dashboards.toastmasters.org/export.aspx?type=CSV&report=districtsummary~6/30/2026~7/29/2026~2026-2027',
+    ])
+    expect(storage.writes.map(w => w.path)).toEqual([
+      '/data/cache/raw-csv/2026-07-26/all-districts.csv',
+      '/data/cache/raw-csv/2026-07-27/all-districts.csv',
+      '/data/cache/raw-csv/2026-07-28/all-districts.csv',
+      '/data/cache/raw-csv/2026-07-29/all-districts.csv',
+    ])
+    expect(result.emptySkipped).toBe(0)
+    expect(result.mismatches).toBe(0)
+  })
+
+  it('collects per-district reports for an explicit date list', async () => {
+    const storage = createSpyStorage()
+    const orchestrator = new BackfillOrchestrator(
+      baseConfig({
+        storage,
+        liveProgramYear: SIM_LIVE_PROGRAM_YEAR,
+        dates: [new Date('2026-07-26T00:00:00')],
+      })
+    )
+    const sim = createSimulatedDownloader()
+    orchestrator.downloader.downloadCsv = sim.downloadCsv
+
+    const result = await orchestrator.runPhase2Collection({
+      [SIM_LIVE_PROGRAM_YEAR]: ['61'],
+    })
+
+    expect(result.errors).toBe(0)
+    expect(sim.requestedUrls).toEqual([
+      'https://dashboards.toastmasters.org/export.aspx?type=CSV&report=districtperformance~61~6/30/2026~7/26/2026~2026-2027',
+      'https://dashboards.toastmasters.org/export.aspx?type=CSV&report=divisionperformance~61~6/30/2026~7/26/2026~2026-2027',
+      'https://dashboards.toastmasters.org/export.aspx?type=CSV&report=clubperformance~61~6/30/2026~7/26/2026~2026-2027',
+    ])
+    expect(storage.writes.map(w => w.path)).toEqual([
+      '/data/cache/raw-csv/2026-07-26/district-61/district-performance.csv',
+      '/data/cache/raw-csv/2026-07-26/district-61/division-performance.csv',
+      '/data/cache/raw-csv/2026-07-26/district-61/club-performance.csv',
+      '/data/cache/raw-csv/2026-07-26/metadata.json',
+    ])
+  })
+
   it('rejects a response whose footer as-of date is not the date requested', async () => {
     const storage = createSpyStorage()
     const orchestrator = new BackfillOrchestrator(baseConfig({ storage }))

--- a/packages/collector-cli/src/__tests__/BackfillOrchestrator.livePath.test.ts
+++ b/packages/collector-cli/src/__tests__/BackfillOrchestrator.livePath.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Backfill against the LIVE program year (#1384).
+ *
+ * `BackfillOrchestrator` called `downloadCsv` without `pathStyle`, so
+ * `buildExportUrl` fell through to `/{programYear}/export.aspx` — a path that
+ * does not exist for the live year (HTTP 500). Four days of real PY 2026-2027
+ * data (2026-07-26 → 07-29) were unreachable as a result.
+ *
+ * These tests drive the orchestrator through a simulator of the real endpoint
+ * (see `fakes/dashboardExportSimulator.ts`), so the URL `buildExportUrl`
+ * actually produces is what decides pass/fail — the same way it does in prod.
+ *
+ * The archive direction is the dangerous one: the root path ignores the
+ * `~{programYear}` token, so a historical fetch routed there silently returns
+ * something other than what was asked for. Those cases are pinned too.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  BackfillOrchestrator,
+  type BackfillConfig,
+  type BackfillStorage,
+} from '../services/BackfillOrchestrator.js'
+import {
+  createSimulatedDownloader,
+  SIM_LIVE_PROGRAM_YEAR,
+  SIM_TODAY,
+} from './fakes/dashboardExportSimulator.js'
+
+/** Storage that records every write so we can assert on what got ingested. */
+function createSpyStorage(): BackfillStorage & {
+  writes: Array<{ path: string; content: string }>
+} {
+  const writes: Array<{ path: string; content: string }> = []
+  return {
+    writes,
+    async exists() {
+      return false
+    },
+    async read() {
+      return ''
+    },
+    async write(path: string, content: string) {
+      writes.push({ path, content })
+    },
+  }
+}
+
+function baseConfig(overrides: Partial<BackfillConfig> = {}): BackfillConfig {
+  return {
+    startYear: 2026,
+    endYear: 2026,
+    frequency: 'weekly',
+    ratePerSecond: 1000,
+    outputDir: '/data/cache',
+    ...overrides,
+  }
+}
+
+describe('BackfillOrchestrator — live program year (#1384)', () => {
+  beforeEach(() => {
+    // The orchestrator asks the dashboard which program year is live; that
+    // question is "as of now", so the clock has to be pinned. Only Date is
+    // faked — the rate limiter's timers must stay real.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date(`${SIM_TODAY}T12:00:00Z`))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reaches the live program year at the root path, not /{PY}/ (RED before #1384)', async () => {
+    const storage = createSpyStorage()
+    const orchestrator = new BackfillOrchestrator(baseConfig({ storage }))
+    const sim = createSimulatedDownloader()
+    orchestrator.downloader.downloadCsv = sim.downloadCsv
+
+    const result = await orchestrator.runPhase1Discovery()
+
+    // Before the fix every request went to /2026-2027/export.aspx → HTTP 500,
+    // so nothing was discovered and nothing was written.
+    expect(result.districtsPerYear[SIM_LIVE_PROGRAM_YEAR]).toEqual([
+      '61',
+      '128',
+      'U',
+    ])
+    expect(storage.writes.length).toBeGreaterThan(0)
+
+    // Not one districtsummary request may carry the archive prefix for the
+    // live year — that URL is the 500.
+    const archivePrefixed = sim.requestedUrls.filter(u =>
+      u.includes(`/${SIM_LIVE_PROGRAM_YEAR}/export.aspx`)
+    )
+    expect(archivePrefixed).toEqual([])
+  })
+
+  it('fetches per-district reports for the live year at the root path too', async () => {
+    const storage = createSpyStorage()
+    const orchestrator = new BackfillOrchestrator(
+      baseConfig({ storage, frequency: 'monthly' })
+    )
+    const sim = createSimulatedDownloader()
+    orchestrator.downloader.downloadCsv = sim.downloadCsv
+
+    const result = await orchestrator.runPhase2Collection({
+      [SIM_LIVE_PROGRAM_YEAR]: ['61'],
+    })
+
+    expect(result.errors).toBe(0)
+    expect(
+      sim.requestedUrls.filter(u =>
+        u.includes(`/${SIM_LIVE_PROGRAM_YEAR}/export.aspx`)
+      )
+    ).toEqual([])
+    expect(
+      storage.writes.filter(w => w.path.endsWith('club-performance.csv')).length
+    ).toBeGreaterThan(0)
+  })
+
+  it('keeps historical years on /{PY}/ — byte-exact URLs, unchanged', async () => {
+    const orchestrator = new BackfillOrchestrator(
+      baseConfig({
+        startYear: 2024,
+        endYear: 2024,
+        frequency: 'monthly',
+        storage: createSpyStorage(),
+      })
+    )
+    const sim = createSimulatedDownloader()
+    orchestrator.downloader.downloadCsv = sim.downloadCsv
+
+    await orchestrator.runPhase1Discovery()
+
+    expect(sim.requestedUrls.length).toBeGreaterThan(0)
+    for (const url of sim.requestedUrls) {
+      expect(url).toMatch(
+        /^https:\/\/dashboards\.toastmasters\.org\/2024-2025\/export\.aspx\?/
+      )
+    }
+    // The exact first URL, pinned. Any drift here is a silent history rewrite.
+    expect(sim.requestedUrls[0]).toBe(
+      'https://dashboards.toastmasters.org/2024-2025/export.aspx' +
+        '?type=CSV&report=districtsummary~6/30/2024~7/1/2024~2024-2025'
+    )
+  })
+
+  it('never routes a historical year to the root path even when it is the live one that is asked for', async () => {
+    const orchestrator = new BackfillOrchestrator(
+      baseConfig({
+        startYear: 2024,
+        endYear: 2026,
+        frequency: 'monthly',
+        storage: createSpyStorage(),
+      })
+    )
+    const sim = createSimulatedDownloader()
+    orchestrator.downloader.downloadCsv = sim.downloadCsv
+
+    await orchestrator.runPhase1Discovery()
+
+    for (const url of sim.requestedUrls) {
+      const isRoot = /toastmasters\.org\/export\.aspx/.test(url)
+      const askedForLiveYear = url.endsWith(SIM_LIVE_PROGRAM_YEAR)
+      // Root path ⇔ the live program year. Never one without the other.
+      expect(isRoot).toBe(askedForLiveYear)
+    }
+  })
+
+  it('skips empty (zero-data-row) responses instead of ingesting them', async () => {
+    const storage = createSpyStorage()
+    const orchestrator = new BackfillOrchestrator(baseConfig({ storage }))
+    const sim = createSimulatedDownloader()
+    orchestrator.downloader.downloadCsv = sim.downloadCsv
+
+    await orchestrator.runPhase1Discovery()
+
+    // 2026-07-01 … 07-25 is TI's dark window: HTTP 200, valid footer, no rows.
+    // Writing those would publish a bogus snapshot under a real date.
+    const darkWindowWrites = storage.writes.filter(w =>
+      /raw-csv\/2026-07-(0[1-9]|1\d|2[0-5])\//.test(w.path)
+    )
+    expect(darkWindowWrites).toEqual([])
+
+    // …while the dates that do have data are written.
+    expect(
+      storage.writes.some(w => w.path.includes('raw-csv/2026-07-29/'))
+    ).toBe(true)
+  })
+
+  it('rejects a response whose footer as-of date is not the date requested', async () => {
+    const storage = createSpyStorage()
+    const orchestrator = new BackfillOrchestrator(baseConfig({ storage }))
+
+    // Simulates the #1342 trap: the root path with an empty month-end slot
+    // ignores the as-of date and returns *today*, with a valid DISTRICT header
+    // and a plausible footer. Nothing in the CSV body flags it as wrong.
+    orchestrator.downloader.downloadCsv = vi.fn().mockResolvedValue({
+      url: 'https://dashboards.toastmasters.org/export.aspx',
+      content:
+        '"REGION","DISTRICT","Paid Clubs"\n"02","61","150"\n' +
+        `Month of Aug, As of 08/02/2026`,
+      statusCode: 200,
+      byteSize: 80,
+    })
+
+    const result = await orchestrator.runPhase1Discovery()
+
+    // Not one of the requested dates is 2026-08-02, so every response is a
+    // mismatch — nothing may be written and nothing discovered.
+    expect(storage.writes).toEqual([])
+    expect(result.districtsPerYear[SIM_LIVE_PROGRAM_YEAR]).toEqual([])
+  })
+})

--- a/packages/collector-cli/src/__tests__/BackfillOrchestrator.livePath.test.ts
+++ b/packages/collector-cli/src/__tests__/BackfillOrchestrator.livePath.test.ts
@@ -22,6 +22,10 @@ import {
   type BackfillStorage,
 } from '../services/BackfillOrchestrator.js'
 import {
+  buildExportUrl,
+  type BackfillDateSpec,
+} from '../services/HttpCsvDownloader.js'
+import {
   createSimulatedDownloader,
   SIM_LIVE_PROGRAM_YEAR,
   SIM_TODAY,
@@ -44,6 +48,21 @@ function createSpyStorage(): BackfillStorage & {
       writes.push({ path, content })
     },
   }
+}
+
+/**
+ * Drop the run's live-year resolution probes, keeping only the requests made
+ * for the dates being backfilled.
+ *
+ * The probes are as-of *today* and are the one place that deliberately asks
+ * for `/{live PY}/export.aspx` — that 500 is how the orchestrator learns the
+ * year has no archive path. No collection date in these tests is today, so the
+ * as-of is an unambiguous discriminator.
+ */
+function collectionUrls(urls: string[]): string[] {
+  const [y, m, d] = SIM_TODAY.split('-')
+  const todayAsOf = `~${parseInt(m!, 10)}/${parseInt(d!, 10)}/${y}~`
+  return urls.filter(u => !u.includes(todayAsOf))
 }
 
 function baseConfig(overrides: Partial<BackfillConfig> = {}): BackfillConfig {
@@ -89,7 +108,7 @@ describe('BackfillOrchestrator — live program year (#1384)', () => {
 
     // Not one districtsummary request may carry the archive prefix for the
     // live year — that URL is the 500.
-    const archivePrefixed = sim.requestedUrls.filter(u =>
+    const archivePrefixed = collectionUrls(sim.requestedUrls).filter(u =>
       u.includes(`/${SIM_LIVE_PROGRAM_YEAR}/export.aspx`)
     )
     expect(archivePrefixed).toEqual([])
@@ -109,7 +128,7 @@ describe('BackfillOrchestrator — live program year (#1384)', () => {
 
     expect(result.errors).toBe(0)
     expect(
-      sim.requestedUrls.filter(u =>
+      collectionUrls(sim.requestedUrls).filter(u =>
         u.includes(`/${SIM_LIVE_PROGRAM_YEAR}/export.aspx`)
       )
     ).toEqual([])
@@ -159,7 +178,7 @@ describe('BackfillOrchestrator — live program year (#1384)', () => {
 
     await orchestrator.runPhase1Discovery()
 
-    for (const url of sim.requestedUrls) {
+    for (const url of collectionUrls(sim.requestedUrls)) {
       const isRoot = /toastmasters\.org\/export\.aspx/.test(url)
       const askedForLiveYear = url.endsWith(SIM_LIVE_PROGRAM_YEAR)
       // Root path ⇔ the live program year. Never one without the other.
@@ -250,6 +269,75 @@ describe('BackfillOrchestrator — live program year (#1384)', () => {
       '/data/cache/raw-csv/2026-07-26/district-61/club-performance.csv',
       '/data/cache/raw-csv/2026-07-26/metadata.json',
     ])
+  })
+
+  it('keeps a year that still HAS an archive path on /{PY}/, even when the root path is serving it', async () => {
+    // The July rollover window: the root path serves the PRIOR program year
+    // because the new one has not published yet, so resolveActiveProgramYear
+    // reports pathStyle:'live' for 2025-2026. That does NOT mean 2025-2026
+    // lost its archive path — and the root path cannot serve historical as-of
+    // dates (it returns zero rows). Routing the whole year there would skip
+    // every date and exit 0, which is the silent-failure direction.
+    const storage = createSpyStorage()
+    const orchestrator = new BackfillOrchestrator(
+      baseConfig({
+        storage,
+        startYear: 2025,
+        endYear: 2025,
+        frequency: 'monthly',
+      })
+    )
+
+    const seen: Array<{ url: string }> = []
+    orchestrator.downloader.downloadCsv = vi
+      .fn()
+      .mockImplementation(async (spec: BackfillDateSpec) => {
+        const url = buildExportUrl(spec)
+        seen.push({ url })
+        const asOf = `${spec.date.getMonth() + 1}/${spec.date.getDate()}/${spec.date.getFullYear()}`
+        // Root serves the prior year's June close (the rollover window).
+        const content =
+          spec.pathStyle === 'live'
+            ? `"REGION","DISTRICT"\n"02","61"\nMonth of Jun, As of ${asOf}`
+            : `"REGION","DISTRICT"\n"02","61"\nMonth of Jun, As of ${asOf}`
+        return { url, content, statusCode: 200, byteSize: content.length }
+      })
+
+    await orchestrator.runPhase1Discovery()
+
+    // /2025-2026/ answers, so the year is NOT root-only and every collection
+    // request must use it.
+    const collectionUrls = seen
+      .map(s => s.url)
+      .filter(u => !u.includes('~8/2/2026~')) // drop the resolution probes
+    expect(collectionUrls.length).toBeGreaterThan(0)
+    for (const url of collectionUrls) {
+      expect(url).toContain('/2025-2026/export.aspx')
+    }
+  })
+
+  it('reports mismatches so the caller can fail the run', async () => {
+    const orchestrator = new BackfillOrchestrator(
+      baseConfig({
+        storage: createSpyStorage(),
+        liveProgramYear: SIM_LIVE_PROGRAM_YEAR,
+        dates: [new Date('2026-07-26T00:00:00')],
+      })
+    )
+    orchestrator.downloader.downloadCsv = vi.fn().mockResolvedValue({
+      url: 'https://dashboards.toastmasters.org/export.aspx',
+      content: '"REGION","DISTRICT"\n"02","61"\nMonth of Aug, As of 08/02/2026',
+      statusCode: 200,
+      byteSize: 80,
+    })
+
+    const result = await orchestrator.runPhase1Discovery()
+
+    expect(result.mismatches).toBe(1)
+    // A run that ingested nothing because everything was wrong must not be
+    // indistinguishable from a clean run.
+    const summary = await orchestrator.run()
+    expect(summary.mismatches).toBeGreaterThan(0)
   })
 
   it('rejects a response whose footer as-of date is not the date requested', async () => {

--- a/packages/collector-cli/src/__tests__/BackfillOrchestrator.test.ts
+++ b/packages/collector-cli/src/__tests__/BackfillOrchestrator.test.ts
@@ -246,9 +246,13 @@ describe('BackfillOrchestrator storage paths (#125)', () => {
 
     orchestrator.downloader.downloadCsv = vi.fn().mockResolvedValue({
       url: 'https://test.example.com',
-      content: 'some,csv,data\n',
+      // Needs at least one data row. A header-only body is exactly what the
+      // dashboard returns for a period it has no data for, and #1384 skips
+      // those instead of writing a bogus snapshot. This test is about the
+      // storage path shape, so the fixture has to be a realistic response.
+      content: 'some,csv,data\n1,2,3\n',
       statusCode: 200,
-      byteSize: 14,
+      byteSize: 20,
     })
 
     await orchestrator.runPhase2Collection({

--- a/packages/collector-cli/src/__tests__/fakes/dashboardExportSimulator.ts
+++ b/packages/collector-cli/src/__tests__/fakes/dashboardExportSimulator.ts
@@ -1,0 +1,176 @@
+/**
+ * A fake `dashboards.toastmasters.org/export.aspx` (#1384).
+ *
+ * Every rule below was measured against the live dashboard on 2026-08-02 and is
+ * annotated with the probe that established it. The point of simulating the
+ * endpoint rather than stubbing `downloadCsv` is that the URL `buildExportUrl`
+ * produces is then genuinely under test — a backfill pointed at the wrong path
+ * fails here exactly the way it fails in production.
+ *
+ * Measured rules:
+ *  A. `/{PY}/export.aspx` for the **live** program year → HTTP 500. The live
+ *     year has no archive path yet.
+ *  B. `/export.aspx` (root) serves the live year and **ignores the trailing
+ *     `~{programYear}` token**.
+ *  C. Root also **ignores the as-of date when the month-end slot is empty**,
+ *     serving *today* instead. Only the slot's presence matters, not its value
+ *     (probes B and M returned byte-identical bodies for 7/31 vs 6/30).
+ *  D. `/{PY}/export.aspx` for an archived year honours the requested as-of.
+ *  E. A date the dashboard has no data for returns HTTP 200 with a header row,
+ *     a valid-looking footer and **zero data rows**.
+ */
+
+import {
+  buildExportUrl,
+  type BackfillDateSpec,
+} from '../../services/HttpCsvDownloader.js'
+
+/** The program year the bare /export.aspx currently serves. */
+export const SIM_LIVE_PROGRAM_YEAR = '2026-2027'
+
+/** "Today" for the simulator — what root returns when the as-of is ignored. */
+export const SIM_TODAY = '2026-08-02'
+
+/**
+ * TI published PY 2026-2027 data on this date. Earlier July dates are the
+ * dark window: HTTP 200, valid footer, no rows (#1384).
+ */
+export const SIM_FIRST_LIVE_DATE = '2026-07-26'
+
+/** As-of dates the 2025-2026 archive still serves data for. */
+export const SIM_ARCHIVED_DATES_WITH_DATA = new Set([
+  '2026-03-15',
+  '2026-06-30',
+])
+
+const SUMMARY_HEADER = '"REGION","DISTRICT","Paid Clubs"'
+const SUMMARY_ROWS = ['"02","61","150"', '"14","128","127"', '"DNAR","U","21"']
+const DISTRICT_HEADER = '"District","Division","Area","Club Number"'
+const DISTRICT_ROWS = ['"61","A","01","00001234"', '"61","B","02","00005678"']
+
+const MONTH_ABBR = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+
+export interface SimulatedResponse {
+  status: number
+  body: string
+}
+
+/** Parse an `M/D/YYYY` URL date into `YYYY-MM-DD`. */
+function usDateToIso(value: string): string | undefined {
+  const m = value.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/)
+  if (!m) return undefined
+  return `${m[3]}-${m[1]!.padStart(2, '0')}-${m[2]!.padStart(2, '0')}`
+}
+
+function isoToUsDate(iso: string): string {
+  const [y, mo, d] = iso.split('-')
+  return `${parseInt(mo!, 10)}/${parseInt(d!, 10)}/${y}`
+}
+
+/** Build a body with the TM footer: `Month of Jul, As of 07/26/2026`. */
+function buildCsv(
+  header: string,
+  rows: string[],
+  monthIso: string,
+  asOfIso: string
+): string {
+  const monthName = MONTH_ABBR[parseInt(monthIso.slice(5, 7), 10) - 1]!
+  const [y, mo, d] = asOfIso.split('-')
+  const footer = `Month of ${monthName}, As of ${mo}/${d}/${y}`
+  return [header, ...rows, footer].join('\n')
+}
+
+/**
+ * Answer a request for an export URL exactly as the live dashboard does.
+ */
+export function simulateDashboardExport(url: string): SimulatedResponse {
+  const match = url.match(
+    /^https:\/\/dashboards\.toastmasters\.org(?:\/(\d{4}-\d{4}))?\/export\.aspx\?type=CSV&report=(.+)$/
+  )
+  if (!match) return { status: 404, body: 'Not found' }
+
+  const pathYear = match[1]
+  const segments = match[2]!.split('~')
+  const reportType = segments[0]!
+  const requestedAsOf = usDateToIso(segments[segments.length - 2] ?? '')
+  const monthEndSlot = segments[segments.length - 3] ?? ''
+
+  // Rule A — the live program year has no archive path.
+  if (pathYear === SIM_LIVE_PROGRAM_YEAR) {
+    return { status: 500, body: 'URL Rewrite Module Error.' }
+  }
+
+  if (!requestedAsOf) return { status: 500, body: 'URL Rewrite Module Error.' }
+
+  const isRoot = pathYear === undefined
+
+  // Rule C — root with an empty month-end slot ignores the as-of and serves
+  // today. Root also ignores the ~{programYear} token entirely (rule B), so
+  // the year it serves is always the live one.
+  const servedAsOf = isRoot && monthEndSlot === '' ? SIM_TODAY : requestedAsOf
+
+  // Which month the body claims. With data present the footer tracks the
+  // as-of month; with no data it echoes the requested month-end slot.
+  const hasData = isRoot
+    ? servedAsOf >= SIM_FIRST_LIVE_DATE
+    : SIM_ARCHIVED_DATES_WITH_DATA.has(servedAsOf)
+
+  const monthEndIso = usDateToIso(monthEndSlot)
+  const monthIso = hasData ? servedAsOf : (monthEndIso ?? servedAsOf)
+
+  const [header, rows] =
+    reportType === 'districtsummary'
+      ? [SUMMARY_HEADER, SUMMARY_ROWS]
+      : [DISTRICT_HEADER, DISTRICT_ROWS]
+
+  return {
+    status: 200,
+    body: buildCsv(header, hasData ? rows : [], monthIso, servedAsOf),
+  }
+}
+
+export interface SimulatedDownload {
+  url: string
+  content: string
+  statusCode: number
+  byteSize: number
+}
+
+/**
+ * A `downloadCsv` replacement that routes the **real** `buildExportUrl` output
+ * through the simulator and throws on non-2xx just like `HttpCsvDownloader`.
+ * Every URL it is asked for is appended to `requestedUrls`.
+ */
+export function createSimulatedDownloader(): {
+  downloadCsv: (spec: BackfillDateSpec) => Promise<SimulatedDownload>
+  requestedUrls: string[]
+} {
+  const requestedUrls: string[] = []
+  return {
+    requestedUrls,
+    async downloadCsv(spec: BackfillDateSpec): Promise<SimulatedDownload> {
+      const url = buildExportUrl(spec)
+      requestedUrls.push(url)
+      const { status, body } = simulateDashboardExport(url)
+      if (status !== 200) {
+        throw new Error(`HTTP ${status}: Internal Server Error`)
+      }
+      return { url, content: body, statusCode: status, byteSize: body.length }
+    },
+  }
+}
+
+export { usDateToIso, isoToUsDate }

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -977,6 +977,25 @@ export function createCLI(): Command {
       'biweekly'
     )
     .option(
+      '--dates <list>',
+      'Comma-separated YYYY-MM-DD collection dates to backfill instead of a ' +
+        "year grid. Each date's program year is derived from the date, so a " +
+        'list may span years. Overrides --start-year/--end-year/--frequency.',
+      (value: string) => {
+        const dates = value
+          .split(',')
+          .map(d => d.trim())
+          .filter(Boolean)
+        for (const d of dates) {
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) {
+            console.error(`Error: Invalid date "${d}". Expected YYYY-MM-DD.`)
+            process.exit(ExitCode.COMPLETE_FAILURE)
+          }
+        }
+        return dates
+      }
+    )
+    .option(
       '--rate <number>',
       'Maximum requests per second (default: 2)',
       (value: string) => {
@@ -1020,13 +1039,27 @@ export function createCLI(): Command {
         output?: string
         gcsBucket?: string
         gcsPrefix: string
+        dates?: string[]
       }) => {
         const { BackfillOrchestrator, GcsBackfillStorage } =
           await import('./services/BackfillOrchestrator.js')
         type DateFrequency = 'daily' | 'weekly' | 'biweekly' | 'monthly'
 
-        const startYear = options.startYear ?? 2017
-        const endYear = options.endYear ?? new Date().getFullYear()
+        // An explicit --dates list replaces the year grid; the year range is
+        // then derived from the dates so the scope banner stays honest (#1384).
+        const explicitDates = options.dates?.map(d => new Date(`${d}T00:00:00`))
+        const dateYears = explicitDates?.map(d =>
+          d.getMonth() >= 6 ? d.getFullYear() : d.getFullYear() - 1
+        )
+
+        const startYear =
+          dateYears !== undefined
+            ? Math.min(...dateYears)
+            : (options.startYear ?? 2017)
+        const endYear =
+          dateYears !== undefined
+            ? Math.max(...dateYears)
+            : (options.endYear ?? new Date().getFullYear())
         const frequency = options.frequency as DateFrequency
 
         // Determine storage backend
@@ -1071,7 +1104,12 @@ export function createCLI(): Command {
           phase: options.phase as 'discover' | 'collect' | 'all',
           resume: options.resume,
           storage,
+          ...(explicitDates ? { dates: explicitDates } : {}),
         })
+
+        if (explicitDates && options.verbose) {
+          console.error(`[INFO] Dates: ${options.dates?.join(', ')}`)
+        }
 
         // Show scope before starting
         const scope = orchestrator.calculateScope()

--- a/packages/collector-cli/src/cli.ts
+++ b/packages/collector-cli/src/cli.ts
@@ -986,6 +986,10 @@ export function createCLI(): Command {
           .split(',')
           .map(d => d.trim())
           .filter(Boolean)
+        if (dates.length === 0) {
+          console.error('Error: --dates was given but contains no dates.')
+          process.exit(ExitCode.COMPLETE_FAILURE)
+        }
         for (const d of dates) {
           if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) {
             console.error(`Error: Invalid date "${d}". Expected YYYY-MM-DD.`)
@@ -1127,8 +1131,24 @@ export function createCLI(): Command {
         )
 
         try {
-          await orchestrator.run()
-          console.error('[DONE] Backfill complete')
+          const summary = await orchestrator.run()
+          console.error(
+            `[DONE] Backfill complete — requests=${summary.requestsMade} ` +
+              `emptySkipped=${summary.emptySkipped} ` +
+              `mismatches=${summary.mismatches} errors=${summary.errors}`
+          )
+
+          // A mismatch means the dashboard handed back a period we did not ask
+          // for. Nothing was ingested, but the run must not look clean: exiting
+          // 0 here is how a silent history rewrite would slip past CI (#1384).
+          if (summary.mismatches > 0) {
+            console.error(
+              `[ERROR] ${summary.mismatches} response(s) were not for the ` +
+                `requested period and were refused — see the logs above.`
+            )
+            process.exit(ExitCode.COMPLETE_FAILURE)
+          }
+
           process.exit(ExitCode.SUCCESS)
         } catch (error) {
           const errorMessage =

--- a/packages/collector-cli/src/services/BackfillOrchestrator.ts
+++ b/packages/collector-cli/src/services/BackfillOrchestrator.ts
@@ -30,7 +30,10 @@ import {
   buildCsvPathFromReport,
   buildMetadataPath,
 } from '../utils/CachePaths.js'
-import { resolveActiveProgramYear } from '../utils/programYearResolver.js'
+import {
+  isValidDistrictSummaryCsv,
+  resolveActiveProgramYear,
+} from '../utils/programYearResolver.js'
 import {
   BackfillContentMismatchError,
   resolveExportPathStyle,
@@ -198,6 +201,19 @@ export interface Phase1Result {
   mismatches: number
 }
 
+/** What a completed `run()` actually did (#1384). */
+export interface BackfillRunSummary {
+  requestsMade: number
+  /** Dates the dashboard answered 200 for but had no data on. */
+  emptySkipped: number
+  /**
+   * Responses refused because they were not for the requested period. Any
+   * value above zero means the run is NOT trustworthy — callers must fail.
+   */
+  mismatches: number
+  errors: number
+}
+
 export interface BackfillProgress {
   phase: number
   total: number
@@ -287,8 +303,7 @@ export class BackfillOrchestrator {
     startTime: Date.now(),
   }
 
-  private liveProgramYearResolved = false
-  private liveProgramYear: string | undefined
+  private liveProgramYearPromise: Promise<string | undefined> | undefined
 
   /**
    * The program years this run targets — derived from an explicit `dates` list
@@ -327,25 +342,35 @@ export class BackfillOrchestrator {
   }
 
   /**
-   * Which program year the bare `/export.aspx` currently serves, resolved once
-   * per run and memoised (#1384).
+   * The program year that can ONLY be reached at the bare `/export.aspx`,
+   * resolved once per run and memoised (#1384).
    *
-   * Resolved by asking the dashboard rather than by reading the calendar: TM's
-   * rollover lags July 1, so the live year is a fact about their data, not
-   * about today's date (#1284). Anything we cannot confirm is live stays on
-   * the archive path, whose URL constrains the year — the safe default.
+   * Note what this is *not*: it is not simply "the year the root path is
+   * currently serving". During TM's July rollover the root path serves the
+   * PRIOR program year (its June close is still running) while that year keeps
+   * a perfectly good `/{PY}/` archive path. Routing the whole year to the root
+   * on that basis would be a silent disaster — the root path cannot serve
+   * historical as-of dates, so every date would come back with zero rows, be
+   * skipped, and the run would exit 0 having ingested nothing.
+   *
+   * So a year only counts once we have confirmed it has no archive path, by
+   * asking for one. That is the property that actually forces our hand.
    *
    * A backfill whose range cannot contain the live year skips the probe
    * entirely, so purely historical runs issue exactly the requests they always
    * did.
    */
   private async getLiveProgramYear(): Promise<string | undefined> {
-    if (this.liveProgramYearResolved) return this.liveProgramYear
-    this.liveProgramYearResolved = true
+    // Memoise the PROMISE, not the value: two phases starting concurrently
+    // would otherwise both see "not resolved yet", and the loser would route
+    // the live year to /{PY}/ and take a 500.
+    this.liveProgramYearPromise ??= this.resolveRootOnlyProgramYear()
+    return this.liveProgramYearPromise
+  }
 
+  private async resolveRootOnlyProgramYear(): Promise<string | undefined> {
     if (this.config.liveProgramYear !== undefined) {
-      this.liveProgramYear = this.config.liveProgramYear
-      return this.liveProgramYear
+      return this.config.liveProgramYear
     }
 
     const today = toYYYYMMDD(new Date())
@@ -375,16 +400,60 @@ export class BackfillOrchestrator {
       }
     )
 
-    this.liveProgramYear =
-      resolution.pathStyle === 'live' ? resolution.programYear : undefined
+    if (resolution.pathStyle !== 'live') {
+      logger.info('Resolved the live program year for backfill (#1384)', {
+        today,
+        liveProgramYear: null,
+        reason: resolution.reason,
+      })
+      return undefined
+    }
+
+    // The root path is serving `resolution.programYear` — but that alone does
+    // not mean the year lost its archive path. Ask for it.
+    const hasArchivePath = await this.archivePathExists(
+      resolution.programYear,
+      today
+    )
+    const rootOnly = hasArchivePath ? undefined : resolution.programYear
 
     logger.info('Resolved the live program year for backfill (#1384)', {
       today,
-      liveProgramYear: this.liveProgramYear ?? null,
+      servedAtRoot: resolution.programYear,
+      hasArchivePath,
+      liveProgramYear: rootOnly ?? null,
       reason: resolution.reason,
     })
 
-    return this.liveProgramYear
+    return rootOnly
+  }
+
+  /**
+   * Does `/{programYear}/export.aspx` exist? (#1384)
+   *
+   * TM returns HTTP 500 "URL Rewrite Module Error." for the year that is
+   * currently live and has therefore not been archived yet. A 200 whose body
+   * is a real districtsummary means the archive path is available — even an
+   * out-of-range as-of date answers with a valid header row and no data, which
+   * is enough to prove the path resolves.
+   */
+  private async archivePathExists(
+    programYear: string,
+    date: string
+  ): Promise<boolean> {
+    try {
+      const dateObj = new Date(`${date}T00:00:00`)
+      const result = await this.downloader.downloadCsv({
+        programYear,
+        reportType: 'districtsummary',
+        date: dateObj,
+        monthEndDate: computeMonthEndDate(dateObj),
+        pathStyle: 'archive',
+      })
+      return isValidDistrictSummaryCsv(result.content)
+    } catch {
+      return false
+    }
   }
 
   /**
@@ -798,7 +867,13 @@ export class BackfillOrchestrator {
   /**
    * Run the full backfill pipeline.
    */
-  async run(): Promise<void> {
+  async run(): Promise<BackfillRunSummary> {
+    const summary: BackfillRunSummary = {
+      requestsMade: 0,
+      emptySkipped: 0,
+      mismatches: 0,
+      errors: 0,
+    }
     const scope = this.calculateScope()
     const phase = this.config.phase ?? 'all'
 
@@ -833,6 +908,9 @@ export class BackfillOrchestrator {
 
       // Phase 1: Discovery
       const phase1Result = await this.runPhase1Discovery()
+      summary.requestsMade += phase1Result.requestsMade
+      summary.emptySkipped += phase1Result.emptySkipped
+      summary.mismatches += phase1Result.mismatches
       logger.info('Phase 1 complete', {
         districtsPerYear: Object.fromEntries(
           Object.entries(phase1Result.districtsPerYear).map(([y, d]) => [
@@ -848,18 +926,22 @@ export class BackfillOrchestrator {
 
       if (phase === 'discover') {
         logger.info('Discovery-only mode — stopping after Phase 1')
-        return
+        return summary
       }
 
       if (this.aborted) {
         logger.info('Aborted after Phase 1')
-        return
+        return summary
       }
 
       // Phase 2: Collection
       const phase2Result = await this.runPhase2Collection(
         phase1Result.districtsPerYear
       )
+      summary.requestsMade += phase2Result.requestsMade
+      summary.emptySkipped += phase2Result.emptySkipped
+      summary.mismatches += phase2Result.mismatches
+      summary.errors += phase2Result.errors
       logger.info('Phase 2 complete', {
         requestsMade: phase2Result.requestsMade,
         errors: phase2Result.errors,
@@ -869,13 +951,15 @@ export class BackfillOrchestrator {
 
       if (phase === 'collect' || this.aborted) {
         logger.info('Collection complete — run transform separately')
-        return
+        return summary
       }
 
       // Phase 3: Transform (placeholder — runs existing pipeline)
       logger.info(
         'Phase 3: Transform — run the existing transform pipeline on collected data'
       )
+
+      return summary
     } finally {
       process.removeListener('SIGINT', handler)
     }

--- a/packages/collector-cli/src/services/BackfillOrchestrator.ts
+++ b/packages/collector-cli/src/services/BackfillOrchestrator.ts
@@ -169,6 +169,16 @@ export interface BackfillConfig {
    * extra request and its URLs are unchanged.
    */
   liveProgramYear?: string
+  /**
+   * An explicit list of collection dates, replacing the generated
+   * `startYear…endYear × frequency` grid (#1384).
+   *
+   * Recovering a handful of specific days — e.g. the four PY 2026-2027 dates
+   * the #1342 outage skipped — is otherwise impossible: the smallest grid that
+   * contains them is a full year of daily requests. Each date's program year is
+   * derived from the date itself, so a list may span years.
+   */
+  dates?: Date[]
 }
 
 export interface BackfillScope {
@@ -280,6 +290,32 @@ export class BackfillOrchestrator {
   private liveProgramYearResolved = false
   private liveProgramYear: string | undefined
 
+  /**
+   * The program years this run targets — derived from an explicit `dates` list
+   * when one is given, otherwise from the `startYear…endYear` range (#1384).
+   */
+  private targetProgramYears(): string[] {
+    if (this.config.dates) {
+      return [
+        ...new Set(this.config.dates.map(d => calculateProgramYear(d))),
+      ].sort()
+    }
+    return this.downloader.getProgramYearRange(
+      this.config.startYear,
+      this.config.endYear
+    )
+  }
+
+  /** The collection dates belonging to one program year (#1384). */
+  private datesForYear(year: string): Date[] {
+    if (this.config.dates) {
+      return this.config.dates
+        .filter(d => calculateProgramYear(d) === year)
+        .sort((a, b) => a.getTime() - b.getTime())
+    }
+    return this.downloader.generateDateGrid(year, this.config.frequency)
+  }
+
   constructor(config: BackfillConfig) {
     this.config = config
     this.downloader = new HttpCsvDownloader({
@@ -315,10 +351,7 @@ export class BackfillOrchestrator {
     const today = toYYYYMMDD(new Date())
     const calendarPY = calculateProgramYear(today)
     const candidates = new Set([calendarPY, getPriorProgramYear(calendarPY)])
-    const targetYears = this.downloader.getProgramYearRange(
-      this.config.startYear,
-      this.config.endYear
-    )
+    const targetYears = this.targetProgramYears()
     if (!targetYears.some(y => candidates.has(y))) {
       logger.info(
         'Backfill range is entirely historical — every fetch uses /{programYear}/ (#1384)',
@@ -399,10 +432,22 @@ export class BackfillOrchestrator {
    * Calculate the total scope of the backfill operation.
    */
   calculateScope(): BackfillScope {
-    const programYears = this.downloader.getProgramYearRange(
-      this.config.startYear,
-      this.config.endYear
-    )
+    const programYears = this.targetProgramYears()
+
+    if (this.config.dates) {
+      // An explicit date list is not a per-year grid: count the dates directly
+      // so the scope banner does not overstate a 4-date recovery run (#1384).
+      const datesPerYear = Math.max(
+        ...programYears.map(y => this.datesForYear(y).length)
+      )
+      return {
+        programYears,
+        datesPerYear,
+        phase1Requests: this.config.dates.length,
+        requestsPerDistrict: datesPerYear * 3,
+      }
+    }
+
     const dates = this.downloader.generateDateGrid(
       programYears[0]!,
       this.config.frequency
@@ -468,10 +513,7 @@ export class BackfillOrchestrator {
 
       this.progress.currentYear = year
       const pathStyle = resolveExportPathStyle(year, liveProgramYear)
-      const dates = this.downloader.generateDateGrid(
-        year,
-        this.config.frequency
-      )
+      const dates = this.datesForYear(year)
       const discoveredDistricts = new Set<string>()
 
       for (const date of dates) {
@@ -608,10 +650,7 @@ export class BackfillOrchestrator {
     // Calculate total
     let total = 0
     for (const [year, districts] of Object.entries(districtsPerYear)) {
-      const dates = this.downloader.generateDateGrid(
-        year,
-        this.config.frequency
-      )
+      const dates = this.datesForYear(year)
       total += districts.length * reportTypes.length * dates.length
     }
 
@@ -640,10 +679,7 @@ export class BackfillOrchestrator {
 
       this.progress.currentYear = year
       const pathStyle = resolveExportPathStyle(year, liveProgramYear)
-      const dates = this.downloader.generateDateGrid(
-        year,
-        this.config.frequency
-      )
+      const dates = this.datesForYear(year)
 
       for (const districtId of districts) {
         if (this.aborted) break

--- a/packages/collector-cli/src/services/BackfillOrchestrator.ts
+++ b/packages/collector-cli/src/services/BackfillOrchestrator.ts
@@ -19,15 +19,23 @@ import {
   HttpCsvDownloader,
   computeMonthEndDate,
   type DateFrequency,
+  type ExportPathStyle,
   type ReportType,
 } from './HttpCsvDownloader.js'
 import { logger } from '../utils/logger.js'
 import {
   toYYYYMMDD,
   calculateProgramYear,
+  getPriorProgramYear,
   buildCsvPathFromReport,
   buildMetadataPath,
 } from '../utils/CachePaths.js'
+import { resolveActiveProgramYear } from '../utils/programYearResolver.js'
+import {
+  BackfillContentMismatchError,
+  resolveExportPathStyle,
+  verifyBackfillCsv,
+} from '../utils/backfillContentGuard.js'
 
 // ── Storage Abstraction ──────────────────────────────────────────────
 
@@ -151,6 +159,16 @@ export interface BackfillConfig {
   phase?: 'discover' | 'collect' | 'all'
   resume?: boolean
   storage?: BackfillStorage
+  /**
+   * The program year currently served by the bare `/export.aspx` (#1384).
+   *
+   * That year has no `/{programYear}/` archive path — requesting one returns
+   * HTTP 500 — so it can only be fetched from the root. When omitted, it is
+   * resolved once per run by asking the dashboard, and only when the backfill
+   * range could actually contain it: a purely historical backfill makes no
+   * extra request and its URLs are unchanged.
+   */
+  liveProgramYear?: string
 }
 
 export interface BackfillScope {
@@ -164,6 +182,10 @@ export interface Phase1Result {
   districtsPerYear: Record<string, string[]>
   totalDistricts: number
   requestsMade: number
+  /** Dates the dashboard answered 200 for but had no data on (#1384). */
+  emptySkipped: number
+  /** Responses rejected because they were not for the requested period. */
+  mismatches: number
 }
 
 export interface BackfillProgress {
@@ -255,6 +277,9 @@ export class BackfillOrchestrator {
     startTime: Date.now(),
   }
 
+  private liveProgramYearResolved = false
+  private liveProgramYear: string | undefined
+
   constructor(config: BackfillConfig) {
     this.config = config
     this.downloader = new HttpCsvDownloader({
@@ -263,6 +288,111 @@ export class BackfillOrchestrator {
       cooldownMs: config.cooldownMs ?? 5000,
     })
     this.storage = config.storage ?? new LocalBackfillStorage()
+  }
+
+  /**
+   * Which program year the bare `/export.aspx` currently serves, resolved once
+   * per run and memoised (#1384).
+   *
+   * Resolved by asking the dashboard rather than by reading the calendar: TM's
+   * rollover lags July 1, so the live year is a fact about their data, not
+   * about today's date (#1284). Anything we cannot confirm is live stays on
+   * the archive path, whose URL constrains the year — the safe default.
+   *
+   * A backfill whose range cannot contain the live year skips the probe
+   * entirely, so purely historical runs issue exactly the requests they always
+   * did.
+   */
+  private async getLiveProgramYear(): Promise<string | undefined> {
+    if (this.liveProgramYearResolved) return this.liveProgramYear
+    this.liveProgramYearResolved = true
+
+    if (this.config.liveProgramYear !== undefined) {
+      this.liveProgramYear = this.config.liveProgramYear
+      return this.liveProgramYear
+    }
+
+    const today = toYYYYMMDD(new Date())
+    const calendarPY = calculateProgramYear(today)
+    const candidates = new Set([calendarPY, getPriorProgramYear(calendarPY)])
+    const targetYears = this.downloader.getProgramYearRange(
+      this.config.startYear,
+      this.config.endYear
+    )
+    if (!targetYears.some(y => candidates.has(y))) {
+      logger.info(
+        'Backfill range is entirely historical — every fetch uses /{programYear}/ (#1384)',
+        { targetYears }
+      )
+      return undefined
+    }
+
+    const resolution = await resolveActiveProgramYear(
+      today,
+      async (programYear, pathStyle) => {
+        const date = new Date(`${today}T00:00:00`)
+        const result = await this.downloader.downloadCsv({
+          programYear,
+          reportType: 'districtsummary',
+          date,
+          monthEndDate: computeMonthEndDate(date),
+          pathStyle,
+        })
+        return result.content
+      }
+    )
+
+    this.liveProgramYear =
+      resolution.pathStyle === 'live' ? resolution.programYear : undefined
+
+    logger.info('Resolved the live program year for backfill (#1384)', {
+      today,
+      liveProgramYear: this.liveProgramYear ?? null,
+      reason: resolution.reason,
+    })
+
+    return this.liveProgramYear
+  }
+
+  /**
+   * Verify a downloaded body against the request that produced it, then say
+   * whether it may be stored (#1384).
+   *
+   * A mismatch throws: it means the dashboard gave us a different period than
+   * we asked for, and writing it would put wrong data under a real date.
+   */
+  private acceptDownload(args: {
+    content: string
+    programYear: string
+    date: Date
+    pathStyle: ExportPathStyle
+    url: string
+    context: Record<string, unknown>
+  }): 'store' | 'skip' {
+    const dateStr = toYYYYMMDD(args.date)
+    const verdict = verifyBackfillCsv({
+      content: args.content,
+      programYear: args.programYear,
+      date: dateStr,
+      pathStyle: args.pathStyle,
+    })
+
+    if (verdict.status === 'mismatch') {
+      throw new BackfillContentMismatchError(
+        `Refusing to ingest ${args.url}: ${verdict.reason}`,
+        { programYear: args.programYear, date: dateStr, url: args.url }
+      )
+    }
+
+    if (verdict.status === 'empty') {
+      logger.warn(
+        'Dashboard returned no data for this date — skipping, not ingesting (#1384)',
+        { ...args.context, date: dateStr, reason: verdict.reason }
+      )
+      return 'skip'
+    }
+
+    return 'store'
   }
 
   /**
@@ -313,7 +443,10 @@ export class BackfillOrchestrator {
   async runPhase1Discovery(): Promise<Phase1Result> {
     const scope = this.calculateScope()
     const districtsPerYear: Record<string, string[]> = {}
+    const liveProgramYear = await this.getLiveProgramYear()
     let requestsMade = 0
+    let emptySkipped = 0
+    let mismatches = 0
 
     this.progress = {
       phase: 1,
@@ -334,6 +467,7 @@ export class BackfillOrchestrator {
       if (this.aborted) break
 
       this.progress.currentYear = year
+      const pathStyle = resolveExportPathStyle(year, liveProgramYear)
       const dates = this.downloader.generateDateGrid(
         year,
         this.config.frequency
@@ -372,11 +506,25 @@ export class BackfillOrchestrator {
             reportType: 'districtsummary',
             date,
             monthEndDate: computeMonthEndDate(date),
+            pathStyle,
           })
 
           requestsMade++
           this.progress.completed++
           this.progress.requestsMade = requestsMade
+
+          const disposition = this.acceptDownload({
+            content: result.content,
+            programYear: year,
+            date,
+            pathStyle,
+            url: result.url,
+            context: { phase: 1, year },
+          })
+          if (disposition === 'skip') {
+            emptySkipped++
+            continue
+          }
 
           // Save to storage
           await this.storage.write(key, result.content)
@@ -395,6 +543,7 @@ export class BackfillOrchestrator {
             districtsFound: discoveredDistricts.size,
           })
         } catch (error) {
+          if (error instanceof BackfillContentMismatchError) mismatches++
           logger.error('Phase 1: failed to download summary', {
             year,
             date: date.toISOString().split('T')[0],
@@ -425,7 +574,13 @@ export class BackfillOrchestrator {
       0
     )
 
-    return { districtsPerYear, totalDistricts, requestsMade }
+    return {
+      districtsPerYear,
+      totalDistricts,
+      requestsMade,
+      emptySkipped,
+      mismatches,
+    }
   }
 
   /**
@@ -433,14 +588,22 @@ export class BackfillOrchestrator {
    */
   async runPhase2Collection(
     districtsPerYear: Record<string, string[]>
-  ): Promise<{ requestsMade: number; errors: number }> {
+  ): Promise<{
+    requestsMade: number
+    errors: number
+    emptySkipped: number
+    mismatches: number
+  }> {
     const reportTypes: ReportType[] = [
       'districtperformance',
       'divisionperformance',
       'clubperformance',
     ]
+    const liveProgramYear = await this.getLiveProgramYear()
     let requestsMade = 0
     let errors = 0
+    let emptySkipped = 0
+    let mismatches = 0
 
     // Calculate total
     let total = 0
@@ -476,6 +639,7 @@ export class BackfillOrchestrator {
       if (this.aborted) break
 
       this.progress.currentYear = year
+      const pathStyle = resolveExportPathStyle(year, liveProgramYear)
       const dates = this.downloader.generateDateGrid(
         year,
         this.config.frequency
@@ -513,11 +677,25 @@ export class BackfillOrchestrator {
                 districtId,
                 date,
                 monthEndDate: computeMonthEndDate(date),
+                pathStyle,
               })
 
               requestsMade++
               this.progress.completed++
               this.progress.requestsMade = requestsMade
+
+              const disposition = this.acceptDownload({
+                content: result.content,
+                programYear: year,
+                date,
+                pathStyle,
+                url: result.url,
+                context: { phase: 2, year, districtId, reportType },
+              })
+              if (disposition === 'skip') {
+                emptySkipped++
+                continue
+              }
 
               await this.storage.write(key, result.content)
 
@@ -543,6 +721,7 @@ export class BackfillOrchestrator {
               }
             } catch (error) {
               errors++
+              if (error instanceof BackfillContentMismatchError) mismatches++
               logger.error('Phase 2: failed to download', {
                 year,
                 districtId,
@@ -577,7 +756,7 @@ export class BackfillOrchestrator {
       }
     }
 
-    return { requestsMade, errors }
+    return { requestsMade, errors, emptySkipped, mismatches }
   }
 
   /**
@@ -627,6 +806,8 @@ export class BackfillOrchestrator {
         ),
         totalDistricts: phase1Result.totalDistricts,
         requestsMade: phase1Result.requestsMade,
+        emptySkipped: phase1Result.emptySkipped,
+        mismatches: phase1Result.mismatches,
       })
 
       if (phase === 'discover') {
@@ -646,6 +827,8 @@ export class BackfillOrchestrator {
       logger.info('Phase 2 complete', {
         requestsMade: phase2Result.requestsMade,
         errors: phase2Result.errors,
+        emptySkipped: phase2Result.emptySkipped,
+        mismatches: phase2Result.mismatches,
       })
 
       if (phase === 'collect' || this.aborted) {

--- a/packages/collector-cli/src/services/HttpCsvDownloader.ts
+++ b/packages/collector-cli/src/services/HttpCsvDownloader.ts
@@ -101,8 +101,17 @@ function formatDateForUrl(date: Date): string {
  * data collected on date D belongs to the PREVIOUS month's closing period.
  * e.g., data collected on 9/8/2025 is the August 2025 closing → month-end = 8/31/2025.
  *
- * Special case: if the collection date is in the same month as the program year start
- * (July), the month-end is 7/31 of the start year.
+ * NOTE (#1384): only the *presence* of this value in the export URL matters,
+ * not the value itself. Measured against the live dashboard, requesting
+ * `districtsummary~6/30/2026~7/26/2026~…` and `districtsummary~7/31/2026~…`
+ * returns byte-identical bodies — the served period is derived from the as-of
+ * date. What is NOT interchangeable is leaving the slot empty: the root
+ * `/export.aspx` then ignores the as-of date and serves today instead. So keep
+ * passing this, but do not read meaning into which month-end comes out.
+ *
+ * (An earlier version of this docstring claimed a July special case returning
+ * 7/31 of the start year. No such branch was ever implemented, and per the
+ * above it would have made no difference.)
  *
  * @param collectionDate - The date data was collected/scraped
  * @returns The last day of the previous month

--- a/packages/collector-cli/src/utils/__tests__/backfillContentGuard.test.ts
+++ b/packages/collector-cli/src/utils/__tests__/backfillContentGuard.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for the backfill fetch guard (#1384).
+ *
+ * Every fixture below is a real shape observed against the live dashboard on
+ * 2026-08-02; the probe letter in each comment identifies which request
+ * produced it.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  resolveExportPathStyle,
+  countCsvDataRows,
+  verifyBackfillCsv,
+} from '../backfillContentGuard.js'
+import { parseFooterAsOfDate } from '../csvFooterParser.js'
+
+const HEADER = '"REGION","DISTRICT","Paid Clubs"'
+const ROW = '"02","61","150"'
+
+function csv(rows: string[], footer: string | undefined): string {
+  return [HEADER, ...rows, ...(footer ? [footer] : [])].join('\n')
+}
+
+describe('resolveExportPathStyle (#1384)', () => {
+  it('uses the root path only for the live program year', () => {
+    expect(resolveExportPathStyle('2026-2027', '2026-2027')).toBe('live')
+  })
+
+  it('uses /{PY}/ for every other year', () => {
+    expect(resolveExportPathStyle('2025-2026', '2026-2027')).toBe('archive')
+    expect(resolveExportPathStyle('2017-2018', '2026-2027')).toBe('archive')
+  })
+
+  it('falls back to /{PY}/ when the live year is unknown', () => {
+    // The archive path is the safe default: its URL constrains the year,
+    // the root path's does not (#1342).
+    expect(resolveExportPathStyle('2026-2027', undefined)).toBe('archive')
+  })
+})
+
+describe('parseFooterAsOfDate (#1384)', () => {
+  it('reads the as-of date from a 3-letter-month footer', () => {
+    expect(
+      parseFooterAsOfDate(csv([ROW], 'Month of Jul, As of 07/26/2026'))
+    ).toBe('2026-07-26')
+  })
+
+  it('reads it from a full-month, quoted footer', () => {
+    expect(
+      parseFooterAsOfDate(csv([ROW], '"Month of March, As of 3/1/2026"'))
+    ).toBe('2026-03-01')
+  })
+
+  it('returns undefined when there is no footer — undecided, not a verdict', () => {
+    expect(parseFooterAsOfDate(csv([ROW], undefined))).toBeUndefined()
+    expect(parseFooterAsOfDate('')).toBeUndefined()
+  })
+})
+
+describe('countCsvDataRows (#1384)', () => {
+  it('excludes the header and the footer', () => {
+    expect(
+      countCsvDataRows(csv([ROW, ROW], 'Month of Jul, As of 07/26/2026'))
+    ).toBe(2)
+  })
+
+  it('reports zero for a header-plus-footer body (probe E)', () => {
+    expect(countCsvDataRows(csv([], 'Month of Jul, As of 07/20/2026'))).toBe(0)
+  })
+
+  it('reports zero for a header-only body', () => {
+    expect(countCsvDataRows(HEADER)).toBe(0)
+  })
+
+  it('counts an unrecognised trailing row as data — conservative by design', () => {
+    expect(countCsvDataRows([HEADER, ROW, 'As of 02/26/2026'].join('\n'))).toBe(
+      2
+    )
+  })
+})
+
+describe('verifyBackfillCsv (#1384)', () => {
+  const liveRequest = {
+    programYear: '2026-2027',
+    date: '2026-07-26',
+    pathStyle: 'live' as const,
+  }
+
+  it('accepts a live-path body whose footer matches the request (probe B)', () => {
+    const verdict = verifyBackfillCsv({
+      ...liveRequest,
+      content: csv([ROW], 'Month of Jul, As of 07/26/2026'),
+    })
+    expect(verdict).toEqual({ status: 'ok' })
+  })
+
+  it('rejects the empty-month-end-slot trap: as-of ignored, today served (probe C)', () => {
+    const verdict = verifyBackfillCsv({
+      ...liveRequest,
+      content: csv([ROW], 'Month of Jul, As of 08/01/2026'),
+    })
+    expect(verdict.status).toBe('mismatch')
+    expect(verdict).toMatchObject({
+      reason: expect.stringContaining('As of 2026-08-01'),
+    })
+  })
+
+  it('rejects the #1342 classic — historical year fetched from the root (probe G)', () => {
+    // Requested PY 2025-2026 as of 2026-06-30; root served today's live data.
+    // The footer-derived program year cannot see this (Jul > Jun rolls the
+    // year back to 2025-2026, matching the request) — the as-of date is what
+    // catches it. That is precisely why both axes exist.
+    const verdict = verifyBackfillCsv({
+      programYear: '2025-2026',
+      date: '2026-06-30',
+      pathStyle: 'live',
+      content: csv([ROW], 'Month of Jul, As of 08/01/2026'),
+    })
+    expect(verdict.status).toBe('mismatch')
+  })
+
+  it('rejects a body whose footer program year disagrees with the request', () => {
+    const verdict = verifyBackfillCsv({
+      programYear: '2024-2025',
+      date: '2026-03-15',
+      pathStyle: 'archive',
+      content: csv([ROW], 'Month of Mar, As of 03/15/2026'),
+    })
+    expect(verdict).toMatchObject({
+      status: 'mismatch',
+      reason: expect.stringContaining('2025-2026'),
+    })
+  })
+
+  it('excuses the July window, where the prior year’s June close is still live (probe H)', () => {
+    // A legitimate archive request for 2025-2026 as of 2025-07-02 comes back
+    // describing June — i.e. PY 2024-2025. Hard-failing this would break
+    // every early-July date of every historical backfill.
+    const verdict = verifyBackfillCsv({
+      programYear: '2025-2026',
+      date: '2025-07-02',
+      pathStyle: 'archive',
+      content: csv([ROW], 'Month of Jun, As of 07/02/2025'),
+    })
+    expect(verdict).toEqual({ status: 'ok' })
+  })
+
+  it('does not excuse a prior-year footer outside July', () => {
+    const verdict = verifyBackfillCsv({
+      programYear: '2025-2026',
+      date: '2025-11-02',
+      pathStyle: 'archive',
+      content: csv([ROW], 'Month of Nov, As of 11/02/2025'),
+    })
+    expect(verdict).toEqual({ status: 'ok' })
+
+    const wrongYear = verifyBackfillCsv({
+      programYear: '2026-2027',
+      date: '2025-11-02',
+      pathStyle: 'archive',
+      content: csv([ROW], 'Month of Nov, As of 11/02/2025'),
+    })
+    expect(wrongYear.status).toBe('mismatch')
+  })
+
+  it('reports a zero-row body as empty, not ok (probe E — TI dark window)', () => {
+    const verdict = verifyBackfillCsv({
+      programYear: '2026-2027',
+      date: '2026-07-20',
+      pathStyle: 'live',
+      content: csv([], 'Month of Jul, As of 07/20/2026'),
+    })
+    expect(verdict).toMatchObject({ status: 'empty' })
+  })
+
+  it('reports the live path misused for history as empty, not ok (probe F)', () => {
+    const verdict = verifyBackfillCsv({
+      programYear: '2025-2026',
+      date: '2026-03-15',
+      pathStyle: 'live',
+      content: csv([], 'Month of Feb, As of 03/15/2026'),
+    })
+    expect(verdict.status).not.toBe('ok')
+  })
+
+  it('accepts a footer-less ARCHIVE body — the URL pinned the year', () => {
+    // Rejecting these would break historical backfills of older exports.
+    const verdict = verifyBackfillCsv({
+      programYear: '2017-2018',
+      date: '2017-09-05',
+      pathStyle: 'archive',
+      content: csv([ROW], undefined),
+    })
+    expect(verdict).toEqual({ status: 'ok' })
+  })
+
+  it('rejects a footer-less LIVE body — nothing pins the year there', () => {
+    const verdict = verifyBackfillCsv({
+      ...liveRequest,
+      content: csv([ROW], undefined),
+    })
+    expect(verdict.status).toBe('mismatch')
+  })
+
+  it('treats a blank body as empty', () => {
+    expect(verifyBackfillCsv({ ...liveRequest, content: '' })).toMatchObject({
+      status: 'empty',
+    })
+    expect(
+      verifyBackfillCsv({ ...liveRequest, content: undefined })
+    ).toMatchObject({ status: 'empty' })
+  })
+})

--- a/packages/collector-cli/src/utils/backfillContentGuard.ts
+++ b/packages/collector-cli/src/utils/backfillContentGuard.ts
@@ -1,0 +1,196 @@
+/**
+ * Backfill fetch guard (#1384).
+ *
+ * Two independent facts about `dashboards.toastmasters.org/export.aspx` make a
+ * backfill dangerous, and neither one shows up as an HTTP error:
+ *
+ *  1. **The root path ignores the `~{programYear}` token** (#1342). Pointing a
+ *     historical fetch at it returns *current* data with a 200 and a valid
+ *     `DISTRICT` header, which `isValidDistrictSummaryCsv` happily accepts —
+ *     history rewritten, silently.
+ *  2. **The root path also ignores the as-of date when the month-end slot is
+ *     empty**, serving today instead:
+ *
+ *     ```
+ *     districtsummary~7/31/2026~7/26/2026~2026-2027  → As of 07/26/2026  correct
+ *     districtsummary~~7/26/2026~2026-2027           → As of 08/01/2026  CURRENT
+ *     ```
+ *
+ * Both are the same class of failure — *we did not get the period we asked
+ * for* — and both are visible in the CSV footer, which we already parse. So
+ * rather than special-casing today's instance, every backfilled body is
+ * checked against the request that produced it, and a disagreement is a hard
+ * failure that never reaches storage.
+ *
+ * A third outcome needs its own handling: the dashboard answers 200 with a
+ * header row, a plausible footer and **zero data rows** for any period it has
+ * nothing for — TI's dark window before a program year publishes, and old
+ * archives that no longer retain arbitrary daily as-of dates. That is not an
+ * error and not data; it is nothing, and writing it would publish a bogus
+ * snapshot under a real date.
+ */
+
+import { getPriorProgramYear } from './CachePaths.js'
+import { parseFooterAsOfDate } from './csvFooterParser.js'
+import { programYearFromCsvFooter } from './programYearResolver.js'
+import type { ExportPathStyle } from '../services/HttpCsvDownloader.js'
+
+/**
+ * Which endpoint shape a program year must be fetched from.
+ *
+ * The live year exists **only** at the bare `/export.aspx` (the archive path
+ * returns HTTP 500 for it); every other year exists **only** under
+ * `/{programYear}/`. `liveProgramYear` is what the root path currently serves —
+ * when it is unknown, everything falls back to the archive path, which is the
+ * safe default because its URL actually constrains the year.
+ */
+export function resolveExportPathStyle(
+  programYear: string,
+  liveProgramYear: string | undefined
+): ExportPathStyle {
+  return liveProgramYear !== undefined && programYear === liveProgramYear
+    ? 'live'
+    : 'archive'
+}
+
+/**
+ * Count the data rows in a CSV body — everything that is not the header, not a
+ * `Month of …, As of …` footer, and not blank.
+ *
+ * Deliberately conservative: anything unrecognised counts as a data row, so a
+ * body is only ever reported empty when it genuinely has nothing in it.
+ */
+export function countCsvDataRows(content: string | undefined | null): number {
+  if (!content) return 0
+  const lines = content
+    .split(/\r?\n/)
+    .map(l => l.trim())
+    .filter(l => l.length > 0)
+    .filter(l => !/^"?Month of\s+[A-Za-z]+,\s*As of\s+[0-9/]+"?$/i.test(l))
+  // The first surviving line is the header row.
+  return Math.max(0, lines.length - 1)
+}
+
+/**
+ * The verdict on a downloaded CSV.
+ *
+ * - `ok`       — it is what was asked for; ingest it.
+ * - `empty`    — 200 with no data rows. Skip it: not an error, but not data.
+ * - `mismatch` — the body is for a different period or year than requested.
+ *                Never ingest; fail loudly.
+ */
+export type BackfillCsvVerdict =
+  | { status: 'ok' }
+  | { status: 'empty'; reason: string }
+  | { status: 'mismatch'; reason: string }
+
+export interface VerifyBackfillCsvInput {
+  content: string | undefined
+  /** The program year token the request carried. */
+  programYear: string
+  /** The as-of date the request carried, `YYYY-MM-DD`. */
+  date: string
+  /** Which endpoint the request went to. */
+  pathStyle: ExportPathStyle
+}
+
+/** Thrown when a downloaded body is not for the period that was requested. */
+export class BackfillContentMismatchError extends Error {
+  constructor(
+    message: string,
+    readonly context: { programYear: string; date: string; url?: string }
+  ) {
+    super(message)
+    this.name = 'BackfillContentMismatchError'
+  }
+}
+
+/**
+ * Decide whether a downloaded CSV may be ingested for the request that
+ * produced it.
+ *
+ * Checks run mismatch-first so a wrong-period body is never softened into a
+ * benign "empty".
+ */
+export function verifyBackfillCsv(
+  input: VerifyBackfillCsvInput
+): BackfillCsvVerdict {
+  const { content, programYear, date, pathStyle } = input
+
+  if (!content || content.trim().length === 0) {
+    return { status: 'empty', reason: 'response body was empty' }
+  }
+
+  const footerAsOf = parseFooterAsOfDate(content)
+
+  if (footerAsOf === undefined) {
+    // No footer — UNDECIDED, not a verdict (#1129). Which way that resolves
+    // depends entirely on whether the URL pinned the year for us:
+    //   archive → the `/{PY}/` path constrains the year, so accept. Some older
+    //             exports genuinely have no footer and rejecting them would
+    //             break historical backfills.
+    //   live    → the endpoint ignores the year token, so an unverifiable body
+    //             is a body we cannot attribute to anything. Reject.
+    if (pathStyle === 'live') {
+      return {
+        status: 'mismatch',
+        reason:
+          'live-path response has no "Month of …, As of …" footer, so the ' +
+          'period it covers cannot be confirmed — the root endpoint ignores ' +
+          'the requested program year (#1342)',
+      }
+    }
+    return countCsvDataRows(content) === 0
+      ? { status: 'empty', reason: 'no data rows' }
+      : { status: 'ok' }
+  }
+
+  if (footerAsOf !== date) {
+    return {
+      status: 'mismatch',
+      reason:
+        `footer is "As of ${footerAsOf}" but ${date} was requested — the ` +
+        'response is not for the requested date (#1384)',
+    }
+  }
+
+  const footerProgramYear = programYearFromCsvFooter(content, date)
+  if (
+    footerProgramYear !== undefined &&
+    footerProgramYear !== programYear &&
+    !isPriorYearCloseWindow(footerProgramYear, programYear, date)
+  ) {
+    return {
+      status: 'mismatch',
+      reason:
+        `footer describes program year ${footerProgramYear} but ` +
+        `${programYear} was requested (#1342)`,
+    }
+  }
+
+  if (countCsvDataRows(content) === 0) {
+    return { status: 'empty', reason: 'no data rows' }
+  }
+
+  return { status: 'ok' }
+}
+
+/**
+ * July is legitimately ambiguous: the prior year's June close keeps updating
+ * for weeks into the new program year, so a July request against year Y can
+ * correctly come back describing Y-1 ("Month of Jun"). Treating that as a
+ * mismatch would hard-fail every early-July date of every historical backfill.
+ *
+ * Only that one window is excused — any other year disagreement stands.
+ */
+function isPriorYearCloseWindow(
+  footerProgramYear: string,
+  requestedProgramYear: string,
+  date: string
+): boolean {
+  if (footerProgramYear !== getPriorProgramYear(requestedProgramYear)) {
+    return false
+  }
+  const startYear = parseInt(requestedProgramYear.split('-')[0]!, 10)
+  return date.startsWith(`${startYear}-07-`)
+}

--- a/packages/collector-cli/src/utils/csvFooterParser.ts
+++ b/packages/collector-cli/src/utils/csvFooterParser.ts
@@ -86,6 +86,41 @@ export function parseFooterDataMonth(
   return undefined
 }
 
+/**
+ * Parse the **"As of" date** from a CSV's `Month of X, As of MM/DD/YYYY` footer.
+ *
+ * This is the single most reliable thing the dashboard tells us about a
+ * response (#1384). Measured across every endpoint shape on 2026-08-02, the
+ * as-of date echoes the date that was requested — with exactly one exception:
+ * when the export URL's month-end slot is left empty, the root `/export.aspx`
+ * ignores the requested as-of and serves *today* instead. Comparing this value
+ * to the date we asked for is therefore what catches a response that is not
+ * for the period we requested, on either the live or the archive path.
+ *
+ * Unlike the "Month of" half of the footer, which tracks the as-of month when
+ * data exists but echoes the requested month-end when the response is empty,
+ * this value is unambiguous.
+ *
+ * @returns `YYYY-MM-DD`, or undefined when no parseable footer is present —
+ *          UNDECIDED, never a verdict (#1129).
+ */
+export function parseFooterAsOfDate(
+  csvContent: string | undefined | null
+): string | undefined {
+  if (!csvContent) return undefined
+
+  const lines = csvContent.split(/\r?\n/).slice(-20)
+  for (const line of lines) {
+    const match = line.match(
+      /^"?Month of\s+[A-Za-z]+,\s*As of\s+([0-9]{1,2})\/([0-9]{1,2})\/([0-9]{4})"?$/i
+    )
+    if (!match) continue
+    return `${match[3]}-${match[1]!.padStart(2, '0')}-${match[2]!.padStart(2, '0')}`
+  }
+
+  return undefined
+}
+
 export function parseClosingPeriodFromCsv(
   csvContent: string,
   requestedDate: string

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,6 +2,7 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `assert-the-echo-field-that-is-invariant-not-the-one-that-looks-semantic.md` — When an upstream echoes your request back, assert the echo field that is invariant across every response shape — not the one that reads most semantically  (2026-08-02)
 - `a-font-swap-reflow-masquerades-as-a-reserve-error.md` — A web-font swap reflow masquerades as a reserve error — pin both states instead of racing them, and ablate the font before attributing CLS to your diff  (2026-08-01)
 - `a-skeleton-that-omits-a-button-under-reserves-by-the-touch-target-floor.md` — A skeleton that omits an interactive element under-reserves by the touch-target floor, not by the element's visual size  (2026-08-01)
 - `an-override-must-match-the-same-element-set-the-utility-it-overrides-paints.md` — A CSS override must match the same element SET the utility it overrides paints — restate that set by hand and you get a silent off-by-one; derive it from the tool instead  (2026-08-01)

--- a/tasks/lessons/lessons/assert-the-echo-field-that-is-invariant-not-the-one-that-looks-semantic.md
+++ b/tasks/lessons/lessons/assert-the-echo-field-that-is-invariant-not-the-one-that-looks-semantic.md
@@ -1,0 +1,82 @@
+---
+date: 2026-08-02
+tier: lesson
+summary: When an upstream echoes your request back, assert the echo field that is invariant across every response shape — not the one that reads most semantically
+tags: [data-pipeline, collector, external-api, verification, backfill, program-year]
+---
+
+# Lesson — Assert the echo field that is *invariant*, not the one that looks semantic
+
+**Date:** 2026-08-02
+**Issue:** #1384 (backfill could not reach the live program year)
+**Related:** #1342 (the export endpoint moved), #1284 (resolve the PY by data)
+
+## What happened
+
+`export.aspx` returns a footer that echoes the request:
+
+```
+Month of Jul, As of 07/26/2026
+```
+
+Two things about it are ignorable by the server — the `~{programYear}` token
+and, when the month-end URL slot is left empty, the as-of date — so a backfill
+can get a 200, a valid `DISTRICT` header, and data for entirely the wrong
+period. The fix was to verify the footer against the request. The interesting
+part was choosing *which half* of the footer to verify.
+
+`Month of X` is the obvious candidate. It is the semantic field: it names the
+reporting period, it is what `parseFooterDataMonth` already extracts, and it is
+what the issue proposed asserting. It is also **wrong**.
+
+Twelve probes against the live endpoint showed `Month of` behaves differently
+depending on whether the response has data:
+
+| response | `Month of` tracks |
+| --- | --- |
+| has data rows | the **as-of** month |
+| no data rows | the requested **month-end slot** |
+
+Asserting it would have hard-failed every legitimate empty response — of which
+there are many, because old archives no longer retain arbitrary daily as-of
+dates. `As of`, by contrast, echoed the requested date in 12 of 12 probes, with
+the single exception being the exact bug we were trying to catch.
+
+The derived program year had the same problem in a subtler form: for the #1342
+classic (a historical year fetched from the root path), the footer-derived year
+*agrees* with the request, because July > June rolls the year back. The check
+that looks like the primary defence catches nothing there; the as-of date is
+what fires.
+
+## The transferable bit
+
+An echoed request parameter is only a useful assertion if it is echoed the
+**same way in every response shape** — success, empty, error, edge case. Rank
+candidate fields by measured invariance, not by how well they describe the
+thing you care about. The semantically-richest field is often the one the
+server computes, and anything the server computes can vary with state you do
+not control.
+
+Concretely, before asserting on an upstream echo:
+
+1. Probe every response shape you can produce, including the empty and
+   error-adjacent ones. Six probes would have suggested `Month of` was fine.
+2. Tabulate which fields are byte-stable against the request across *all* of
+   them.
+3. Assert the invariant one. Keep the semantic one only as defence in depth,
+   and only with an explicit carve-out for the states where it legitimately
+   diverges — here, July, when the prior year's June close is still running.
+
+The failure mode you are avoiding is not a missed bug. It is a guard that
+hard-fails correct traffic, which gets weakened or removed the first time it
+blocks someone — and then catches nothing at all.
+
+## Also worth remembering
+
+`computeMonthEndDate()` returns the *previous* month's end (6/30/2026 for
+2026-07-26) despite a docstring promising a July special case that was never
+implemented. It happens not to matter, because the endpoint only checks that
+the month-end slot is **non-empty** — populated with the "wrong" value it
+returns byte-identical data. A parameter whose value is ignored but whose
+presence is load-bearing is worth a comment at the call site; nobody reading
+`monthEndDate: computeMonthEndDate(date)` would guess it.


### PR DESCRIPTION
Fixes the backfill path for #1384. **Code change plus proof only — nothing was written to GCS and no pipeline was run.** The ingest of 2026-07-26 → 07-29 is a separate, operator-approved step; a runbook is at the bottom.

## The bug

`BackfillOrchestrator` called `downloadCsv` at both sites without `pathStyle`, so `buildExportUrl` fell through to `/{programYear}/` — which does not exist for the live program year:

```
/2026-2027/export.aspx?…districtsummary~7/31/2026~7/26/2026~2026-2027  → HTTP 500
/export.aspx?…districtsummary~7/31/2026~7/26/2026~2026-2027            → HTTP 200
```

## How the Red state was proven

Two ways, because a network test does not belong in CI.

**Live**, against the real dashboard on 2026-08-02: the archive URL for the live year returns `HTTP 500 URL Rewrite Module Error.`

**In the suite**, `src/__tests__/fakes/dashboardExportSimulator.ts` — a simulator whose every rule was measured from 13 live probes. Tests route the *real* `buildExportUrl` output through it, so the URL the orchestrator actually builds is what decides pass/fail. At `d6cbeb55` (test-only commit) **5 of 6 failed**, each with `Phase 1: failed to download summary` for every date. The one that passed is the guard for the direction that must not change.

## What changed

- **`pathStyle` resolved per program year at both call sites**, once per run, memoised.
- **A year counts as root-only only after its archive path is asked for and refused.** Not simply "root is serving it" — during the July rollover root serves the *prior* year while that year keeps a working `/{PY}/`. Routing it to root would return zero rows for every historical date, skip them all, and exit 0. (Caught in review; see below.)
- **Every body is verified against the request that produced it** (`utils/backfillContentGuard.ts`). Mismatch → hard failure, never ingested. Zero data rows → skipped.
- **`--dates`** accepts an explicit `YYYY-MM-DD` list, because the smallest grid containing four specific days was a full year of daily requests.
- **`run()` returns a summary; the CLI exits non-zero on any mismatch.**

## What the footer assertion rejects

| condition | verdict |
|---|---|
| footer `As of` ≠ requested date | **mismatch** — hard failure |
| footer program year ≠ requested year (outside the July close window) | **mismatch** — hard failure |
| no footer, **live** path | **mismatch** — nothing pins the year there |
| no footer, **archive** path | accepted — the URL pins the year (old exports lack footers) |
| zero data rows | **skipped**, not ingested |

**The as-of date is the load-bearing axis, and this is the non-obvious part.** For the #1342 classic — a historical year fetched from the root — the footer-derived program year *agrees* with the request (Jul > Jun rolls the year back), so the year check catches nothing. Only the as-of date fires.

The `Month of` half of the footer is deliberately **not** asserted. It tracks the as-of month when data exists but echoes the requested month-end when the response is empty, so asserting it would hard-fail every legitimate empty response. That measurement is the lesson filed in `tasks/lessons/lessons/assert-the-echo-field-that-is-invariant-not-the-one-that-looks-semantic.md`.

## Proof that historical backfills are unchanged

This is the silent-history-rewrite direction, so it is pinned three ways.

1. **Byte-exact URL regression test** (`livePath.test.ts`) — a 2024-2025 backfill's first URL is asserted character-for-character, and every URL must carry the `/2024-2025/` prefix. This test passed *before* the fix and still passes.
2. **A purely historical range makes zero extra requests.** Verified live: `--dates 2024-12-25` logs `range is entirely historical`, skips the live probe, and issues 1 request total.
3. **The July carve-out.** `isPriorYearCloseWindow` excuses a prior-year footer only in the start year's July, where the prior year's June close is legitimately still running. Without it, every historical backfill's early-July dates would hard-fail.

Live spot check: `--dates 2026-03-15` → archive path, 128 districts (the old district list), footer `Month of Mar, As of 03/15/2026`.

## Round-trip proof

Re-fetching dates already held reproduces them **byte-for-byte**:

| date | expected | got | via |
|---|---|---|---|
| 2026-07-26 | `01ecb185` | `01ecb185` | `collector-cli backfill --dates …` |
| 2026-07-27 | `82ad2269` | `82ad2269` | `collector-cli backfill --dates …` |
| 2026-07-30 | `43a3d8b5` | `43a3d8b5` | direct fetch |
| 2026-07-31 | `4c200929` | `4c200929` | direct fetch |

07-26 / 07-27 were produced end-to-end by the fixed CLI writing to a temp dir, then `diff`ed against the independent captures: identical, no diff.

Also verified live: `--dates 2026-07-20` (TI dark window) → `no data rows`, **0 files written**.

## Fresh-context review

A `/review` pass **BLOCKED** the branch and was right to. Fixed in `1e95d269`:

- **The rollover regression above** — turning a loud 500 into a silent no-op. A test now reproduces it.
- **Mismatches never reached the exit code.** A run where every response was wrong exited 0.
- Live-year memo cached the value, not the promise → concurrent-phase race.
- `--dates ",,"` produced `Math.min(...[]) === Infinity`.

Accepted and **not** fixed, flagged for triage:

- **`--resume` re-fetches empty dates every run**, since skipping creates no storage key. Old archives return empty for many as-of dates, so a large historical re-run pays for them again. Correctness over resume cost; worth a follow-up if it bites.
- **Empty-skip turns downstream *skipped* districts into *failed* ones.** A header-only `club-performance.csv` used to reach `TransformService` as `success:true, skipped:true`; a missing file is now `success:false`. Behaviour change on the archive path, deliberate — writing a header-only CSV publishes a bogus snapshot under a real date.
- `scripts/backfill-raw-csv-for-dates.ts` still passes no `pathStyle` **and no `monthEndDate`**, so it would hit trap 2 head-on. It is out of scope here and superseded by `--dates`; it should be retired or fixed separately.

## Verification

- `npm run quality:check` — **exit 0**. 439 test files, 6007 tests, 0 lint errors.
- `npm run test:scripts` — **exit 0**. 26 files, 329 tests.
- `npm run build:collector-cli` after every source change (R16).
- collector-cli: 1025 tests at baseline → **1056** now, zero regressions.

One pre-existing fixture changed: `'some,csv,data\n'` → `'some,csv,data\n1,2,3\n'` in `BackfillOrchestrator.test.ts`. It was header-only and the guard now correctly reads it as empty. **Every assertion in that test is untouched** — it pins storage path shape, not content. The reviewer independently agreed this is a fixture fix, not assertion pinning.

## Runbook — operator-approved ingest of 2026-07-26 → 07-29

Not run. When approved:

```bash
# 1. Dry-run the shape first (2 requests, writes to a temp dir)
collector-cli backfill --dates 2026-07-26 --phase discover -o /tmp/bf-check -v
diff /tmp/bf-check/raw-csv/2026-07-26/all-districts.csv <verified capture>   # must be empty

# 2. The real thing — staging bucket, ~1,132 requests at 2 req/s (~10 min)
collector-cli backfill \
  --dates 2026-07-26,2026-07-27,2026-07-28,2026-07-29 \
  --gcs-bucket toast-stats-data-staging --gcs-prefix '' \
  --rate 2 --resume -v
```

Writes, per date, under `gs://toast-stats-data-staging/raw-csv/{date}/`:
`all-districts.csv`, `district-{id}/{club,division,district}-performance.csv` for all 94 districts, and `metadata.json` (no `isClosingPeriod` key — left undecided by design).

**Verify before promoting:**
- Exit code is 0. A non-zero exit means responses were refused — do not promote.
- Final line reads `mismatches=0`. Any mismatch means wrong-period data.
- `emptySkipped=0` for these four dates; all four have real data.
- `gsutil ls gs://…/raw-csv/2026-07-26/ | wc -l` → 96 (94 districts + all-districts.csv + metadata.json).
- Spot-check a footer: every CSV under `raw-csv/2026-07-2X/` must end `As of 07/2X/2026`.

Then transform → compute analytics → promote through the normal gated path. **Do not backfill 2026-07-01 → 07-25** — that is TI's dark window, not lost data; the collector now skips it, but do not ask for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoCZn3LeJX495jz4KdTQBh
