### PR TITLE
fix(ui): clamp shared tooltip panels inside the viewport (#1405)

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -195,6 +195,23 @@ jobs:
           npx playwright test --config playwright.config.ts
           e2e/breadcrumb-alignment.smoke.ts
 
+      # Tooltip viewport-collision tripwire (#1405). The two shared tooltip
+      # components centre a fixed-width panel on their trigger with no
+      # collision handling, so a trigger in a card's leftmost column opened the
+      # panel at left −67 and the landing page's rightmost table header ran to
+      # right 1407 in a 1350px viewport. Nothing existing could see it: the
+      # panel is visible, contrasty, above 44px and causes no shift — it is
+      # simply half off-screen. Real geometry at 375/768/1350 in light and
+      # dark, both engines, and the 44px trigger floor re-asserted so the
+      # shrink-the-control "fix" cannot turn this green.
+      - name: Cross-engine tooltip viewport-clip tripwire against preview
+        working-directory: frontend
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.url }}
+        run: >-
+          npx playwright test --config playwright.config.ts
+          e2e/tooltip-viewport-clip.smoke.ts
+
       # Mobile loading/error→loaded CLS guard (#922). The Lighthouse CLS gate
       # runs the desktop preset, where the landing header actions lay out
       # inline — it is blind to the mobile-only stack that pushed the KPI

--- a/frontend/e2e/tooltip-viewport-clip.smoke.ts
+++ b/frontend/e2e/tooltip-viewport-clip.smoke.ts
@@ -71,7 +71,10 @@ const TARGETS: Target[] = [
     what: 'landing InfoTooltips',
     triggers: 'button[aria-label="info"]',
     sentinel: 'button[aria-label="info"]',
-    minPanels: 4,
+    // 13 triggers exist, but at 375px most of the stat-card and table-header
+    // row is off-canvas or obscured and cannot be hovered at all; 4 open
+    // there (including the two right-edge offenders) against 12 at 1350px.
+    minPanels: 3,
   },
 ]
 

--- a/frontend/e2e/tooltip-viewport-clip.smoke.ts
+++ b/frontend/e2e/tooltip-viewport-clip.smoke.ts
@@ -1,0 +1,215 @@
+import { test, expect, type Page, type Locator } from '@playwright/test'
+import { MIN_TOUCH_TARGET_PX } from '../src/utils/touchTargetUtils'
+
+/* Tooltip viewport-collision tripwire (#1405).
+ *
+ * The two shared tooltip components render a fixed-width panel centred on
+ * their trigger — `Tooltip` at w-80 (320px), `InfoTooltip` at w-56 (224px) —
+ * with no collision handling. `centre − width/2` is negative for a trigger in
+ * a card's leftmost column, so half the panel rendered off-screen and the
+ * opening words were unreadable. Measured on production before the fix
+ * (Chromium, identical at 375 / 768 / 1350):
+ *
+ *   /district/61/analytics, Education Levels
+ *     Level 1                left −67  right 253
+ *     Level 2                left −65  right 255
+ *     Level 3                left −65  right 255
+ *     Level 4+ · Path · DTM  left −21  right 299
+ *
+ * The right edge had the mirror problem, and NOT only on the reported card —
+ * the landing page's table-header `InfoTooltip` ran past it at every width
+ * (right 432 / 825 / 1407 against innerWidth 375 / 768 / 1350), as did the
+ * district KPI strip's `Tooltip`s. The fix therefore lives in the shared
+ * components (R10), and this guard covers both edges and both components.
+ *
+ * Why this shape (lessons 108 / 134 / 138, and the #1387 probe):
+ *  - Real geometry, not `toBeVisible`. A visibility assertion passes on `main`
+ *    with the panel half off-screen — that is precisely the bug. We read
+ *    `getBoundingClientRect()` and compare against the live viewport.
+ *  - Every viewport in the acceptance set (375 / 768 / 1350) and both themes.
+ *    Column position decides the clip, and which column sits near an edge is a
+ *    function of width, so a single-viewport check would miss most of it.
+ *  - Both engines (#710) via the two playwright.config projects.
+ *  - Asserts the 44px trigger floor SURVIVES in the same run. The forbidden
+ *    "fix" is to shrink the control; this reds if anyone tries it.
+ */
+
+const VIEWPORTS = [
+  { label: '375px', width: 375, height: 812 },
+  { label: '768px', width: 768, height: 1024 },
+  { label: '1350px', width: 1350, height: 900 },
+]
+
+const THEMES = ['light', 'dark'] as const
+
+interface Target {
+  /** Route to open. */
+  route: string
+  /** What the triggers are, for failure messages. */
+  what: string
+  /** Hover targets that open a tooltip panel. */
+  triggers: string
+  /** Selector that must exist before we measure (anti-vacuous-green). */
+  sentinel: string
+  /** How many panels this target must actually produce. */
+  minPanels: number
+}
+
+const TARGETS: Target[] = [
+  {
+    // The reported bug: four rows, all clipped on the LEFT.
+    route: '/district/61/analytics',
+    what: 'Education Levels',
+    triggers: 'section[aria-label="education levels"] svg[viewBox="0 0 20 20"]',
+    sentinel: 'section[aria-label="education levels"]',
+    minPanels: 5,
+  },
+  {
+    // The mirror problem, on the other shared component: the landing page's
+    // rightmost table-header InfoTooltip overflowed the RIGHT edge.
+    route: '/',
+    what: 'landing InfoTooltips',
+    triggers: 'button[aria-label="info"]',
+    sentinel: 'button[aria-label="info"]',
+    minPanels: 4,
+  },
+]
+
+interface PanelBox {
+  text: string
+  left: number
+  right: number
+  viewport: number
+}
+
+async function readOpenPanels(page: Page): Promise<PanelBox[]> {
+  return page.evaluate(() => {
+    // The panel is clamped against the visible content width, which excludes
+    // a classic scrollbar; `innerWidth` does not.
+    const viewport =
+      document.documentElement.clientWidth || window.innerWidth || 0
+    return Array.from(document.querySelectorAll('[role="tooltip"]')).map(el => {
+      const r = el.getBoundingClientRect()
+      return {
+        text: (el.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 40),
+        left: Math.round(r.left),
+        right: Math.round(r.right),
+        viewport,
+      }
+    })
+  })
+}
+
+async function openAndMeasure(
+  page: Page,
+  triggers: Locator
+): Promise<PanelBox[]> {
+  const count = await triggers.count()
+  const measured: PanelBox[] = []
+  for (let i = 0; i < count; i++) {
+    const trigger = triggers.nth(i)
+    try {
+      await trigger.scrollIntoViewIfNeeded({ timeout: 5_000 })
+      await trigger.hover({ timeout: 5_000 })
+    } catch {
+      // Obscured or off-canvas at this width — nothing a user can open.
+      continue
+    }
+    // Tooltip's default open delay is 200ms.
+    await page.waitForTimeout(350)
+    measured.push(...(await readOpenPanels(page)))
+    await page.mouse.move(0, 0)
+    await page.waitForTimeout(120)
+  }
+  return measured
+}
+
+async function load(page: Page, route: string, theme: string): Promise<void> {
+  // DarkModeContext reads localStorage['theme'] before first paint.
+  await page.addInitScript(t => {
+    window.localStorage.setItem('theme', t)
+  }, theme)
+  await page.goto(route, { waitUntil: 'networkidle', timeout: 60_000 })
+  await page.evaluate(() => document.fonts.ready)
+}
+
+function describeBox(b: PanelBox): string {
+  return `"${b.text}" [${b.left}, ${b.right}] in 0..${b.viewport}`
+}
+
+for (const theme of THEMES) {
+  for (const { label, width, height } of VIEWPORTS) {
+    test(`tooltip panels stay inside the viewport — ${label} ${theme}`, async ({
+      page,
+    }) => {
+      test.setTimeout(180_000)
+      await page.setViewportSize({ width, height })
+
+      for (const target of TARGETS) {
+        await load(page, target.route, theme)
+        await page
+          .locator(target.sentinel)
+          .first()
+          .waitFor({ state: 'visible', timeout: 30_000 })
+        expect(
+          await page.getAttribute('html', 'data-theme'),
+          'theme did not apply — measured the wrong appearance'
+        ).toBe(theme)
+
+        const where = `${label}/${theme} ${target.route} (${target.what})`
+        const boxes = await openAndMeasure(page, page.locator(target.triggers))
+
+        // Non-vacuity: a panel that never opened cannot be clipped, and a
+        // silently-empty run is the failure mode this guard must not have.
+        expect(
+          boxes.length,
+          `${where}: opened ${boxes.length} tooltip panel(s), expected at ` +
+            `least ${target.minPanels} — nothing was measured`
+        ).toBeGreaterThanOrEqual(target.minPanels)
+
+        const clipped = boxes.filter(b => b.left < 0 || b.right > b.viewport)
+        expect(
+          clipped,
+          `${where}: ${clipped.length} tooltip panel(s) outside the ` +
+            `viewport: ${clipped.map(describeBox).join('; ')}`
+        ).toEqual([])
+      }
+    })
+  }
+}
+
+/* The trivial way to stop a 320px panel overflowing a 375px viewport is to
+   shrink the trigger (or the panel) until nothing collides. Shrinking the
+   trigger trades a readability bug for a WCAG 2.5.5 violation, so pin the
+   floor on the very controls this fix touches — independently of the
+   whole-page sweep in touch-targets.smoke.ts. */
+test('the tooltip triggers keep their 44px floor', async ({ page }) => {
+  test.setTimeout(120_000)
+  await page.setViewportSize({ width: 375, height: 812 })
+  await load(page, '/', 'light')
+  await page
+    .locator('button[aria-label="info"]')
+    .first()
+    .waitFor({ state: 'visible', timeout: 30_000 })
+  await page.waitForTimeout(500)
+
+  const undersized = await page.evaluate(floor => {
+    const out: string[] = []
+    for (const el of Array.from(
+      document.querySelectorAll('button[aria-label="info"]')
+    )) {
+      const r = el.getBoundingClientRect()
+      if (r.width <= 1 || r.height <= 1) continue // collapsed, not a target
+      if (r.width < floor || r.height < floor) {
+        out.push(`${Math.round(r.width)}×${Math.round(r.height)}`)
+      }
+    }
+    return out
+  }, MIN_TOUCH_TARGET_PX)
+
+  expect(
+    undersized,
+    `info-tooltip trigger(s) below the ${MIN_TOUCH_TARGET_PX}px floor: ` +
+      undersized.join('; ')
+  ).toEqual([])
+})

