### PR TITLE
fix(frontend): Payment Composition + trophy-case integers follow the selected program year (#1396)

### DIFF
--- a/frontend/src/components/DistrictOverview.tsx
+++ b/frontend/src/components/DistrictOverview.tsx
@@ -10,7 +10,13 @@ import type { SnapshotDate } from '../types/snapshotDate'
 
 interface DistrictOverviewProps {
   districtId: string
-  selectedDate?: SnapshotDate
+  /**
+   * The snapshot being displayed. Explicitly `| undefined` so the parent can
+   * pass it unconditionally: a `{...(date && { selectedDate })}` spread would
+   * advertise an undated render path, and undated is how the payment card came
+   * to show the wrong program year (#1396).
+   */
+  selectedDate?: SnapshotDate | undefined
   programYearStartDate?: string
   /**
    * Pre-fetched performance targets from the usePerformanceTargets hook.

--- a/frontend/src/components/DistrictOverview.tsx
+++ b/frontend/src/components/DistrictOverview.tsx
@@ -32,8 +32,14 @@ export const DistrictOverview: React.FC<DistrictOverviewProps> = ({
     error,
   } = useDistrictAnalytics(districtId, programYearStartDate, selectedDate)
 
-  // District-level fields not carried in per-club analytics (payment breakdowns).
-  const { ranking: districtRanking } = useDistrictRanking(districtId)
+  // District-level fields not carried in per-club analytics (payment
+  // breakdowns). Scoped to the SAME snapshot the analytics above use — an
+  // unscoped read here showed the current year's Payment Composition under a
+  // past program year (#1396 / R3).
+  const { ranking: districtRanking } = useDistrictRanking(
+    districtId,
+    selectedDate
+  )
 
   const clubCount = analytics?.allClubs.length ?? 0
   const avgMembersPerClub =

--- a/frontend/src/components/__tests__/DistrictOverview.programYear.test.tsx
+++ b/frontend/src/components/__tests__/DistrictOverview.programYear.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * DistrictOverview — Payment Composition must follow the selected program year
+ * (#1396).
+ *
+ * The reported symptom: with a PAST program year selected, the card rendered
+ * `New 73 · April 587 · October 941 · 1,602 payment events` — byte-identical to
+ * the CURRENT year's `v1/rankings.json` row for D61 — while the Distinguished
+ * Composition bar beside it was correctly year-scoped. The card is fed by
+ * `useDistrictRanking`, which took no date; the parent already has one.
+ *
+ * The card's own percentages add to 100 whichever year it shows, which is why
+ * the failure reads as plausible data rather than an obvious error. So this
+ * asserts the numbers, not that the card rendered.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { DistrictOverview } from '../DistrictOverview'
+import { fetchCdnRankings, fetchCdnRankingsForDate } from '../../services/cdn'
+import type { CdnRankingsData } from '../../services/cdn'
+import { snap } from '../../test-utils/snapshotDate'
+import type { SnapshotDate } from '../../types/snapshotDate'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnRankings: vi.fn(),
+  fetchCdnRankingsForDate: vi.fn(),
+}))
+
+vi.mock('../../hooks/useDistrictAnalytics', () => ({
+  useDistrictAnalytics: vi.fn(() => ({
+    data: {
+      allClubs: [{ clubId: '1' }, { clubId: '2' }],
+      totalMembership: 2000,
+      distinguishedClubs: {
+        smedley: 1,
+        presidents: 2,
+        select: 3,
+        distinguished: 4,
+      },
+    },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+const mockedLatest = vi.mocked(fetchCdnRankings)
+const mockedForDate = vi.mocked(fetchCdnRankingsForDate)
+
+type Row = CdnRankingsData['rankings'][number] & {
+  newPayments: number
+  aprilPayments: number
+  octoberPayments: number
+  latePayments: number
+  charterPayments: number
+}
+
+function row(
+  payments: Pick<
+    Row,
+    | 'newPayments'
+    | 'aprilPayments'
+    | 'octoberPayments'
+    | 'latePayments'
+    | 'charterPayments'
+  >
+): Row {
+  return {
+    districtId: '61',
+    districtName: 'District 61',
+    region: '07',
+    paidClubs: 100,
+    paidClubBase: 98,
+    clubGrowthPercent: 2,
+    totalPayments: 3000,
+    paymentBase: 2900,
+    paymentGrowthPercent: 3,
+    activeClubs: 100,
+    distinguishedClubs: 30,
+    selectDistinguished: 8,
+    presidentsDistinguished: 4,
+    distinguishedPercent: 30,
+    clubsRank: 10,
+    paymentsRank: 12,
+    distinguishedRank: 14,
+    aggregateScore: 400,
+    overallRank: 11,
+    ...payments,
+  }
+}
+
+/** The observed current-year row: 73 + 587 + 941 + 1 + 0 = 1602 events. */
+const CURRENT: CdnRankingsData = {
+  rankings: [
+    row({
+      newPayments: 73,
+      aprilPayments: 587,
+      octoberPayments: 941,
+      latePayments: 1,
+      charterPayments: 0,
+    }),
+  ],
+  asOfDate: '2026-07-31',
+  generatedAt: '2026-07-31T00:00:00Z',
+}
+
+/** The 2024-2025 year-end row: 40 + 300 + 500 + 2 + 1 = 843 events. */
+const PAST: CdnRankingsData = {
+  rankings: [
+    row({
+      newPayments: 40,
+      aprilPayments: 300,
+      octoberPayments: 500,
+      latePayments: 2,
+      charterPayments: 1,
+    }),
+  ],
+  snapshotDate: snap('2025-06-30'),
+  asOfDate: '2025-07-18',
+  generatedAt: '2025-07-18T00:00:00Z',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedLatest.mockResolvedValue(CURRENT)
+  mockedForDate.mockImplementation((date: SnapshotDate) =>
+    Promise.resolve(date === '2025-06-30' ? PAST : CURRENT)
+  )
+})
+afterEach(() => cleanup())
+
+function renderOverview(
+  selectedDate: SnapshotDate,
+  programYearStartDate: string
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <DistrictOverview
+        districtId="61"
+        selectedDate={selectedDate}
+        programYearStartDate={programYearStartDate}
+      />
+    </QueryClientProvider>
+  )
+}
+
+describe('DistrictOverview — Payment Composition year scoping (#1396)', () => {
+  it("shows the selected past year's payments, not the current year's", async () => {
+    renderOverview(snap('2025-06-30'), '2024-07-01')
+
+    const card = await screen.findByTestId('payment-composition')
+    await waitFor(() => expect(card).toHaveTextContent(/843 payment events/))
+    // 1,602 is the CURRENT year's total. Its appearance here is the bug.
+    expect(card).not.toHaveTextContent(/1,602 payment events/)
+    expect(mockedForDate).toHaveBeenCalledWith(snap('2025-06-30'))
+  })
+
+  it('still shows the current year on a current-year snapshot (no regression)', async () => {
+    renderOverview(snap('2026-07-31'), '2025-07-01')
+
+    const card = await screen.findByTestId('payment-composition')
+    await waitFor(() => expect(card).toHaveTextContent(/1,602 payment events/))
+  })
+})

