### PR TITLE
fix(frontend): the browsable district list follows the displayed program year (#1398)

### DIFF
--- a/frontend/src/__tests__/integration/errorPage.test.tsx
+++ b/frontend/src/__tests__/integration/errorPage.test.tsx
@@ -37,12 +37,17 @@ function Throw404(): React.JSX.Element {
 }
 
 /**
- * Build a QueryClient with the `['districts']` cache pre-seeded so
+ * Build a QueryClient with the `['districts', 'latest']` cache pre-seeded so
  * `useDistricts()` (which ErrorPage now calls for route-aware recovery)
  * resolves synchronously with NO network. `staleTime: Infinity` stops a
  * background refetch (default staleTime 0 would otherwise hit the real CDN and
  * make these tests network-flaky); we always seed, so the queryFn never runs.
  * An empty array models the "districts unresolved" path deterministically.
+ *
+ * The `'latest'` suffix is the hook's undated key (#1398): `useDistricts` now
+ * takes an optional snapshot date so past-year districts stay reachable, and
+ * ErrorPage deliberately stays undated — a 404's recovery links should point at
+ * districts that exist NOW. Seeding the bare `['districts']` silently misses.
  */
 function makeClient(districts: DistrictsResponse['districts']) {
   const client = new QueryClient({
@@ -50,7 +55,7 @@ function makeClient(districts: DistrictsResponse['districts']) {
       queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
     },
   })
-  client.setQueryData<DistrictsResponse>(['districts'], { districts })
+  client.setQueryData<DistrictsResponse>(['districts', 'latest'], { districts })
   return client
 }
 

--- a/frontend/src/hooks/__tests__/useDistricts.test.tsx
+++ b/frontend/src/hooks/__tests__/useDistricts.test.tsx
@@ -119,7 +119,7 @@ const idsOf = (data: { districts: { id: string }[] } | undefined) =>
   data?.districts.map(d => d.id) ?? []
 
 describe('useDistricts — the list follows the displayed snapshot (#1398)', () => {
-  it("includes a district that existed in the SELECTED year but not today", async () => {
+  it('includes a district that existed in the SELECTED year but not today', async () => {
     const { result } = renderDistricts(snap('2025-06-30'))
 
     await waitFor(() => expect(result.current.data).toBeDefined())

--- a/frontend/src/hooks/__tests__/useDistricts.test.tsx
+++ b/frontend/src/hooks/__tests__/useDistricts.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * useDistricts (#1398) — the browsable district list must describe the snapshot
+ * the page is DISPLAYING, not whatever the pipeline published last.
+ *
+ * The hook derived its list from the undated `fetchCdnRankings()`, i.e. the
+ * CURRENT program year only. Districts are realigned between years, so a
+ * district that existed in a past year and does not exist now was simply absent
+ * from the list on a past-year URL — and `DistrictDetailPage` reads that list as
+ * an existence gate, dropping the visitor onto the limited Global-Rankings page.
+ *
+ * The numbers below are the real CDN counts on 2026-08-02: the 2025-06-30
+ * snapshot carries 132 districts and `v1/rankings.json` carries 94. D27 is in
+ * the first set and not the second.
+ *
+ * Same defect as #1396, one hook over, so the same two traps apply: the date
+ * must be part of the query key (or year B is served from year A's entry and
+ * the fix looks applied while nothing changes), and the undated path must stay
+ * byte-identical for the common case.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useDistricts } from '../useDistricts'
+import { fetchCdnRankings, fetchCdnRankingsForDate } from '../../services/cdn'
+import type { CdnRankingsData } from '../../services/cdn'
+import { snap } from '../../test-utils/snapshotDate'
+import type { SnapshotDate } from '../../types/snapshotDate'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnRankings: vi.fn(),
+  fetchCdnRankingsForDate: vi.fn(),
+}))
+
+const mockedLatest = vi.mocked(fetchCdnRankings)
+const mockedForDate = vi.mocked(fetchCdnRankingsForDate)
+
+type Row = CdnRankingsData['rankings'][number]
+
+function row(districtId: string, districtName?: string): Row {
+  return {
+    districtId,
+    districtName: districtName ?? districtId,
+    region: '06',
+    paidClubs: 90,
+    paidClubBase: 88,
+    clubGrowthPercent: 2,
+    totalPayments: 2919,
+    paymentBase: 2754,
+    paymentGrowthPercent: 6,
+    activeClubs: 92,
+    distinguishedClubs: 38,
+    selectDistinguished: 4,
+    presidentsDistinguished: 14,
+    distinguishedPercent: 43,
+    clubsRank: 29,
+    paymentsRank: 20,
+    distinguishedRank: 71,
+    aggregateScore: 279,
+    overallRank: 33,
+  }
+}
+
+/** What `v1/rankings.json` serves today — no D27, no D34. */
+const CURRENT: CdnRankingsData = {
+  rankings: [row('61'), row('46'), row('F', 'F')],
+  asOfDate: '2026-08-02',
+  generatedAt: '2026-08-02T00:00:00Z',
+}
+
+/** The 2024-2025 year-end snapshot — D27 existed then. */
+const PY_2024: CdnRankingsData = {
+  rankings: [row('61'), row('46'), row('27'), row('F', 'F')],
+  snapshotDate: snap('2025-06-30'),
+  asOfDate: '2025-07-18',
+  generatedAt: '2025-07-18T00:00:00Z',
+}
+
+/** The 2023-2024 year-end snapshot — a different past year, for the cache probe. */
+const PY_2023: CdnRankingsData = {
+  rankings: [row('61'), row('46'), row('34'), row('F', 'F')],
+  snapshotDate: snap('2024-06-30'),
+  asOfDate: '2024-07-17',
+  generatedAt: '2024-07-17T00:00:00Z',
+}
+
+const BY_DATE: Record<string, CdnRankingsData> = {
+  '2025-06-30': PY_2024,
+  '2024-06-30': PY_2023,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedLatest.mockResolvedValue(CURRENT)
+  mockedForDate.mockImplementation((date: SnapshotDate) =>
+    Promise.resolve(BY_DATE[date] ?? CURRENT)
+  )
+})
+afterEach(() => cleanup())
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function renderDistricts(
+  date: SnapshotDate | undefined,
+  client: QueryClient = makeClient()
+) {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return renderHook(
+    ({ d }: { d: SnapshotDate | undefined }) => useDistricts(d),
+    { wrapper, initialProps: { d: date } }
+  )
+}
+
+const idsOf = (data: { districts: { id: string }[] } | undefined) =>
+  data?.districts.map(d => d.id) ?? []
+
+describe('useDistricts — the list follows the displayed snapshot (#1398)', () => {
+  it("includes a district that existed in the SELECTED year but not today", async () => {
+    const { result } = renderDistricts(snap('2025-06-30'))
+
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    // D27 is in the 2024-2025 snapshot and absent from `v1/rankings.json`.
+    // Missing it here is exactly why /district/27?py=2024 falls back to the
+    // limited Global-Rankings page.
+    expect(idsOf(result.current.data)).toContain('27')
+    expect(mockedForDate).toHaveBeenCalledWith(snap('2025-06-30'))
+    expect(mockedLatest).not.toHaveBeenCalled()
+  })
+
+  it('carries the district name off the selected snapshot, not the latest one', async () => {
+    const { result } = renderDistricts(snap('2025-06-30'))
+
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(result.current.data?.districts).toContainEqual({
+      id: '27',
+      name: '27',
+    })
+  })
+
+  it("does not serve one program year's list from another year's cache entry", async () => {
+    // One QueryClient across both renders — a key that omits the date would
+    // make the second year a cache HIT on the first, so the fix would look
+    // applied while the list never changed.
+    const client = makeClient()
+    const { result, rerender } = renderDistricts(snap('2025-06-30'), client)
+    await waitFor(() => expect(idsOf(result.current.data)).toContain('27'))
+
+    rerender({ d: snap('2024-06-30') })
+    await waitFor(() => expect(idsOf(result.current.data)).toContain('34'))
+    expect(idsOf(result.current.data)).not.toContain('27')
+
+    // And back again — the first year must still be its own list.
+    rerender({ d: snap('2025-06-30') })
+    await waitFor(() => expect(idsOf(result.current.data)).toContain('27'))
+    expect(idsOf(result.current.data)).not.toContain('34')
+  })
+
+  it('keys each snapshot separately so cached years cannot collide', async () => {
+    const client = makeClient()
+    const { result, rerender } = renderDistricts(snap('2025-06-30'), client)
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    rerender({ d: snap('2024-06-30') })
+    await waitFor(() => expect(idsOf(result.current.data)).toContain('34'))
+
+    expect(client.getQueryData(['districts', '2025-06-30'])).toBeDefined()
+    expect(client.getQueryData(['districts', '2024-06-30'])).toBeDefined()
+  })
+})
+
+describe('useDistricts — undated latest path is unchanged (#1398)', () => {
+  it('reads v1/rankings.json and yields the current list when given no date', async () => {
+    const client = makeClient()
+    const { result } = renderDistricts(undefined, client)
+
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(idsOf(result.current.data)).toEqual(['61', '46', 'F'])
+    expect(mockedLatest).toHaveBeenCalled()
+    expect(mockedForDate).not.toHaveBeenCalled()
+  })
+
+  it('serves the undated list from its own cache entry', async () => {
+    const client = makeClient()
+    const { result } = renderDistricts(undefined, client)
+    await waitFor(() => expect(result.current.data).toBeDefined())
+
+    expect(client.getQueryData(['districts', 'latest'])).toBeDefined()
+  })
+
+  it('keeps the current list distinct from a dated one on the same client', async () => {
+    const client = makeClient()
+    const undated = renderDistricts(undefined, client)
+    await waitFor(() => expect(undated.result.current.data).toBeDefined())
+    expect(idsOf(undated.result.current.data)).not.toContain('27')
+
+    const dated = renderDistricts(snap('2025-06-30'), client)
+    await waitFor(() => expect(dated.result.current.data).toBeDefined())
+    expect(idsOf(dated.result.current.data)).toContain('27')
+    // The undated entry must not have been overwritten by the dated fetch.
+    expect(idsOf(undated.result.current.data)).not.toContain('27')
+  })
+})

--- a/frontend/src/hooks/useDistricts.ts
+++ b/frontend/src/hooks/useDistricts.ts
@@ -1,16 +1,65 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query'
-import { fetchCdnRankings } from '../services/cdn'
+import { fetchCdnRankings, fetchCdnRankingsForDate } from '../services/cdn'
 import type { DistrictsResponse } from '../types/districts'
+import type { SnapshotDate } from '../types/snapshotDate'
 
 /**
  * React Query hook to fetch available districts.
  * Derives district list from CDN rankings data (#173).
+ *
+ * ## Scoped to the DISPLAYED snapshot, not to `latest` (#1398)
+ *
+ * This hook read the undated `fetchCdnRankings()` — the CURRENT program year
+ * only. Districts are realigned between years, so the roster is not stable:
+ * the 2025-06-30 snapshot carries 132 districts and `v1/rankings.json` carries
+ * 94. `DistrictDetailPage` reads this list as an EXISTENCE GATE, so all 38
+ * districts realigned away since (D27 among them) were judged not to exist on
+ * any year's URL and their visitors landed on the limited Global-Rankings page.
+ * The parent owns the date; passing it is R3. Sibling of #1396, one hook over.
+ *
+ * The date is part of the query key — omitting it would make each new year a
+ * cache HIT on the previous one, which looks exactly like a working fix and
+ * isn't. `date ?? 'latest'` keeps the undated path on its own entry (nothing
+ * else keys on `['districts']` — checked; unlike #1396's `useLatestAsOfDate`
+ * coupling, this key has a single owner).
+ *
+ * Two deliberate non-choices:
+ *
+ * - **The cdn.ts latest-fallback is allowed to stand here**, unlike in
+ *   `useDistrictRanking`, which suppresses it. `fetchCdnRankingsForDate`
+ *   silently serves `v1/rankings.json` when a per-date file 404s. There, the
+ *   wrong year's *numbers* are a silent data lie, so "no row" is the honest
+ *   answer. Here the list is a navigational index behind an existence gate:
+ *   falling back to the current roster is exactly today's behaviour, whereas
+ *   an empty list would send EVERY district — current year included — to the
+ *   Global-Rankings fallback. Degrading to the status quo beats a
+ *   self-inflicted outage. (All per-date rankings files exist, so this path
+ *   means a pipeline gap, not a routine state.)
+ * - **No `placeholderData: prev => prev`.** Holding the previous year's roster
+ *   across a year switch renders the old year's district set under the new
+ *   year's heading until the fetch lands — a transient copy of this very bug.
+ *
+ * Consumer audit (#1398): only `DistrictDetailPage` gates on membership of this
+ * list. The other eleven consumers use it solely to resolve `districtName` for
+ * a heading/breadcrumb, and every district absent from the current roster is
+ * numerically named (only `F` and `U` are not, and both exist in both years),
+ * so `District {id}` renders identically whether the list is dated or not.
+ * `ErrorPage` (404 recovery) and `ClubHistoryPage` (inherently all-years)
+ * genuinely want the current roster and stay undated on purpose. If a second
+ * gate is ever added to one of those pages, it must pass its date too.
+ *
+ * @param date - The snapshot the page is displaying. Omit only for a genuine
+ *               "which districts exist now" read.
  */
-export const useDistricts = (): UseQueryResult<DistrictsResponse, Error> => {
+export const useDistricts = (
+  date?: SnapshotDate | undefined
+): UseQueryResult<DistrictsResponse, Error> => {
   return useQuery<DistrictsResponse, Error>({
-    queryKey: ['districts'],
+    queryKey: ['districts', date ?? 'latest'],
     queryFn: async () => {
-      const { rankings } = await fetchCdnRankings()
+      const { rankings } = date
+        ? await fetchCdnRankingsForDate(date)
+        : await fetchCdnRankings()
       return {
         districts: rankings.map(r => ({
           id: r.districtId,

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -69,12 +69,6 @@ const DistrictDetailPageInner: React.FC = () => {
     setSelectedDate,
   } = useUrlProgramYear()
 
-  // Fetch district info
-  const { data: districtsData } = useDistricts()
-  const selectedDistrict = districtsData?.districts?.find(
-    d => d.id === districtId
-  )
-
   // Fetch cached dates for date selector
   const { data: cachedDatesData } = useDistrictCachedDates(districtId || '')
 
@@ -145,6 +139,17 @@ const DistrictDetailPageInner: React.FC = () => {
     // for why, and why a `|| endDate` fallback must not come back (#1323).
     return mostRecent
   }, [selectedDate, effectiveProgramYear, allCachedDates])
+
+  // Fetch district info. Scoped to the snapshot this page is DISPLAYING: the
+  // roster below is an existence gate (see the `!selectedDistrict` branch), and
+  // the current year's roster does not contain the districts realigned away
+  // since — so a past-year URL for one of them fell through to the limited
+  // Global-Rankings page (#1398). Declared after `effectiveEndDate` because it
+  // consumes it; the gate itself is far below.
+  const { data: districtsData } = useDistricts(effectiveEndDate ?? undefined)
+  const selectedDistrict = districtsData?.districts?.find(
+    d => d.id === districtId
+  )
 
   // Determine if we have valid dates for API calls
   const hasValidDates =
@@ -367,7 +372,15 @@ const DistrictDetailPageInner: React.FC = () => {
   // If districts data has loaded but this district isn't in the tracked list,
   // show a limited page with Global Rankings (available for all districts)
   // instead of blank data. Only 6 districts have detailed per-district analytics.
-  if (districtsData && !selectedDistrict && districtId) {
+  //
+  // `cachedDatesData` gates the gate (#1398): the roster is only authoritative
+  // once we know WHICH snapshot to read it from. Until the per-district date
+  // index lands, `effectiveEndDate` is null and `useDistricts` is still on the
+  // undated current-year entry — the roster that omits past-year districts. And
+  // it loses that race routinely: the index is 388KB against rankings.json's
+  // 88KB, so without this the past-year district page would flash the "limited
+  // data" fallback before the dated roster arrived.
+  if (cachedDatesData && districtsData && !selectedDistrict && districtId) {
     return (
       <ErrorBoundary>
         <div className="district-detail-page-root">

--- a/frontend/src/pages/__tests__/DistrictDetailPage.pastYearDistrict.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.pastYearDistrict.test.tsx
@@ -20,6 +20,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import DistrictDetailPage from '../DistrictDetailPage'
 import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
 import { fetchCdnRankings, fetchCdnRankingsForDate } from '../../services/cdn'
+import { useDistrictCachedDates } from '../../hooks/useDistrictData'
 import type { CdnRankingsData } from '../../services/cdn'
 import { snap } from '../../test-utils/snapshotDate'
 import type { SnapshotDate } from '../../types/snapshotDate'
@@ -150,13 +151,22 @@ vi.mock('../../hooks/useLatestAsOfDate', () => ({
 }))
 
 vi.mock('../../hooks/useDistrictData', () => ({
-  useDistrictCachedDates: vi.fn(() => ({
-    // PY2024 → 2025-06-30 · PY2025 → 2026-06-30
-    data: { dates: ['2026-06-30', '2025-06-30'] },
-    isLoading: false,
-    error: null,
-  })),
+  useDistrictCachedDates: vi.fn(),
 }))
+
+/** PY2024 → 2025-06-30 · PY2025 → 2026-06-30. Re-applied every test, because a
+    `mockReturnValue` set inside one would otherwise leak into the next. */
+const DATES_LOADED = {
+  data: { dates: ['2026-06-30', '2025-06-30'] },
+  isLoading: false,
+  error: null,
+} as unknown as ReturnType<typeof useDistrictCachedDates>
+
+const DATES_LOADING = {
+  data: undefined,
+  isLoading: true,
+  error: null,
+} as unknown as ReturnType<typeof useDistrictCachedDates>
 
 vi.mock('../../hooks/useDistrictAnalytics', () => ({
   useDistrictAnalytics: vi.fn(() => ({
@@ -204,6 +214,7 @@ const mockedForDate = vi.mocked(fetchCdnRankingsForDate)
 beforeEach(() => {
   vi.clearAllMocks()
   localStorageMock.getItem.mockReturnValue(null)
+  vi.mocked(useDistrictCachedDates).mockReturnValue(DATES_LOADED)
   mockedLatest.mockResolvedValue(CURRENT)
   mockedForDate.mockImplementation((date: SnapshotDate) =>
     Promise.resolve(date === '2025-06-30' ? PY_2024 : CURRENT_PINNED)
@@ -270,6 +281,19 @@ describe('DistrictDetailPage — past-year districts are reachable (#1398)', () 
     await waitFor(() =>
       expect(screen.getByTestId('district-detail-lede')).toBeInTheDocument()
     )
+    expect(screen.queryByText(LIMITED)).not.toBeInTheDocument()
+  })
+
+  it('does not flash the fallback while the snapshot index is still loading', async () => {
+    // The 388KB per-district date index routinely loses the race to the 88KB
+    // rankings.json, so there is a real window where the roster is loaded but
+    // still the UNDATED one. Firing the gate in that window would flash the
+    // "limited data" page at every past-year district before its real page.
+    vi.mocked(useDistrictCachedDates).mockReturnValue(DATES_LOADING)
+
+    const client = renderAt('/district/27?py=2024&date=2025-06-30')
+    await districtListLanded(client)
+
     expect(screen.queryByText(LIMITED)).not.toBeInTheDocument()
   })
 

--- a/frontend/src/pages/__tests__/DistrictDetailPage.pastYearDistrict.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.pastYearDistrict.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * DistrictDetailPage (#1398) — a district that existed in the SELECTED program
+ * year must render its district page, not the limited Global-Rankings fallback.
+ *
+ * `districtsData && !selectedDistrict` at DistrictDetailPage:370 is an
+ * existence gate over `useDistricts()`. That hook read the undated
+ * `fetchCdnRankings()` — the CURRENT year only — so every district realigned
+ * away since (38 of them: 132 in the 2025-06-30 snapshot vs 94 today) was
+ * judged not to exist on ANY year's URL. D27 is the concrete case.
+ *
+ * The gate itself is correct and stays: a district present in neither year
+ * still has to reach the fallback, which is why the third test exists.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import DistrictDetailPage from '../DistrictDetailPage'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import { fetchCdnRankings, fetchCdnRankingsForDate } from '../../services/cdn'
+import type { CdnRankingsData } from '../../services/cdn'
+import { snap } from '../../test-utils/snapshotDate'
+import type { SnapshotDate } from '../../types/snapshotDate'
+
+// ---------------------------------------------------------------------------
+// Environment shims (mirrors the DistrictDetailPage.rankingProgramYear harness)
+// ---------------------------------------------------------------------------
+
+const localStorageMock = {
+  getItem: vi.fn(() => null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+  length: 0,
+  key: vi.fn(() => null),
+}
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+})
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | null = null
+  readonly rootMargin: string = ''
+  readonly scrollMargin: string = ''
+  readonly thresholds: ReadonlyArray<number> = []
+  private readonly callback: (
+    entries: IntersectionObserverEntry[],
+    observer: IntersectionObserver
+  ) => void
+  constructor(
+    callback: (
+      entries: IntersectionObserverEntry[],
+      observer: IntersectionObserver
+    ) => void
+  ) {
+    this.callback = callback
+  }
+  observe(target: Element): void {
+    setTimeout(() => {
+      this.callback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        this
+      )
+    }, 0)
+  }
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+}
+Object.defineProperty(global, 'IntersectionObserver', {
+  value: MockIntersectionObserver,
+  writable: true,
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures — the district rosters the two years do NOT share
+// ---------------------------------------------------------------------------
+
+type Row = CdnRankingsData['rankings'][number]
+
+function row(districtId: string): Row {
+  return {
+    districtId,
+    districtName: districtId,
+    region: '06',
+    paidClubs: 90,
+    paidClubBase: 88,
+    clubGrowthPercent: 2,
+    totalPayments: 2919,
+    paymentBase: 2754,
+    paymentGrowthPercent: 6,
+    activeClubs: 92,
+    distinguishedClubs: 38,
+    selectDistinguished: 4,
+    presidentsDistinguished: 14,
+    distinguishedPercent: 43,
+    clubsRank: 29,
+    paymentsRank: 20,
+    distinguishedRank: 71,
+    aggregateScore: 279,
+    overallRank: 33,
+  }
+}
+
+/** `v1/rankings.json` today — D27 has been realigned away. */
+const CURRENT: CdnRankingsData = {
+  rankings: [row('61')],
+  asOfDate: '2026-08-02',
+  generatedAt: '2026-08-02T00:00:00Z',
+}
+
+/** The same roster served as a real per-date hit for the current year. */
+const CURRENT_PINNED: CdnRankingsData = {
+  ...CURRENT,
+  snapshotDate: snap('2026-06-30'),
+}
+
+/** The 2024-2025 year-end snapshot — D27 was a district then. */
+const PY_2024: CdnRankingsData = {
+  rankings: [row('61'), row('27')],
+  snapshotDate: snap('2025-06-30'),
+  asOfDate: '2025-07-18',
+  generatedAt: '2025-07-18T00:00:00Z',
+}
+
+// ---------------------------------------------------------------------------
+// Module mocks — everything EXCEPT useDistricts, which is under test
+// ---------------------------------------------------------------------------
+
+vi.mock('../../services/cdn', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../services/cdn')>()
+  return {
+    ...actual,
+    fetchCdnRankings: vi.fn(),
+    fetchCdnRankingsForDate: vi.fn(),
+  }
+})
+
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  }),
+  useGlobalFreshness: () => ({ asOfDate: undefined, isLatest: false }),
+}))
+
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    // PY2024 → 2025-06-30 · PY2025 → 2026-06-30
+    data: { dates: ['2026-06-30', '2025-06-30'] },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+vi.mock('../../hooks/useDistrictAnalytics', () => ({
+  useDistrictAnalytics: vi.fn(() => ({
+    data: {
+      allClubs: [],
+      distinguishedClubs: {
+        total: 0,
+        smedley: 0,
+        presidents: 0,
+        select: 0,
+        distinguished: 0,
+      },
+      totalMembership: 1000,
+      membershipChange: 0,
+      performanceTargets: null,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('../../hooks/useAggregatedAnalytics', () => ({
+  useAggregatedAnalytics: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    usedFallback: false,
+  })),
+}))
+
+vi.mock('../../hooks/usePerformanceTargets', () => ({
+  usePerformanceTargets: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+vi.mock('../../hooks/useCompetitiveAwards', () => ({
+  useCompetitiveAwards: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+const mockedLatest = vi.mocked(fetchCdnRankings)
+const mockedForDate = vi.mocked(fetchCdnRankingsForDate)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorageMock.getItem.mockReturnValue(null)
+  mockedLatest.mockResolvedValue(CURRENT)
+  mockedForDate.mockImplementation((date: SnapshotDate) =>
+    Promise.resolve(date === '2025-06-30' ? PY_2024 : CURRENT_PINNED)
+  )
+})
+afterEach(() => cleanup())
+
+function renderAt(url: string) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <Routes>
+            <Route
+              path="/district/:districtId"
+              element={<DistrictDetailPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+  return client
+}
+
+/**
+ * The existence gate only fires once `districtsData` is defined — before that
+ * the full page renders regardless. Asserting without waiting for the list to
+ * land would pass in the loading window and prove nothing. Prefix-matched so
+ * this is indifferent to whether the key carries a date.
+ */
+async function districtListLanded(client: QueryClient) {
+  await waitFor(() =>
+    expect(
+      client
+        .getQueriesData({ queryKey: ['districts'] })
+        .some(([, data]) => data !== undefined)
+    ).toBe(true)
+  )
+}
+
+const LIMITED = /This district has limited data available/i
+
+describe('DistrictDetailPage — past-year districts are reachable (#1398)', () => {
+  it('renders the district page for a district that existed in the selected year', async () => {
+    const client = renderAt('/district/27?py=2024&date=2025-06-30')
+    await districtListLanded(client)
+
+    // The full page header, not the "Back to Rankings" stub.
+    await waitFor(() =>
+      expect(screen.getByTestId('district-detail-lede')).toBeInTheDocument()
+    )
+    expect(screen.queryByText(LIMITED)).not.toBeInTheDocument()
+    expect(mockedForDate).toHaveBeenCalledWith(snap('2025-06-30'))
+  })
+
+  it('still renders a current-year district on the current year', async () => {
+    const client = renderAt('/district/61?py=2025&date=2026-06-30')
+    await districtListLanded(client)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('district-detail-lede')).toBeInTheDocument()
+    )
+    expect(screen.queryByText(LIMITED)).not.toBeInTheDocument()
+  })
+
+  it('keeps the Global-Rankings fallback for a district in no year', async () => {
+    const client = renderAt('/district/99?py=2024&date=2025-06-30')
+    await districtListLanded(client)
+
+    await waitFor(() => expect(screen.getByText(LIMITED)).toBeInTheDocument())
+    expect(screen.queryByTestId('district-detail-lede')).not.toBeInTheDocument()
+  })
+})

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -3,6 +3,7 @@
 
 ## lessons (manifest-pinned + session-judged)
 - `a-deliberately-shared-query-key-is-a-coupling-with-no-compiler.md` — Two hooks sharing a React Query key to avoid a duplicate fetch are coupled with nothing but a comment — narrowing one hook's key silently re-scopes or breaks the other, so decide explicitly and pay the fetch  (2026-08-03)
+- `a-query-scoped-by-an-async-value-runs-unscoped-first.md` — A query keyed on a value that itself arrives asynchronously runs UNSCOPED on first render, so any gate reading its result must wait for the scoping value — not just for the result  (2026-08-03)
 - `a-geometry-ablation-overstates-the-reflow-arrival-order-decides-what-counts.md` — A fonts-blocked geometry ablation shows every reflow the swap could cause, not the ones it does — arrival order decides which count, so tune against the real cold load  (2026-08-02)
 - `a-new-workflows-own-path-filter-cannot-be-exercised-by-the-pr-that-adds-it.md` — A path-filtered workflow's own filter can never be exercised by the PR that introduces it — the diff always contains the workflow file, so the filtered case reads as "mixed" until after merge; open the probe PR against a scratch base branch that widens only `pull_request.branches`  (2026-08-02)
 - `a-sampled-scanner-report-mis-attributes-the-nodes-it-truncated.md` — A scanner harness that prints the first N nodes of a violation silently re-attributes the rest to the first cause — count by distinct fingerprint, not by the sample  (2026-08-02)

--- a/tasks/lessons/lessons/a-query-scoped-by-an-async-value-runs-unscoped-first.md
+++ b/tasks/lessons/lessons/a-query-scoped-by-an-async-value-runs-unscoped-first.md
@@ -1,0 +1,87 @@
+---
+date: 2026-08-03
+tier: lesson
+summary: A query keyed on a value that itself arrives asynchronously runs UNSCOPED on first render, so any gate reading its result must wait for the scoping value — not just for the result
+tags: [frontend, hooks, react-query, caching, program-year, loading-states]
+---
+
+# A query scoped by an async value runs unscoped first
+
+**Date:** 2026-08-03
+**Issue:** #1398 (past-year districts fell through to the Global-Rankings page)
+**Related:** #1396 (the sibling fix), R3
+
+## What happened
+
+`useDistricts` built the browsable district list from the undated
+`fetchCdnRankings()` — the current program year only. Districts get realigned
+between years (132 in the 2025-06-30 snapshot, 94 today), and
+`DistrictDetailPage` uses that list as an **existence gate**, so every district
+realigned away since was judged not to exist on *any* year's URL and its
+visitors landed on the limited Global-Rankings page.
+
+The fix is #1396's, one hook over: take the date the page already owns, put it
+in the query key. Done — except the page then flickered.
+
+## The non-obvious part
+
+The date being threaded in, `effectiveEndDate`, is itself derived from a
+**fetch** (the per-district snapshot-date index). So the first render has no
+date, and the hook runs its `date ?? 'latest'` branch — the *unscoped* one, the
+exact query whose answer caused the bug. Only after the index lands does the key
+change and the correctly-scoped fetch start.
+
+That is a race, and I assumed it was a narrow one. Measuring said otherwise:
+
+| file                                | size  |
+| ----------------------------------- | ----- |
+| `config/district-snapshot-index.json` | 388KB |
+| `v1/rankings.json`                    | 88KB  |
+
+The roster that produces the *wrong* answer is 4.4× smaller than the file that
+tells you which roster to ask for. The unscoped answer wins the race
+**routinely**, not occasionally — so a past-year district page would render the
+"This district has limited data available" fallback first and its real page
+second. Not the original bug, but the same pixels, on every load.
+
+## The transferable lesson
+
+**Scoping a query by a value that arrives asynchronously does not make the
+query scoped — it makes it unscoped for one window, then scoped.** Any consumer
+that acts on the result (a gate, a redirect, a 404, an analytics event) must
+wait for the *scoping value*, not merely for the result to be non-undefined.
+`data !== undefined` is the wrong readiness signal here: it is true during the
+unscoped window.
+
+React Query hides this well. When the key changes the new entry starts empty, so
+the gate goes quiet again on its own — which is why the flash is a flash and not
+a stuck page, and why it survives a naive test that only waits for the final
+state.
+
+## How to apply
+
+- When threading a date/tenant/locale into a query key, ask **where that value
+  comes from**. If it comes from another query, you have an unscoped window.
+- Gate the *consumer* on the scoping value's own arrival —
+  `if (cachedDatesData && districtsData && !selectedDistrict)`, not just
+  `if (districtsData && !selectedDistrict)`.
+- Prefer that to `enabled:` on the query when a legitimately absent value must
+  still produce an answer: here a district with *no* snapshots never gets a
+  date, and disabling the fetch would have left it with no roster at all — the
+  fallback page it actually needs would never render.
+- **Measure the race rather than reasoning about it.** Two `curl -w
+  %{size_download}` calls turned "there is a theoretical flash" into "the wrong
+  answer wins by 4.4×." That flipped this from a nit to a required guard.
+- Pin it with a test that holds the scoping query in its loading state for the
+  whole test (`mockReturnValue`, not `mockReturnValueOnce`) and asserts the gate
+  stays shut. Re-apply the loaded default in `beforeEach` — `vi.clearAllMocks()`
+  clears calls, **not** implementations, so a persistent `mockReturnValue` set
+  inside one test leaks into the next.
+
+## Related
+
+- [[a-deliberately-shared-query-key-is-a-coupling-with-no-compiler]] — #1396,
+  the same defect one hook over; that lesson covers the key itself, this one
+  covers the window before the key is right.
+- R3 (`tasks/rules.md`) — both bugs are the same violation: the parent owned the
+  date and the child answered from `latest` instead.

--- a/tasks/lessons/lessons/a-query-scoped-by-an-async-value-runs-unscoped-first.md
+++ b/tasks/lessons/lessons/a-query-scoped-by-an-async-value-runs-unscoped-first.md
@@ -72,6 +72,10 @@ state.
 - **Measure the race rather than reasoning about it.** Two `curl -w
   %{size_download}` calls turned "there is a theoretical flash" into "the wrong
   answer wins by 4.4×." That flipped this from a nit to a required guard.
+- Grep the key literal across `__tests__/` too, not just `src/`. #1396's lesson
+  says "a key that appears in two files is an undeclared contract" — the second
+  file here was a test harness seeding `setQueryData(['districts'], …)`, which
+  simply stopped matching and silently degraded the assertion's subject.
 - Pin it with a test that holds the scoping query in its loading state for the
   whole test (`mockReturnValue`, not `mockReturnValueOnce`) and asserts the gate
   stays shut. Re-apply the loaded default in `beforeEach` — `vi.clearAllMocks()`


### PR DESCRIPTION
Makes the browsable district list follow the program year the page is showing, so a district that existed then and does not exist now is reachable. Addresses #1398.

> Developed stacked on #1397 (now merged as `5e032caf`) because both touch `DistrictDetailPage.tsx`. Rebased onto `main` with `--onto`; `git diff --stat origin/main..HEAD` is this PR's seven files only.

## The bug

`useDistricts` derived its list from the undated `fetchCdnRankings()` — the **current** program year only. Districts get realigned between years, so the roster is not stable:

| source | districts | D27? |
|---|---|---|
| `snapshots/2025-06-30/all-districts-rankings.json` | **132** | yes |
| `snapshots/2026-06-30/all-districts-rankings.json` | **128** | yes |
| `v1/rankings.json` (today, as-of 2026-08-02) | **94** | **no** |

`DistrictDetailPage:375` reads that list as an **existence gate**, so all 38 districts realigned away since were judged not to exist on *any* year's URL and their visitors landed on the limited Global-Rankings page.

Same defect as #1396, one hook over, and the same two traps applied.

## The fix

- `useDistricts(date?)` reads `snapshots/{date}/all-districts-rankings.json` when given a date, **with the date in the query key** — so year B is never served out of year A's entry (asserted by switching years back and forth on one `QueryClient`).
- Undated stays byte-identical (`date ?? 'latest'`, `fetchCdnRankings`). Unlike #1396's `useLatestAsOfDate` coupling there was **no** sharing to preserve — nothing else keys on `['districts']`.
- `DistrictDetailPage` passes `effectiveEndDate`, matching the `useDistrictRanking` / `useCompetitiveAwards` calls beside it. The declaration moved below that memo because it now consumes it.

## The second half: the gate had to wait for the date too

`effectiveEndDate` is itself derived from a fetch, so the **first render has no date** and the hook runs its unscoped branch — the exact query that caused the bug. I assumed that window was narrow. Measuring said otherwise:

```
config/district-snapshot-index.json   388,643 B
v1/rankings.json                       87,572 B
snapshots/2025-06-30/…-rankings.json   11,177 B
```

The roster that gives the **wrong** answer is 4.4× smaller than the file that tells you which roster to ask for, so it wins that race routinely. Without a guard, every past-year district page would flash the "This district has limited data available" fallback before its real page. The gate now also waits on `cachedDatesData`. `enabled:` on the query was the wrong tool: a district with *no* snapshots never gets a date, and disabling the fetch would have denied it the fallback page it actually needs.

## Consumer audit (the #1396 key-sharing trap)

Twelve consumers, checked individually:

| consumer | uses the list for | verdict |
|---|---|---|
| `DistrictDetailPage` | **existence gate** + name | **dated** — the bug |
| `DistrictClubsPage`, `DistrictDivisionsPage`, `DistrictRankingsPage`, `DistrictAnalyticsPage`, `DistrictTrendsPage`, `DistrictActionListPage`, `DistrictGridPage`, `ClubDetailPage`, `DistrictChangesPage` | `rawName` for a heading/breadcrumb only | left undated |
| `ErrorPage` (404 recovery) | which districts exist **now** | undated on purpose |
| `ClubHistoryPage` | inherently all-years | undated on purpose |

No consumer shares the `['districts']` key with another hook (grepped; `RegionsLeaderboard`'s `field="districts"` and `cdn.ts`'s `raw['districts']` are unrelated). The name-only consumers are a *measured* non-issue rather than an assumption: every district absent from the current roster is numerically named, so `rawName` falls through to `District {id}` and renders identically either way. Only `F` and `U` have non-numeric names and both exist in both years. This is recorded in the hook's doc comment, with the caveat that a second gate on any of those pages must pass its date.

The one place the key *was* shared turned out to be a test harness: `errorPage.test.tsx` seeded `setQueryData(['districts'], …)`, which stopped matching and silently degraded the assertion's subject. Fixed by following the key, not by weakening the expectation.

## Other undated `fetchCdnRankings()` callers — the requested sweep

| caller | status |
|---|---|
| `useLatestAsOfDate.ts:49` | correct — its job *is* "latest" |
| `DistrictsPage.tsx:296`, `RegionsPage.tsx:53`, `RegionPage.tsx:287` | correct — all three are `effectiveDate ? ForDate : latest` **and** key on `['district-rankings', effectiveDate ?? 'latest']` |
| `services/searchIndex.ts:254` (`loadSearchIndex`) | **the third instance — reported, not fixed here.** The omni-search index is built from the current roster, so a past-year-only district (D27) is unfindable by search at any year. Different shape from this bug: the header search bar is global chrome with no program year to violate, so scoping it is a product decision (should search find districts that no longer exist?), not a mechanical R3 fix. Worth its own issue. |

## Deliberate non-choices

- **No `placeholderData: prev => prev`** (siblings use it). Holding the previous year's roster across a year switch renders the old year's district set under the new year's heading — a transient copy of this very bug.
- **The `cdn.ts` latest-fallback is allowed to stand here**, unlike in `useDistrictRanking`, which suppresses it. There, the wrong year's *numbers* are a silent data lie, so "no row" is honest. Here the list is a navigational index behind an existence gate: falling back to the current roster is exactly today's behaviour, whereas reporting "no districts" would send **every** district — current year included — to the Global-Rankings fallback. Degrading to the status quo beats a self-inflicted outage.

## Tests — Red first

| test | red state |
|---|---|
| `useDistricts.test.tsx` | 6 of 7 failed: dated call returned the current roster (no D27), year two was a cache hit on year one, no `['districts', <date>]` entries |
| `DistrictDetailPage.pastYearDistrict.test.tsx` | `/district/27?py=2024&date=2025-06-30` rendered the Global-Rankings fallback |
| …its flash-guard case | verified separately by reverting only the `cachedDatesData &&` clause — the sole failure |

Three counterpart tests pin what must **not** change: the undated path still calls `fetchCdnRankings` under `['districts', 'latest']`, a current-year district still renders, and a district present in *no* year still reaches the fallback. The gate's own semantics are unchanged.

A first draft of the page test passed against the unfixed code — it asserted before the roster query resolved, inside the window where the gate cannot fire. It now waits on a prefix-matched `getQueriesData({ queryKey: ['districts'] })` so it is indifferent to whether the key carries a date.

## Gates

`npm run test` (frontend 332 files / 3906 tests, plus collector-cli 1090, analytics-core 886, shared-contracts 162, mcp-server 67) · `test:scripts` (27 / 353) · `typecheck` · `typecheck:tests` · `lint` · `lint:yaml` · `format:check` · `test:no-page-mounts:check` (R22) · `test:projects:check` (R20, 332 = 233 + 99) — all green locally, re-run **after** the rebase onto merged `main`, not only before it.

Refs #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoCZn3LeJX495jz4KdTQBh