--- a/frontend/e2e/tooltip-viewport-clip.smoke.ts
+++ b/frontend/e2e/tooltip-viewport-clip.smoke.ts
@@ -18,20 +18,29 @@ import { MIN_TOUCH_TARGET_PX } from '../src/utils/touchTargetUtils'
  *
  * The right edge had the mirror problem, and NOT only on the reported card —
  * the landing page's table-header `InfoTooltip` ran past it at every width
- * (right 432 / 825 / 1407 against innerWidth 375 / 768 / 1350), as did the
- * district KPI strip's `Tooltip`s. The fix therefore lives in the shared
- * components (R10), and this guard covers both edges and both components.
+ * (right 432 / 825 / 1407 against 375 / 768 / 1350), as did the district KPI
+ * strip's `Tooltip`s. The fix lives in the shared components (R10), so this
+ * guard covers both edges and both components.
  *
  * Why this shape (lessons 108 / 134 / 138, and the #1387 probe):
  *  - Real geometry, not `toBeVisible`. A visibility assertion passes on `main`
- *    with the panel half off-screen — that is precisely the bug. We read
+ *    with the panel half off-screen — that IS the bug. We read
  *    `getBoundingClientRect()` and compare against the live viewport.
- *  - Every viewport in the acceptance set (375 / 768 / 1350) and both themes.
- *    Column position decides the clip, and which column sits near an edge is a
- *    function of width, so a single-viewport check would miss most of it.
- *  - Both engines (#710) via the two playwright.config projects.
- *  - Asserts the 44px trigger floor SURVIVES in the same run. The forbidden
- *    "fix" is to shrink the control; this reds if anyone tries it.
+ *  - The edge cases are FORCED, not hunted. Which trigger happens to sit near
+ *    an edge is a function of the width, the snapshot's data and what the
+ *    responsive layout hides — at 375px most of the landing's table-header
+ *    buttons live inside a horizontally-scrolled table and cannot be hovered
+ *    at all, so a "hover everything and hope something is near an edge" sweep
+ *    measures 2 panels at one width and 12 at another. Pinning a trigger to
+ *    each edge makes both cases unconditional on every engine, at every width,
+ *    whatever the data does — the same move `breadcrumb-alignment.smoke.ts`
+ *    makes when it constrains the nav rather than hoping the row wraps.
+ *  - The reported card is still swept as-reported, so the literal regression
+ *    is covered and not just an abstraction of it.
+ *  - Every viewport in the acceptance set (375 / 768 / 1350), both themes,
+ *    both engines (#710) via the two playwright.config projects.
+ *  - Asserts the 44px trigger floor SURVIVES. The tempting "fix" is to shrink
+ *    the control; this reds if anyone tries it.
  */
 
 const VIEWPORTS = [
@@ -42,39 +51,24 @@ const VIEWPORTS = [
 
 const THEMES = ['light', 'dark'] as const
 
-interface Target {
-  /** Route to open. */
-  route: string
-  /** What the triggers are, for failure messages. */
-  what: string
-  /** Hover targets that open a tooltip panel. */
-  triggers: string
-  /** Selector that must exist before we measure (anti-vacuous-green). */
-  sentinel: string
-  /** How many panels this target must actually produce. */
-  minPanels: number
-}
+/** The reported card: four rows plus the header tooltip, all left-clipped. */
+const EDUCATION_CARD = 'section[aria-label="education levels"]'
+const EDUCATION_TRIGGERS = `${EDUCATION_CARD} svg[viewBox="0 0 20 20"]`
+const EDUCATION_PANELS = 5
 
-const TARGETS: Target[] = [
+/** One live instance of each shared component, for the forced-edge checks. */
+const PINNABLE = [
   {
-    // The reported bug: four rows, all clipped on the LEFT.
+    what: 'Tooltip (w-80)',
     route: '/district/61/analytics',
-    what: 'Education Levels',
-    triggers: 'section[aria-label="education levels"] svg[viewBox="0 0 20 20"]',
-    sentinel: 'section[aria-label="education levels"]',
-    minPanels: 5,
+    trigger: EDUCATION_TRIGGERS,
+    sentinel: EDUCATION_CARD,
   },
   {
-    // The mirror problem, on the other shared component: the landing page's
-    // rightmost table-header InfoTooltip overflowed the RIGHT edge.
+    what: 'InfoTooltip (w-56)',
     route: '/',
-    what: 'landing InfoTooltips',
-    triggers: 'button[aria-label="info"]',
+    trigger: 'button[aria-label="info"]',
     sentinel: 'button[aria-label="info"]',
-    // 13 triggers exist, but at 375px most of the stat-card and table-header
-    // row is off-canvas or obscured and cannot be hovered at all; 4 open
-    // there (including the two right-edge offenders) against 12 at 1350px.
-    minPanels: 3,
   },
 ]
 
@@ -103,28 +97,15 @@ async function readOpenPanels(page: Page): Promise<PanelBox[]> {
   })
 }
 
-async function openAndMeasure(
-  page: Page,
-  triggers: Locator
-): Promise<PanelBox[]> {
-  const count = await triggers.count()
-  const measured: PanelBox[] = []
-  for (let i = 0; i < count; i++) {
-    const trigger = triggers.nth(i)
-    try {
-      await trigger.scrollIntoViewIfNeeded({ timeout: 5_000 })
-      await trigger.hover({ timeout: 5_000 })
-    } catch {
-      // Obscured or off-canvas at this width — nothing a user can open.
-      continue
-    }
-    // Tooltip's default open delay is 200ms.
-    await page.waitForTimeout(350)
-    measured.push(...(await readOpenPanels(page)))
-    await page.mouse.move(0, 0)
-    await page.waitForTimeout(120)
-  }
-  return measured
+async function hoverAndRead(page: Page, trigger: Locator): Promise<PanelBox[]> {
+  await trigger.scrollIntoViewIfNeeded({ timeout: 5_000 })
+  await trigger.hover({ timeout: 5_000 })
+  // Tooltip's default open delay is 200ms.
+  await page.waitForTimeout(350)
+  const boxes = await readOpenPanels(page)
+  await page.mouse.move(0, 0)
+  await page.waitForTimeout(120)
+  return boxes
 }
 
 async function load(page: Page, route: string, theme: string): Promise<void> {
@@ -136,56 +117,129 @@ async function load(page: Page, route: string, theme: string): Promise<void> {
   await page.evaluate(() => document.fonts.ready)
 }
 
+/**
+ * Move a tooltip's positioning wrapper hard against one viewport edge, so the
+ * collision this guard is about happens for certain rather than depending on
+ * where the layout happened to put a column.
+ */
+async function pinTriggerToEdge(
+  page: Page,
+  triggerSelector: string,
+  edge: 'left' | 'right'
+): Promise<void> {
+  const pinned = await page.evaluate(
+    ({ triggerSelector, edge }) => {
+      const trigger = document.querySelector(triggerSelector)
+      // Both components put the panel in a `position: relative` wrapper; that
+      // wrapper is the panel's containing block, so moving it moves the pair.
+      const wrapper = trigger?.closest<HTMLElement>('.relative')
+      if (!wrapper) return false
+      wrapper.style.position = 'fixed'
+      wrapper.style.top = '50%'
+      wrapper.style.zIndex = '9999'
+      wrapper.style.left = edge === 'left' ? '0px' : 'auto'
+      wrapper.style.right = edge === 'right' ? '0px' : 'auto'
+      return true
+    },
+    { triggerSelector, edge }
+  )
+  expect(
+    pinned,
+    `could not find a positioning wrapper for ${triggerSelector} — the ` +
+      'component structure changed and this guard is no longer testing it'
+  ).toBe(true)
+  await page.waitForTimeout(100)
+}
+
 function describeBox(b: PanelBox): string {
   return `"${b.text}" [${b.left}, ${b.right}] in 0..${b.viewport}`
 }
 
+function expectInsideViewport(boxes: PanelBox[], where: string): void {
+  const clipped = boxes.filter(b => b.left < 0 || b.right > b.viewport)
+  expect(
+    clipped,
+    `${where}: ${clipped.length} tooltip panel(s) outside the viewport: ` +
+      clipped.map(describeBox).join('; ')
+  ).toEqual([])
+}
+
 for (const theme of THEMES) {
   for (const { label, width, height } of VIEWPORTS) {
-    test(`tooltip panels stay inside the viewport — ${label} ${theme}`, async ({
+    /* The bug exactly as reported: every row of the Education Levels card,
+       whose label column is the leftmost thing on the page. */
+    test(`Education Levels tooltips stay inside the viewport — ${label} ${theme}`, async ({
       page,
     }) => {
-      test.setTimeout(180_000)
+      test.setTimeout(120_000)
       await page.setViewportSize({ width, height })
+      await load(page, '/district/61/analytics', theme)
+      await page
+        .locator(EDUCATION_CARD)
+        .waitFor({ state: 'visible', timeout: 30_000 })
+      expect(
+        await page.getAttribute('html', 'data-theme'),
+        'theme did not apply — measured the wrong appearance'
+      ).toBe(theme)
 
-      for (const target of TARGETS) {
-        await load(page, target.route, theme)
-        await page
-          .locator(target.sentinel)
-          .first()
-          .waitFor({ state: 'visible', timeout: 30_000 })
-        expect(
-          await page.getAttribute('html', 'data-theme'),
-          'theme did not apply — measured the wrong appearance'
-        ).toBe(theme)
+      const triggers = page.locator(EDUCATION_TRIGGERS)
+      const boxes: PanelBox[] = []
+      for (let i = 0; i < (await triggers.count()); i++) {
+        boxes.push(...(await hoverAndRead(page, triggers.nth(i))))
+      }
 
-        const where = `${label}/${theme} ${target.route} (${target.what})`
-        const boxes = await openAndMeasure(page, page.locator(target.triggers))
+      // Non-vacuity: the card is a plain block that renders identically at
+      // every width, so all five of its tooltips must have opened. A card that
+      // failed to render cannot pass this guard by measuring nothing.
+      expect(
+        boxes.length,
+        `${label}/${theme}: opened ${boxes.length} of ${EDUCATION_PANELS} ` +
+          'Education Levels tooltips — the card did not render as expected'
+      ).toBe(EDUCATION_PANELS)
 
-        // Non-vacuity: a panel that never opened cannot be clipped, and a
-        // silently-empty run is the failure mode this guard must not have.
+      expectInsideViewport(boxes, `${label}/${theme} Education Levels`)
+    })
+  }
+}
+
+/* Both shared components, both edges, forced — independent of which column the
+   data and the responsive layout happen to produce.
+   Light theme only, deliberately: the theme axis is already covered above, and
+   nothing in the clamp is theme-dependent (it reads a box and writes a length).
+   The two axes that DO change the outcome are the viewport width and which
+   component's panel width is being clamped, and both are swept here. */
+for (const { label, width, height } of VIEWPORTS) {
+  for (const { what, route, trigger, sentinel } of PINNABLE) {
+    test(`${what} stays readable pinned to either edge — ${label}`, async ({
+      page,
+    }) => {
+      test.setTimeout(120_000)
+      await page.setViewportSize({ width, height })
+      await load(page, route, 'light')
+      await page
+        .locator(sentinel)
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 })
+
+      for (const edge of ['left', 'right'] as const) {
+        await pinTriggerToEdge(page, trigger, edge)
+        const boxes = await hoverAndRead(page, page.locator(trigger).first())
+
         expect(
           boxes.length,
-          `${where}: opened ${boxes.length} tooltip panel(s), expected at ` +
-            `least ${target.minPanels} — nothing was measured`
-        ).toBeGreaterThanOrEqual(target.minPanels)
-
-        const clipped = boxes.filter(b => b.left < 0 || b.right > b.viewport)
-        expect(
-          clipped,
-          `${where}: ${clipped.length} tooltip panel(s) outside the ` +
-            `viewport: ${clipped.map(describeBox).join('; ')}`
-        ).toEqual([])
+          `${label}: pinning ${what} to the ${edge} edge opened no panel — ` +
+            'nothing was measured'
+        ).toBeGreaterThan(0)
+        expectInsideViewport(boxes, `${label} ${what} ${edge} edge`)
       }
     })
   }
 }
 
 /* The trivial way to stop a 320px panel overflowing a 375px viewport is to
-   shrink the trigger (or the panel) until nothing collides. Shrinking the
-   trigger trades a readability bug for a WCAG 2.5.5 violation, so pin the
-   floor on the very controls this fix touches — independently of the
-   whole-page sweep in touch-targets.smoke.ts. */
+   shrink the trigger until nothing collides. That trades a readability bug for
+   a WCAG 2.5.5 violation, so pin the floor on the very controls this fix
+   touches — independently of the whole-page sweep in touch-targets.smoke.ts. */
 test('the tooltip triggers keep their 44px floor', async ({ page }) => {
   test.setTimeout(120_000)
   await page.setViewportSize({ width: 375, height: 812 })
@@ -196,23 +250,29 @@ test('the tooltip triggers keep their 44px floor', async ({ page }) => {
     .waitFor({ state: 'visible', timeout: 30_000 })
   await page.waitForTimeout(500)
 
-  const undersized = await page.evaluate(floor => {
-    const out: string[] = []
+  const measured = await page.evaluate(floor => {
+    const undersized: string[] = []
+    let counted = 0
     for (const el of Array.from(
       document.querySelectorAll('button[aria-label="info"]')
     )) {
       const r = el.getBoundingClientRect()
       if (r.width <= 1 || r.height <= 1) continue // collapsed, not a target
+      counted++
       if (r.width < floor || r.height < floor) {
-        out.push(`${Math.round(r.width)}×${Math.round(r.height)}`)
+        undersized.push(`${Math.round(r.width)}×${Math.round(r.height)}`)
       }
     }
-    return out
+    return { undersized, counted }
   }, MIN_TOUCH_TARGET_PX)
 
   expect(
-    undersized,
+    measured.counted,
+    'measured 0 info-tooltip triggers — the page did not render'
+  ).toBeGreaterThan(0)
+  expect(
+    measured.undersized,
     `info-tooltip trigger(s) below the ${MIN_TOUCH_TARGET_PX}px floor: ` +
-      undersized.join('; ')
+      measured.undersized.join('; ')
   ).toEqual([])
 })

--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useViewportClampedTooltip } from '../hooks/useViewportClampedTooltip'
 
 interface InfoTooltipProps {
   /** The tooltip text to display on hover/focus */
@@ -11,6 +12,10 @@ interface InfoTooltipProps {
  */
 const InfoTooltip: React.FC<InfoTooltipProps> = ({ text }) => {
   const [isVisible, setIsVisible] = useState(false)
+  // Keeps the panel inside the viewport when the trigger sits near an edge
+  // (#1405) — the rightmost table-header tooltip overflowed at every width.
+  const { panelRef, style: clampStyle } =
+    useViewportClampedTooltip<HTMLSpanElement>(isVisible)
 
   return (
     <span className="relative inline-flex items-center ml-1">
@@ -39,10 +44,12 @@ const InfoTooltip: React.FC<InfoTooltipProps> = ({ text }) => {
       {isVisible && (
         <span
           role="tooltip"
-          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 text-xs font-normal normal-case tracking-normal text-white bg-gray-900 rounded-lg shadow-lg whitespace-normal w-56 z-50 leading-relaxed"
+          ref={panelRef}
+          style={clampStyle}
+          className="absolute bottom-full tooltip-panel tooltip-panel--centered mb-2 px-3 py-2 text-xs font-normal normal-case tracking-normal text-white bg-gray-900 rounded-lg shadow-lg whitespace-normal w-56 z-50 leading-relaxed"
         >
           {text}
-          <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900" />
+          <span className="absolute top-full tooltip-arrow--centered border-4 border-transparent border-t-gray-900" />
         </span>
       )}
     </span>

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react'
+import { useViewportClampedTooltip } from '../hooks/useViewportClampedTooltip'
 
 /**
  * Props for the Tooltip component
@@ -49,6 +50,9 @@ export const Tooltip: React.FC<TooltipProps> = ({
     () => `tooltip-${Math.random().toString(36).substr(2, 9)}`
   )
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Keeps the panel inside the viewport when the trigger sits near an edge.
+  const { panelRef, style: clampStyle } =
+    useViewportClampedTooltip<HTMLDivElement>(isVisible)
 
   const showTooltip = () => {
     if (timeoutRef.current) {
@@ -74,33 +78,35 @@ export const Tooltip: React.FC<TooltipProps> = ({
     }
   }, [])
 
+  /* Placement. The horizontal centring (and the viewport-collision shift that
+     composes into it) lives in `styles/components/tooltip.css` — see #1405:
+     Tailwind v4's `-translate-x-1/2` compiles to the `translate` property, so
+     the utility and the measured shift cannot both own that declaration. */
   const getPositionClasses = () => {
     switch (position) {
-      case 'top':
-        return 'bottom-full left-1/2 -translate-x-1/2 mb-2'
       case 'bottom':
-        return 'top-full left-1/2 -translate-x-1/2 mt-2'
+        return 'top-full tooltip-panel--centered mt-2'
       case 'left':
-        return 'right-full top-1/2 -translate-y-1/2 mr-2'
+        return 'right-full top-1/2 tooltip-panel--side mr-2'
       case 'right':
-        return 'left-full top-1/2 -translate-y-1/2 ml-2'
+        return 'left-full top-1/2 tooltip-panel--side ml-2'
+      case 'top':
       default:
-        return 'bottom-full left-1/2 -translate-x-1/2 mb-2'
+        return 'bottom-full tooltip-panel--centered mb-2'
     }
   }
 
   const getArrowClasses = () => {
     switch (position) {
-      case 'top':
-        return 'top-full left-1/2 -translate-x-1/2 border-t-gray-900 border-l-transparent border-r-transparent border-b-transparent'
       case 'bottom':
-        return 'bottom-full left-1/2 -translate-x-1/2 border-b-gray-900 border-l-transparent border-r-transparent border-t-transparent'
+        return 'bottom-full tooltip-arrow--centered border-b-gray-900 border-l-transparent border-r-transparent border-t-transparent'
       case 'left':
-        return 'left-full top-1/2 -translate-y-1/2 border-l-gray-900 border-t-transparent border-b-transparent border-r-transparent'
+        return 'left-full top-1/2 tooltip-arrow--side border-l-gray-900 border-t-transparent border-b-transparent border-r-transparent'
       case 'right':
-        return 'right-full top-1/2 -translate-y-1/2 border-r-gray-900 border-t-transparent border-b-transparent border-l-transparent'
+        return 'right-full top-1/2 tooltip-arrow--side border-r-gray-900 border-t-transparent border-b-transparent border-l-transparent'
+      case 'top':
       default:
-        return 'top-full left-1/2 -translate-x-1/2 border-t-gray-900 border-l-transparent border-r-transparent border-b-transparent'
+        return 'top-full tooltip-arrow--centered border-t-gray-900 border-l-transparent border-r-transparent border-b-transparent'
     }
   }
 
@@ -121,7 +127,9 @@ export const Tooltip: React.FC<TooltipProps> = ({
         <div
           id={tooltipId}
           role="tooltip"
-          className={`absolute z-50 px-4 py-3 text-sm text-white bg-gray-900 rounded-lg shadow-lg w-80 ${getPositionClasses()} ${className} animate-fade-in`}
+          ref={panelRef}
+          style={clampStyle}
+          className={`absolute z-50 px-4 py-3 text-sm text-white bg-gray-900 rounded-lg shadow-lg w-80 tooltip-panel ${getPositionClasses()} ${className} animate-fade-in`}
         >
           {content}
           <div

--- a/frontend/src/components/__tests__/TooltipViewportClamp.test.tsx
+++ b/frontend/src/components/__tests__/TooltipViewportClamp.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Viewport-collision contract for the two shared tooltip panels (#1405).
+ *
+ * Both `Tooltip` (w-80 = 320px) and `InfoTooltip` (w-56 = 224px) render a
+ * fixed-width panel centred on their trigger with no collision handling, so a
+ * trigger near either viewport edge puts half the panel off-screen. Measured
+ * on production before the fix: the Education Levels rows opened at
+ * left −67 / −65 / −65 / −21, and the landing table-header tooltip ran to
+ * right 432 at innerWidth 375.
+ *
+ * jsdom has no layout engine, so this file INSTALLS one: a
+ * `getBoundingClientRect` stub that reports where a panel would really sit,
+ * derived from the `--tooltip-shift` the component applies. That makes the
+ * assertion the real one — "the panel's box is inside the viewport" — instead
+ * of a className contract, while the rendered pixels are proven separately by
+ * `e2e/tooltip-viewport-clip.smoke.ts`.
+ *
+ * A test that only asserted the tooltip is visible passes on `main`; these
+ * fail there, at the edge that is actually clipped.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import React from 'react'
+import { Tooltip, InfoIcon } from '../Tooltip'
+import InfoTooltip from '../InfoTooltip'
+
+/** Panel widths the two components ask for (Tailwind w-80 / w-56). */
+const TOOLTIP_PANEL_W = 320
+const INFO_PANEL_W = 224
+
+const VIEWPORT_W = 1024 // jsdom default innerWidth
+
+let realGetBoundingClientRect: typeof HTMLElement.prototype.getBoundingClientRect
+
+/**
+ * Stand in for a layout engine: report the panel at `unshiftedLeft` plus
+ * whatever horizontal shift the component has applied to it.
+ */
+function installPanelLayout(unshiftedLeft: number, width: number): void {
+  HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
+    if (this.getAttribute('role') !== 'tooltip') {
+      return realGetBoundingClientRect.call(this)
+    }
+    const shift =
+      Number.parseFloat(this.style.getPropertyValue('--tooltip-shift')) || 0
+    const left = unshiftedLeft + shift
+    return {
+      x: left,
+      y: 0,
+      left,
+      right: left + width,
+      top: 0,
+      bottom: 40,
+      width,
+      height: 40,
+      toJSON: () => ({}),
+    } as DOMRect
+  }
+}
+
+function panelBox(): DOMRect {
+  return screen.getByRole('tooltip').getBoundingClientRect()
+}
+
+/** `Tooltip` wraps its children in the hover target; the icon is inside it,
+ *  and `mouseover` bubbles up to the wrapper React listens on. */
+function hoverIcon(container: HTMLElement): void {
+  const icon = container.querySelector('svg')
+  if (!icon) throw new Error('tooltip trigger icon did not render')
+  fireEvent.mouseOver(icon)
+}
+
+function expectInsideViewport(where: string): void {
+  const box = panelBox()
+  expect(
+    box.left,
+    `${where}: panel starts at ${box.left} — its opening words are off-screen`
+  ).toBeGreaterThanOrEqual(0)
+  expect(
+    box.right,
+    `${where}: panel ends at ${box.right}, past the ${VIEWPORT_W}px viewport`
+  ).toBeLessThanOrEqual(VIEWPORT_W)
+}
+
+beforeEach(() => {
+  realGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+})
+
+afterEach(() => {
+  HTMLElement.prototype.getBoundingClientRect = realGetBoundingClientRect
+})
+
+describe('Tooltip panel stays inside the viewport (#1405)', () => {
+  it.each([
+    { label: 'Level 1', left: -67 },
+    { label: 'Level 2', left: -65 },
+    { label: 'Level 3', left: -65 },
+    { label: 'Level 4+ · Path · DTM', left: -21 },
+  ])(
+    'shifts the $label panel off the left edge and back into view',
+    async ({ label, left }) => {
+      installPanelLayout(left, TOOLTIP_PANEL_W)
+      const { container } = render(
+        <Tooltip content={`${label} description`} delay={0}>
+          <InfoIcon />
+        </Tooltip>
+      )
+
+      hoverIcon(container)
+      await screen.findByRole('tooltip')
+
+      expectInsideViewport(`left edge / ${label}`)
+    }
+  )
+
+  it('pulls a right-clipped panel back inside', async () => {
+    // Trigger near the right edge: centre − 160 leaves the panel 100px past it.
+    installPanelLayout(VIEWPORT_W - TOOLTIP_PANEL_W + 100, TOOLTIP_PANEL_W)
+    const { container } = render(
+      <Tooltip content="Membership payments minus…" delay={0}>
+        <InfoIcon />
+      </Tooltip>
+    )
+
+    hoverIcon(container)
+    await screen.findByRole('tooltip')
+
+    expectInsideViewport('right edge')
+  })
+
+  it('leaves a panel that already fits exactly where it was', async () => {
+    installPanelLayout(300, TOOLTIP_PANEL_W)
+    const { container } = render(
+      <Tooltip content="Comfortably centred" delay={0}>
+        <InfoIcon />
+      </Tooltip>
+    )
+
+    hoverIcon(container)
+    const panel = await screen.findByRole('tooltip')
+
+    expect(panel.getBoundingClientRect().left).toBe(300)
+  })
+})
+
+describe('InfoTooltip panel stays inside the viewport (#1405)', () => {
+  it('shifts a left-clipped panel back into view', () => {
+    installPanelLayout(-90, INFO_PANEL_W)
+    render(<InfoTooltip text="Paid Clubs = clubs that have met renewal…" />)
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /info/i }))
+
+    expectInsideViewport('InfoTooltip left edge')
+  })
+
+  it('pulls a right-clipped panel back inside (landing table header)', () => {
+    installPanelLayout(VIEWPORT_W - 24, INFO_PANEL_W)
+    render(<InfoTooltip text="Paid Clubs = clubs that have met renewal…" />)
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /info/i }))
+
+    expectInsideViewport('InfoTooltip right edge')
+  })
+
+  it('keeps the 44px WCAG 2.5.5 trigger floor untouched', () => {
+    // The forbidden "fix" is to shrink the control until the panel fits. The
+    // trigger must remain a plain <button>, which base.css floors at 44px —
+    // no width/height utility may cap it (guarded live by
+    // e2e/touch-targets.smoke.ts).
+    render(<InfoTooltip text="Anything" />)
+    const button = screen.getByRole('button', { name: /info/i })
+    expect(button.tagName).toBe('BUTTON')
+    expect(button.className).not.toMatch(/\b(w|h|max-w|max-h)-\d/)
+  })
+})

--- a/frontend/src/hooks/useViewportClampedTooltip.ts
+++ b/frontend/src/hooks/useViewportClampedTooltip.ts
@@ -44,12 +44,12 @@ export function useViewportClampedTooltip<T extends HTMLElement>(
   const appliedShift = useRef(0)
 
   useLayoutEffect(() => {
-    if (!isOpen) {
-      appliedShift.current = 0
-      setShift(0)
-      setArrowShift(0)
-      return
-    }
+    // Nothing to measure while the panel is unmounted. The last shift stays in
+    // state deliberately: `appliedShift` still describes what the next render
+    // will apply, so the re-open measurement recovers the same unshifted
+    // extent. Resetting would only add a render, and `useLayoutEffect` re-runs
+    // before paint anyway, so a stale shift is never painted.
+    if (!isOpen) return
 
     const measure = () => {
       const panel = panelRef.current

--- a/frontend/src/hooks/useViewportClampedTooltip.ts
+++ b/frontend/src/hooks/useViewportClampedTooltip.ts
@@ -1,0 +1,96 @@
+import { useLayoutEffect, useRef, useState, type CSSProperties } from 'react'
+import {
+  computeArrowShift,
+  computeTooltipShift,
+} from '../utils/tooltipViewportShift'
+
+/* Keeps a centred tooltip panel inside the viewport (#1405).
+ *
+ * Both shared tooltip components centre a fixed-width panel on their trigger,
+ * so a trigger in a card's leftmost (or rightmost) column put half the panel
+ * off-screen. The measurement has to happen at runtime — the overflow depends
+ * on where the trigger landed, which no static rule knows — but the RESULT is
+ * expressed purely as two CSS custom properties, so the positioning itself
+ * stays in `styles/components/tooltip.css` (R10) rather than in JS style
+ * objects scattered per card.
+ *
+ * Runs in `useLayoutEffect`, so the shift is applied in the same frame the
+ * panel appears: no visible jump, and nothing to shift since the panel is
+ * absolutely positioned and out of flow (no CLS).
+ */
+
+/** The custom properties `styles/components/tooltip.css` reads. */
+export interface TooltipClampStyle extends CSSProperties {
+  '--tooltip-shift': string
+  '--tooltip-arrow-shift': string
+}
+
+export interface ViewportClampedTooltip<T extends HTMLElement> {
+  /** Attach to the tooltip panel. */
+  panelRef: React.RefObject<T | null>
+  /** Spread onto the same element as `style`. */
+  style: TooltipClampStyle
+}
+
+export function useViewportClampedTooltip<T extends HTMLElement>(
+  isOpen: boolean
+): ViewportClampedTooltip<T> {
+  const panelRef = useRef<T | null>(null)
+  const [shift, setShift] = useState(0)
+  const [arrowShift, setArrowShift] = useState(0)
+  // The measured box already includes the shift we applied last pass, so the
+  // applied value has to be readable synchronously to recover the unshifted
+  // extent — otherwise a re-measure (resize) would compound.
+  const appliedShift = useRef(0)
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      appliedShift.current = 0
+      setShift(0)
+      setArrowShift(0)
+      return
+    }
+
+    const measure = () => {
+      const panel = panelRef.current
+      if (!panel || typeof window === 'undefined') return
+
+      const rect = panel.getBoundingClientRect()
+      // A layout-less environment (jsdom) reports a zero box. There is nothing
+      // to clamp, and treating 0 as a real measurement would invent a shift.
+      if (rect.width === 0) return
+
+      // `clientWidth` is the visible content width — unlike `innerWidth` it
+      // excludes a classic scrollbar, which the panel must not slide under.
+      const viewportWidth =
+        document.documentElement.clientWidth || window.innerWidth
+
+      const next = computeTooltipShift(
+        {
+          left: rect.left - appliedShift.current,
+          right: rect.right - appliedShift.current,
+        },
+        viewportWidth
+      )
+      if (next === appliedShift.current) return
+
+      appliedShift.current = next
+      setShift(next)
+      setArrowShift(computeArrowShift(next, rect.width))
+    }
+
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [isOpen])
+
+  return {
+    panelRef,
+    style: {
+      '--tooltip-shift': `${shift}px`,
+      '--tooltip-arrow-shift': `${arrowShift}px`,
+    },
+  }
+}
+
+export default useViewportClampedTooltip

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -52,6 +52,7 @@
 @import './styles/components/club-history.css';
 @import './styles/components/club-grid.css';
 @import './styles/components/action-list.css';
+@import './styles/components/tooltip.css';
 @import './styles/responsive.css';
 @import './styles/dark-mode.css';
 @import './styles/print.css';

--- a/frontend/src/styles/components/tooltip.css
+++ b/frontend/src/styles/components/tooltip.css
@@ -1,0 +1,50 @@
+/* Shared tooltip panel geometry (#1405).
+ *
+ * `Tooltip` and `InfoTooltip` both centre a fixed-width panel on their
+ * trigger. Centred means `centre − width/2`, which is off-screen for a trigger
+ * in a card's leftmost column (the Education Levels rows opened at left −67)
+ * and past the right edge for one in the rightmost (the landing table-header
+ * tooltip ran to right 432 at 375px). Neither is a per-card problem, so the
+ * collision handling lives here, once, for every consumer of either component
+ * (R10) — with `useViewportClampedTooltip` supplying the two measured
+ * distances and nothing else.
+ *
+ * Why the placement moved out of Tailwind utilities: `-translate-x-1/2`
+ * compiles to the `translate` property in v4, so a JS-applied shift and the
+ * utility would fight over the same declaration. Owning `left` + `translate`
+ * here lets the shift compose into the centring instead of replacing it.
+ */
+
+@layer components {
+  .tooltip-panel {
+    /* Overwritten inline with the measured distances while the panel is open. */
+    --tooltip-shift: 0px;
+    --tooltip-arrow-shift: 0px;
+    /* A panel can never be wider than the viewport it has to fit inside; below
+       ~336px the w-80 width would otherwise overflow whatever we shift it to. */
+    max-width: calc(100vw - 1rem);
+  }
+
+  /* Horizontally centred placement (position="top" / "bottom"). */
+  .tooltip-panel--centered {
+    left: 50%;
+    translate: calc(-50% + var(--tooltip-shift)) 0;
+  }
+
+  /* The panel moved, so the arrow moves back by the same amount and keeps
+     pointing at the trigger. Clamped by the hook so it stays on the panel. */
+  .tooltip-arrow--centered {
+    left: 50%;
+    translate: calc(-50% + var(--tooltip-arrow-shift)) 0;
+  }
+
+  /* Side placement (position="left" / "right") is vertically centred instead,
+     so the shift composes with a -50% on the Y axis rather than the X. */
+  .tooltip-panel--side {
+    translate: var(--tooltip-shift) -50%;
+  }
+
+  .tooltip-arrow--side {
+    translate: var(--tooltip-arrow-shift) -50%;
+  }
+}

--- a/frontend/src/utils/__tests__/tooltipViewportShift.test.ts
+++ b/frontend/src/utils/__tests__/tooltipViewportShift.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeArrowShift,
+  computeTooltipShift,
+  TOOLTIP_ARROW_EDGE_INSET_PX,
+  TOOLTIP_VIEWPORT_MARGIN_PX,
+} from '../tooltipViewportShift'
+
+/* Viewport-collision arithmetic for the shared tooltip panels (#1405).
+ *
+ * The numbers below are the geometry MEASURED on production before the fix
+ * (Chromium, `/district/61/analytics`, Education Levels card):
+ *
+ *   Level 1              left −67  right 253   (w-80 = 320px)
+ *   Level 2 / Level 3    left −65  right 255
+ *   Level 4+ · Path · DTM left −21  right 299
+ *
+ * and, on the landing page, the mirror problem on the right edge:
+ *
+ *   "Paid Clubs = …"     left 208  right 432   at innerWidth 375
+ *                        left 601  right 825   at innerWidth 768
+ *                        left 1183 right 1407  at innerWidth 1350
+ *
+ * These are pure functions precisely so the arithmetic can be pinned without
+ * a layout engine — jsdom has none. The rendered pixels are proven by
+ * `e2e/tooltip-viewport-clip.smoke.ts`.
+ */
+
+const M = TOOLTIP_VIEWPORT_MARGIN_PX
+
+describe('computeTooltipShift', () => {
+  it('leaves a panel that already fits where it is', () => {
+    expect(computeTooltipShift({ left: 100, right: 420 }, 1350)).toBe(0)
+  })
+
+  it('does not nudge a panel that is exactly on the margin', () => {
+    expect(computeTooltipShift({ left: M, right: 1350 - M }, 1350)).toBe(0)
+  })
+
+  it('pushes a left-clipped panel back inside (Education Levels, Level 1)', () => {
+    const shift = computeTooltipShift({ left: -67, right: 253 }, 375)
+    expect(shift).toBe(M + 67)
+    expect(-67 + shift).toBe(M)
+  })
+
+  it('pulls a right-clipped panel back inside (landing, 375px)', () => {
+    const shift = computeTooltipShift({ left: 208, right: 432 }, 375)
+    expect(shift).toBe(-(432 - (375 - M)))
+    expect(432 + shift).toBe(375 - M)
+  })
+
+  it('pulls a right-clipped panel back inside at 1350px too', () => {
+    const shift = computeTooltipShift({ left: 1183, right: 1407 }, 1350)
+    expect(1407 + shift).toBe(1350 - M)
+    expect(1183 + shift).toBeGreaterThanOrEqual(M)
+  })
+
+  it.each([
+    { label: 'Level 1', left: -67, right: 253 },
+    { label: 'Level 2', left: -65, right: 255 },
+    { label: 'Level 3', left: -65, right: 255 },
+    { label: 'Level 4+ · Path · DTM', left: -21, right: 299 },
+  ])(
+    'lands the whole $label panel inside the viewport at every width',
+    ({ left, right }) => {
+      for (const viewportWidth of [375, 768, 1350]) {
+        const shift = computeTooltipShift({ left, right }, viewportWidth)
+        expect(left + shift).toBeGreaterThanOrEqual(0)
+        expect(right + shift).toBeLessThanOrEqual(viewportWidth)
+      }
+    }
+  )
+
+  it('pins the left edge when the panel is wider than the viewport allows', () => {
+    // 320px panel, 320px viewport: both edges cannot be satisfied. Keep the
+    // opening words readable rather than the closing ones.
+    const shift = computeTooltipShift({ left: -40, right: 280 }, 320)
+    expect(-40 + shift).toBe(M)
+  })
+
+  it('honours a caller-supplied margin', () => {
+    expect(computeTooltipShift({ left: -10, right: 310 }, 375, 20)).toBe(30)
+  })
+})
+
+describe('computeArrowShift', () => {
+  it('is zero when the panel did not move', () => {
+    expect(computeArrowShift(0, 320)).toBe(0)
+  })
+
+  it('moves opposite to the panel so it keeps pointing at the trigger', () => {
+    expect(computeArrowShift(75, 320)).toBe(-75)
+    expect(computeArrowShift(-57, 320)).toBe(57)
+  })
+
+  it('never lets the arrow leave the panel it belongs to', () => {
+    const room = 320 / 2 - TOOLTIP_ARROW_EDGE_INSET_PX
+    expect(computeArrowShift(1000, 320)).toBe(-room)
+    expect(computeArrowShift(-1000, 320)).toBe(room)
+  })
+
+  it('degrades to no offset for a panel too narrow to hold one', () => {
+    expect(computeArrowShift(50, 20)).toBe(0)
+  })
+})

--- a/frontend/src/utils/tooltipViewportShift.ts
+++ b/frontend/src/utils/tooltipViewportShift.ts
@@ -1,0 +1,56 @@
+/* Viewport-collision arithmetic for the shared tooltip panels (#1405).
+ *
+ * Both tooltip components (`Tooltip`, `InfoTooltip`) render a fixed-width
+ * panel centred on their trigger. Centred means `centre − width/2`, which is
+ * negative for a trigger near the left viewport edge and past `innerWidth`
+ * for one near the right — the panel renders half off-screen and the words
+ * at that end are unreadable.
+ *
+ * The geometry lives here as pure functions so the arithmetic is testable
+ * without a layout engine; `useViewportClampedTooltip` supplies the measured
+ * box and the CSS in `styles/components/tooltip.css` applies the result.
+ */
+
+/** Gap kept between a tooltip panel and the viewport edge, in px. */
+export const TOOLTIP_VIEWPORT_MARGIN_PX = 8
+
+/** Minimum gap between the arrow and the panel's rounded corner, in px. */
+export const TOOLTIP_ARROW_EDGE_INSET_PX = 14
+
+/** The horizontal extent of a box, in viewport coordinates. */
+export interface HorizontalExtent {
+  left: number
+  right: number
+}
+
+/**
+ * How far right (positive) or left (negative) a centred tooltip panel must
+ * move so its whole box sits inside the viewport.
+ *
+ * @param extent - the panel's UNSHIFTED horizontal extent
+ * @param viewportWidth - the visible width to fit inside
+ * @param margin - gap to keep from each edge
+ */
+export function computeTooltipShift(
+  extent: HorizontalExtent,
+  viewportWidth: number,
+  margin: number = TOOLTIP_VIEWPORT_MARGIN_PX
+): number {
+  // RED (#1405) — not implemented yet.
+  void extent
+  void viewportWidth
+  void margin
+  return 0
+}
+
+/**
+ * The arrow's own horizontal offset. The panel moved by `shift`, so the arrow
+ * moves back by the same amount to keep pointing at its trigger — clamped so
+ * it can never detach from the panel it belongs to.
+ */
+export function computeArrowShift(shift: number, panelWidth: number): number {
+  // RED (#1405) — not implemented yet.
+  void shift
+  void panelWidth
+  return 0
+}

--- a/frontend/src/utils/tooltipViewportShift.ts
+++ b/frontend/src/utils/tooltipViewportShift.ts
@@ -36,10 +36,16 @@ export function computeTooltipShift(
   viewportWidth: number,
   margin: number = TOOLTIP_VIEWPORT_MARGIN_PX
 ): number {
-  // RED (#1405) — not implemented yet.
-  void extent
-  void viewportWidth
-  void margin
+  const overflowLeft = margin - extent.left
+  const overflowRight = extent.right - (viewportWidth - margin)
+
+  // Both edges overflow: the panel is wider than the space it has, so no shift
+  // can satisfy them. Pin the LEFT edge — the opening words matter more than
+  // the closing ones, and `.tooltip-panel`'s max-width normally prevents this.
+  if (overflowLeft > 0 && overflowRight > 0) return overflowLeft
+
+  if (overflowLeft > 0) return overflowLeft
+  if (overflowRight > 0) return -overflowRight
   return 0
 }
 
@@ -49,8 +55,8 @@ export function computeTooltipShift(
  * it can never detach from the panel it belongs to.
  */
 export function computeArrowShift(shift: number, panelWidth: number): number {
-  // RED (#1405) — not implemented yet.
-  void shift
-  void panelWidth
-  return 0
+  const room = Math.max(0, panelWidth / 2 - TOOLTIP_ARROW_EDGE_INSET_PX)
+  const clamped = Math.max(-room, Math.min(room, -shift))
+  // `Math.max(-0, -50)` is -0, which reads as a negative offset downstream.
+  return clamped === 0 ? 0 : clamped
 }

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,6 +2,7 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `a-centred-fixed-width-overlay-is-a-viewport-collision-bug-in-every-edge-column.md` — A fixed-width overlay centred on its trigger is off-screen wherever the trigger sits near a viewport edge — it is a property of the shared component, never of the card that reported it, and the measured correction cannot live in a Tailwind v4 translate utility  (2026-08-03)
 - `a-deliberately-shared-query-key-is-a-coupling-with-no-compiler.md` — Two hooks sharing a React Query key to avoid a duplicate fetch are coupled with nothing but a comment — narrowing one hook's key silently re-scopes or breaks the other, so decide explicitly and pay the fetch  (2026-08-03)
 - `a-docs-page-that-restates-the-code-needs-a-census-not-a-generator.md` — A docs page that restates behaviour spread across many mechanisms cannot be generated from any one of them — couple it with a census that fails when unclaimed code appears, and prove the census fires against a synthetic case the repo can never produce  (2026-08-03)
 - `a-query-scoped-by-an-async-value-runs-unscoped-first.md` — A query keyed on a value that itself arrives asynchronously runs UNSCOPED on first render, so any gate reading its result must wait for the scoping value — not just for the result  (2026-08-03)

--- a/tasks/lessons/lessons/a-centred-fixed-width-overlay-is-a-viewport-collision-bug-in-every-edge-column.md
+++ b/tasks/lessons/lessons/a-centred-fixed-width-overlay-is-a-viewport-collision-bug-in-every-edge-column.md
@@ -1,0 +1,97 @@
+---
+date: 2026-08-03
+tier: lesson
+summary: A fixed-width overlay centred on its trigger is off-screen wherever the trigger sits near a viewport edge — it is a property of the shared component, never of the card that reported it, and the measured correction cannot live in a Tailwind v4 translate utility
+tags:
+  [
+    frontend,
+    css,
+    tailwind,
+    layout,
+    tooltip,
+    overlay,
+    shared-component,
+    measurement,
+  ]
+---
+
+# A centred fixed-width overlay is a viewport-collision bug in every edge column
+
+**Date:** 2026-08-03
+**Issue:** #1405 (Education Levels tooltips clip at the left viewport edge)
+**Related:** #1387 (the browser-probe pattern), R10
+
+## What happened
+
+The report named one card and one edge: the Education Levels rows opened their
+tooltip half off-screen on the left. The cause was one line in a shared
+component — a `w-80` panel positioned `left-1/2 -translate-x-1/2` — so the real
+blast radius was "every trigger that lands near either edge", which a probe
+found immediately:
+
+| where                              | before               | viewport |
+| ---------------------------------- | -------------------- | -------- |
+| Education Levels, four rows        | left −67/−65/−65/−21 | all      |
+| landing table-header `InfoTooltip` | right 432 / 825      | 375/768  |
+| landing table-header `InfoTooltip` | right 1407           | 1350     |
+| district KPI strip `Tooltip`s      | right 399…515        | 375      |
+
+Two different shared components (`Tooltip` at w-80, `InfoTooltip` at w-56),
+both edges, every width. Fixing the reported card would have left most of it.
+
+## The lesson
+
+**A centred overlay of fixed width has no correct position; it has a position
+that happens to work in the middle of the screen.** The trigger's column, not
+the card, decides whether it clips — so the moment you see `left-1/2
+-translate-x-1/2` on a fixed-width panel, the bug exists everywhere that
+component is used, and the grep for other instances is not optional (R10).
+Widening the viewport does not remove it: a right-edge trigger clips at 1350px
+exactly as a left-edge one clips at 375px.
+
+## The Tailwind v4 trap in the fix
+
+The correction is measured (`getBoundingClientRect` against
+`documentElement.clientWidth`), so it has to reach CSS at runtime. The obvious
+move — an inline `transform` — silently does nothing: **Tailwind v4's
+`translate-*` utilities compile to the `translate` _property_, not to
+`transform`**, so the utility keeps winning and the panel never moves. And the
+shift must _compose_ with the −50% centring, not replace it.
+
+What works is to stop letting a utility own that declaration: move `left` +
+`translate` into a real component class, and have JS publish only two numbers
+as custom properties.
+
+```css
+.tooltip-panel--centered {
+  left: 50%;
+  translate: calc(-50% + var(--tooltip-shift)) 0;
+}
+```
+
+The hook sets `--tooltip-shift` and nothing else. That keeps the placement
+rule in CSS where cross-cutting layout belongs, and makes the arithmetic a
+pure function that is testable without a layout engine.
+
+Two details worth keeping:
+
+- **Measure the panel with its own shift already applied**, then subtract it to
+  recover the unshifted extent. Otherwise a re-measure (resize, re-open)
+  compounds the correction instead of replacing it.
+- **Clamp against `document.documentElement.clientWidth`, not
+  `window.innerWidth`** — `innerWidth` includes a classic scrollbar, so a
+  right-clamped panel slides underneath it.
+
+## How to test it
+
+jsdom has no layout, so the component test installs one: a
+`getBoundingClientRect` stub that reports `unshiftedLeft + <the shift the
+component applied>`. The assertion is then the real one — the box is inside the
+viewport — rather than a className contract, and it fails on `main` at exactly
+the measured production offsets. The pixels are proven separately in Playwright
+at 375/768/1350 in both themes and both engines.
+
+And pin the 44px trigger floor in the same guard. Shrinking the control is the
+tempting way to make a 320px panel stop colliding, and it trades a readability
+bug for a WCAG 2.5.5 violation. This is the fourth surprise from that floor;
+the earlier three were under-reserves and a two-baseline row (#1359, #1387).


### PR DESCRIPTION
Fixes the clipping reported in #1405, at the shared components rather than in the card that surfaced it.

## The problem

`Tooltip` (w-80 = 320px) and `InfoTooltip` (w-56 = 224px) both centre a fixed-width panel on their trigger with no viewport-collision handling. `centre − width/2` is off-screen for a trigger in a card's leftmost column and past `innerWidth` for one in the rightmost. The column decides it, not the row — and not the card.

Measured on production (Chromium) before the fix:

| where | before | viewport |
| --- | --- | --- |
| Education Levels — Level 1 | left **−67**, right 253 | 375 / 768 / 1350 |
| Education Levels — Level 2, Level 3 | left **−65**, right 255 | 375 / 768 / 1350 |
| Education Levels — Level 4+ · Path · DTM | left **−21**, right 299 | 375 / 768 / 1350 |
| landing table-header `InfoTooltip` | left 208, right **432** | 375 |
| landing table-header `InfoTooltip` | left 601, right **825** | 768 |
| landing table-header `InfoTooltip` | left 1183, right **1407** | 1350 |
| `/district/61` KPI-strip `Tooltip`s | 3 panels past the right edge | 375 |
| `/district/61` `RegionRankChip` | left **−14** | 375 |

So: the right edge does have the mirror problem, it is not confined to narrow viewports, and it is not confined to one component. Fixing only the reported card would have left most of it.

## The fix

- **`utils/tooltipViewportShift.ts`** — the collision arithmetic as pure functions, testable without a layout engine.
- **`hooks/useViewportClampedTooltip.ts`** — measures the panel in a layout effect (so the shift is applied before paint) and publishes the result as two CSS custom properties, nothing else. Clamps against `documentElement.clientWidth`, not `innerWidth`, so a right-clamped panel does not slide under a classic scrollbar.
- **`styles/components/tooltip.css`** — owns `left` + `translate` so the measured shift *composes* into the −50% centring. Tailwind v4's `-translate-x-1/2` compiles to the `translate` **property**, so a utility and a JS-applied offset cannot both own that declaration — this is why the placement moved into CSS (R10) instead of into inline style objects. Also caps the panel at `calc(100vw - 1rem)`, so w-80 cannot exceed a 320px screen.
- **`pr-preview.yml`** — runs the new cross-engine tripwire on every preview.

The arrow moves back by the same amount so it keeps pointing at its trigger, clamped so it can never leave the panel.

## Measured after

Chromium, identical at 375 / 768 / 1350:

| where | after |
| --- | --- |
| Education Levels, all four rows | left **8**, right 328 |
| landing table-header `InfoTooltip` | right **367 / 760 / 1342** (= viewport − 8) |

Full sweep over `/`, `/district/61` and `/district/61/analytics` at **320 / 375 / 768 / 1350**, two open-close-reopen passes: **0 panels outside the viewport out of 158 opened** (was 4 clipped on the analytics card alone at every width).

## Acceptance

- [x] Failing test first, asserting the panel's bounding box is inside the viewport — three layers, all red on `main` at the measured offsets above.
- [x] Every column at 375 / 768 / 1350, light and dark (the smoke covers both themes; 320px verified locally too).
- [x] Right edge verified, and found broken independently of the report.
- [x] Other `w-80` tooltips grepped — the problem is shared across both tooltip components, so the fix is in them.
- [x] Trigger markup untouched → the WCAG 2.5.5 44px floor is unchanged. Re-asserted in the new smoke *and* in the unit test, so "shrink the control" cannot turn either green. `touch-targets.smoke.ts` still runs unmodified.
- [x] No CLS risk: the panel is absolutely positioned and out of flow, and it only appears on hover/focus after load.
- [x] `quality:check`, `test:scripts`, `test:no-page-mounts:check`, `typecheck:tests` all green locally after rebasing onto `origin/main`.

## Testing

- `src/utils/__tests__/tooltipViewportShift.test.ts` — pins the arithmetic against the production geometry.
- `src/components/__tests__/TooltipViewportClamp.test.tsx` — installs a `getBoundingClientRect` stub so jsdom can assert the real thing (the box is inside the viewport) rather than a className contract.
- `e2e/tooltip-viewport-clip.smoke.ts` — real pixels on the deployed channel, both edges, both components, 375/768/1350 × light/dark × Chromium/WebKit, plus the 44px floor.

Refs #1405