--- a/frontend/src/components/__tests__/DistrictOverview.programYear.test.tsx
+++ b/frontend/src/components/__tests__/DistrictOverview.programYear.test.tsx
@@ -90,7 +90,13 @@ function row(
   }
 }
 
-/** The observed current-year row: 73 + 587 + 941 + 1 + 0 = 1602 events. */
+/**
+ * The observed current-year row: 73 + 587 + 941 + 1 + 0 = 1602 events.
+ *
+ * No `snapshotDate` — that is what `v1/rankings.json` (the `fetchCdnRankings`
+ * latest path) returns, and it is also how `fetchCdnRankingsForDate` marks its
+ * silent fallback. Per-date HITS below pin it.
+ */
 const CURRENT: CdnRankingsData = {
   rankings: [
     row({
@@ -103,6 +109,12 @@ const CURRENT: CdnRankingsData = {
   ],
   asOfDate: '2026-07-31',
   generatedAt: '2026-07-31T00:00:00Z',
+}
+
+/** The same row served as a real per-date hit for the current year. */
+const CURRENT_PINNED: CdnRankingsData = {
+  ...CURRENT,
+  snapshotDate: snap('2026-07-31'),
 }
 
 /** The 2024-2025 year-end row: 40 + 300 + 500 + 2 + 1 = 843 events. */
@@ -125,7 +137,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockedLatest.mockResolvedValue(CURRENT)
   mockedForDate.mockImplementation((date: SnapshotDate) =>
-    Promise.resolve(date === '2025-06-30' ? PAST : CURRENT)
+    Promise.resolve(date === '2025-06-30' ? PAST : CURRENT_PINNED)
   )
 })
 afterEach(() => cleanup())

--- a/frontend/src/hooks/__tests__/useDistrictRanking.test.tsx
+++ b/frontend/src/hooks/__tests__/useDistrictRanking.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * useDistrictRanking (#1396) — the rankings row must be scoped to the snapshot
+ * the page is DISPLAYING, not to the pipeline's `latest`.
+ *
+ * The hook fetched `v1/rankings.json` under a fixed `['district-rankings',
+ * 'latest']` key with no date argument, so a district Overview showing a PAST
+ * program year rendered the CURRENT year's Payment Composition (and the
+ * current year's trophy-case integers) while every neighbouring card was
+ * correctly year-scoped. Textbook R3: the parent owned the date and the child
+ * ignored it.
+ *
+ * The fixtures below are the real observed numbers from the report: D61's
+ * current-year row (73 / 587 / 941 / 1 / 0 = 1602 events) is what the past-year
+ * card was showing.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useDistrictRanking } from '../useDistrictRanking'
+import { fetchCdnRankings, fetchCdnRankingsForDate } from '../../services/cdn'
+import type { CdnRankingsData } from '../../services/cdn'
+import { snap } from '../../test-utils/snapshotDate'
+import type { SnapshotDate } from '../../types/snapshotDate'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnRankings: vi.fn(),
+  fetchCdnRankingsForDate: vi.fn(),
+}))
+
+const mockedLatest = vi.mocked(fetchCdnRankings)
+const mockedForDate = vi.mocked(fetchCdnRankingsForDate)
+
+/** A rankings row carrying the payment breakdown the card consumes. */
+type Row = CdnRankingsData['rankings'][number] & {
+  newPayments: number
+  aprilPayments: number
+  octoberPayments: number
+  latePayments: number
+  charterPayments: number
+}
+
+function row(payments: {
+  newPayments: number
+  aprilPayments: number
+  octoberPayments: number
+  latePayments: number
+  charterPayments: number
+  paidClubs?: number
+  totalPayments?: number
+}): Row {
+  return {
+    districtId: '61',
+    districtName: 'District 61',
+    region: '07',
+    paidClubs: payments.paidClubs ?? 100,
+    paidClubBase: 98,
+    clubGrowthPercent: 2,
+    totalPayments: payments.totalPayments ?? 3000,
+    paymentBase: 2900,
+    paymentGrowthPercent: 3,
+    activeClubs: 100,
+    distinguishedClubs: 30,
+    selectDistinguished: 8,
+    presidentsDistinguished: 4,
+    distinguishedPercent: 30,
+    clubsRank: 10,
+    paymentsRank: 12,
+    distinguishedRank: 14,
+    aggregateScore: 400,
+    overallRank: 11,
+    ...payments,
+  }
+}
+
+/** What `v1/rankings.json` serves today — the CURRENT program year. */
+const CURRENT: CdnRankingsData = {
+  rankings: [
+    row({
+      newPayments: 73,
+      aprilPayments: 587,
+      octoberPayments: 941,
+      latePayments: 1,
+      charterPayments: 0,
+      paidClubs: 94,
+      totalPayments: 1602,
+    }),
+  ],
+  asOfDate: '2026-07-31',
+  generatedAt: '2026-07-31T00:00:00Z',
+}
+
+/** The 2024-2025 year-end snapshot — a genuinely different year. */
+const PY_2024: CdnRankingsData = {
+  rankings: [
+    row({
+      newPayments: 40,
+      aprilPayments: 300,
+      octoberPayments: 500,
+      latePayments: 2,
+      charterPayments: 1,
+      paidClubs: 128,
+      totalPayments: 843,
+    }),
+  ],
+  snapshotDate: snap('2025-06-30'),
+  asOfDate: '2025-07-18',
+  generatedAt: '2025-07-18T00:00:00Z',
+}
+
+/** The 2023-2024 year-end snapshot — the second year, for the cache probe. */
+const PY_2023: CdnRankingsData = {
+  rankings: [
+    row({
+      newPayments: 55,
+      aprilPayments: 320,
+      octoberPayments: 480,
+      latePayments: 3,
+      charterPayments: 2,
+      paidClubs: 121,
+      totalPayments: 860,
+    }),
+  ],
+  snapshotDate: snap('2024-06-30'),
+  asOfDate: '2024-07-17',
+  generatedAt: '2024-07-17T00:00:00Z',
+}
+
+const BY_DATE: Record<string, CdnRankingsData> = {
+  '2025-06-30': PY_2024,
+  '2024-06-30': PY_2023,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedLatest.mockResolvedValue(CURRENT)
+  mockedForDate.mockImplementation((date: SnapshotDate) =>
+    Promise.resolve(BY_DATE[date] ?? CURRENT)
+  )
+})
+afterEach(() => cleanup())
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function renderRanking(date: SnapshotDate | undefined, client: QueryClient) {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return renderHook(
+    ({ d }: { d: SnapshotDate | undefined }) => useDistrictRanking('61', d),
+    { wrapper, initialProps: { d: date } }
+  )
+}
+
+describe('useDistrictRanking — snapshot scoping (#1396)', () => {
+  it("returns the SELECTED snapshot's row, not the pipeline's latest", async () => {
+    const { result } = renderRanking(snap('2025-06-30'), makeClient())
+
+    await waitFor(() => expect(result.current.ranking).not.toBeNull())
+    // 40/300/500 is the 2024-2025 year-end row. 73/587/941 is what
+    // `v1/rankings.json` serves today — seeing it here IS the bug.
+    expect(result.current.ranking?.newPayments).toBe(40)
+    expect(result.current.ranking?.aprilPayments).toBe(300)
+    expect(result.current.ranking?.octoberPayments).toBe(500)
+    // The trophy-case integer inputs come off the same row (#840).
+    expect(result.current.ranking?.paidClubs).toBe(128)
+    expect(mockedForDate).toHaveBeenCalledWith(snap('2025-06-30'))
+    expect(mockedLatest).not.toHaveBeenCalled()
+  })
+
+  it("does not serve one program year from another year's cache entry", async () => {
+    // One QueryClient across both renders — a key that omits the date would
+    // make the second year a cache HIT on the first, so the fix would look
+    // applied while the numbers never changed.
+    const client = makeClient()
+    const { result, rerender } = renderRanking(snap('2025-06-30'), client)
+    await waitFor(() => expect(result.current.ranking?.newPayments).toBe(40))
+
+    rerender({ d: snap('2024-06-30') })
+    await waitFor(() => expect(result.current.ranking?.newPayments).toBe(55))
+    expect(result.current.ranking?.paidClubs).toBe(121)
+
+    // And back again — the first year must still be its own row.
+    rerender({ d: snap('2025-06-30') })
+    await waitFor(() => expect(result.current.ranking?.newPayments).toBe(40))
+  })
+
+  it('keys each snapshot separately so cached years cannot collide', async () => {
+    const client = makeClient()
+    const { result, rerender } = renderRanking(snap('2025-06-30'), client)
+    await waitFor(() => expect(result.current.ranking).not.toBeNull())
+    rerender({ d: snap('2024-06-30') })
+    await waitFor(() => expect(result.current.ranking?.newPayments).toBe(55))
+
+    expect(
+      client.getQueryData(['district-rankings', '2025-06-30'])
+    ).toBeDefined()
+    expect(
+      client.getQueryData(['district-rankings', '2024-06-30'])
+    ).toBeDefined()
+  })
+
+  it('suppresses the cdn.ts silent latest-fallback instead of showing another snapshot', async () => {
+    // `fetchCdnRankingsForDate` falls back to `v1/rankings.json` when a per-date
+    // file 404s, and marks that by leaving `snapshotDate` unset. Rendering the
+    // current year's numbers under a past date is the exact #1396 symptom, so
+    // the hook must report "no row" rather than the wrong row.
+    mockedForDate.mockResolvedValue(CURRENT)
+
+    const { result } = renderRanking(snap('2025-06-30'), makeClient())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.ranking).toBeNull()
+  })
+})
+
+describe('useDistrictRanking — latest path (#1321 key sharing)', () => {
+  it("reads v1/rankings.json under useLatestAsOfDate's shared key when no date is given", async () => {
+    const client = makeClient()
+    const { result } = renderRanking(undefined, client)
+
+    await waitFor(() => expect(result.current.ranking).not.toBeNull())
+    expect(result.current.ranking?.newPayments).toBe(73)
+    expect(mockedLatest).toHaveBeenCalled()
+    expect(mockedForDate).not.toHaveBeenCalled()
+    // `useLatestAsOfDate` shares this exact key + queryFn so the two don't both
+    // pull the ~126KB file. Changing it here would silently double the fetch.
+    expect(client.getQueryData(['district-rankings', 'latest'])).toBeDefined()
+  })
+})

