### PR TITLE
fix(test-infra): type the jest-axe shim's axe() options parameter — unreds main (#1389)

### DIFF
--- a/docs/design/820-tanstack-table-evaluation.md
+++ b/docs/design/820-tanstack-table-evaluation.md
@@ -1,0 +1,106 @@
+# #820 evaluation: shared table primitive vs. TanStack Table
+
+**Date:** 2026-05-27 · read-only spike, no code changed · ref `docs/design/table-ux-review-2026-05-27.md`
+**Trigger:** operator leaning toward adopting TanStack Table (option B) for the table program.
+
+---
+
+## The decisive finding: the two tables share ZERO code
+
+#820 was framed as "extract a shared primitive between the district landing table and
+the club table." The inventory kills that framing:
+
+|                | Club table (+ infra)                                                                                                               | Landing rankings table                                     | Shared       |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------ |
+| Implementation | ~1,940 LoC (`ClubsTable.tsx` + `useColumnFilters` + `columnFilterUtils` + `ColumnHeader` + filter components + #834 column-groups) | ~260 LoC bespoke `<th>`/`<td>` JSX in `DistrictsPage.tsx`  | **0 LoC**    |
+| Column model   | `COLUMN_CONFIGS` array, 13 cols (`filters/types.ts:146`)                                                                           | hardcoded JSX                                              | none         |
+| Sorting        | `SortField`+dir, switch comparator (`ClubsTable.tsx:209`)                                                                          | `sortBy` enum, inline comparator (`DistrictsPage.tsx:250`) | pattern only |
+| Filtering      | full pipeline, drawer, 3 filter types (~1,440 LoC)                                                                                 | region select + global search (~60 LoC)                    | none         |
+| Sticky         | semantic `STICKY_COLUMN_FIELD='name'`                                                                                              | CSS `left:0 / left:200px`                                  | none         |
+| Card view      | `ClubCard` at <640                                                                                                                 | none                                                       | none         |
+
+Epic A rebuilt the two tables **separately**, not onto a common model. So a bespoke
+**shared** primitive (#820's original "option A") is **not justified** — R6 (verify real
+overlap before abstracting): the overlap is essentially nil, and the two surfaces have
+very different jobs (rankings = simple read-only scan; club = filter-heavy, growing
+column set). Forcing a shared component would be a textbook premature abstraction.
+
+## TanStack Table fit (option B)
+
+TanStack Table v8: headless, framework-agnostic core + React adapter, **MIT**, maintained
+by the same org as the **TanStack Query already in our stack**, ~**9–15 KB gzip**
+(`@tanstack/react-table`). Passes the ron-sa dependency gate easily (maintained, MIT,
+right-sized, replaces >100 LoC of logic we'd otherwise own forever).
+
+**What it natively provides (and we currently hand-roll on the club table):**
+
+- ✅ Column model (`columnDef` / `createColumnHelper`) — replaces `COLUMN_CONFIGS` plumbing
+- ✅ Sorting (state + comparators) — replaces the switch comparator
+- ✅ **Column visibility** — this is _exactly_ what the in-flight #834 hand-rolls (a
+  `columnVisibility` state + persistence). TanStack gives it for free.
+- ✅ Column sizing, **column pinning** (sticky) — replaces ad-hoc CSS sticky
+- ✅ Faceted filtering helpers (`getFacetedRowModel` / `getFacetedUniqueValues` /
+  `getFacetedMinMaxValues`) — can power our count badges / quick-filter counts
+- ✅ Grouping/aggregation (column groups for headers)
+
+**What we still own (headless = no UI):**
+
+- Filter **UI** (the Filters drawer, Text/Numeric/Categorical components, quick-filter
+  row) — preserved; only the filter _state shape_ re-points at TanStack's filter state
+- Card view (<640), CSV export, search box, row click-through
+- The responsive **breakpoint→hide** logic from Epic A (TanStack gives the visibility
+  _state_; we still map breakpoints to it)
+
+## The reframed recommendation
+
+**Adopt TanStack Table for the CLUB table only. Do not build a shared primitive. Do not
+migrate the rankings table.**
+
+- **Club table:** TanStack removes/absorbs the column-model + sort + sizing + pinning
+  plumbing **and the entire #834 visibility/groups mechanism**, and makes #795's delta
+  columns trivial (just more `columnDef`s in a "Changes" group). Net ~40–50% reduction of
+  the club table's _structural_ (non-filter) code; the filter UI is preserved.
+- **Rankings table:** ~260 LoC of simple bespoke JSX, 0 shared surface, read-only, not
+  growing. Migrating it is churn with ~0 benefit (and would re-touch Epic A's work for
+  nothing). **Leave it bespoke.**
+
+This is the honest reading of #820: the answer is "neither extract a shared primitive nor
+keep hand-rolling — adopt a library, scoped to where the complexity actually lives."
+
+## Sequencing consequence (why holding #834 was right)
+
+#834 (C1) is hand-rolling `columnVisibility` + a groups menu + localStorage persistence —
+the precise thing TanStack provides. Merging it adds bespoke plumbing we'd immediately
+re-point. Recommended Epic C re-sequence:
+
+1. **Adopt TanStack on the club table** (migrate column model + sort + sizing + pinning;
+   keep the filter pipeline/drawer; keep card view). _New first sprint._
+2. **Column groups on TanStack visibility** — rebuild #834's group toggle on
+   `columnVisibility`; the menu UI + persistence survive, the bespoke plumbing is dropped.
+3. **#795 delta columns** as a "Changes" column group — now trivial.
+
+#834 disposition: **don't merge as-is.** Re-scope it to step 2 (keep its UI/persistence
+commits, drop the bespoke visibility state). Its branch is preserved on origin.
+
+## Migration cost / risk (honest)
+
+- **Re-touches Epic A's club-table column/sort work** (just shipped) — that plumbing gets
+  replaced by TanStack. A's _responsive card view_ and the _filter pipeline/drawer_ (Epic
+  B) largely survive. So it's a partial redo of A, not B.
+- **New dependency** — low risk (MIT, TanStack org, ~9–15 KB, mirrors TanStack Query).
+- **Learning/consistency** — one table on TanStack, one bespoke. Acceptable given the
+  rankings table is trivial; documented in the ADR so it's a deliberate split, not drift.
+- **ADR-006** (column-model standard) should be updated / superseded to record "club table
+  = TanStack; rankings = bespoke" as the standard.
+
+## Decisions to confirm
+
+1. Adopt TanStack Table — **club table only** (recommended) vs. both vs. don't adopt.
+2. Re-sequence Epic C to **adopt-first → groups on TanStack → delta columns**, and
+   **re-scope #834** (don't merge bespoke) vs. merge #834 then adopt later.
+
+## Sources
+
+- [@tanstack/react-table — Bundlephobia](https://bundlephobia.com/package/@tanstack/react-table)
+- [TanStack Table v8 — Introduction](https://tanstack.com/table/v8/docs/introduction)
+- [TanStack Table V9 roadmap (smaller core)](https://github.com/TanStack/table/discussions/5270)

--- a/docs/investigations/2026-07-09-district44-stale-vs-live-restatement.md
+++ b/docs/investigations/2026-07-09-district44-stale-vs-live-restatement.md
@@ -1,0 +1,154 @@
+# District 44 stale-vs-live discrepancy — upstream restatement, no internal bug
+
+**Date:** 2026-07-09 · **Type:** research-only investigation (no code changes)
+**Symptom:** `ts.taverns.red/district/44?date=2026-06-30` shows 125 clubs / 5,151 payments;
+the live TM dashboard shows 127 / 5,202. Delta = two late-June charters
+("Finer Women Speak", chartered 06/25, +30; "City of Refuge", chartered 06/29, +21).
+
+## Verdict
+
+**Pure upstream restatement lag. No internal aggregation bug.** Our snapshot is a
+faithful, internally consistent copy of the dashboard at crawl time
+(2026-07-09T09:03Z). TM mutated the June close **later the same day, under the
+same "As of 07/08/2026" stamp**. Self-heals on the next daily crawl; CPAA
+auto-promotes it. No code change warranted.
+
+---
+
+## Q1 — TM dashboard update cadence
+
+### "A day behind" — confirmed, with the precise mechanism
+
+- Our daily pipeline is triggered by a launchd job at **05:00 America/Toronto
+  (09:00 UTC)** (`.github/workflows/data-pipeline.yml:20-24`; GH cron was too
+  unreliable, #1242).
+- Today's run collected at **2026-07-09T09:03:04Z**
+  (`raw-csv/2026-07-08/metadata.json` → `timestamp: 1783587784114` =
+  2026-07-09T09:03:04Z) — yet the CSV footers read **"Month of Jun, As of
+  07/08/2026"**, so the collector keyed the crawl to `raw-csv/2026-07-08/`.
+- Mechanism: TM's overnight batch publishes data stamped with the **previous
+  business day's** as-of date. A crawl on day N always retrieves "As of N−1"
+  data. That is the exact sense in which "the dashboard is always a day behind."
+
+### The as-of stamp is NOT a content version (new finding)
+
+Fetched live at ~2026-07-09T15:30Z:
+
+```
+$ curl -s "https://dashboards.toastmasters.org/export.aspx?type=CSV&report=districtperformance~44~~~2025-2026" | tail -1
+Month of Jun, As of 07/08/2026
+```
+
+Same "As of 07/08/2026" stamp as our 09:03Z crawl — but the live export now has
+**127 club rows, Total-to-Date sum 5,202**, including both missing charters. Our
+09:03Z crawl of the identical endpoint got 125 / 5,151. **TM mutates the
+reporting data intraday during closing without advancing the as-of stamp.** Two
+crawls with identical footers can carry different data; content is settled only
+after the month formally closes.
+
+### The restatement window (from `docs/month-end-closing-dates.json`)
+
+Regular months close ~5–14 days into the next month. **June (program year end)
+stays open far longer** — late dues and late-processed charters are folded
+retroactively into the June close:
+
+| PY-end June | Closed on | Window  |
+| ----------- | --------- | ------- |
+| 2017-06     | 07-24     | 24 days |
+| 2018-06     | 07-23     | 23 days |
+| 2019-06     | 07-16     | 16 days |
+| 2020-06     | 07-12     | 12 days |
+| 2021-06     | 07-18     | 18 days |
+| 2022-06     | 07-25     | 25 days |
+| 2023-06     | 07-19     | 19 days |
+| 2024-06     | 07-19     | 19 days |
+| 2025-06     | 07-20     | 20 days |
+
+Expect **2026-06 to remain mutable until roughly July 16–25**. The dashboard's
+own banner ("reports … are not yet final") says the same. Charter date ≠
+processing date: our snapshot already contains **Dobbins Toastmasters (chartered
+2026-06-25)** and **LMLA C3 (2026-06-22)** — same charter week as the two
+missing clubs, but processed by TM before our crawl. "Finer Women Speak"
+(also chartered 06-25) was processed ~2 weeks after its charter date.
+
+## Q2 — No internal aggregation across crawl dates
+
+The user's "aggregating from multiple sources" suspicion is true only
+**within a single crawl**, never across dates:
+
+- `DataTransformer.transformRawCSV()`
+  (`packages/analytics-core/src/transformation/DataTransformer.ts:89-133`)
+  receives one `RawCSVData` (the three CSVs of **one** crawl of one district).
+  `extractClubs(clubPerformance, districtPerformance)` (line 105) merges payment
+  fields from district-performance into the club-performance club list — same
+  crawl, one club universe. Divisions, areas, **and totals are all derived from
+  that single merged clubs array** (lines 114-119, comment at 107-113, #1124).
+- `calculateTotals(clubs)` (lines 538-575): `totalClubs = clubs.length`,
+  `totalPayments = Σ club.paymentsCount`, distinguished tiers classified
+  per-club from the verbatim status column. **By construction, `clubs[]` and
+  `totals` cannot diverge** — there is no code path where a club appears in the
+  list but not in totals, or vice-versa.
+- `TransformService.transform()` (`packages/collector-cli`) is the single
+  district-loop (per the CLAUDE.md tripwire); `sourceCsvDate` is recorded at
+  `TransformService.ts:1083`. The closing remap re-keys the whole crawl
+  (raw-csv/2026-07-08 → snapshots/2026-06-30); it never splices two crawls.
+- `FindAClubMerger.mergeFacIntoSnapshot()` enriches existing clubs with FAC
+  metadata (address/coordinates) and stores FAC-only clubs **separately** as
+  `prospectiveClubs` (#489/#490) — it adds nothing to `clubs[]` or totals.
+- `ClubTrendsStore` / `TimeSeriesIndexWriter` are downstream accumulators
+  (sync → upsert → save); they never feed back into snapshots.
+
+## Q3 — Internal consistency of our 2026-06-30 snapshot: verified
+
+From `https://cdn.taverns.red/snapshots/2026-06-30/district_44.json`
+(prod CDN, `collectedAt: 2026-07-09T09:03:04.787Z` — today's run already
+refreshed this pinned snapshot):
+
+| Check                 | clubs[]                    | totals                   | Match              |
+| --------------------- | -------------------------- | ------------------------ | ------------------ |
+| Club count            | `len(clubs) = 125`         | `totalClubs = 125`       | ✓                  |
+| Payments              | `Σ paymentsCount = 5151`   | `totalPayments = 5151`   | ✓                  |
+| Membership            | `Σ membershipCount = 2350` | `totalMembership = 2350` | ✓                  |
+| Distinguished D/S/P/M | —                          | 22/11/9/17 (Σ=59)        | ✓ = live dashboard |
+
+Distinguished counts match live exactly because the two new charters carry no
+DCP status yet. Neither "City of Refuge" nor "Finer Women Speak" appears in
+`clubs[]` — absent from list **and** totals, consistently. Club status mix:
+115 Active / 6 Suspended / 4 Ineligible.
+
+## Q4 — Recommendation: no code change
+
+1. **Self-heals automatically.** Tomorrow's 09:00 UTC crawl (as-of 07/09) picks
+   up 127 clubs; the closing remap re-keys it onto `snapshots/2026-06-30`. The
+   CPAA promote policy after amendments #1092/#1289/#1292
+   (`docs/investigations/closing-period-promote-policy-2026-06-03.md`) treats
+   counter and base moves on closing-pinned dates as pure provenance — a +2-club
+   / +51-payment lump auto-promotes without operator action. This exact pattern
+   has promoted daily through 07-01…07-08.
+2. **The UX caveat already exists.** The normalized freshness pill (#1296,
+   #1310) shows an amber dot with "_June 2026 month-end reconciliation — figures
+   update daily until finalized. As of {date}_"
+   (`frontend/src/components/DataControlsBar.tsx:58`,
+   `frontend/src/utils/dataFreshness.ts`) whenever the viewed date is the
+   pinned latest month-end — which `?date=2026-06-30` currently is. We do not
+   present the June close as final.
+3. **One durable insight for epic #1319 (snapshot-date-guard):** the as-of
+   stamp is a _floor_, not a content version — identical `sourceCsvDate` on two
+   crawls does not imply identical data (proven today). Any future logic that
+   dedupes/short-circuits on "as-of unchanged" would be wrong during closing.
+   Worth a note on the epic; no sprint needed now.
+4. **Minor doc drift (optional chore):** `docs/data-pipeline-flow.md:25` still
+   says the daily mode is "Scheduled (08:00 + 11:00 UTC)"; the actual trigger is
+   the single external launchd dispatch at 05:00 Toronto (09:00 UTC), per the
+   workflow header. A second afternoon crawl during the closing window would
+   halve restatement staleness, but given the pill messaging and daily
+   self-heal, it is not warranted.
+
+## Evidence trail
+
+- `gsutil ls gs://toast-stats-data-staging/raw-csv/` → …07-06, 07-07, 07-08 (no 07-09; today's crawl keyed to 07-08 by its as-of footer)
+- `gsutil cat gs://toast-stats-data-staging/raw-csv/2026-07-08/metadata.json` → `date: 2026-07-08`, `timestamp: 2026-07-09T09:03:04Z`
+- `curl --compressed https://cdn.taverns.red/snapshots/2026-06-30/district_44.json` → totals/clubs verification above
+- Live export (2026-07-09 ~15:30Z): 127 rows, Σ 5,202, footer "Month of Jun, As of 07/08/2026", both charters present
+- `docs/month-end-closing-dates.json` — closing registry (ADR-011)
+- Lessons: `tasks/lessons/lessons/key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate.md` (recurrence #4 of the divergence class), `resolve-the-active-program-year-by-data-not-the-calendar.md`

--- a/docs/investigations/2026-07-27-current-py-not-showing.md
+++ b/docs/investigations/2026-07-27-current-py-not-showing.md
@@ -1,0 +1,140 @@
+---
+title: 'ts.taverns.red not showing current Program Year — 2026-07-27'
+tags: [program-year, cdn, gcs, closing-period, investigation]
+status: active
+created: 2026-07-27
+---
+
+# ts.taverns.red not showing current Program Year — 2026-07-27
+
+**Symptom reported:** site doesn't show PY 2026-2027 as current.
+**Type:** research-only investigation, no code changes.
+
+## Verdict
+
+**CDN is fresh and correctly mirrors the GCS bucket. The bucket has no PY
+2026-2027 data yet because TM has only just rolled its live dashboard over to
+July — this pipeline produces month-end snapshots only, so no 2026-07-31
+snapshot can exist until the July close finishes (historically ~12–25 days
+into August). The homepage/selector defaulting to PY 2025-2026 is correct,
+data-driven, by-design behavior.** However, there IS one real bug: the
+`/history` page renders a static "2026-27 · LIVE" chip computed from the
+calendar, disconnected from the fact that zero pages have any 2026-2027 data —
+this is the most likely source of the "not showing current PY" impression.
+
+## Q1 — Is the CDN fresh vs. the GCS bucket?
+
+Yes, exactly in sync, no CDN staleness:
+
+- `curl https://cdn.taverns.red/v1/latest.json` → `latestSnapshotDate:
+"2026-06-30"`, `generatedAt: "2026-07-27T21:29:43.337Z"` (today).
+- `gsutil ls gs://toast-stats-data-staging/snapshots/` → newest is
+  `2026-06-30/`.
+- `gsutil ls gs://toast-stats-data-ca/snapshots/` (= `GCS_BUCKET_PRODUCTION`,
+  the bucket the CDN url-map actually serves — see
+  `.github/workflows/data-pipeline.yml:88,1632-1661`) → newest is also
+  `2026-06-30/`.
+- Both buckets agree; the CDN manifest matches both. No promotion lag, no
+  CDN cache staleness.
+
+## Q2 — Why does the bucket itself stop at 2026-06-30?
+
+- `raw-csv/` in staging has a row for **every day through 2026-07-26**
+  (`gsutil ls gs://toast-stats-data-staging/raw-csv/` → …07-24, 07-25,
+  07-26) — the daily crawl is running, not stalled.
+- But `raw-csv/2026-07-26/metadata.json` records
+  `"programYear": "2025-2026", "isClosingPeriod": true, "dataMonth":
+"2026-06", "closingPeriodSource": "csv-footer"` — the collector correctly
+  detected, from the CSV footer, that TM's dashboard was **still serving June
+  closing data** at crawl time (09:00 UTC) on 07-26.
+  `gsutil cat gs://toast-stats-data-staging/raw-csv/2026-07-26/district-61/district-performance.csv
+| tail -1` → `"Month of Jun, As of 07/26/2026"`.
+- A live fetch of the same TM export **right now** (same day, later) —
+  `curl "https://dashboards.toastmasters.org/export.aspx?type=CSV&report=districtperformance~61~~~2026-2027"
+| tail -1` → `"Month of Jul, As of 07/26/2026"` — shows TM has since rolled
+  over to July, intraday, after our crawl. Same pattern documented in
+  [`2026-07-09-district44-stale-vs-live-restatement.md`](./2026-07-09-district44-stale-vs-live-restatement.md):
+  TM mutates content during closing without a stable version signal; a crawl
+  captures whatever TM happens to be serving at that instant.
+- **This pipeline only writes month-end snapshots** (`v1/dates.json` entries
+  are all `*-06-30`, `*-07-31`, … — no daily granularity for PY content).
+  Even once July data is consistently live on TM's side, there is no
+  `2026-07-31` snapshot until the July close **finishes**, which per
+  `docs/month-end-closing-dates.json` history has taken 12–25 days into the
+  following month for every recorded year. Expect the first PY 2026-2027 data
+  point (`2026-07-31`) to land roughly through mid-to-late August, not July.
+
+## Q3 — Is the frontend's "current Program Year" resolution correct?
+
+Traced with an Explore subagent (full paths verified):
+
+- `frontend/src/hooks/useDefaultProgramYear.ts:28-43` derives the default PY
+  from `getAvailableProgramYears(data.dates)[0]` — the newest PY with a real
+  snapshot — not the calendar. With the dates index maxing out at
+  `2026-06-30`, this correctly resolves to **2025-2026**.
+- `frontend/src/hooks/useProgramYearControls.ts:79-99` and
+  `frontend/src/pages/DistrictTrendsPage.tsx:64-93` self-heal any stale
+  `?py=` URL param back to `availableProgramYears[0]`.
+- `frontend/src/components/ProgramYearSelector.tsx:156-164` only renders
+  `<option>`s for years with data — **2026-2027 does not appear in the
+  dropdown at all**, by design.
+- This all matches the intentional fix documented in
+  [`resolve-the-active-program-year-by-data-not-the-calendar.md`](../../tasks/lessons/lessons/resolve-the-active-program-year-by-data-not-the-calendar.md).
+  **No bug here** — this is the collector-side lesson's frontend sibling,
+  already applied correctly.
+
+## Q4 — The one real bug found
+
+`frontend/src/pages/HistoryPage.tsx:6-8,21,45-47`:
+
+```ts
+import { getCurrentProgramYear, formatProgramYearShort } from '../utils/programYear'
+...
+const currentPY = getCurrentProgramYear()   // calendar-based, NOT data-driven
+...
+{formatProgramYearShort(currentPY.year)}
+<span className="history-page-year-chip__live">· LIVE</span>
+```
+
+`getCurrentProgramYear()` (`frontend/src/utils/programYear.ts:36-51`) is
+pure `new Date()` arithmetic (month ≥ 7 → PY started this calendar year) —
+the exact calendar-vs-data antipattern the collector-side lesson and the
+snapshot-date-guard epic (`tasks/epic-snapshot-date-guard.md`) already
+catalogued and fixed everywhere else. It renders a **"2026-27 · LIVE"**
+chip on `/history` right now, even though:
+
+- No page anywhere on the site has any 2026-2027 data.
+- The PY selector dropdown doesn't even list 2026-2027 as an option.
+- The chip is a `<span>`, not a link — clicking it does nothing.
+
+This predates the PY-selector epic (introduced in `dbf6b0c0`, well before the
+data-driven-default work in `e42675be`/`089c2f0a`/`cc6a19eb`) and was never
+swept up by it. It's the one surface on the site that visually "announces" PY
+2026-2027 while every other page silently and correctly stays on 2025-2026 —
+plausibly the exact thing a user notices and reads as "not showing the
+current Program Year."
+
+## Recommendation
+
+Not a data-freshness bug, not a CDN bug. One small frontend fix warranted:
+`HistoryPage.tsx`'s "current/LIVE" chip should source its year from the same
+data-driven default (`useDefaultProgramYear`) as the rest of the site, or be
+relabeled to something like "2026-27 (starts here once data lands)" so it
+doesn't imply live content that doesn't exist. Small, single-file,
+`useDefaultProgramYear` already exists — Lightweight DoD scope.
+
+## Evidence trail
+
+- `curl --compressed https://cdn.taverns.red/v1/latest.json`
+- `gsutil ls gs://toast-stats-data-staging/{raw-csv,snapshots}/`
+- `gsutil ls gs://toast-stats-data-ca/{raw-csv,snapshots}/`
+- `gsutil cat gs://toast-stats-data-staging/raw-csv/2026-07-26/metadata.json`
+- `gsutil cat gs://toast-stats-data-staging/raw-csv/2026-07-26/district-61/district-performance.csv`
+- `curl "https://dashboards.toastmasters.org/export.aspx?type=CSV&report=districtperformance~61~~~2026-2027"`
+- `.github/workflows/data-pipeline.yml:88,1632-1661` (bucket roles, promotion, CDN invalidation)
+- `frontend/src/hooks/useDefaultProgramYear.ts`, `useProgramYearControls.ts`,
+  `components/ProgramYearSelector.tsx`, `pages/HistoryPage.tsx`,
+  `utils/programYear.ts`
+- Related lessons: `tasks/lessons/lessons/resolve-the-active-program-year-by-data-not-the-calendar.md`,
+  `tasks/epic-snapshot-date-guard.md`,
+  `docs/investigations/2026-07-09-district44-stale-vs-live-restatement.md`

--- a/elite-clubs-10yr.html
+++ b/elite-clubs-10yr.html
@@ -1,0 +1,368 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Elite Toastmasters Clubs — 10-Year Track Record</title>
+<style>
+  :root { --ink:#1a1a2e; --paper:#faf9f7; --line:#e6e2da; --amber:#D4873F; --muted:#8a8577; }
+  * { box-sizing:border-box; }
+  body { margin:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,sans-serif;
+    color:var(--ink); background:var(--paper); line-height:1.5; }
+  header { padding:32px 28px 16px; max-width:1200px; margin:0 auto; }
+  h1 { font-size:1.7rem; margin:0 0 6px; letter-spacing:-0.02em; }
+  .sub { color:var(--muted); font-size:.92rem; }
+  .crit { margin:14px 0 0; padding:12px 16px; background:#fff; border:1px solid var(--line);
+    border-left:3px solid var(--amber); border-radius:8px; font-size:.88rem; }
+  .crit b { color:var(--amber); }
+  .wrap { max-width:1200px; margin:8px auto 40px; padding:0 28px; overflow-x:auto; }
+  table { border-collapse:collapse; width:100%; font-size:.86rem; background:#fff;
+    border:1px solid var(--line); border-radius:10px; overflow:hidden; }
+  th,td { padding:8px 10px; text-align:left; border-bottom:1px solid var(--line); white-space:nowrap; }
+  thead th { background:#f2efe9; font-weight:600; position:sticky; top:0; font-size:.78rem;
+    text-transform:uppercase; letter-spacing:.03em; color:#5a5648; }
+  .num { text-align:right; font-variant-numeric:tabular-nums; }
+  .name { white-space:normal; min-width:220px; font-weight:500; }
+  .muted { color:var(--muted); }
+  tbody tr:hover { background:#fbf7f0; }
+  a { color:var(--amber); text-decoration:none; font-weight:600; }
+  a:hover { text-decoration:underline; }
+  .yrgrp { text-align:center; }
+  footer { max-width:1200px; margin:0 auto 40px; padding:0 28px; color:var(--muted); font-size:.8rem; }
+</style></head>
+<body>
+<header>
+  <h1>Elite Toastmasters Clubs &mdash; 10-Year Track Record</h1>
+  <div class="sub">35 clubs worldwide, sourced from Toast Stats snapshots (ts.taverns.red).</div>
+  <div class="crit">Every club below had <b>&ge;30 members</b> <b>and all 10 DCP goals</b> in
+    <b>each</b> of the last 10 program years (year-ends June&nbsp;30, 2017&ndash;2026 &middot; PY&nbsp;2016&#8209;17 through 2025&#8209;26).
+    Membership columns show year-end members per program year. &nbsp;<i>Caveat:</i> the 2017/2018 snapshots
+    cover 103/107 districts (vs 128+ today), so elite clubs in districts not yet captured then are not included &mdash; this list is a floor.</div>
+</header>
+<div class="wrap">
+<table>
+<thead><tr>
+  <th class="num">#</th><th class="num">Dist</th><th class="num">Club&nbsp;#</th><th>Club</th>
+  <th class='num'>'17</th><th class='num'>'18</th><th class='num'>'19</th><th class='num'>'20</th><th class='num'>'21</th><th class='num'>'22</th><th class='num'>'23</th><th class='num'>'24</th><th class='num'>'25</th><th class='num'>'26</th>
+  <th>Toast&nbsp;Stats</th><th>Find&#8209;a&#8209;Club</th>
+</tr></thead>
+<tbody>
+<tr>
+      <td class="num muted">1</td>
+      <td class="num">03</td>
+      <td class="num">499</td>
+      <td class="name">Gilbert Toastmasters Club</td>
+      <td class="num">46</td><td class="num">49</td><td class="num">42</td><td class="num">38</td><td class="num">38</td><td class="num">39</td><td class="num">51</td><td class="num">48</td><td class="num">47</td><td class="num">42</td>
+      <td><a href="https://ts.taverns.red/district/03/club/00000499/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/499" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">2</td>
+      <td class="num">05</td>
+      <td class="num">7</td>
+      <td class="name">San Diego Toastmasters 7</td>
+      <td class="num">47</td><td class="num">40</td><td class="num">53</td><td class="num">37</td><td class="num">30</td><td class="num">50</td><td class="num">56</td><td class="num">58</td><td class="num">56</td><td class="num">60</td>
+      <td><a href="https://ts.taverns.red/district/05/club/00000007/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/7" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">3</td>
+      <td class="num">41</td>
+      <td class="num">3936</td>
+      <td class="name">Toastmasters Club of New Delhi</td>
+      <td class="num">41</td><td class="num">44</td><td class="num">51</td><td class="num">35</td><td class="num">35</td><td class="num">31</td><td class="num">39</td><td class="num">37</td><td class="num">45</td><td class="num">44</td>
+      <td><a href="https://ts.taverns.red/district/41/club/00003936/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/3936" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">4</td>
+      <td class="num">46</td>
+      <td class="num">1949</td>
+      <td class="name">New York Toastmasters Club</td>
+      <td class="num">64</td><td class="num">74</td><td class="num">72</td><td class="num">80</td><td class="num">76</td><td class="num">70</td><td class="num">81</td><td class="num">78</td><td class="num">92</td><td class="num">95</td>
+      <td><a href="https://ts.taverns.red/district/46/club/00001949/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1949" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">5</td>
+      <td class="num">46</td>
+      <td class="num">2895</td>
+      <td class="name">Bryant Park Toastmasters Club</td>
+      <td class="num">63</td><td class="num">59</td><td class="num">60</td><td class="num">61</td><td class="num">57</td><td class="num">51</td><td class="num">45</td><td class="num">38</td><td class="num">35</td><td class="num">30</td>
+      <td><a href="https://ts.taverns.red/district/46/club/00002895/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/2895" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">6</td>
+      <td class="num">46</td>
+      <td class="num">3890961</td>
+      <td class="name">Columbia University Toastmasters Club</td>
+      <td class="num">48</td><td class="num">53</td><td class="num">83</td><td class="num">68</td><td class="num">59</td><td class="num">60</td><td class="num">57</td><td class="num">37</td><td class="num">55</td><td class="num">76</td>
+      <td><a href="https://ts.taverns.red/district/46/club/03890961/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/3890961" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">7</td>
+      <td class="num">47</td>
+      <td class="num">1600</td>
+      <td class="name">First Bahamas Branch of Toastmasters</td>
+      <td class="num">48</td><td class="num">62</td><td class="num">39</td><td class="num">69</td><td class="num">55</td><td class="num">41</td><td class="num">102</td><td class="num">84</td><td class="num">78</td><td class="num">54</td>
+      <td><a href="https://ts.taverns.red/district/47/club/00001600/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1600" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">8</td>
+      <td class="num">47</td>
+      <td class="num">7178</td>
+      <td class="name">Healing Communicators Club</td>
+      <td class="num">58</td><td class="num">62</td><td class="num">54</td><td class="num">53</td><td class="num">54</td><td class="num">47</td><td class="num">81</td><td class="num">84</td><td class="num">77</td><td class="num">68</td>
+      <td><a href="https://ts.taverns.red/district/47/club/00007178/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/7178" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">9</td>
+      <td class="num">67</td>
+      <td class="num">9295</td>
+      <td class="name">Legacy</td>
+      <td class="num">43</td><td class="num">36</td><td class="num">36</td><td class="num">34</td><td class="num">37</td><td class="num">35</td><td class="num">43</td><td class="num">44</td><td class="num">39</td><td class="num">41</td>
+      <td><a href="https://ts.taverns.red/district/67/club/00009295/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/9295" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">10</td>
+      <td class="num">80</td>
+      <td class="num">8531</td>
+      <td class="name">SCCCI Mandarin Club</td>
+      <td class="num">53</td><td class="num">48</td><td class="num">64</td><td class="num">39</td><td class="num">39</td><td class="num">46</td><td class="num">40</td><td class="num">50</td><td class="num">55</td><td class="num">51</td>
+      <td><a href="https://ts.taverns.red/district/80/club/00008531/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/8531" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">11</td>
+      <td class="num">80</td>
+      <td class="num">9104</td>
+      <td class="name">SRC Toastmasters Club</td>
+      <td class="num">63</td><td class="num">60</td><td class="num">54</td><td class="num">52</td><td class="num">52</td><td class="num">56</td><td class="num">52</td><td class="num">60</td><td class="num">53</td><td class="num">52</td>
+      <td><a href="https://ts.taverns.red/district/80/club/00009104/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/9104" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">12</td>
+      <td class="num">80</td>
+      <td class="num">9165</td>
+      <td class="name">Tampines Changkat Toastmasters</td>
+      <td class="num">62</td><td class="num">71</td><td class="num">71</td><td class="num">67</td><td class="num">62</td><td class="num">61</td><td class="num">70</td><td class="num">80</td><td class="num">66</td><td class="num">61</td>
+      <td><a href="https://ts.taverns.red/district/80/club/00009165/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/9165" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">13</td>
+      <td class="num">80</td>
+      <td class="num">670365</td>
+      <td class="name">NTU Alumni Toastmasters Club</td>
+      <td class="num">41</td><td class="num">41</td><td class="num">37</td><td class="num">46</td><td class="num">41</td><td class="num">44</td><td class="num">38</td><td class="num">40</td><td class="num">41</td><td class="num">43</td>
+      <td><a href="https://ts.taverns.red/district/80/club/00670365/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/670365" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">14</td>
+      <td class="num">80</td>
+      <td class="num">691812</td>
+      <td class="name">AIA Toastmasters Club</td>
+      <td class="num">48</td><td class="num">33</td><td class="num">44</td><td class="num">32</td><td class="num">35</td><td class="num">34</td><td class="num">40</td><td class="num">36</td><td class="num">53</td><td class="num">55</td>
+      <td><a href="https://ts.taverns.red/district/80/club/00691812/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/691812" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">15</td>
+      <td class="num">82</td>
+      <td class="num">918672</td>
+      <td class="name">Ralph Toastmasters Club</td>
+      <td class="num">46</td><td class="num">53</td><td class="num">52</td><td class="num">52</td><td class="num">57</td><td class="num">58</td><td class="num">56</td><td class="num">50</td><td class="num">49</td><td class="num">49</td>
+      <td><a href="https://ts.taverns.red/district/82/club/00918672/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/918672" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">16</td>
+      <td class="num">82</td>
+      <td class="num">1355969</td>
+      <td class="name">AATSL Toastmasters Club</td>
+      <td class="num">36</td><td class="num">40</td><td class="num">46</td><td class="num">46</td><td class="num">51</td><td class="num">35</td><td class="num">36</td><td class="num">31</td><td class="num">38</td><td class="num">31</td>
+      <td><a href="https://ts.taverns.red/district/82/club/01355969/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1355969" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">17</td>
+      <td class="num">82</td>
+      <td class="num">3598897</td>
+      <td class="name">Awakening Toastmasters</td>
+      <td class="num">43</td><td class="num">47</td><td class="num">49</td><td class="num">51</td><td class="num">51</td><td class="num">51</td><td class="num">56</td><td class="num">56</td><td class="num">56</td><td class="num">56</td>
+      <td><a href="https://ts.taverns.red/district/82/club/03598897/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/3598897" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">18</td>
+      <td class="num">85</td>
+      <td class="num">996251</td>
+      <td class="name">1st Bilingual Zhangjiang</td>
+      <td class="num">44</td><td class="num">47</td><td class="num">41</td><td class="num">37</td><td class="num">33</td><td class="num">33</td><td class="num">38</td><td class="num">43</td><td class="num">38</td><td class="num">38</td>
+      <td><a href="https://ts.taverns.red/district/85/club/00996251/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/996251" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">19</td>
+      <td class="num">85</td>
+      <td class="num">1015193</td>
+      <td class="name">Lighthouse Shanghai Toastmasters Club</td>
+      <td class="num">40</td><td class="num">40</td><td class="num">39</td><td class="num">41</td><td class="num">38</td><td class="num">32</td><td class="num">33</td><td class="num">31</td><td class="num">59</td><td class="num">37</td>
+      <td><a href="https://ts.taverns.red/district/85/club/01015193/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1015193" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">20</td>
+      <td class="num">87</td>
+      <td class="num">6622</td>
+      <td class="name">Kuching Mandarin Toastmasters Club</td>
+      <td class="num">38</td><td class="num">36</td><td class="num">36</td><td class="num">37</td><td class="num">35</td><td class="num">33</td><td class="num">35</td><td class="num">32</td><td class="num">34</td><td class="num">33</td>
+      <td><a href="https://ts.taverns.red/district/87/club/00006622/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/6622" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">21</td>
+      <td class="num">90</td>
+      <td class="num">2274</td>
+      <td class="name">Parramatta Club</td>
+      <td class="num">66</td><td class="num">65</td><td class="num">68</td><td class="num">64</td><td class="num">51</td><td class="num">45</td><td class="num">43</td><td class="num">48</td><td class="num">50</td><td class="num">52</td>
+      <td><a href="https://ts.taverns.red/district/90/club/00002274/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/2274" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">22</td>
+      <td class="num">92</td>
+      <td class="num">1766</td>
+      <td class="name">Daffodils Toastmasters Club</td>
+      <td class="num">57</td><td class="num">63</td><td class="num">67</td><td class="num">66</td><td class="num">75</td><td class="num">55</td><td class="num">52</td><td class="num">49</td><td class="num">43</td><td class="num">38</td>
+      <td><a href="https://ts.taverns.red/district/92/club/00001766/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1766" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">23</td>
+      <td class="num">92</td>
+      <td class="num">9496</td>
+      <td class="name">LA Nineteen Twenty-Four Club</td>
+      <td class="num">40</td><td class="num">43</td><td class="num">40</td><td class="num">39</td><td class="num">48</td><td class="num">45</td><td class="num">43</td><td class="num">47</td><td class="num">43</td><td class="num">46</td>
+      <td><a href="https://ts.taverns.red/district/92/club/00009496/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/9496" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">24</td>
+      <td class="num">98</td>
+      <td class="num">1246728</td>
+      <td class="name">Mulund Toastmasters Club</td>
+      <td class="num">73</td><td class="num">72</td><td class="num">61</td><td class="num">72</td><td class="num">60</td><td class="num">57</td><td class="num">75</td><td class="num">78</td><td class="num">87</td><td class="num">84</td>
+      <td><a href="https://ts.taverns.red/district/98/club/01246728/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1246728" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">25</td>
+      <td class="num">105</td>
+      <td class="num">1118594</td>
+      <td class="name">Khimji Toastmasters</td>
+      <td class="num">46</td><td class="num">45</td><td class="num">51</td><td class="num">48</td><td class="num">40</td><td class="num">40</td><td class="num">44</td><td class="num">30</td><td class="num">33</td><td class="num">30</td>
+      <td><a href="https://ts.taverns.red/district/105/club/01118594/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1118594" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">26</td>
+      <td class="num">116</td>
+      <td class="num">7148</td>
+      <td class="name">Doha Toastmasters Club</td>
+      <td class="num">57</td><td class="num">59</td><td class="num">42</td><td class="num">59</td><td class="num">45</td><td class="num">48</td><td class="num">46</td><td class="num">58</td><td class="num">52</td><td class="num">57</td>
+      <td><a href="https://ts.taverns.red/district/116/club/00007148/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/7148" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">27</td>
+      <td class="num">116</td>
+      <td class="num">727851</td>
+      <td class="name">Indian Club Toastmasters</td>
+      <td class="num">52</td><td class="num">56</td><td class="num">46</td><td class="num">47</td><td class="num">45</td><td class="num">41</td><td class="num">41</td><td class="num">42</td><td class="num">42</td><td class="num">46</td>
+      <td><a href="https://ts.taverns.red/district/116/club/00727851/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/727851" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">28</td>
+      <td class="num">120</td>
+      <td class="num">1128480</td>
+      <td class="name">Medley Toastmasters Club</td>
+      <td class="num">78</td><td class="num">72</td><td class="num">53</td><td class="num">48</td><td class="num">44</td><td class="num">44</td><td class="num">45</td><td class="num">57</td><td class="num">59</td><td class="num">57</td>
+      <td><a href="https://ts.taverns.red/district/120/club/01128480/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1128480" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">29</td>
+      <td class="num">120</td>
+      <td class="num">1363550</td>
+      <td class="name">Madras Toastmasters Club</td>
+      <td class="num">50</td><td class="num">70</td><td class="num">86</td><td class="num">55</td><td class="num">53</td><td class="num">39</td><td class="num">38</td><td class="num">42</td><td class="num">40</td><td class="num">42</td>
+      <td><a href="https://ts.taverns.red/district/120/club/01363550/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1363550" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">30</td>
+      <td class="num">121</td>
+      <td class="num">585650</td>
+      <td class="name">Mangalore Club</td>
+      <td class="num">42</td><td class="num">46</td><td class="num">44</td><td class="num">44</td><td class="num">44</td><td class="num">46</td><td class="num">43</td><td class="num">40</td><td class="num">33</td><td class="num">33</td>
+      <td><a href="https://ts.taverns.red/district/121/club/00585650/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/585650" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">31</td>
+      <td class="num">121</td>
+      <td class="num">691074</td>
+      <td class="name">Kochi Club</td>
+      <td class="num">50</td><td class="num">53</td><td class="num">55</td><td class="num">47</td><td class="num">53</td><td class="num">41</td><td class="num">50</td><td class="num">60</td><td class="num">52</td><td class="num">51</td>
+      <td><a href="https://ts.taverns.red/district/121/club/00691074/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/691074" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">32</td>
+      <td class="num">125</td>
+      <td class="num">1141787</td>
+      <td class="name">Toastmasters Club of Pune</td>
+      <td class="num">47</td><td class="num">53</td><td class="num">54</td><td class="num">49</td><td class="num">40</td><td class="num">40</td><td class="num">39</td><td class="num">45</td><td class="num">36</td><td class="num">55</td>
+      <td><a href="https://ts.taverns.red/district/125/club/01141787/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1141787" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">33</td>
+      <td class="num">125</td>
+      <td class="num">1543586</td>
+      <td class="name">Toastmasters Club of Pune South East</td>
+      <td class="num">44</td><td class="num">53</td><td class="num">55</td><td class="num">52</td><td class="num">46</td><td class="num">41</td><td class="num">39</td><td class="num">50</td><td class="num">49</td><td class="num">49</td>
+      <td><a href="https://ts.taverns.red/district/125/club/01543586/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/1543586" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">34</td>
+      <td class="num">125</td>
+      <td class="num">4421153</td>
+      <td class="name">Toastmasters Club of Pune North West</td>
+      <td class="num">79</td><td class="num">81</td><td class="num">63</td><td class="num">42</td><td class="num">43</td><td class="num">35</td><td class="num">32</td><td class="num">30</td><td class="num">41</td><td class="num">39</td>
+      <td><a href="https://ts.taverns.red/district/125/club/04421153/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/4421153" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+<tr>
+      <td class="num muted">35</td>
+      <td class="num">130</td>
+      <td class="num">670876</td>
+      <td class="name">Ouaga Forum Toastmasters Club</td>
+      <td class="num">36</td><td class="num">51</td><td class="num">59</td><td class="num">33</td><td class="num">51</td><td class="num">51</td><td class="num">49</td><td class="num">40</td><td class="num">52</td><td class="num">34</td>
+      <td><a href="https://ts.taverns.red/district/130/club/00670876/history" target="_blank" rel="noopener">History &#8599;</a></td>
+      <td><a href="https://www.toastmasters.org/find-a-club/670876" target="_blank" rel="noopener">Find&#8209;a&#8209;Club &#8599;</a></td>
+    </tr>
+</tbody></table>
+</div>
+<footer>Membership = year-end <code>membershipCount</code>; DCP goals = all 10 achieved (<code>dcpGoals=10</code>).
+Toast Stats links open each club's full multi-year history; Find-a-Club links open the official Toastmasters International club page.
+Generated from prod CDN snapshots.</footer>
+</body></html>

--- a/frontend/src/__tests__/accessibility/DistrictsPage.loaded.axe.test.tsx
+++ b/frontend/src/__tests__/accessibility/DistrictsPage.loaded.axe.test.tsx
@@ -27,7 +27,6 @@ import DistrictsPage from '../../pages/DistrictsPage'
 import { fetchCdnRankings, fetchCdnCompetitiveAwards } from '../../services/cdn'
 import { renderWithProviders } from '../test-utils'
 
-// @ts-expect-error - jest-axe matcher types vs vitest expect
 expect.extend(toHaveNoViolations)
 
 // A full-page mount plus a whole-tree axe walk. Same honest categorization as

--- a/frontend/src/types/jest-axe.d.ts
+++ b/frontend/src/types/jest-axe.d.ts
@@ -1,5 +1,17 @@
 declare module 'jest-axe' {
-  export function axe(element: Element | Document): Promise<unknown>
+  /**
+   * `axe(container, options)` — the second parameter is axe-core's run
+   * options, which call sites use to scope a scan to specific rules
+   * (`{ runOnly: { type: 'rule', values: ['aria-allowed-attr'] } }`, #1360).
+   *
+   * It was declared with a single parameter until #1389. The test tree was
+   * excluded from tsc, so the arity was never checked against a real call —
+   * the same blind spot that hid the `toHaveNoViolations` shape below.
+   */
+  export function axe(
+    element: Element | Document,
+    options?: Record<string, unknown>
+  ): Promise<unknown>
 
   /**
    * jest-axe's export is a matchers OBJECT — `{ toHaveNoViolations }` — which

--- a/scratch-artifacts/elite-clubs.html
+++ b/scratch-artifacts/elite-clubs.html
@@ -1,0 +1,488 @@
+<title>Elite Toastmasters Clubs — 10-Year Track Record</title>
+<style>
+  :root {
+    --paper:#FBF8F3; --card:#FFFFFF; --ink:#24201B; --muted:#8B8373;
+    --line:#E9E2D6; --line-soft:#F1EBE0; --amber:#C97A34; --amber-ink:#9A5A1E;
+    --amber-wash:#FBEEDD;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--paper); color:var(--ink);
+    font-family:"Helvetica Neue",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    -webkit-font-smoothing:antialiased; line-height:1.5; }
+  .shell { max-width:1180px; margin:0 auto; padding:clamp(28px,5vw,60px) clamp(18px,4vw,40px) 64px; }
+
+  .eyebrow { font-size:.72rem; font-weight:700; letter-spacing:.18em; text-transform:uppercase;
+    color:var(--amber-ink); margin:0 0 14px; }
+  h1 { font-size:clamp(2rem,5.2vw,3.4rem); line-height:1.02; letter-spacing:-.03em; font-weight:800;
+    margin:0; text-wrap:balance; max-width:16ch; }
+  .thesis { margin:18px 0 0; max-width:60ch; font-size:1.02rem; color:#4c463c; }
+  .thesis b { color:var(--amber-ink); font-weight:700; }
+
+  .stats { display:flex; flex-wrap:wrap; gap:0; margin:30px 0 8px; border:1px solid var(--line);
+    border-radius:12px; overflow:hidden; background:var(--card); }
+  .stat { flex:1 1 130px; padding:16px 20px; border-right:1px solid var(--line-soft); }
+  .stat:last-child { border-right:0; }
+  .stat .n { font-size:1.8rem; font-weight:800; letter-spacing:-.02em; font-variant-numeric:tabular-nums; }
+  .stat .l { font-size:.74rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); margin-top:2px; }
+
+  .tablecard { margin-top:26px; background:var(--card); border:1px solid var(--line); border-radius:14px;
+    overflow:hidden; }
+  .scroll { overflow-x:auto; }
+  table { border-collapse:collapse; width:100%; font-size:.85rem; }
+  thead th { position:sticky; top:0; background:#F5F0E7; color:#6b6455; z-index:2;
+    font-size:.68rem; font-weight:700; text-transform:uppercase; letter-spacing:.07em;
+    padding:12px 9px; text-align:left; white-space:nowrap; border-bottom:1px solid var(--line); }
+  tbody td { padding:9px; border-bottom:1px solid var(--line-soft); white-space:nowrap; vertical-align:middle; }
+  tbody tr:last-child td { border-bottom:0; }
+  tbody tr:hover { background:#FCF6EC; }
+
+  .rank, .yr, .cnum, .dist, .lo, .hi { font-variant-numeric:tabular-nums; text-align:right;
+    font-family:ui-monospace,"SF Mono",Menlo,monospace; }
+  th.yr { text-align:right; }
+  .rank { color:var(--muted); font-size:.78rem; }
+  .dist { font-weight:600; }
+  .dist::before { content:"D"; color:var(--muted); font-weight:400; }
+  .cnum { color:#57503f; }
+  .club { white-space:normal; min-width:210px; font-weight:600; letter-spacing:-.005em; }
+  .yr { color:#4c463c; padding-left:7px; padding-right:7px; }
+  .lo { color:var(--muted); } .hi { color:var(--amber-ink); font-weight:700; }
+  .trend { width:104px; }
+  .spark { display:block; }
+
+  .lk a { display:inline-block; padding:4px 11px; border:1px solid var(--line); border-radius:999px;
+    font-size:.76rem; font-weight:600; color:var(--amber-ink); text-decoration:none;
+    background:#fff; transition:background .12s,border-color .12s; white-space:nowrap; }
+  .lk a:hover { background:var(--amber-wash); border-color:var(--amber); }
+  .lk a:focus-visible { outline:2px solid var(--amber); outline-offset:2px; }
+
+  .foot { margin-top:22px; color:var(--muted); font-size:.8rem; max-width:70ch; }
+  .foot b { color:#57503f; }
+  @media (prefers-reduced-motion:reduce) { * { transition:none !important; } }
+</style>
+
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#C97A34" stop-opacity="0.22"/>
+    <stop offset="1" stop-color="#C97A34" stop-opacity="0"/>
+  </linearGradient>
+</defs></svg>
+
+<div class="shell">
+  <p class="eyebrow">Toastmasters International &middot; A Decade of Excellence</p>
+  <h1>Clubs that never missed a beat.</h1>
+  <p class="thesis">Every club here held <b>30 or more members</b> and achieved <b>all 10
+    Distinguished&nbsp;Club&nbsp;Program goals</b> in <b>every one</b> of the last ten program years
+    &mdash; year-ends June&nbsp;30, 2017 through 2026 (PY&nbsp;2016&#8209;17 &rarr; 2025&#8209;26). A perfect
+    ten-for-ten decade.</p>
+
+  <div class="stats">
+    <div class="stat"><div class="n">35</div><div class="l">Clubs worldwide</div></div>
+    <div class="stat"><div class="n">10</div><div class="l">Program years, unbroken</div></div>
+    <div class="stat"><div class="n">19</div><div class="l">Districts</div></div>
+    <div class="stat"><div class="n">5</div><div class="l">Continents</div></div>
+  </div>
+
+  <div class="tablecard"><div class="scroll">
+  <table>
+    <thead><tr>
+      <th class="rank">#</th><th>10-yr trend</th><th class="dist">Dist</th><th class="cnum">Club&nbsp;#</th>
+      <th>Club</th><th class='yr'>&rsquo;17</th><th class='yr'>&rsquo;18</th><th class='yr'>&rsquo;19</th><th class='yr'>&rsquo;20</th><th class='yr'>&rsquo;21</th><th class='yr'>&rsquo;22</th><th class='yr'>&rsquo;23</th><th class='yr'>&rsquo;24</th><th class='yr'>&rsquo;25</th><th class='yr'>&rsquo;26</th><th class="lo">Low</th><th class="hi">Peak</th>
+      <th>Toast&nbsp;Stats</th><th>Find-a-Club</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+      <td class="rank">1</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,10.7 L13.9,6.1 L24.8,16.8 L35.7,23.0 L46.6,23.0 L57.4,21.5 L68.3,3.0 L79.2,7.6 L90.1,9.2 L101.0,16.8 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,10.7 L13.9,6.1 L24.8,16.8 L35.7,23.0 L46.6,23.0 L57.4,21.5 L68.3,3.0 L79.2,7.6 L90.1,9.2 L101.0,16.8" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="16.8" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">03</td>
+      <td class="cnum">499</td>
+      <td class="club">Gilbert Toastmasters Club</td>
+      <td class="yr">46</td><td class="yr">49</td><td class="yr">42</td><td class="yr">38</td><td class="yr">38</td><td class="yr">39</td><td class="yr">51</td><td class="yr">48</td><td class="yr">47</td><td class="yr">42</td>
+      <td class="lo">38</td><td class="hi">51</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/03/club/00000499/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/499" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">2</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,11.7 L13.9,16.3 L24.8,7.7 L35.7,18.3 L46.6,23.0 L57.4,9.7 L68.3,5.7 L79.2,4.3 L90.1,5.7 L101.0,3.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,11.7 L13.9,16.3 L24.8,7.7 L35.7,18.3 L46.6,23.0 L57.4,9.7 L68.3,5.7 L79.2,4.3 L90.1,5.7 L101.0,3.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="3.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">05</td>
+      <td class="cnum">7</td>
+      <td class="club">San Diego Toastmasters 7</td>
+      <td class="yr">47</td><td class="yr">40</td><td class="yr">53</td><td class="yr">37</td><td class="yr">30</td><td class="yr">50</td><td class="yr">56</td><td class="yr">58</td><td class="yr">56</td><td class="yr">60</td>
+      <td class="lo">30</td><td class="hi">60</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/05/club/00000007/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/7" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">3</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,13.0 L13.9,10.0 L24.8,3.0 L35.7,19.0 L46.6,19.0 L57.4,23.0 L68.3,15.0 L79.2,17.0 L90.1,9.0 L101.0,10.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,13.0 L13.9,10.0 L24.8,3.0 L35.7,19.0 L46.6,19.0 L57.4,23.0 L68.3,15.0 L79.2,17.0 L90.1,9.0 L101.0,10.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="10.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">41</td>
+      <td class="cnum">3936</td>
+      <td class="club">Toastmasters Club of New Delhi</td>
+      <td class="yr">41</td><td class="yr">44</td><td class="yr">51</td><td class="yr">35</td><td class="yr">35</td><td class="yr">31</td><td class="yr">39</td><td class="yr">37</td><td class="yr">45</td><td class="yr">44</td>
+      <td class="lo">31</td><td class="hi">51</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/41/club/00003936/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/3936" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">4</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,23.0 L13.9,16.5 L24.8,17.8 L35.7,12.7 L46.6,15.3 L57.4,19.1 L68.3,12.0 L79.2,14.0 L90.1,4.9 L101.0,3.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,23.0 L13.9,16.5 L24.8,17.8 L35.7,12.7 L46.6,15.3 L57.4,19.1 L68.3,12.0 L79.2,14.0 L90.1,4.9 L101.0,3.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="3.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">46</td>
+      <td class="cnum">1949</td>
+      <td class="club">New York Toastmasters Club</td>
+      <td class="yr">64</td><td class="yr">74</td><td class="yr">72</td><td class="yr">80</td><td class="yr">76</td><td class="yr">70</td><td class="yr">81</td><td class="yr">78</td><td class="yr">92</td><td class="yr">95</td>
+      <td class="lo">64</td><td class="hi">95</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/46/club/00001949/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1949" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">5</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,3.0 L13.9,5.4 L24.8,4.8 L35.7,4.2 L46.6,6.6 L57.4,10.3 L68.3,13.9 L79.2,18.2 L90.1,20.0 L101.0,23.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,3.0 L13.9,5.4 L24.8,4.8 L35.7,4.2 L46.6,6.6 L57.4,10.3 L68.3,13.9 L79.2,18.2 L90.1,20.0 L101.0,23.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="23.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">46</td>
+      <td class="cnum">2895</td>
+      <td class="club">Bryant Park Toastmasters Club</td>
+      <td class="yr">63</td><td class="yr">59</td><td class="yr">60</td><td class="yr">61</td><td class="yr">57</td><td class="yr">51</td><td class="yr">45</td><td class="yr">38</td><td class="yr">35</td><td class="yr">30</td>
+      <td class="lo">30</td><td class="hi">63</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/46/club/00002895/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/2895" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">6</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,18.2 L13.9,16.0 L24.8,3.0 L35.7,9.5 L46.6,13.4 L57.4,13.0 L68.3,14.3 L79.2,23.0 L90.1,15.2 L101.0,6.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,18.2 L13.9,16.0 L24.8,3.0 L35.7,9.5 L46.6,13.4 L57.4,13.0 L68.3,14.3 L79.2,23.0 L90.1,15.2 L101.0,6.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="6.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">46</td>
+      <td class="cnum">3890961</td>
+      <td class="club">Columbia University Toastmasters Club</td>
+      <td class="yr">48</td><td class="yr">53</td><td class="yr">83</td><td class="yr">68</td><td class="yr">59</td><td class="yr">60</td><td class="yr">57</td><td class="yr">37</td><td class="yr">55</td><td class="yr">76</td>
+      <td class="lo">37</td><td class="hi">83</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/46/club/03890961/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/3890961" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">7</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,20.1 L13.9,15.7 L24.8,23.0 L35.7,13.5 L46.6,17.9 L57.4,22.4 L68.3,3.0 L79.2,8.7 L90.1,10.6 L101.0,18.2 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,20.1 L13.9,15.7 L24.8,23.0 L35.7,13.5 L46.6,17.9 L57.4,22.4 L68.3,3.0 L79.2,8.7 L90.1,10.6 L101.0,18.2" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="18.2" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">47</td>
+      <td class="cnum">1600</td>
+      <td class="club">First Bahamas Branch of Toastmasters</td>
+      <td class="yr">48</td><td class="yr">62</td><td class="yr">39</td><td class="yr">69</td><td class="yr">55</td><td class="yr">41</td><td class="yr">102</td><td class="yr">84</td><td class="yr">78</td><td class="yr">54</td>
+      <td class="lo">39</td><td class="hi">102</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/47/club/00001600/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1600" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">8</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,17.1 L13.9,14.9 L24.8,19.2 L35.7,19.8 L46.6,19.2 L57.4,23.0 L68.3,4.6 L79.2,3.0 L90.1,6.8 L101.0,11.6 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,17.1 L13.9,14.9 L24.8,19.2 L35.7,19.8 L46.6,19.2 L57.4,23.0 L68.3,4.6 L79.2,3.0 L90.1,6.8 L101.0,11.6" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="11.6" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">47</td>
+      <td class="cnum">7178</td>
+      <td class="club">Healing Communicators Club</td>
+      <td class="yr">58</td><td class="yr">62</td><td class="yr">54</td><td class="yr">53</td><td class="yr">54</td><td class="yr">47</td><td class="yr">81</td><td class="yr">84</td><td class="yr">77</td><td class="yr">68</td>
+      <td class="lo">47</td><td class="hi">84</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/47/club/00007178/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/7178" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">9</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,5.0 L13.9,19.0 L24.8,19.0 L35.7,23.0 L46.6,17.0 L57.4,21.0 L68.3,5.0 L79.2,3.0 L90.1,13.0 L101.0,9.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,5.0 L13.9,19.0 L24.8,19.0 L35.7,23.0 L46.6,17.0 L57.4,21.0 L68.3,5.0 L79.2,3.0 L90.1,13.0 L101.0,9.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="9.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">67</td>
+      <td class="cnum">9295</td>
+      <td class="club">Legacy</td>
+      <td class="yr">43</td><td class="yr">36</td><td class="yr">36</td><td class="yr">34</td><td class="yr">37</td><td class="yr">35</td><td class="yr">43</td><td class="yr">44</td><td class="yr">39</td><td class="yr">41</td>
+      <td class="lo">34</td><td class="hi">44</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/67/club/00009295/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/9295" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">10</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,11.8 L13.9,15.8 L24.8,3.0 L35.7,23.0 L46.6,23.0 L57.4,17.4 L68.3,22.2 L79.2,14.2 L90.1,10.2 L101.0,13.4 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,11.8 L13.9,15.8 L24.8,3.0 L35.7,23.0 L46.6,23.0 L57.4,17.4 L68.3,22.2 L79.2,14.2 L90.1,10.2 L101.0,13.4" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="13.4" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">80</td>
+      <td class="cnum">8531</td>
+      <td class="club">SCCCI Mandarin Club</td>
+      <td class="yr">53</td><td class="yr">48</td><td class="yr">64</td><td class="yr">39</td><td class="yr">39</td><td class="yr">46</td><td class="yr">40</td><td class="yr">50</td><td class="yr">55</td><td class="yr">51</td>
+      <td class="lo">39</td><td class="hi">64</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/80/club/00008531/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/8531" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">11</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,3.0 L13.9,8.5 L24.8,19.4 L35.7,23.0 L46.6,23.0 L57.4,15.7 L68.3,23.0 L79.2,8.5 L90.1,21.2 L101.0,23.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,3.0 L13.9,8.5 L24.8,19.4 L35.7,23.0 L46.6,23.0 L57.4,15.7 L68.3,23.0 L79.2,8.5 L90.1,21.2 L101.0,23.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="23.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">80</td>
+      <td class="cnum">9104</td>
+      <td class="club">SRC Toastmasters Club</td>
+      <td class="yr">63</td><td class="yr">60</td><td class="yr">54</td><td class="yr">52</td><td class="yr">52</td><td class="yr">56</td><td class="yr">52</td><td class="yr">60</td><td class="yr">53</td><td class="yr">52</td>
+      <td class="lo">52</td><td class="hi">63</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/80/club/00009104/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/9104" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">12</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,21.9 L13.9,12.5 L24.8,12.5 L35.7,16.7 L46.6,21.9 L57.4,23.0 L68.3,13.5 L79.2,3.0 L90.1,17.7 L101.0,23.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,21.9 L13.9,12.5 L24.8,12.5 L35.7,16.7 L46.6,21.9 L57.4,23.0 L68.3,13.5 L79.2,3.0 L90.1,17.7 L101.0,23.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="23.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">80</td>
+      <td class="cnum">9165</td>
+      <td class="club">Tampines Changkat Toastmasters</td>
+      <td class="yr">62</td><td class="yr">71</td><td class="yr">71</td><td class="yr">67</td><td class="yr">62</td><td class="yr">61</td><td class="yr">70</td><td class="yr">80</td><td class="yr">66</td><td class="yr">61</td>
+      <td class="lo">61</td><td class="hi">80</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/80/club/00009165/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/9165" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">13</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,14.1 L13.9,14.1 L24.8,23.0 L35.7,3.0 L46.6,14.1 L57.4,7.4 L68.3,20.8 L79.2,16.3 L90.1,14.1 L101.0,9.7 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,14.1 L13.9,14.1 L24.8,23.0 L35.7,3.0 L46.6,14.1 L57.4,7.4 L68.3,20.8 L79.2,16.3 L90.1,14.1 L101.0,9.7" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="9.7" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">80</td>
+      <td class="cnum">670365</td>
+      <td class="club">NTU Alumni Toastmasters Club</td>
+      <td class="yr">41</td><td class="yr">41</td><td class="yr">37</td><td class="yr">46</td><td class="yr">41</td><td class="yr">44</td><td class="yr">38</td><td class="yr">40</td><td class="yr">41</td><td class="yr">43</td>
+      <td class="lo">37</td><td class="hi">46</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/80/club/00670365/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/670365" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">14</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,9.1 L13.9,22.1 L24.8,12.6 L35.7,23.0 L46.6,20.4 L57.4,21.3 L68.3,16.0 L79.2,19.5 L90.1,4.7 L101.0,3.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,9.1 L13.9,22.1 L24.8,12.6 L35.7,23.0 L46.6,20.4 L57.4,21.3 L68.3,16.0 L79.2,19.5 L90.1,4.7 L101.0,3.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="3.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">80</td>
+      <td class="cnum">691812</td>
+      <td class="club">AIA Toastmasters Club</td>
+      <td class="yr">48</td><td class="yr">33</td><td class="yr">44</td><td class="yr">32</td><td class="yr">35</td><td class="yr">34</td><td class="yr">40</td><td class="yr">36</td><td class="yr">53</td><td class="yr">55</td>
+      <td class="lo">32</td><td class="hi">55</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/80/club/00691812/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/691812" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">15</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,23.0 L13.9,11.3 L24.8,13.0 L35.7,13.0 L46.6,4.7 L57.4,3.0 L68.3,6.3 L79.2,16.3 L90.1,18.0 L101.0,18.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,23.0 L13.9,11.3 L24.8,13.0 L35.7,13.0 L46.6,4.7 L57.4,3.0 L68.3,6.3 L79.2,16.3 L90.1,18.0 L101.0,18.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="18.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">82</td>
+      <td class="cnum">918672</td>
+      <td class="club">Ralph Toastmasters Club</td>
+      <td class="yr">46</td><td class="yr">53</td><td class="yr">52</td><td class="yr">52</td><td class="yr">57</td><td class="yr">58</td><td class="yr">56</td><td class="yr">50</td><td class="yr">49</td><td class="yr">49</td>
+      <td class="lo">46</td><td class="hi">58</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/82/club/00918672/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/918672" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">16</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,18.0 L13.9,14.0 L24.8,8.0 L35.7,8.0 L46.6,3.0 L57.4,19.0 L68.3,18.0 L79.2,23.0 L90.1,16.0 L101.0,23.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,18.0 L13.9,14.0 L24.8,8.0 L35.7,8.0 L46.6,3.0 L57.4,19.0 L68.3,18.0 L79.2,23.0 L90.1,16.0 L101.0,23.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="23.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">82</td>
+      <td class="cnum">1355969</td>
+      <td class="club">AATSL Toastmasters Club</td>
+      <td class="yr">36</td><td class="yr">40</td><td class="yr">46</td><td class="yr">46</td><td class="yr">51</td><td class="yr">35</td><td class="yr">36</td><td class="yr">31</td><td class="yr">38</td><td class="yr">31</td>
+      <td class="lo">31</td><td class="hi">51</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/82/club/01355969/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1355969" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">17</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,23.0 L13.9,16.8 L24.8,13.8 L35.7,10.7 L46.6,10.7 L57.4,10.7 L68.3,3.0 L79.2,3.0 L90.1,3.0 L101.0,3.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,23.0 L13.9,16.8 L24.8,13.8 L35.7,10.7 L46.6,10.7 L57.4,10.7 L68.3,3.0 L79.2,3.0 L90.1,3.0 L101.0,3.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="3.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">82</td>
+      <td class="cnum">3598897</td>
+      <td class="club">Awakening Toastmasters</td>
+      <td class="yr">43</td><td class="yr">47</td><td class="yr">49</td><td class="yr">51</td><td class="yr">51</td><td class="yr">51</td><td class="yr">56</td><td class="yr">56</td><td class="yr">56</td><td class="yr">56</td>
+      <td class="lo">43</td><td class="hi">56</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/82/club/03598897/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/3598897" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">18</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,7.3 L13.9,3.0 L24.8,11.6 L35.7,17.3 L46.6,23.0 L57.4,23.0 L68.3,15.9 L79.2,8.7 L90.1,15.9 L101.0,15.9 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,7.3 L13.9,3.0 L24.8,11.6 L35.7,17.3 L46.6,23.0 L57.4,23.0 L68.3,15.9 L79.2,8.7 L90.1,15.9 L101.0,15.9" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="15.9" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">85</td>
+      <td class="cnum">996251</td>
+      <td class="club">1st Bilingual Zhangjiang</td>
+      <td class="yr">44</td><td class="yr">47</td><td class="yr">41</td><td class="yr">37</td><td class="yr">33</td><td class="yr">33</td><td class="yr">38</td><td class="yr">43</td><td class="yr">38</td><td class="yr">38</td>
+      <td class="lo">33</td><td class="hi">47</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/85/club/00996251/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/996251" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">19</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,16.6 L13.9,16.6 L24.8,17.3 L35.7,15.9 L46.6,18.0 L57.4,22.3 L68.3,21.6 L79.2,23.0 L90.1,3.0 L101.0,18.7 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,16.6 L13.9,16.6 L24.8,17.3 L35.7,15.9 L46.6,18.0 L57.4,22.3 L68.3,21.6 L79.2,23.0 L90.1,3.0 L101.0,18.7" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="18.7" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">85</td>
+      <td class="cnum">1015193</td>
+      <td class="club">Lighthouse Shanghai Toastmasters Club</td>
+      <td class="yr">40</td><td class="yr">40</td><td class="yr">39</td><td class="yr">41</td><td class="yr">38</td><td class="yr">32</td><td class="yr">33</td><td class="yr">31</td><td class="yr">59</td><td class="yr">37</td>
+      <td class="lo">31</td><td class="hi">59</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/85/club/01015193/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1015193" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">20</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,3.0 L13.9,9.7 L24.8,9.7 L35.7,6.3 L46.6,13.0 L57.4,19.7 L68.3,13.0 L79.2,23.0 L90.1,16.3 L101.0,19.7 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,3.0 L13.9,9.7 L24.8,9.7 L35.7,6.3 L46.6,13.0 L57.4,19.7 L68.3,13.0 L79.2,23.0 L90.1,16.3 L101.0,19.7" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="19.7" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">87</td>
+      <td class="cnum">6622</td>
+      <td class="club">Kuching Mandarin Toastmasters Club</td>
+      <td class="yr">38</td><td class="yr">36</td><td class="yr">36</td><td class="yr">37</td><td class="yr">35</td><td class="yr">33</td><td class="yr">35</td><td class="yr">32</td><td class="yr">34</td><td class="yr">33</td>
+      <td class="lo">32</td><td class="hi">38</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/87/club/00006622/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/6622" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">21</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,4.6 L13.9,5.4 L24.8,3.0 L35.7,6.2 L46.6,16.6 L57.4,21.4 L68.3,23.0 L79.2,19.0 L90.1,17.4 L101.0,15.8 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,4.6 L13.9,5.4 L24.8,3.0 L35.7,6.2 L46.6,16.6 L57.4,21.4 L68.3,23.0 L79.2,19.0 L90.1,17.4 L101.0,15.8" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="15.8" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">90</td>
+      <td class="cnum">2274</td>
+      <td class="club">Parramatta Club</td>
+      <td class="yr">66</td><td class="yr">65</td><td class="yr">68</td><td class="yr">64</td><td class="yr">51</td><td class="yr">45</td><td class="yr">43</td><td class="yr">48</td><td class="yr">50</td><td class="yr">52</td>
+      <td class="lo">43</td><td class="hi">68</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/90/club/00002274/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/2274" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">22</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,12.7 L13.9,9.5 L24.8,7.3 L35.7,7.9 L46.6,3.0 L57.4,13.8 L68.3,15.4 L79.2,17.1 L90.1,20.3 L101.0,23.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,12.7 L13.9,9.5 L24.8,7.3 L35.7,7.9 L46.6,3.0 L57.4,13.8 L68.3,15.4 L79.2,17.1 L90.1,20.3 L101.0,23.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="23.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">92</td>
+      <td class="cnum">1766</td>
+      <td class="club">Daffodils Toastmasters Club</td>
+      <td class="yr">57</td><td class="yr">63</td><td class="yr">67</td><td class="yr">66</td><td class="yr">75</td><td class="yr">55</td><td class="yr">52</td><td class="yr">49</td><td class="yr">43</td><td class="yr">38</td>
+      <td class="lo">38</td><td class="hi">75</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/92/club/00001766/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1766" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">23</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,20.8 L13.9,14.1 L24.8,20.8 L35.7,23.0 L46.6,3.0 L57.4,9.7 L68.3,14.1 L79.2,5.2 L90.1,14.1 L101.0,7.4 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,20.8 L13.9,14.1 L24.8,20.8 L35.7,23.0 L46.6,3.0 L57.4,9.7 L68.3,14.1 L79.2,5.2 L90.1,14.1 L101.0,7.4" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="7.4" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">92</td>
+      <td class="cnum">9496</td>
+      <td class="club">LA Nineteen Twenty-Four Club</td>
+      <td class="yr">40</td><td class="yr">43</td><td class="yr">40</td><td class="yr">39</td><td class="yr">48</td><td class="yr">45</td><td class="yr">43</td><td class="yr">47</td><td class="yr">43</td><td class="yr">46</td>
+      <td class="lo">39</td><td class="hi">48</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/92/club/00009496/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/9496" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">24</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,12.3 L13.9,13.0 L24.8,20.3 L35.7,13.0 L46.6,21.0 L57.4,23.0 L68.3,11.0 L79.2,9.0 L90.1,3.0 L101.0,5.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,12.3 L13.9,13.0 L24.8,20.3 L35.7,13.0 L46.6,21.0 L57.4,23.0 L68.3,11.0 L79.2,9.0 L90.1,3.0 L101.0,5.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="5.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">98</td>
+      <td class="cnum">1246728</td>
+      <td class="club">Mulund Toastmasters Club</td>
+      <td class="yr">73</td><td class="yr">72</td><td class="yr">61</td><td class="yr">72</td><td class="yr">60</td><td class="yr">57</td><td class="yr">75</td><td class="yr">78</td><td class="yr">87</td><td class="yr">84</td>
+      <td class="lo">57</td><td class="hi">87</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/98/club/01246728/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1246728" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">25</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,7.8 L13.9,8.7 L24.8,3.0 L35.7,5.9 L46.6,13.5 L57.4,13.5 L68.3,9.7 L79.2,23.0 L90.1,20.1 L101.0,23.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,7.8 L13.9,8.7 L24.8,3.0 L35.7,5.9 L46.6,13.5 L57.4,13.5 L68.3,9.7 L79.2,23.0 L90.1,20.1 L101.0,23.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="23.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">105</td>
+      <td class="cnum">1118594</td>
+      <td class="club">Khimji Toastmasters</td>
+      <td class="yr">46</td><td class="yr">45</td><td class="yr">51</td><td class="yr">48</td><td class="yr">40</td><td class="yr">40</td><td class="yr">44</td><td class="yr">30</td><td class="yr">33</td><td class="yr">30</td>
+      <td class="lo">30</td><td class="hi">51</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/105/club/01118594/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1118594" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">26</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,5.4 L13.9,3.0 L24.8,23.0 L35.7,3.0 L46.6,19.5 L57.4,15.9 L68.3,18.3 L79.2,4.2 L90.1,11.2 L101.0,5.4 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,5.4 L13.9,3.0 L24.8,23.0 L35.7,3.0 L46.6,19.5 L57.4,15.9 L68.3,18.3 L79.2,4.2 L90.1,11.2 L101.0,5.4" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="5.4" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">116</td>
+      <td class="cnum">7148</td>
+      <td class="club">Doha Toastmasters Club</td>
+      <td class="yr">57</td><td class="yr">59</td><td class="yr">42</td><td class="yr">59</td><td class="yr">45</td><td class="yr">48</td><td class="yr">46</td><td class="yr">58</td><td class="yr">52</td><td class="yr">57</td>
+      <td class="lo">42</td><td class="hi">59</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/116/club/00007148/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/7148" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">27</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,8.3 L13.9,3.0 L24.8,16.3 L35.7,15.0 L46.6,17.7 L57.4,23.0 L68.3,23.0 L79.2,21.7 L90.1,21.7 L101.0,16.3 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,8.3 L13.9,3.0 L24.8,16.3 L35.7,15.0 L46.6,17.7 L57.4,23.0 L68.3,23.0 L79.2,21.7 L90.1,21.7 L101.0,16.3" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="16.3" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">116</td>
+      <td class="cnum">727851</td>
+      <td class="club">Indian Club Toastmasters</td>
+      <td class="yr">52</td><td class="yr">56</td><td class="yr">46</td><td class="yr">47</td><td class="yr">45</td><td class="yr">41</td><td class="yr">41</td><td class="yr">42</td><td class="yr">42</td><td class="yr">46</td>
+      <td class="lo">41</td><td class="hi">56</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/116/club/00727851/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/727851" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">28</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,3.0 L13.9,6.5 L24.8,17.7 L35.7,20.6 L46.6,23.0 L57.4,23.0 L68.3,22.4 L79.2,15.4 L90.1,14.2 L101.0,15.4 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,3.0 L13.9,6.5 L24.8,17.7 L35.7,20.6 L46.6,23.0 L57.4,23.0 L68.3,22.4 L79.2,15.4 L90.1,14.2 L101.0,15.4" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="15.4" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">120</td>
+      <td class="cnum">1128480</td>
+      <td class="club">Medley Toastmasters Club</td>
+      <td class="yr">78</td><td class="yr">72</td><td class="yr">53</td><td class="yr">48</td><td class="yr">44</td><td class="yr">44</td><td class="yr">45</td><td class="yr">57</td><td class="yr">59</td><td class="yr">57</td>
+      <td class="lo">44</td><td class="hi">78</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/120/club/01128480/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1128480" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">29</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,18.0 L13.9,9.7 L24.8,3.0 L35.7,15.9 L46.6,16.8 L57.4,22.6 L68.3,23.0 L79.2,21.3 L90.1,22.2 L101.0,21.3 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,18.0 L13.9,9.7 L24.8,3.0 L35.7,15.9 L46.6,16.8 L57.4,22.6 L68.3,23.0 L79.2,21.3 L90.1,22.2 L101.0,21.3" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="21.3" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">120</td>
+      <td class="cnum">1363550</td>
+      <td class="club">Madras Toastmasters Club</td>
+      <td class="yr">50</td><td class="yr">70</td><td class="yr">86</td><td class="yr">55</td><td class="yr">53</td><td class="yr">39</td><td class="yr">38</td><td class="yr">42</td><td class="yr">40</td><td class="yr">42</td>
+      <td class="lo">38</td><td class="hi">86</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/120/club/01363550/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1363550" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">30</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,9.2 L13.9,3.0 L24.8,6.1 L35.7,6.1 L46.6,6.1 L57.4,3.0 L68.3,7.6 L79.2,12.2 L90.1,23.0 L101.0,23.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,9.2 L13.9,3.0 L24.8,6.1 L35.7,6.1 L46.6,6.1 L57.4,3.0 L68.3,7.6 L79.2,12.2 L90.1,23.0 L101.0,23.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="23.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">121</td>
+      <td class="cnum">585650</td>
+      <td class="club">Mangalore Club</td>
+      <td class="yr">42</td><td class="yr">46</td><td class="yr">44</td><td class="yr">44</td><td class="yr">44</td><td class="yr">46</td><td class="yr">43</td><td class="yr">40</td><td class="yr">33</td><td class="yr">33</td>
+      <td class="lo">33</td><td class="hi">46</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/121/club/00585650/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/585650" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">31</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,13.5 L13.9,10.4 L24.8,8.3 L35.7,16.7 L46.6,10.4 L57.4,23.0 L68.3,13.5 L79.2,3.0 L90.1,11.4 L101.0,12.5 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,13.5 L13.9,10.4 L24.8,8.3 L35.7,16.7 L46.6,10.4 L57.4,23.0 L68.3,13.5 L79.2,3.0 L90.1,11.4 L101.0,12.5" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="12.5" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">121</td>
+      <td class="cnum">691074</td>
+      <td class="club">Kochi Club</td>
+      <td class="yr">50</td><td class="yr">53</td><td class="yr">55</td><td class="yr">47</td><td class="yr">53</td><td class="yr">41</td><td class="yr">50</td><td class="yr">60</td><td class="yr">52</td><td class="yr">51</td>
+      <td class="lo">41</td><td class="hi">60</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/121/club/00691074/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/691074" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">32</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,11.4 L13.9,5.1 L24.8,4.1 L35.7,9.3 L46.6,18.8 L57.4,18.8 L68.3,19.8 L79.2,13.5 L90.1,23.0 L101.0,3.0 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,11.4 L13.9,5.1 L24.8,4.1 L35.7,9.3 L46.6,18.8 L57.4,18.8 L68.3,19.8 L79.2,13.5 L90.1,23.0 L101.0,3.0" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="3.0" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">125</td>
+      <td class="cnum">1141787</td>
+      <td class="club">Toastmasters Club of Pune</td>
+      <td class="yr">47</td><td class="yr">53</td><td class="yr">54</td><td class="yr">49</td><td class="yr">40</td><td class="yr">40</td><td class="yr">39</td><td class="yr">45</td><td class="yr">36</td><td class="yr">55</td>
+      <td class="lo">36</td><td class="hi">55</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/125/club/01141787/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1141787" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">33</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,16.8 L13.9,5.5 L24.8,3.0 L35.7,6.8 L46.6,14.2 L57.4,20.5 L68.3,23.0 L79.2,9.2 L90.1,10.5 L101.0,10.5 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,16.8 L13.9,5.5 L24.8,3.0 L35.7,6.8 L46.6,14.2 L57.4,20.5 L68.3,23.0 L79.2,9.2 L90.1,10.5 L101.0,10.5" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="10.5" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">125</td>
+      <td class="cnum">1543586</td>
+      <td class="club">Toastmasters Club of Pune South East</td>
+      <td class="yr">44</td><td class="yr">53</td><td class="yr">55</td><td class="yr">52</td><td class="yr">46</td><td class="yr">41</td><td class="yr">39</td><td class="yr">50</td><td class="yr">49</td><td class="yr">49</td>
+      <td class="lo">39</td><td class="hi">55</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/125/club/01543586/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/1543586" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">34</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,3.8 L13.9,3.0 L24.8,10.1 L35.7,18.3 L46.6,17.9 L57.4,21.0 L68.3,22.2 L79.2,23.0 L90.1,18.7 L101.0,19.5 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,3.8 L13.9,3.0 L24.8,10.1 L35.7,18.3 L46.6,17.9 L57.4,21.0 L68.3,22.2 L79.2,23.0 L90.1,18.7 L101.0,19.5" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="19.5" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">125</td>
+      <td class="cnum">4421153</td>
+      <td class="club">Toastmasters Club of Pune North West</td>
+      <td class="yr">79</td><td class="yr">81</td><td class="yr">63</td><td class="yr">42</td><td class="yr">43</td><td class="yr">35</td><td class="yr">32</td><td class="yr">30</td><td class="yr">41</td><td class="yr">39</td>
+      <td class="lo">30</td><td class="hi">81</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/125/club/04421153/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/4421153" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+<tr>
+      <td class="rank">35</td>
+      <td class="trend"><svg class="spark" viewBox="0 0 104 26" width="104" height="26" aria-hidden="true"><path d="M3.0,20.7 L13.9,9.2 L24.8,3.0 L35.7,23.0 L46.6,9.2 L57.4,9.2 L68.3,10.7 L79.2,17.6 L90.1,8.4 L101.0,22.2 L101.0,23.0 L3.0,23.0 Z" fill="url(#g)"/><path d="M3.0,20.7 L13.9,9.2 L24.8,3.0 L35.7,23.0 L46.6,9.2 L57.4,9.2 L68.3,10.7 L79.2,17.6 L90.1,8.4 L101.0,22.2" fill="none" stroke="var(--amber)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="101.0" cy="22.2" r="2.1" fill="var(--amber)"/></svg></td>
+      <td class="dist">130</td>
+      <td class="cnum">670876</td>
+      <td class="club">Ouaga Forum Toastmasters Club</td>
+      <td class="yr">36</td><td class="yr">51</td><td class="yr">59</td><td class="yr">33</td><td class="yr">51</td><td class="yr">51</td><td class="yr">49</td><td class="yr">40</td><td class="yr">52</td><td class="yr">34</td>
+      <td class="lo">33</td><td class="hi">59</td>
+      <td class="lk"><a href="https://ts.taverns.red/district/130/club/00670876/history" target="_blank" rel="noopener">History</a></td>
+      <td class="lk"><a href="https://www.toastmasters.org/find-a-club/670876" target="_blank" rel="noopener">Find&#8209;a&#8209;Club</a></td>
+    </tr>
+    </tbody>
+  </table>
+  </div></div>
+
+  <p class="foot">Membership is each program year&rsquo;s <b>year-end member count</b>; DCP is <b>all 10 goals
+    achieved</b>. Sparklines trace each club&rsquo;s ten year-end counts (dot = 2026). <b>Toast&nbsp;Stats</b>
+    opens the club&rsquo;s full multi-year history; <b>Find-a-Club</b> opens its official Toastmasters page
+    (member sign-in may be required). Sourced from Toast&nbsp;Stats snapshots.
+    Coverage note: the 2017&ndash;18 snapshots span 103&ndash;107 districts vs 128+ today, so elite clubs in
+    districts not yet captured then are not listed &mdash; treat this as a floor, not a ceiling.</p>
+</div>


### PR DESCRIPTION
`main` is red at `ec97c30d`. `npm run typecheck:tests` fails:

```
DistrictsPage.loaded.axe.test.tsx(30,1):   error TS2578: Unused '@ts-expect-error' directive.
DistrictsPage.loaded.axe.test.tsx(139,42): error TS2554: Expected 1 arguments, but got 2.
```

This blocks every open PR — `Quality Gates` fails first, so `Test Suite`, `Build Applications` and `Security Scan` are skipped and branches get no CI evidence at all.

## Cause — a merge-order interaction, not a bad change

Two PRs that were each green in isolation:

- **#1382** added `DistrictsPage.loaded.axe.test.tsx`, which calls `axe(container, { runOnly: { type: 'rule', values: ['aria-allowed-attr'] } })` — a scoped scan.
- **#1383** turned on `typecheck:tests` and fixed `src/types/jest-axe.d.ts`'s `toHaveNoViolations` declaration.

Neither could see the other. Together they red `main`, and both errors trace to the same hand-rolled shim.

## Fix — the shim, not the test

`axe(container, options)` is a legitimate call; the second parameter is axe-core's run options. The shim declared `axe` with a **single** parameter, so the call was an arity error. Typed the optional second parameter.

That also makes the file's `@ts-expect-error` on `expect.extend` unused (TS2578), so it is removed.

**That removal is the gate proving itself.** It is exactly the mechanism #1368 described: fixing a declaration exposes the suppressions that were masking it. Eight such directives were inert before #1383; this is a ninth, added while the gate was still in flight.

## Verification

| check | before | after |
| --- | --- | --- |
| `typecheck:tests` | 2 errors | **0**, exit 0 |
| `DistrictsPage.loaded.axe.test.tsx` | — | 3/3 pass |
| production `tsc -p tsconfig.json` | exit 0 | exit 0 (unaffected) |
| `npm run quality:check` | fails | **OK** |
| `npm run test:scripts` | — | **OK** |

Production strictness is untouched; the change is confined to the ambient module declaration plus the now-redundant directive.

References #1389.