--- a/frontend/src/hooks/useDistrictRanking.ts
+++ b/frontend/src/hooks/useDistrictRanking.ts
@@ -1,25 +1,58 @@
 /* useDistrictRanking — fetch the single district's row out of the shared
-   rankings.json cache. Returns null while loading or if not found.
+   rankings cache. Returns null while loading or if not found.
    Used to surface district-level fields that aren't carried in the
    per-club analytics (e.g. payment breakdowns: new / april / october /
-   late / charter). */
+   late / charter) plus the raw integers the trophy-case countdown derives
+   from (#840).
+
+   ## Scoped to the DISPLAYED snapshot, not to `latest` (#1396)
+
+   This hook took no date and always read `v1/rankings.json`, so a district
+   Overview showing a PAST program year rendered the CURRENT year's Payment
+   Composition while every card beside it was correctly year-scoped. The
+   parent owns the date; passing it is R3. The date is part of the query key
+   — omitting it would make each new year a cache HIT on the previous one,
+   which looks exactly like a working fix and isn't.
+
+   `date` stays optional: with none, this is the old latest path AND it keeps
+   sharing `['district-rankings', 'latest']` + `fetchCdnRankings` with
+   `useLatestAsOfDate` (#1321), which genuinely wants the latest as-of date.
+   A page that passes a date no longer shares that entry, so it pays for a
+   second rankings fetch — the honest price of showing the year it claims to
+   show. (The durable fix for the duplication is #1321's follow-up: carry
+   `sourceCsvDate` on the 152-byte `v1/latest.json` manifest so
+   `useLatestAsOfDate` stops reading rankings.json at all.) */
 
 import { useQuery } from '@tanstack/react-query'
-import { fetchCdnRankings } from '../services/cdn'
+import { fetchCdnRankings, fetchCdnRankingsForDate } from '../services/cdn'
 import type { DistrictRanking } from '../types/districts'
+import type { SnapshotDate } from '../types/snapshotDate'
 
-export function useDistrictRanking(districtId: string | undefined): {
+export function useDistrictRanking(
+  districtId: string | undefined,
+  /** The snapshot the page is displaying. Omit only for a genuine
+      "whatever is newest" read. */
+  date?: SnapshotDate | undefined
+): {
   ranking: DistrictRanking | null
   isLoading: boolean
 } {
   const { data, isLoading } = useQuery({
-    queryKey: ['district-rankings', 'latest'],
-    queryFn: fetchCdnRankings,
+    queryKey: ['district-rankings', date ?? 'latest'],
+    queryFn: date ? () => fetchCdnRankingsForDate(date) : fetchCdnRankings,
     staleTime: 15 * 60 * 1000,
   })
 
+  // `fetchCdnRankingsForDate` silently falls back to the CURRENT
+  // `v1/rankings.json` when a per-date file 404s, and signals that by leaving
+  // `snapshotDate` unset. Serving that under a past date is the very bug this
+  // hook was fixed for, so report "no row" rather than another year's row.
+  // (Every date the page can select comes from the CDN dates index, so a miss
+  // here means a pipeline gap, not a routine state.)
+  const isFallback = date !== undefined && data?.snapshotDate !== date
+
   const ranking =
-    data?.rankings && districtId
+    data?.rankings && districtId && !isFallback
       ? (data.rankings.find(r => r.districtId === districtId) ?? null)
       : null
 

--- a/frontend/src/hooks/useDistrictRanking.ts
+++ b/frontend/src/hooks/useDistrictRanking.ts
@@ -18,10 +18,26 @@
    sharing `['district-rankings', 'latest']` + `fetchCdnRankings` with
    `useLatestAsOfDate` (#1321), which genuinely wants the latest as-of date.
    A page that passes a date no longer shares that entry, so it pays for a
-   second rankings fetch — the honest price of showing the year it claims to
-   show. (The durable fix for the duplication is #1321's follow-up: carry
-   `sourceCsvDate` on the 152-byte `v1/latest.json` manifest so
-   `useLatestAsOfDate` stops reading rankings.json at all.) */
+   second rankings fetch. That is cheap: the per-date
+   `snapshots/{date}/all-districts-rankings.json` measures ~11KB against
+   `v1/rankings.json`'s ~87KB (both served uncompressed), so the dated page
+   adds ~11KB rather than doubling the ~87KB. The durable fix for the
+   duplication is still #1321's follow-up — carry `sourceCsvDate` on the
+   152-byte `v1/latest.json` manifest so `useLatestAsOfDate` stops reading
+   rankings.json at all.
+
+   Two deliberate non-choices:
+   - No `placeholderData: prev => prev`, unlike the sibling rankings queries on
+     DistrictsPage/RegionPage. Keeping the previous entry across a year switch
+     means rendering the OLD year's numbers under the NEW year's heading until
+     the fetch lands — a transient copy of the bug this hook was fixed for. A
+     brief empty card is the correct answer to "we don't have that year yet".
+   - A fallback miss reports plain `null`, which consumers render as an empty
+     card rather than distinguishing it from "no data". That is the right
+     PIXEL — the wrong year's row is never an acceptable substitute — but it is
+     silent. It is also unreachable today: all 157 per-date rankings files
+     exist, and every per-district snapshot date appears in the global dates
+     index, so a miss means a pipeline gap. */
 
 import { useQuery } from '@tanstack/react-query'
 import { fetchCdnRankings, fetchCdnRankingsForDate } from '../services/cdn'

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -514,9 +514,11 @@ const DistrictDetailPageInner: React.FC = () => {
                 {hasValidDates && effectiveProgramYear && (
                   <DistrictOverview
                     districtId={districtId}
-                    {...(effectiveEndDate && {
-                      selectedDate: effectiveEndDate,
-                    })}
+                    /* Unconditional: `hasValidDates` above already means
+                       `effectiveEndDate !== null`, and the old conditional
+                       spread left an undated path open — the one that showed
+                       the wrong year's payments (#1396). */
+                    selectedDate={effectiveEndDate ?? undefined}
                     programYearStartDate={effectiveProgramYear.startDate}
                     performanceTargets={performanceTargets ?? undefined}
                   />

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -259,8 +259,14 @@ const DistrictDetailPageInner: React.FC = () => {
 
   // Rankings row supplies the raw integer counts used to derive the
   // trophy-case tile integers when the canonical `*Remaining` fields
-  // are absent or the target tier is above Distinguished (#840).
-  const { ranking: districtRanking } = useDistrictRanking(districtId)
+  // are absent or the target tier is above Distinguished (#840). Scoped to
+  // `effectiveEndDate` like `useCompetitiveAwards` above — counting a past
+  // year's `nextTierGap` down against the CURRENT year's paidClubs/payments
+  // is the second half of #1396.
+  const { ranking: districtRanking } = useDistrictRanking(
+    districtId,
+    effectiveEndDate ?? undefined
+  )
   const distinguishedRankingInputs = React.useMemo(() => {
     if (!districtRanking) return null
     return {

--- a/frontend/src/pages/__tests__/DistrictDetailPage.rankingProgramYear.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.rankingProgramYear.test.tsx
@@ -1,0 +1,319 @@
+/**
+ * DistrictDetailPage — the rankings row has TWO consumers, and both must be
+ * scoped to the displayed program year (#1396).
+ *
+ * The reported bug was the Payment Composition card (DistrictOverview). But
+ * `DistrictDetailPage` reads the SAME `useDistrictRanking` row to build
+ * `distinguishedRankingInputs`, which derives the trophy-case headline integers
+ * whenever the canonical `*Remaining` fields are absent or the next tier is
+ * above Distinguished (#840). That path is reachable on a past-year view —
+ * `useCompetitiveAwards` is date-scoped, so a past year's `nextTierGap` was
+ * being counted down against the CURRENT year's paidClubs/payments.
+ *
+ * Fixtures are chosen so the two years derive visibly different integers:
+ *
+ *   past  (base 100 clubs / 1000 payments / 10 distinguished, tier Select)
+ *         → 103-100 = 3 clubs · 1030-1000 = 30 payments · 50-10 = 40 clubs
+ *   current (base 200 / 2000 / 20)
+ *         → 206-200 = 6 clubs · 2060-2000 = 60 payments · 100-20 = 80 clubs
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import DistrictDetailPage from '../DistrictDetailPage'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import { fetchCdnRankings, fetchCdnRankingsForDate } from '../../services/cdn'
+import type { CdnRankingsData } from '../../services/cdn'
+import { snap } from '../../test-utils/snapshotDate'
+import type { SnapshotDate } from '../../types/snapshotDate'
+
+// ---------------------------------------------------------------------------
+// Environment shims (mirrors the DistrictDetailPage.leanHub harness)
+// ---------------------------------------------------------------------------
+
+const localStorageMock = {
+  getItem: vi.fn(() => null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+  length: 0,
+  key: vi.fn(() => null),
+}
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+})
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | null = null
+  readonly rootMargin: string = ''
+  readonly scrollMargin: string = ''
+  readonly thresholds: ReadonlyArray<number> = []
+  private readonly callback: (
+    entries: IntersectionObserverEntry[],
+    observer: IntersectionObserver
+  ) => void
+  constructor(
+    callback: (
+      entries: IntersectionObserverEntry[],
+      observer: IntersectionObserver
+    ) => void
+  ) {
+    this.callback = callback
+  }
+  observe(target: Element): void {
+    setTimeout(() => {
+      this.callback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        this
+      )
+    }, 0)
+  }
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+}
+Object.defineProperty(global, 'IntersectionObserver', {
+  value: MockIntersectionObserver,
+  writable: true,
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures — the rankings rows the two years must NOT share
+// ---------------------------------------------------------------------------
+
+type Row = CdnRankingsData['rankings'][number]
+
+function row(v: {
+  paidClubBase: number
+  paidClubs: number
+  paymentBase: number
+  totalPayments: number
+  distinguishedClubs: number
+}): Row {
+  return {
+    districtId: '61',
+    districtName: 'District 61',
+    region: '07',
+    clubGrowthPercent: 0,
+    paymentGrowthPercent: 0,
+    activeClubs: v.paidClubs,
+    selectDistinguished: 0,
+    presidentsDistinguished: 0,
+    distinguishedPercent: 10,
+    clubsRank: 10,
+    paymentsRank: 12,
+    distinguishedRank: 14,
+    aggregateScore: 400,
+    overallRank: 11,
+    ...v,
+  }
+}
+
+const CURRENT: CdnRankingsData = {
+  rankings: [
+    row({
+      paidClubBase: 200,
+      paidClubs: 200,
+      paymentBase: 2000,
+      totalPayments: 2000,
+      distinguishedClubs: 20,
+    }),
+  ],
+  asOfDate: '2026-06-30',
+  generatedAt: '2026-06-30T00:00:00Z',
+}
+
+const PAST: CdnRankingsData = {
+  rankings: [
+    row({
+      paidClubBase: 100,
+      paidClubs: 100,
+      paymentBase: 1000,
+      totalPayments: 1000,
+      distinguishedClubs: 10,
+    }),
+  ],
+  snapshotDate: snap('2025-06-30'),
+  asOfDate: '2025-07-18',
+  generatedAt: '2025-07-18T00:00:00Z',
+}
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../services/cdn', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../services/cdn')>()
+  return {
+    ...actual,
+    fetchCdnRankings: vi.fn(),
+    fetchCdnRankingsForDate: vi.fn(),
+  }
+})
+
+// The header's freshness pill shares `useDistrictRanking`'s 'latest' key
+// (#1321). Mock it so `fetchCdnRankings` has exactly ONE possible caller left:
+// a rankings consumer that failed to scope itself to the displayed year.
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  }),
+  useGlobalFreshness: () => ({ asOfDate: undefined, isLatest: false }),
+}))
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: vi.fn(() => ({
+    data: { districts: [{ id: '61', name: 'District 61' }] },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    // PY2024 → 2025-06-30 · PY2025 → 2026-06-30
+    data: { dates: ['2026-06-30', '2025-06-30'] },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+vi.mock('../../hooks/useDistrictAnalytics', () => ({
+  useDistrictAnalytics: vi.fn(() => ({
+    data: {
+      allClubs: [],
+      distinguishedClubs: {
+        total: 0,
+        smedley: 0,
+        presidents: 0,
+        select: 0,
+        distinguished: 0,
+      },
+      totalMembership: 1000,
+      membershipChange: 0,
+      performanceTargets: null,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('../../hooks/useAggregatedAnalytics', () => ({
+  useAggregatedAnalytics: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    usedFallback: false,
+  })),
+}))
+
+vi.mock('../../hooks/usePerformanceTargets', () => ({
+  usePerformanceTargets: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+// No canonical `*Remaining` fields and a next tier ABOVE Distinguished — the
+// exact shape that forces the rankings-row derivation (#840).
+vi.mock('../../hooks/useCompetitiveAwards', () => ({
+  useCompetitiveAwards: vi.fn(() => ({
+    data: {
+      distinguishedDistrict: {
+        '61': {
+          districtId: '61',
+          currentTier: 'Distinguished',
+          allPrerequisitesMet: true,
+          prerequisites: {
+            dspSubmitted: true,
+            trainingMet: true,
+            marketAnalysisSubmitted: true,
+            communicationPlanSubmitted: true,
+            regionAdvisorVisitMet: true,
+          },
+          nextTierGap: {
+            tier: 'Select',
+            paymentGrowthGap: 3,
+            clubGrowthGap: 3,
+            distinguishedPercentGap: 40,
+            netClubGrowthGap: 3,
+          },
+        },
+      },
+    },
+    isLoading: false,
+  })),
+}))
+
+const mockedLatest = vi.mocked(fetchCdnRankings)
+const mockedForDate = vi.mocked(fetchCdnRankingsForDate)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorageMock.getItem.mockReturnValue(null)
+  mockedLatest.mockResolvedValue(CURRENT)
+  mockedForDate.mockImplementation((date: SnapshotDate) =>
+    Promise.resolve(date === '2025-06-30' ? PAST : CURRENT)
+  )
+})
+afterEach(() => cleanup())
+
+function renderAt(url: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <Routes>
+            <Route
+              path="/district/:districtId"
+              element={<DistrictDetailPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+const tileValues = () =>
+  screen
+    .getAllByTestId('gap-tile-value')
+    .map(el => el.textContent?.trim() ?? '')
+
+describe('DistrictDetailPage — trophy-case ranking inputs follow the PY (#1396)', () => {
+  it("derives the gap tiles from the PAST year's rankings row", async () => {
+    renderAt('/district/61?py=2024')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('distinguished-gap-tiles')).toBeInTheDocument()
+    )
+    // 6 clubs / 60 payments / 80 clubs is the CURRENT year's derivation.
+    await waitFor(() =>
+      expect(tileValues()).toEqual(['3 clubs', '30 payments', '40 clubs'])
+    )
+    expect(mockedForDate).toHaveBeenCalledWith(snap('2025-06-30'))
+    // Nothing may fall back to `v1/rankings.json` while a year is displayed.
+    expect(mockedLatest).not.toHaveBeenCalled()
+  })
+
+  it("derives them from the current year's row on a current-year view", async () => {
+    renderAt('/district/61?py=2025')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('distinguished-gap-tiles')).toBeInTheDocument()
+    )
+    await waitFor(() =>
+      expect(tileValues()).toEqual(['6 clubs', '60 payments', '80 clubs'])
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/DistrictDetailPage.rankingProgramYear.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.rankingProgramYear.test.tsx
@@ -115,6 +115,7 @@ function row(v: {
   }
 }
 
+/** No `snapshotDate` — the shape `v1/rankings.json` (the latest path) returns. */
 const CURRENT: CdnRankingsData = {
   rankings: [
     row({
@@ -127,6 +128,12 @@ const CURRENT: CdnRankingsData = {
   ],
   asOfDate: '2026-06-30',
   generatedAt: '2026-06-30T00:00:00Z',
+}
+
+/** The same row served as a real per-date hit for the current year. */
+const CURRENT_PINNED: CdnRankingsData = {
+  ...CURRENT,
+  snapshotDate: snap('2026-06-30'),
 }
 
 const PAST: CdnRankingsData = {
@@ -260,7 +267,7 @@ beforeEach(() => {
   localStorageMock.getItem.mockReturnValue(null)
   mockedLatest.mockResolvedValue(CURRENT)
   mockedForDate.mockImplementation((date: SnapshotDate) =>
-    Promise.resolve(date === '2025-06-30' ? PAST : CURRENT)
+    Promise.resolve(date === '2025-06-30' ? PAST : CURRENT_PINNED)
   )
 })
 afterEach(() => cleanup())

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,6 +2,7 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `a-deliberately-shared-query-key-is-a-coupling-with-no-compiler.md` — Two hooks sharing a React Query key to avoid a duplicate fetch are coupled with nothing but a comment — narrowing one hook's key silently re-scopes or breaks the other, so decide explicitly and pay the fetch  (2026-08-03)
 - `a-geometry-ablation-overstates-the-reflow-arrival-order-decides-what-counts.md` — A fonts-blocked geometry ablation shows every reflow the swap could cause, not the ones it does — arrival order decides which count, so tune against the real cold load  (2026-08-02)
 - `a-new-workflows-own-path-filter-cannot-be-exercised-by-the-pr-that-adds-it.md` — A path-filtered workflow's own filter can never be exercised by the PR that introduces it — the diff always contains the workflow file, so the filtered case reads as "mixed" until after merge; open the probe PR against a scratch base branch that widens only `pull_request.branches`  (2026-08-02)
 - `a-sampled-scanner-report-mis-attributes-the-nodes-it-truncated.md` — A scanner harness that prints the first N nodes of a violation silently re-attributes the rest to the first cause — count by distinct fingerprint, not by the sample  (2026-08-02)

--- a/tasks/lessons/lessons/a-deliberately-shared-query-key-is-a-coupling-with-no-compiler.md
+++ b/tasks/lessons/lessons/a-deliberately-shared-query-key-is-a-coupling-with-no-compiler.md
@@ -1,0 +1,79 @@
+---
+date: 2026-08-03
+tier: lesson
+summary: Two hooks sharing a React Query key to avoid a duplicate fetch are coupled with nothing but a comment — narrowing one hook's key silently re-scopes or breaks the other, so decide explicitly and pay the fetch
+tags: [frontend, hooks, react-query, caching, program-year, coupling]
+---
+
+# A deliberately shared query key is a coupling with no compiler
+
+**Date:** 2026-08-03
+**Issue:** #1396 (Payment Composition showed the current year on a past year)
+**Related:** #1321 (the sharing), #1310, R3
+
+## What happened
+
+`useDistrictRanking` fetched `v1/rankings.json` under a fixed
+`['district-rankings', 'latest']` key with no date, so a district page showing a
+**past** program year rendered the **current** year's payment breakdown. The fix
+is obvious: take the date the parent already has, and put it in the query key so
+React Query cannot serve year B out of year A's entry.
+
+The non-obvious part was that a second hook — `useLatestAsOfDate` — deliberately
+uses **that exact key and queryFn**, so the two don't both pull the same ~126KB
+file on pages that read both. Nothing enforces that; it is a comment:
+
+```ts
+// Shares `useDistrictRanking`'s key/queryFn/staleTime so the two don't fetch
+// the same 126KB rankings.json under competing keys (#1321).
+```
+
+So the "obvious" fix had a trap on either side of it:
+
+- Re-key the hook unconditionally → `useLatestAsOfDate` keeps its own key and
+  the sharing quietly dies (a doubled fetch, no test fails), **or**, if you
+  "helpfully" re-key both, `useLatestAsOfDate` starts returning a *historical*
+  as-of date to a pill whose entire job is to report the **latest** one.
+- Leave the key alone and only change the fetcher → every year is a cache hit on
+  the first one. The numbers never change, and the fix *looks* applied.
+
+## The transferable lesson
+
+**A shared cache key is a coupling that no type, test, or compiler protects.**
+The only record of it is prose, and prose does not fail CI. When you narrow one
+consumer's key, the other consumer's behaviour changes silently — in whichever
+direction you weren't thinking about.
+
+Treat "who else keys on this?" as a required step of any cache-key change, and
+resolve it **explicitly** rather than by whichever edit is smaller. Here: keep
+the old key on the undated path (so the sharing survives untouched for the hook
+that genuinely wants "latest"), and let the dated path key on its date and pay
+for a second fetch. An extra request is a fair price for a page that shows the
+year it claims to show; a silently de-scoped freshness pill is not.
+
+## How to apply
+
+- Before editing a `queryKey`, grep the key's literal across the app. A key that
+  appears in two files is an undeclared contract.
+- Make the divergence conditional on the new parameter (`date ?? 'latest'`) so
+  the pre-existing path is byte-for-byte unchanged and the old sharing holds.
+- Pin the sharing with a test that asserts the cache entry exists under the
+  shared key — `client.getQueryData(['district-rankings', 'latest'])` — so the
+  next refactor breaks a test instead of a network budget.
+- Prove the *other* half too: render year A, then year B on the **same**
+  `QueryClient`, and assert the values change. A single-year test passes
+  identically with and without the date in the key.
+- Name the cost in the PR. "This adds one fetch to the district page, and here
+  is the follow-up that removes it" is a decision; silence is a regression
+  waiting to be discovered by someone else.
+
+## Related
+
+- R3 (`tasks/rules.md`) — the parent owned the date and the child re-derived
+  "latest" from nothing. The cache key is where R3 violations hide.
+- [[key-per-snapshot-fetches-on-the-snapshot-date-not-the-as-of-sourcecsvdate]]
+  — the sibling trap about *which* date belongs in the key.
+- [[assert-the-echo-field-that-is-invariant-not-the-one-that-looks-semantic]] —
+  the guard used here (`snapshotDate === requestedDate`) works because
+  `fetchCdnRankingsForDate` echoes its argument on a real hit and leaves it
+  unset on the silent latest-fallback.


### PR DESCRIPTION
Fixes the silent cross-year data on `/district/:id` reported in #1396.

## The bug

`useDistrictRanking` took no date and read `v1/rankings.json` under a fixed
`['district-rankings', 'latest']` key. On a **past** program year the district
Overview therefore rendered the **current** year's numbers while every card
beside it was correctly year-scoped — a textbook **R3** violation (the parent
owned the date and never passed it).

## Both consumers were affected, not one

The issue asked to check the second consumer rather than assume it was fine. It
is **not** fine. `DistrictDetailPage:263` builds `distinguishedRankingInputs`
from the same row, and `useCompetitiveAwards` beside it *is* date-scoped — so a
past year's `nextTierGap` was counted down against the **current** year's
`paidClubs`/`totalPayments`. Confirmed on production, not just in a test (see
the D46 row below: `6109 payments` remaining, captioned `+0.5%`).

## The fix

- `useDistrictRanking(districtId, date?)` uses `fetchCdnRankingsForDate` when
  given a date, **with the date in the query key** — so year B cannot be served
  out of year A's entry (the failure mode where the fix looks applied and the
  numbers never change). Asserted by switching years back and forth on one
  `QueryClient`.
- `DistrictOverview` passes `selectedDate`; `DistrictDetailPage` passes
  `effectiveEndDate`, matching the `useCompetitiveAwards` call beside it.
- `fetchCdnRankingsForDate` silently falls back to the current
  `v1/rankings.json` on a per-date 404, marking it by leaving `snapshotDate`
  unset. The hook now reports "no row" for that case rather than re-committing
  the same bug through the back door. Guarding on the echoed `snapshotDate`
  rather than on a derived program year deliberately avoids the Lesson 139 trap
  (a year-end freeze's `sourceCsvDate` lands in July, i.e. the *next* PY).

## What happened to the `useLatestAsOfDate` key sharing (#1321)

Deliberately **kept on the undated path, given up on the dated one.**

`useLatestAsOfDate` genuinely wants the latest as-of date, and its comments say
twice that it shares this key/queryFn so the two don't both pull the same ~126KB
file. With no date the hook is byte-for-byte the old latest path and that
sharing is intact (pinned by a test asserting the cache entry still exists under
`['district-rankings', 'latest']`). A page that passes a date keys on that date
instead, so the district detail page now issues **one extra rankings fetch**.

That is the correct price: the alternative is a page showing a year it isn't
displaying. The durable fix for the duplication is the follow-up already noted
in `useLatestAsOfDate` — carry `sourceCsvDate` on the 152-byte `v1/latest.json`
manifest so it stops reading `rankings.json` at all.

## Live verification — prod (unfixed) vs preview (fixed)

Same URL, same CDN data, `?py=2024&date=2025-06-30`:

| surface | prod today | this PR's preview | the 2024-25 CDN row |
|---|---|---|---|
| D61 Payment Composition | **1,602** payment events | **5,753** payment events | 1258+2271+2015+19+190 = **5,753** |
| D46 trophy case (Gap to Smedley) | **13 clubs · 6109 payments** | **4 clubs · 107 payments** | derives 4 / 107 / 9 from base 89/3753/45 |

`1,602` is byte-identical to the current year's `v1/rankings.json` row for D61 —
the reported symptom. `6109 payments remaining` under a `+0.5%` caption is the
same bug in the trophy case, counting a past year's Smedley gap against this
year's 1,562 payments-to-date.

No regression on the common case: `/district/61` on the current PY 2026-27 shows
`1,602 payment events` on the preview, unchanged from prod. Network trace on the
preview confirms the per-date fetch is real —
`snapshots/2025-06-30/all-districts-rankings.json` → 200.

## Tests

Red first; all three failed for the right reason before the fix:

| test | red state |
|---|---|
| `useDistrictRanking.test.tsx` | returned `73` (current) when asked for the 2024-25 snapshot; year two was a cache hit on year one |
| `DistrictOverview.programYear.test.tsx` | card rendered `1,602 payment events` on a past-year view |
| `DistrictDetailPage.rankingProgramYear.test.tsx` | gap tiles derived `6 / 60 / 80` instead of `3 / 30 / 40`; `fetchCdnRankingsForDate` never called |

Each has a current-year counterpart pinning the common case against regression.

## Gates

`npm run test` (frontend 330 files / 3895 tests, plus collector-cli,
analytics-core, shared-contracts, mcp-server) · `npm run test:scripts` (27 / 353)
· `typecheck` · `typecheck:tests` · `lint` · `lint:yaml` · `format:check` ·
`test:no-page-mounts:check` (R22) · `test:projects:check` (R20) — all green.

## Fresh-context review

Reviewed by an independent fresh-context agent: **APPROVE-WITH-NITS, no
high-priority findings.** It independently re-verified the 157/157 per-date file
availability, confirmed the mid-PR fixture change is fidelity (the mock now
echoes `snapshotDate` exactly as `cdn.ts:205` does) and not assertion pinning,
and confirmed R20/R22 hold. Two findings applied in `92a706b4`; two answered as
deliberate non-choices and documented in the hook:

- **Applied** — `DistrictDetailPage` passed `selectedDate` through a
  `{...(effectiveEndDate && {…})}` spread that the enclosing `hasValidDates`
  guard already made unconditional. It advertised an undated path into
  `DistrictOverview` — exactly how this bug happened. Now passed directly, prop
  widened to `SnapshotDate | undefined`.
- **Applied** — corrected the cost note: the per-date file is **~11KB** vs
  `v1/rankings.json`'s **~87KB** (measured, both uncompressed). The dated page
  adds ~11KB; it does not double the big file. The inherited "126KB" was stale.
- **Declined, documented** — no `placeholderData: prev => prev` (the siblings
  use it). Holding the previous entry across a year switch renders the *old*
  year's numbers under the *new* year's heading until the fetch lands — a
  transient copy of this very bug. A brief empty card is the correct answer to
  "we don't have that year yet".
- **Declined, documented** — a fallback miss returns plain `null`, which renders
  as an empty card rather than a distinguishable diagnostic state. That is the
  right pixel (another year's row is never an acceptable substitute) but it is
  silent. Unreachable today: all 157 per-date files exist and every
  per-district snapshot date appears in the global dates index.

## Adjacent finding, deliberately out of scope

`useDistricts` also derives the browsable district list from `fetchCdnRankings()`
(current year only), which is why a district present in 2024-25 but absent this
year (e.g. D27, 132 districts then vs 94 now) falls back to the limited
Global-Rankings page on a past-year URL. Same family as this bug, different
blast radius — worth its own issue rather than smuggling into this one.

Refs #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoCZn3LeJX495jz4KdTQBh
