### PR TITLE
feat(scripts): validate the distinguished calculators against the CEO Report's published years (#1429)

### DIFF
--- a/scripts/lib/__tests__/ceoReportOracle.test.ts
+++ b/scripts/lib/__tests__/ceoReportOracle.test.ts
@@ -1,0 +1,445 @@
+/**
+ * CEO Report oracle — decision logic tests (#1429, epic #1426).
+ *
+ * The TI CEO Report publishes five years of the exact totals our
+ * calculators produce, so it is an external oracle for per-era rulesets
+ * that were reconstructed from rule documents and never checked against a
+ * published number (Lesson 160 — back-solve from what the system itself
+ * published rather than trusting the documents).
+ *
+ * These tests pin the comparator's behaviour, not the numbers: the
+ * published figures live once in `ceoReportOracle.ts` and every expectation
+ * below is derived from that table, so a re-transcription cannot drift from
+ * the tests silently.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  CEO_REPORT_FIGURES,
+  CEO_REPORT_METRICS,
+  CEO_REPORT_REPORT_DATE,
+  CEO_REPORT_SOURCE_URL,
+  compareToCeoReport,
+  formatComparisonTable,
+  splitDistrictTiers,
+  type CeoReportFigures,
+  type CeoReportMetric,
+  type ComputedProgramYearTotals,
+} from '../ceoReportOracle.js'
+
+/** Districts that neither earned a tier nor are unknowable. */
+const OTHER_DISTRICTS = 60
+
+function figuresFor(programYear: string): CeoReportFigures {
+  const row = CEO_REPORT_FIGURES.find(f => f.programYear === programYear)
+  if (!row) throw new Error(`no published row for ${programYear}`)
+  return row
+}
+
+/** The last published row — the only one carrying every metric. */
+const LATEST = CEO_REPORT_FIGURES[CEO_REPORT_FIGURES.length - 1]!
+
+/**
+ * Computed totals that reproduce a published row exactly. Tests perturb
+ * one field at a time from here, so every expectation is relative to the
+ * oracle table rather than a second transcription of it.
+ */
+function computedMatching(
+  figures: CeoReportFigures
+): ComputedProgramYearTotals {
+  return {
+    programYear: figures.programYear,
+    districtTiers: {
+      Distinguished: figures.distinguishedDistricts,
+      NotDistinguished: OTHER_DISTRICTS,
+    },
+    distinguishedClubs: figures.distinguishedClubs,
+    selectDistinguishedClubs: figures.selectDistinguishedClubs,
+    presidentsDistinguishedClubs: figures.presidentsDistinguishedClubs,
+    ...(figures.smedleyDistinguishedClubs === undefined
+      ? {}
+      : { smedleyDistinguishedClubs: figures.smedleyDistinguishedClubs }),
+    totalDistinguishedClubs: figures.totalDistinguishedClubs,
+    paidClubs: figures.paidClubs,
+  }
+}
+
+/** Every published year, computed to match. The all-green baseline. */
+function allMatching(): ComputedProgramYearTotals[] {
+  return CEO_REPORT_FIGURES.map(computedMatching)
+}
+
+function bumpMetric(
+  computed: ComputedProgramYearTotals,
+  metric: CeoReportMetric
+): ComputedProgramYearTotals {
+  if (metric === 'distinguishedDistricts') {
+    return {
+      ...computed,
+      districtTiers: {
+        ...computed.districtTiers,
+        Distinguished: (computed.districtTiers.Distinguished ?? 0) + 1,
+      },
+    }
+  }
+  return { ...computed, [metric]: (computed[metric] ?? 0) + 1 }
+}
+
+describe('CEO_REPORT_FIGURES — the transcribed oracle table', () => {
+  it('carries the report source URL and report date', () => {
+    expect(CEO_REPORT_SOURCE_URL).toMatch(/^https:\/\/www\.toastmasters\.org\//)
+    expect(CEO_REPORT_REPORT_DATE).toMatch(/^\d{4}-\d{2}$/)
+  })
+
+  it('publishes five consecutive program years in YYYY-YYYY form', () => {
+    expect(CEO_REPORT_FIGURES).toHaveLength(5)
+    for (const row of CEO_REPORT_FIGURES) {
+      expect(row.programYear).toMatch(/^\d{4}-\d{4}$/)
+    }
+    const startYears = CEO_REPORT_FIGURES.map(f =>
+      Number.parseInt(f.programYear.slice(0, 4), 10)
+    )
+    for (let i = 1; i < startYears.length; i++) {
+      expect(startYears[i]).toBe(startYears[i - 1]! + 1)
+      // "YYYY-YYYY" must be a single program year, not a span.
+      const row = CEO_REPORT_FIGURES[i]!
+      expect(row.programYear.slice(5)).toBe(String(startYears[i]! + 1))
+    }
+  })
+
+  it("sums each row's club tiers to that row's published clubs total", () => {
+    // Transcription guard: the report states the tiers and the total
+    // independently, and they agree. A typo in any of the five numbers
+    // breaks this identity.
+    for (const row of CEO_REPORT_FIGURES) {
+      const tierSum =
+        row.distinguishedClubs +
+        row.selectDistinguishedClubs +
+        row.presidentsDistinguishedClubs +
+        (row.smedleyDistinguishedClubs ?? 0)
+      expect(tierSum).toBe(row.totalDistinguishedClubs)
+    }
+  })
+
+  it('models Smedley as absent — never zero — before the tier existed', () => {
+    const withSmedley = CEO_REPORT_FIGURES.filter(
+      f => f.smedleyDistinguishedClubs !== undefined
+    )
+    expect(withSmedley).toHaveLength(1)
+    expect(withSmedley[0]!.programYear).toBe(LATEST.programYear)
+    for (const row of CEO_REPORT_FIGURES.slice(0, -1)) {
+      expect(row.smedleyDistinguishedClubs).toBeUndefined()
+      expect(row).not.toHaveProperty('smedleyDistinguishedClubs', 0)
+    }
+  })
+
+  it('is frozen so no consumer can mutate the oracle', () => {
+    expect(Object.isFrozen(CEO_REPORT_FIGURES)).toBe(true)
+    for (const row of CEO_REPORT_FIGURES) {
+      expect(Object.isFrozen(row)).toBe(true)
+    }
+  })
+})
+
+describe('splitDistrictTiers', () => {
+  it('folds Unknown into neither side of the distinguished split', () => {
+    // DistinguishedDistrictTier includes 'Unknown' for a district whose
+    // required prerequisites are unknowable because that year's export
+    // lacks the column (#1116 item 5). Counting it as not-distinguished
+    // would make a real ruleset bug look like a data gap.
+    const split = splitDistrictTiers({
+      Distinguished: 10,
+      Select: 5,
+      Presidents: 3,
+      Smedley: 2,
+      NotDistinguished: 40,
+      Unknown: 7,
+    })
+
+    expect(split.distinguished).toBe(20)
+    expect(split.notDistinguished).toBe(40)
+    expect(split.unknown).toBe(7)
+    expect(split.total).toBe(67)
+    // Explicitly: Unknown is in neither side.
+    expect(split.distinguished + split.notDistinguished).toBe(60)
+  })
+
+  it('treats absent tiers as zero without inventing an Unknown bucket', () => {
+    const split = splitDistrictTiers({ Distinguished: 4 })
+    expect(split).toEqual({
+      distinguished: 4,
+      notDistinguished: 0,
+      unknown: 0,
+      total: 4,
+    })
+  })
+})
+
+describe('compareToCeoReport', () => {
+  it('reports a distinguished-district mismatch with computed/published/delta', () => {
+    const published = figuresFor('2024-2025')
+    const short = {
+      ...computedMatching(published),
+      districtTiers: {
+        Distinguished: published.distinguishedDistricts - 2,
+        NotDistinguished: OTHER_DISTRICTS,
+      },
+    }
+    const others = CEO_REPORT_FIGURES.filter(
+      f => f.programYear !== published.programYear
+    ).map(computedMatching)
+
+    const result = compareToCeoReport([...others, short])
+
+    expect(result.ok).toBe(false)
+    expect(result.findings).toContainEqual({
+      kind: 'mismatch',
+      programYear: '2024-2025',
+      metric: 'distinguishedDistricts',
+      computed: published.distinguishedDistricts - 2,
+      published: published.distinguishedDistricts,
+      delta: -2,
+    })
+  })
+
+  it('passes a year whose computed totals reproduce the published row', () => {
+    const result = compareToCeoReport(allMatching())
+
+    expect(result.ok).toBe(true)
+    expect(result.findings).toEqual([])
+    for (const year of result.years) {
+      expect(year.noData).toBe(false)
+      expect(year.findings).toEqual([])
+      expect(year.metrics.every(m => m.status !== 'mismatch')).toBe(true)
+    }
+  })
+
+  it('never folds Unknown districts into either side of the comparison', () => {
+    const published = figuresFor('2023-2024')
+    const withUnknowns: ComputedProgramYearTotals = {
+      ...computedMatching(published),
+      districtTiers: {
+        Distinguished: published.distinguishedDistricts,
+        NotDistinguished: OTHER_DISTRICTS,
+        Unknown: 5,
+      },
+    }
+
+    const result = compareToCeoReport([withUnknowns])
+    const year = result.years.find(y => y.programYear === '2023-2024')!
+
+    // The distinguished count still matches — the Unknowns went nowhere
+    // near it, and they did not inflate the not-distinguished side either.
+    expect(year.districts).toEqual({
+      distinguished: published.distinguishedDistricts,
+      notDistinguished: OTHER_DISTRICTS,
+      unknown: 5,
+      total: published.distinguishedDistricts + OTHER_DISTRICTS + 5,
+    })
+    const districtsRow = year.metrics.find(
+      m => m.metric === 'distinguishedDistricts'
+    )!
+    expect(districtsRow.status).toBe('match')
+    expect(districtsRow.computed).toBe(published.distinguishedDistricts)
+  })
+
+  it('reports a program year absent from the archive as noData, not a mismatch', () => {
+    // 2021-22 may be genuinely absent (HistoryPage calls it the COVID gap)
+    // — a missing year must never be reported as a scoring failure.
+    const supplied = CEO_REPORT_FIGURES.filter(
+      f => f.programYear !== '2021-2022'
+    ).map(computedMatching)
+
+    const result = compareToCeoReport(supplied)
+    const year = result.years.find(y => y.programYear === '2021-2022')!
+
+    expect(year.noData).toBe(true)
+    expect(year.findings).toEqual([
+      { kind: 'noData', programYear: '2021-2022' },
+    ])
+    expect(result.findings.filter(f => f.kind === 'mismatch')).toHaveLength(0)
+    expect(year.metrics.every(m => m.computed === undefined)).toBe(true)
+  })
+
+  it('distinguishes a computed zero from a missing year', () => {
+    const published = figuresFor('2021-2022')
+    const zeroed: ComputedProgramYearTotals = {
+      programYear: published.programYear,
+      districtTiers: {},
+      distinguishedClubs: 0,
+      selectDistinguishedClubs: 0,
+      presidentsDistinguishedClubs: 0,
+      totalDistinguishedClubs: 0,
+      paidClubs: 0,
+    }
+
+    const result = compareToCeoReport([zeroed])
+    const year = result.years.find(y => y.programYear === '2021-2022')!
+
+    expect(year.noData).toBe(false)
+    expect(year.findings.some(f => f.kind === 'noData')).toBe(false)
+    expect(year.findings).toContainEqual({
+      kind: 'mismatch',
+      programYear: '2021-2022',
+      metric: 'distinguishedDistricts',
+      computed: 0,
+      published: published.distinguishedDistricts,
+      delta: -published.distinguishedDistricts,
+    })
+  })
+
+  it('flags computed tier counts that do not sum to the computed total', () => {
+    // Independent of the published comparison: the four tiers are counted
+    // per letter code and the total is counted separately, so an
+    // unrecognised status code shows up here and nowhere else.
+    const published = LATEST
+    const skewed: ComputedProgramYearTotals = {
+      ...computedMatching(published),
+      totalDistinguishedClubs: published.totalDistinguishedClubs + 3,
+    }
+
+    const result = compareToCeoReport([skewed])
+    const year = result.years.find(
+      y => y.programYear === published.programYear
+    )!
+
+    expect(year.findings).toContainEqual({
+      kind: 'tierSumMismatch',
+      programYear: published.programYear,
+      tierSum: published.totalDistinguishedClubs,
+      computedTotal: published.totalDistinguishedClubs + 3,
+      delta: 3,
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it('checks every metric the report publishes, not just the headline count', () => {
+    // A sentinel keyed on one field cannot detect drift in any other.
+    for (const metric of CEO_REPORT_METRICS) {
+      const perturbed = bumpMetric(computedMatching(LATEST), metric)
+      const result = compareToCeoReport([perturbed])
+
+      const mismatches = result.findings.filter(
+        f => f.kind === 'mismatch' && f.metric === metric
+      )
+      expect(
+        mismatches,
+        `no mismatch reported for metric ${metric}`
+      ).toHaveLength(1)
+      expect(result.ok).toBe(false)
+    }
+  })
+
+  it('reports a published metric the computed totals omit', () => {
+    const partial: ComputedProgramYearTotals = computedMatching(LATEST)
+    delete (partial as { smedleyDistinguishedClubs?: number })
+      .smedleyDistinguishedClubs
+
+    const result = compareToCeoReport([partial])
+    const year = result.years.find(y => y.programYear === LATEST.programYear)!
+
+    expect(year.findings).toContainEqual({
+      kind: 'missingMetric',
+      programYear: LATEST.programYear,
+      metric: 'smedleyDistinguishedClubs',
+      published: LATEST.smedleyDistinguishedClubs!,
+    })
+    expect(year.noData).toBe(false)
+  })
+
+  it('flags a computed Smedley count in a year the tier did not exist', () => {
+    const published = figuresFor('2022-2023')
+    const early: ComputedProgramYearTotals = {
+      ...computedMatching(published),
+      smedleyDistinguishedClubs: 12,
+      totalDistinguishedClubs: published.totalDistinguishedClubs + 12,
+    }
+
+    const result = compareToCeoReport([early])
+    const year = result.years.find(y => y.programYear === '2022-2023')!
+
+    expect(year.findings).toContainEqual({
+      kind: 'unpublishedMetric',
+      programYear: '2022-2023',
+      metric: 'smedleyDistinguishedClubs',
+      computed: 12,
+    })
+  })
+
+  it('does not flag an absent Smedley count in a year the tier did not exist', () => {
+    const result = compareToCeoReport([
+      computedMatching(figuresFor('2022-2023')),
+    ])
+    const year = result.years.find(y => y.programYear === '2022-2023')!
+
+    expect(year.findings).toEqual([])
+    const smedleyRow = year.metrics.find(
+      m => m.metric === 'smedleyDistinguishedClubs'
+    )!
+    expect(smedleyRow.status).toBe('notApplicable')
+    expect(smedleyRow.published).toBeUndefined()
+    expect(smedleyRow.computed).toBeUndefined()
+  })
+
+  it('ignores computed years the report does not publish', () => {
+    const extra: ComputedProgramYearTotals = {
+      ...computedMatching(LATEST),
+      programYear: '2019-2020',
+    }
+
+    const result = compareToCeoReport([...allMatching(), extra])
+
+    expect(result.ok).toBe(true)
+    expect(result.years.map(y => y.programYear)).toEqual(
+      CEO_REPORT_FIGURES.map(f => f.programYear)
+    )
+  })
+
+  it('is pure — the same input compares identically twice and mutates nothing', () => {
+    const input = allMatching()
+    const before = JSON.stringify(input)
+    const first = compareToCeoReport(input)
+    const second = compareToCeoReport(input)
+
+    expect(JSON.stringify(input)).toBe(before)
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+
+  it('echoes the oracle provenance on the result', () => {
+    const result = compareToCeoReport([])
+    expect(result.source).toEqual({
+      url: CEO_REPORT_SOURCE_URL,
+      reportDate: CEO_REPORT_REPORT_DATE,
+    })
+  })
+})
+
+describe('formatComparisonTable', () => {
+  it('prints one row per published year and metric with the source header', () => {
+    const table = formatComparisonTable(compareToCeoReport(allMatching()))
+
+    expect(table).toContain(CEO_REPORT_SOURCE_URL)
+    for (const row of CEO_REPORT_FIGURES) {
+      expect(table).toContain(row.programYear)
+    }
+    for (const metric of CEO_REPORT_METRICS) {
+      expect(table).toContain(metric)
+    }
+  })
+
+  it('marks a missing year as no data and a mismatch as a mismatch', () => {
+    const supplied = CEO_REPORT_FIGURES.filter(
+      f => f.programYear !== '2021-2022'
+    ).map(computedMatching)
+    const short = supplied.map(c =>
+      c.programYear === '2024-2025' ? bumpMetric(c, 'paidClubs') : c
+    )
+
+    const table = formatComparisonTable(compareToCeoReport(short))
+
+    expect(table).toMatch(/2021-2022.*no data/s)
+    expect(table).toContain('MISMATCH')
+    // Unknown-tier districts are surfaced in the table, never hidden.
+    expect(table.toLowerCase()).toContain('unknown')
+  })
+})

--- a/scripts/lib/ceoReportOracle.ts
+++ b/scripts/lib/ceoReportOracle.ts
@@ -1,0 +1,518 @@
+/**
+ * CEO Report oracle — pure comparison logic (#1429, epic #1426).
+ *
+ * `DistinguishedDistrictCalculator` scores historical program years under
+ * four per-era rulesets that were reconstructed from TI rule documents and
+ * have never been checked against an externally published count. The TI CEO
+ * Report publishes five years of exactly the totals our calculators produce,
+ * so it is a free external oracle: run our code over the year-end snapshots,
+ * diff against the published numbers, and either the rulesets are confirmed
+ * or we have found a real scoring bug in data users already see (Lesson 160 —
+ * back-solve from numbers the system itself published, rather than trusting
+ * rule documents).
+ *
+ * **Source:** TI CEO Report, August 2026 —
+ * <https://www.toastmasters.org/about/world-headquarters/ceo-reports>
+ *
+ * **What the table below is.** The encoded values are the report's **chart
+ * labels**, transcribed and then independently re-verified against the source
+ * PDF (tier mapping checked geometrically — legend swatch colours sampled and
+ * each stacked segment's pixel height back-solved against its bar total —
+ * not by label position). Distinguished / Select / President's / Smedley is
+ * the correct top-to-bottom order, and only 2025-2026 has a fourth segment.
+ * Every row here sums exactly and is internally consistent.
+ *
+ * **Do not "fix" these values against the report's prose.** The report's own
+ * prose disagrees with its own chart labels in two *unrelated* places:
+ * the six 2025-26 education-award bars sum to 101,915 while the prose says
+ * 101,916, and the membership-building awards sum to 3,564 while the prose
+ * says 3,567 (there the chart labels are the likelier truth — 3,564 against
+ * the prior year's 3,421 gives the +4.2% the report itself prints). Neither
+ * discrepancy touches the distinguished-district counts, the club tiers, the
+ * club totals or the paid-club counts encoded here.
+ *
+ * Smedley Distinguished exists only from 2025-2026 — it is modelled as
+ * **absent** for earlier years, never as zero, so a 5-year series renders it
+ * as starting that year rather than as a flat run of zeros.
+ *
+ * Purity: no I/O of any kind lives here — no network, no filesystem, no GCS —
+ * and the only analytics-core dependency is the `DistinguishedDistrictTier`
+ * *type*. The runner (scripts/validate-vs-ceo-report.ts) reads snapshots and
+ * computes the totals; this module only decides what the diff means.
+ */
+
+import type { DistinguishedDistrictTier } from '../../packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.js'
+
+/** Where the published figures come from. */
+export const CEO_REPORT_SOURCE_URL =
+  'https://www.toastmasters.org/about/world-headquarters/ceo-reports'
+
+/** The edition of the report the figures were transcribed from (YYYY-MM). */
+export const CEO_REPORT_REPORT_DATE = '2026-08'
+
+/** One published row of the report's Numeric Snapshots section. */
+export interface CeoReportFigures {
+  /** Program year in "YYYY-YYYY" form, e.g. "2024-2025". */
+  readonly programYear: string
+  /** Districts recognised as Distinguished or better. */
+  readonly distinguishedDistricts: number
+  /** Clubs at the Distinguished (D) tier only. */
+  readonly distinguishedClubs: number
+  /** Clubs at the Select Distinguished (S) tier only. */
+  readonly selectDistinguishedClubs: number
+  /** Clubs at the President's Distinguished (P) tier only. */
+  readonly presidentsDistinguishedClubs: number
+  /**
+   * Clubs at the Smedley Distinguished (M) tier only. ABSENT — not zero —
+   * for program years before 2025-2026, when the tier did not exist.
+   */
+  readonly smedleyDistinguishedClubs?: number
+  /** Clubs distinguished or better, all tiers. */
+  readonly totalDistinguishedClubs: number
+  /** Paid clubs as of June 30. */
+  readonly paidClubs: number
+}
+
+/**
+ * The published figures. Chart labels from the August 2026 CEO Report,
+ * independently re-verified — see the file header before editing.
+ */
+export const CEO_REPORT_FIGURES: readonly CeoReportFigures[] = Object.freeze([
+  Object.freeze({
+    programYear: '2021-2022',
+    distinguishedDistricts: 8,
+    distinguishedClubs: 974,
+    selectDistinguishedClubs: 995,
+    presidentsDistinguishedClubs: 3758,
+    totalDistinguishedClubs: 5727,
+    paidClubs: 14749,
+  }),
+  Object.freeze({
+    programYear: '2022-2023',
+    distinguishedDistricts: 18,
+    distinguishedClubs: 1598,
+    selectDistinguishedClubs: 1260,
+    presidentsDistinguishedClubs: 3604,
+    totalDistinguishedClubs: 6462,
+    paidClubs: 14271,
+  }),
+  Object.freeze({
+    programYear: '2023-2024',
+    distinguishedDistricts: 33,
+    distinguishedClubs: 1523,
+    selectDistinguishedClubs: 1207,
+    presidentsDistinguishedClubs: 3656,
+    totalDistinguishedClubs: 6386,
+    paidClubs: 13846,
+  }),
+  Object.freeze({
+    programYear: '2024-2025',
+    distinguishedDistricts: 37,
+    distinguishedClubs: 1827,
+    selectDistinguishedClubs: 1274,
+    presidentsDistinguishedClubs: 3636,
+    totalDistinguishedClubs: 6737,
+    paidClubs: 13833,
+  }),
+  Object.freeze({
+    programYear: '2025-2026',
+    distinguishedDistricts: 42,
+    distinguishedClubs: 2349,
+    selectDistinguishedClubs: 1037,
+    presidentsDistinguishedClubs: 1289,
+    smedleyDistinguishedClubs: 1912,
+    totalDistinguishedClubs: 6587,
+    paidClubs: 13708,
+  }),
+])
+
+/**
+ * Every metric the report publishes. A sentinel keyed on one field cannot
+ * detect drift in any other, so the comparison covers all of them — not
+ * just the headline distinguished-district count.
+ */
+export const CEO_REPORT_METRICS = [
+  'distinguishedDistricts',
+  'distinguishedClubs',
+  'selectDistinguishedClubs',
+  'presidentsDistinguishedClubs',
+  'smedleyDistinguishedClubs',
+  'totalDistinguishedClubs',
+  'paidClubs',
+] as const
+
+export type CeoReportMetric = (typeof CEO_REPORT_METRICS)[number]
+
+/** The per-tier club metrics that must add up to the total. */
+const CLUB_TIER_METRICS = [
+  'distinguishedClubs',
+  'selectDistinguishedClubs',
+  'presidentsDistinguishedClubs',
+  'smedleyDistinguishedClubs',
+] as const satisfies readonly CeoReportMetric[]
+
+/** District counts per Distinguished-District tier, as the calculator scores them. */
+export type DistrictTierCounts = Readonly<
+  Partial<Record<DistinguishedDistrictTier, number>>
+>
+
+/** What one program year's snapshots computed, for comparison. */
+export interface ComputedProgramYearTotals {
+  /** Program year in "YYYY-YYYY" form. */
+  readonly programYear: string
+  /**
+   * Districts per scored tier. `Unknown` districts (that year's export
+   * lacks a required prerequisite column, #1116 item 5) belong here and are
+   * folded into NEITHER side of the distinguished split.
+   */
+  readonly districtTiers: DistrictTierCounts
+  readonly distinguishedClubs: number
+  readonly selectDistinguishedClubs: number
+  readonly presidentsDistinguishedClubs: number
+  /** Absent when the snapshot predates the Smedley tier — never zero. */
+  readonly smedleyDistinguishedClubs?: number
+  /**
+   * Clubs distinguished or better, counted INDEPENDENTLY of the four tier
+   * counts (so the two can be cross-checked — an unrecognised status code
+   * shows up as a tier-sum finding and nowhere else).
+   */
+  readonly totalDistinguishedClubs: number
+  readonly paidClubs: number
+}
+
+/** The distinguished / not-distinguished / unknown split of a tier tally. */
+export interface DistrictTierSplit {
+  /** Distinguished, Select, President's or Smedley. */
+  distinguished: number
+  /** Explicitly NotDistinguished. */
+  notDistinguished: number
+  /** Unknowable from that year's export — neither side. */
+  unknown: number
+  /** Every district scored, all three buckets. */
+  total: number
+}
+
+export type CeoReportFinding =
+  /** The program year is absent from the computed input entirely. */
+  | { kind: 'noData'; programYear: string }
+  /** Computed and published both exist and disagree. */
+  | {
+      kind: 'mismatch'
+      programYear: string
+      metric: CeoReportMetric
+      computed: number
+      published: number
+      delta: number
+    }
+  /** The report publishes this metric but the computed totals omit it. */
+  | {
+      kind: 'missingMetric'
+      programYear: string
+      metric: CeoReportMetric
+      published: number
+    }
+  /** We computed a non-zero value for a metric the report does not publish. */
+  | {
+      kind: 'unpublishedMetric'
+      programYear: string
+      metric: CeoReportMetric
+      computed: number
+    }
+  /** The computed tier counts do not add up to the computed total. */
+  | {
+      kind: 'tierSumMismatch'
+      programYear: string
+      tierSum: number
+      computedTotal: number
+      delta: number
+    }
+
+export type MetricStatus =
+  'match' | 'mismatch' | 'missing' | 'unpublished' | 'notApplicable' | 'noData'
+
+export interface MetricComparison {
+  metric: CeoReportMetric
+  published?: number
+  computed?: number
+  /** computed − published, present only when both sides exist. */
+  delta?: number
+  status: MetricStatus
+}
+
+export interface ProgramYearComparison {
+  programYear: string
+  /** True when the program year is absent from the computed input. */
+  noData: boolean
+  /** The district tier split, absent for a noData year. */
+  districts?: DistrictTierSplit
+  metrics: MetricComparison[]
+  findings: CeoReportFinding[]
+}
+
+export interface CeoReportComparison {
+  /** True only when there are no findings at all. */
+  ok: boolean
+  source: { url: string; reportDate: string }
+  /** One entry per PUBLISHED program year, in report order. */
+  years: ProgramYearComparison[]
+  /** Every year's findings, flattened in year order. */
+  findings: CeoReportFinding[]
+}
+
+/**
+ * Split a per-tier district tally into distinguished / not-distinguished /
+ * unknown.
+ *
+ * `Unknown` means the district's metrics earned a tier but a prerequisite
+ * that year's rules REQUIRE is unknowable because the export lacks the
+ * column (#1116 item 5). It is counted on its own and folded into neither
+ * side: silently treating it as not-distinguished would make a real ruleset
+ * bug look like a data gap (and vice versa).
+ */
+export function splitDistrictTiers(
+  tiers: DistrictTierCounts
+): DistrictTierSplit {
+  const at = (tier: DistinguishedDistrictTier): number => tiers[tier] ?? 0
+  const distinguished =
+    at('Distinguished') + at('Select') + at('Presidents') + at('Smedley')
+  const notDistinguished = at('NotDistinguished')
+  const unknown = at('Unknown')
+
+  return {
+    distinguished,
+    notDistinguished,
+    unknown,
+    total: distinguished + notDistinguished + unknown,
+  }
+}
+
+function computedValueFor(
+  metric: CeoReportMetric,
+  computed: ComputedProgramYearTotals,
+  split: DistrictTierSplit
+): number | undefined {
+  if (metric === 'distinguishedDistricts') return split.distinguished
+  return computed[metric]
+}
+
+function compareOneYear(
+  published: CeoReportFigures,
+  computed: ComputedProgramYearTotals | undefined
+): ProgramYearComparison {
+  const { programYear } = published
+
+  if (!computed) {
+    // A year missing from the archive is "no data" — NEVER a scoring
+    // failure. 2021-22 may be genuinely absent (the COVID gap), and a
+    // missing year reported as a mismatch would manufacture a bug.
+    return {
+      programYear,
+      noData: true,
+      metrics: CEO_REPORT_METRICS.map(metric => ({
+        metric,
+        published: published[metric],
+        status: 'noData' as const,
+      })),
+      findings: [{ kind: 'noData', programYear }],
+    }
+  }
+
+  const districts = splitDistrictTiers(computed.districtTiers)
+  const metrics: MetricComparison[] = []
+  const findings: CeoReportFinding[] = []
+
+  for (const metric of CEO_REPORT_METRICS) {
+    const publishedValue = published[metric]
+    const computedValue = computedValueFor(metric, computed, districts)
+
+    if (publishedValue === undefined && computedValue === undefined) {
+      // e.g. Smedley before the tier existed: absent on both sides.
+      metrics.push({ metric, status: 'notApplicable' })
+      continue
+    }
+
+    if (publishedValue === undefined) {
+      // Computed a value the report does not publish for this year. Zero is
+      // benign (a tier that did not exist counts nothing); anything else is
+      // a finding.
+      const value = computedValue as number
+      if (value === 0) {
+        metrics.push({ metric, computed: 0, status: 'notApplicable' })
+        continue
+      }
+      metrics.push({ metric, computed: value, status: 'unpublished' })
+      findings.push({
+        kind: 'unpublishedMetric',
+        programYear,
+        metric,
+        computed: value,
+      })
+      continue
+    }
+
+    if (computedValue === undefined) {
+      metrics.push({ metric, published: publishedValue, status: 'missing' })
+      findings.push({
+        kind: 'missingMetric',
+        programYear,
+        metric,
+        published: publishedValue,
+      })
+      continue
+    }
+
+    const delta = computedValue - publishedValue
+    metrics.push({
+      metric,
+      published: publishedValue,
+      computed: computedValue,
+      delta,
+      status: delta === 0 ? 'match' : 'mismatch',
+    })
+    if (delta !== 0) {
+      findings.push({
+        kind: 'mismatch',
+        programYear,
+        metric,
+        computed: computedValue,
+        published: publishedValue,
+        delta,
+      })
+    }
+  }
+
+  // Internal consistency of the computed side, independent of the published
+  // comparison: the per-tier counts must add up to the independently
+  // counted total.
+  const tierSum = CLUB_TIER_METRICS.reduce(
+    (sum, metric) => sum + (computed[metric] ?? 0),
+    0
+  )
+  if (tierSum !== computed.totalDistinguishedClubs) {
+    findings.push({
+      kind: 'tierSumMismatch',
+      programYear,
+      tierSum,
+      computedTotal: computed.totalDistinguishedClubs,
+      delta: computed.totalDistinguishedClubs - tierSum,
+    })
+  }
+
+  return { programYear, noData: false, districts, metrics, findings }
+}
+
+/**
+ * Compare computed program-year totals against the published CEO Report
+ * figures.
+ *
+ * One entry per PUBLISHED year, in report order — computed years the report
+ * does not cover are ignored (the report is the oracle; years outside its
+ * window have nothing to be checked against). Pure: no I/O, no mutation of
+ * the input.
+ */
+export function compareToCeoReport(
+  computed: readonly ComputedProgramYearTotals[]
+): CeoReportComparison {
+  const byProgramYear = new Map(computed.map(c => [c.programYear, c]))
+
+  const years = CEO_REPORT_FIGURES.map(published =>
+    compareOneYear(published, byProgramYear.get(published.programYear))
+  )
+  const findings = years.flatMap(year => year.findings)
+
+  return {
+    ok: findings.length === 0,
+    source: { url: CEO_REPORT_SOURCE_URL, reportDate: CEO_REPORT_REPORT_DATE },
+    years,
+    findings,
+  }
+}
+
+const STATUS_LABEL: Record<MetricStatus, string> = {
+  match: 'match',
+  mismatch: 'MISMATCH',
+  missing: 'MISSING (not computed)',
+  unpublished: 'UNPUBLISHED (not in report)',
+  notApplicable: 'n/a',
+  noData: 'no data',
+}
+
+function pad(value: string, width: number): string {
+  return value.padEnd(width)
+}
+
+function padStart(value: string, width: number): string {
+  return value.padStart(width)
+}
+
+function num(value: number | undefined): string {
+  return value === undefined ? '–' : value.toLocaleString('en-US')
+}
+
+function signed(value: number | undefined): string {
+  if (value === undefined) return '–'
+  return value > 0 ? `+${value.toLocaleString('en-US')}` : num(value)
+}
+
+const METRIC_WIDTH = Math.max(...CEO_REPORT_METRICS.map(m => m.length))
+
+/**
+ * Render a per-year table of the comparison — printed whether or not the
+ * comparison passed, so a run always shows its work.
+ */
+export function formatComparisonTable(comparison: CeoReportComparison): string {
+  const lines: string[] = [
+    'CEO Report oracle — computed vs published',
+    `Source: ${comparison.source.url} (report ${comparison.source.reportDate})`,
+    '',
+  ]
+
+  for (const year of comparison.years) {
+    if (year.noData) {
+      lines.push(
+        `${year.programYear} — no data (program year absent from the computed input)`
+      )
+    } else {
+      const d = year.districts!
+      lines.push(
+        `${year.programYear} — districts: ${d.distinguished} distinguished · ` +
+          `${d.notDistinguished} not distinguished · ${d.unknown} unknown ` +
+          `(${d.total} scored)`
+      )
+    }
+
+    lines.push(
+      `  ${pad('metric', METRIC_WIDTH)} ${padStart('published', 10)} ` +
+        `${padStart('computed', 10)} ${padStart('delta', 8)}  status`
+    )
+    for (const metric of year.metrics) {
+      lines.push(
+        `  ${pad(metric.metric, METRIC_WIDTH)} ` +
+          `${padStart(num(metric.published), 10)} ` +
+          `${padStart(num(metric.computed), 10)} ` +
+          `${padStart(signed(metric.delta), 8)}  ${STATUS_LABEL[metric.status]}`
+      )
+    }
+
+    for (const finding of year.findings) {
+      if (finding.kind === 'tierSumMismatch') {
+        lines.push(
+          `  ! tier counts sum to ${finding.tierSum} but ${finding.computedTotal} ` +
+            `clubs are distinguished or better (delta ${signed(finding.delta)})`
+        )
+      }
+    }
+    lines.push('')
+  }
+
+  const mismatches = comparison.findings.filter(f => f.kind === 'mismatch')
+  const noData = comparison.findings.filter(f => f.kind === 'noData')
+  lines.push(
+    comparison.ok
+      ? 'RESULT: every published figure reproduced.'
+      : `RESULT: ${comparison.findings.length} finding(s) — ` +
+          `${mismatches.length} mismatch(es), ${noData.length} year(s) with no data.`
+  )
+
+  return lines.join('\n')
+}

--- a/scripts/validate-vs-ceo-report.ts
+++ b/scripts/validate-vs-ceo-report.ts
@@ -1,0 +1,315 @@
+/**
+ * CEO Report oracle — runner (#1429, epic #1426).
+ *
+ * Thin glue around the pure comparator in ./lib/ceoReportOracle.js: for each
+ * program year the TI CEO Report publishes, find that year's last snapshot in
+ * a local cache directory, compute the totals the report publishes, hand them
+ * to the comparator, print the per-year table, and exit non-zero on any
+ * finding.
+ *
+ * All decision logic is unit-tested in
+ * scripts/lib/__tests__/ceoReportOracle.test.ts. Nothing here decides what a
+ * number means — this file only reads files and counts.
+ *
+ * Four correctness constraints this file exists to honour:
+ *
+ * 1. `programYear` is ALWAYS passed to `DistinguishedDistrictCalculator`,
+ *    derived from the SNAPSHOT DATE. The parameter is optional and omitting
+ *    it falls back to `CURRENT_RULESET` — the 2026-27 four-gate set, not a
+ *    fixed year — which would score 2021-22 under rules whose prerequisite
+ *    columns do not exist in that year's export, flipping every district to
+ *    `Unknown`. The program year is NEVER derived from
+ *    `metadata.sourceCsvDate`: a year-end snapshot's source date falls in
+ *    July (Lesson 139), which lands one era late.
+ * 2. Club tiers are re-derived from the raw `clubPerformance` array, never
+ *    read from `totals.distinguished*`. Those totals are written once at
+ *    transform time and never re-derived, so archived 2021-22…2024-25 files
+ *    carry pre-#1124 output whose semantics may differ per year. The raw
+ *    array is persisted verbatim on every snapshot, which makes the count
+ *    version-independent across all five years (Lesson 123).
+ * 3. Tier classification uses analytics-core's `classifyDistinguishedTier`
+ *    only — never the frontend twin `normalizeTierCode`, which is
+ *    case-sensitive on the letter codes and matches only four exact word
+ *    forms including an apostrophe in "president's distinguished", while this
+ *    dataset's documented word form has none.
+ * 4. Two different fields are both called `distinguishedClubs`:
+ *    `rankings[].distinguishedClubs` is TI's "Total Distinguished Clubs"
+ *    column (ALL tiers summed) while `totals.distinguishedClubs` is the D
+ *    tier only. Neither is read here — every club count is derived from
+ *    `clubPerformance` — and the variables below are named so the two cannot
+ *    be confused.
+ *
+ * Logging goes to stderr (R4); `--json` writes the machine-readable
+ * comparison to stdout.
+ *
+ * Usage:
+ *   npx tsx scripts/validate-vs-ceo-report.ts --cache-dir ./cache [--json]
+ *
+ * Exit codes: 0 = every published figure reproduced · 1 = findings ·
+ * 2 = usage or setup error.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type {
+  AllDistrictsRankingsData,
+  DistrictRanking,
+} from '@taverns-red/shared-contracts'
+import { DistinguishedDistrictCalculator } from '../packages/analytics-core/src/rankings/DistinguishedDistrictCalculator.js'
+import { classifyDistinguishedTier } from '../packages/analytics-core/src/analytics/ClubEligibilityUtils.js'
+import {
+  CEO_REPORT_FIGURES,
+  compareToCeoReport,
+  formatComparisonTable,
+  type ComputedProgramYearTotals,
+  type DistrictTierCounts,
+} from './lib/ceoReportOracle.js'
+
+const DATE_DIR_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+const DISTRICT_FILE_PATTERN = /^district_(.+)\.json$/
+
+function log(msg: string): void {
+  process.stderr.write(`${msg}\n`)
+}
+
+interface Args {
+  cacheDir: string
+  json: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+  let cacheDir = './cache'
+  let json = false
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!
+    if (arg === '--json') {
+      json = true
+    } else if (arg === '--cache-dir') {
+      const value = argv[++i]
+      if (!value) throw new Error('--cache-dir needs a directory')
+      cacheDir = value
+    } else if (arg.startsWith('--cache-dir=')) {
+      cacheDir = arg.slice('--cache-dir='.length)
+    } else {
+      throw new Error(`unknown argument: ${arg}`)
+    }
+  }
+
+  return { cacheDir, json }
+}
+
+/**
+ * Program year ("YYYY-YYYY") a snapshot DATE belongs to. Calendar-pure and
+ * local on purpose: the snapshot's directory date is the collection date, so
+ * July 1 starts the new program year. Never call this on
+ * `metadata.sourceCsvDate` — see constraint 1 in the file header.
+ */
+function programYearForSnapshotDate(date: string): string {
+  const year = Number.parseInt(date.slice(0, 4), 10)
+  const month = Number.parseInt(date.slice(5, 7), 10)
+  return month >= 7 ? `${year}-${year + 1}` : `${year - 1}-${year}`
+}
+
+/** Every `YYYY-MM-DD` snapshot directory in the cache, oldest first. */
+function listSnapshotDates(cacheDir: string): string[] {
+  const snapshotsDir = join(cacheDir, 'snapshots')
+  if (!existsSync(snapshotsDir)) return []
+  return readdirSync(snapshotsDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory() && DATE_DIR_PATTERN.test(entry.name))
+    .map(entry => entry.name)
+    .sort()
+}
+
+/**
+ * The last snapshot belonging to a program year — its year-end freeze.
+ *
+ * Selection is by the snapshot's own date, NOT by `sourceCsvDate`: the
+ * June-30 freeze is published ~3 weeks later, so a program-year-equality
+ * guard on the source date drops every completed year (Lesson 139).
+ */
+function selectYearEndSnapshot(
+  dates: string[],
+  programYear: string
+): string | undefined {
+  const inYear = dates.filter(
+    date => programYearForSnapshotDate(date) === programYear
+  )
+  return inYear[inYear.length - 1]
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf-8')) as T
+}
+
+function districtFilesIn(snapshotDir: string): string[] {
+  return readdirSync(snapshotDir)
+    .filter(
+      name =>
+        DISTRICT_FILE_PATTERN.test(name) && !name.endsWith('_reports.json')
+    )
+    .sort()
+}
+
+interface ClubTierTally {
+  /** D tier only — NOT TI's all-tier "Total Distinguished Clubs" column. */
+  dTierClubs: number
+  sTierClubs: number
+  pTierClubs: number
+  mTierClubs: number
+  /** Counted independently of the four tiers: any non-null classification. */
+  distinguishedOrBetterClubs: number
+  /** True when the Smedley tier is present in this year's data at all. */
+  smedleyTierExists: boolean
+}
+
+/**
+ * Count club tiers from the raw `clubPerformance` rows of every district
+ * snapshot — the version-independent source (constraint 2).
+ */
+function tallyClubTiers(
+  snapshotDir: string,
+  rankings: DistrictRanking[]
+): ClubTierTally {
+  const tally: ClubTierTally = {
+    dTierClubs: 0,
+    sTierClubs: 0,
+    pTierClubs: 0,
+    mTierClubs: 0,
+    distinguishedOrBetterClubs: 0,
+    // The tier is also "present" when the era's rankings carry the field,
+    // so a year that simply had no Smedley clubs still reports 0 rather
+    // than absent.
+    smedleyTierExists: rankings.some(r => r.smedleyDistinguished !== undefined),
+  }
+
+  for (const fileName of districtFilesIn(snapshotDir)) {
+    const perDistrict = readJson<{
+      status?: string
+      data?: { clubPerformance?: Array<Record<string, unknown>> }
+    }>(join(snapshotDir, fileName))
+    if (perDistrict.status === 'failed') continue
+
+    for (const club of perDistrict.data?.clubPerformance ?? []) {
+      const raw = club['Club Distinguished Status']
+      const tier = classifyDistinguishedTier(
+        typeof raw === 'string' ? raw : undefined
+      )
+      if (tier === null) continue
+
+      tally.distinguishedOrBetterClubs++
+      if (tier === 'D') tally.dTierClubs++
+      else if (tier === 'S') tally.sTierClubs++
+      else if (tier === 'P') tally.pTierClubs++
+      else if (tier === 'M') {
+        tally.mTierClubs++
+        tally.smedleyTierExists = true
+      }
+    }
+  }
+
+  return tally
+}
+
+/**
+ * Score every district under the rules of the program year the SNAPSHOT
+ * belongs to, and tally the tiers (constraint 1). `Unknown` districts stay
+ * their own bucket — the comparator folds them into neither side.
+ */
+function tallyDistrictTiers(
+  rankings: DistrictRanking[],
+  programYear: string
+): DistrictTierCounts {
+  const calculator = new DistinguishedDistrictCalculator()
+  const statuses = calculator.calculateAll(rankings, programYear)
+
+  const counts: Record<string, number> = {}
+  for (const status of Object.values(statuses)) {
+    counts[status.currentTier] = (counts[status.currentTier] ?? 0) + 1
+  }
+  return counts as DistrictTierCounts
+}
+
+function computeProgramYear(
+  cacheDir: string,
+  snapshotDate: string
+): ComputedProgramYearTotals {
+  const snapshotDir = join(cacheDir, 'snapshots', snapshotDate)
+  const programYear = programYearForSnapshotDate(snapshotDate)
+
+  const rankingsFile = readJson<AllDistrictsRankingsData>(
+    join(snapshotDir, 'all-districts-rankings.json')
+  )
+  const rankings = rankingsFile.rankings ?? []
+
+  const clubs = tallyClubTiers(snapshotDir, rankings)
+  const paidClubsFromRankings = rankings.reduce(
+    (sum, ranking) => sum + (ranking.paidClubs ?? 0),
+    0
+  )
+
+  return {
+    programYear,
+    districtTiers: tallyDistrictTiers(rankings, programYear),
+    distinguishedClubs: clubs.dTierClubs,
+    selectDistinguishedClubs: clubs.sTierClubs,
+    presidentsDistinguishedClubs: clubs.pTierClubs,
+    // Absent — not zero — for years before the tier existed.
+    ...(clubs.smedleyTierExists
+      ? { smedleyDistinguishedClubs: clubs.mTierClubs }
+      : {}),
+    totalDistinguishedClubs: clubs.distinguishedOrBetterClubs,
+    paidClubs: paidClubsFromRankings,
+  }
+}
+
+function main(): void {
+  let args: Args
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (err) {
+    log(`Usage: validate-vs-ceo-report.ts --cache-dir <dir> [--json]`)
+    log(String(err instanceof Error ? err.message : err))
+    process.exit(2)
+  }
+
+  const dates = listSnapshotDates(args.cacheDir)
+  if (dates.length === 0) {
+    log(`No snapshot directories under ${join(args.cacheDir, 'snapshots')}.`)
+    log('Sync the year-end snapshot archive from GCS first (R2).')
+    process.exit(2)
+  }
+
+  const computed: ComputedProgramYearTotals[] = []
+  for (const { programYear } of CEO_REPORT_FIGURES) {
+    const snapshotDate = selectYearEndSnapshot(dates, programYear)
+    if (!snapshotDate) {
+      // Absent is absent — the comparator reports noData, never a mismatch.
+      log(`${programYear}: no snapshot in the cache — reporting no data`)
+      continue
+    }
+    log(`${programYear}: using snapshot ${snapshotDate}`)
+    try {
+      computed.push(computeProgramYear(args.cacheDir, snapshotDate))
+    } catch (err) {
+      log(
+        `${programYear}: could not read snapshot ${snapshotDate} — ` +
+          `${err instanceof Error ? err.message : String(err)}`
+      )
+      process.exit(2)
+    }
+  }
+
+  const comparison = compareToCeoReport(computed)
+
+  log('')
+  log(formatComparisonTable(comparison))
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(comparison, null, 2)}\n`)
+  }
+
+  process.exit(comparison.ok ? 0 : 1)
+}
+
+main()


### PR DESCRIPTION
Ships #1429 — step 0 of the #1426 sequencing. Three new files, no existing file modified.

## What

The TI CEO Report publishes five years of exactly the totals our calculators produce, which
makes it a free external oracle for per-era rulesets that have never been checked against a
published number.

- `scripts/lib/ceoReportOracle.ts` — the five published years as a deep-frozen typed
  constant, plus the pure comparator (`compareToCeoReport`, `splitDistrictTiers`,
  `formatComparisonTable`). Only import is `import type { DistinguishedDistrictTier }` — no
  runtime analytics dependency, no I/O.
- `scripts/lib/__tests__/ceoReportOracle.test.ts` — 22 tests.
- `scripts/validate-vs-ceo-report.ts` — thin glue: cache dir → snapshot selection → counts →
  comparator → table → exit code. Same lib/glue split as `registryFreshness.ts` and
  `snapshotPublishGate.ts`.

## Correctness constraints this encodes

Each of these came out of a parallel read-only audit of the assumptions, and each would have
produced a confident wrong answer:

- **`programYear` is always passed, derived from the snapshot date.** The parameter is
  optional and omitting it falls back to `CURRENT_RULESET` — the 2026-27 four-gate set, not a
  fixed year. Scoring 2021-22 without it applies 2026-27 thresholds and demands prerequisite
  columns that year never had, flipping every district to `Unknown`. Snapshot selection is
  likewise date-based, never `sourceCsvDate` (which falls in July — the Lesson 139 trap).
- **Club tiers are re-derived from raw `clubPerformance`** via analytics-core's
  `classifyDistinguishedTier`, never from `totals.distinguished*`. Snapshots are written once
  and never re-derived, so archived 2021-22…2024-25 files carry pre-#1124 output whose
  semantics may differ per year; the raw array is persisted verbatim, so re-deriving is
  version-independent across all five years. The frontend twin `normalizeTierCode` is
  deliberately not used — it is broken (#1431).
- **Neither field named `distinguishedClubs` is read ambiguously.** `rankings[].distinguishedClubs`
  is all tiers summed; `totals.distinguishedClubs` is D-tier only. Locals are named
  `dTierClubs` / `distinguishedOrBetterClubs` / `paidClubsFromRankings` so the two cannot be
  confused.
- **`Unknown` is counted on its own and folded into neither side** of the
  distinguished/not-distinguished split — otherwise a real ruleset bug reads as a data gap.
- **A missing program year reports `noData`, a computed zero reports a mismatch.** Not
  hypothetical: PY 2021-22 may be genuinely absent from the archive (see #1426 §1).

## Ground truth

The published figures are chart data labels — not present in the PDF's text layer, so they
were transcribed visually. Because a wrong oracle is worse than no oracle (it reports false
mismatches against correct code), the transcription was independently re-verified before
implementation: **0 digit errors, 0 tier mis-assignments**. Tier mapping was confirmed
geometrically — legend swatch RGB sampled, each stacked segment's pixel height back-solved
against its bar total — not by label position, since a swapped Select/President's assignment
is invisible to a re-read. Full method on #1429.

The file header records that the encoded values are the **chart labels**, and that the
report's prose disagrees with its own charts in two unrelated places (education awards
101,915 vs 101,916; membership-building 3,564 vs 3,567), so nobody later "fixes" the table
against prose it was never derived from.

## Testing

| Check | Result |
| --- | --- |
| `vitest scripts/lib/__tests__/ceoReportOracle.test.ts` | **22 passed** |
| 4 mutations of the implementation | each caught (Unknown folded → 2 fail; noData branch removed → 10 fail; tier-sum check disabled → 1 fail; only headline metric compared → 6 fail) |
| `npm run typecheck` | exit 0, all five workspaces |
| `npx prettier --check` (3 new files) | clean |
| Encoded table vs. verified figures | all 5 rows match; all 5 rows' tiers sum to their totals |

**One pre-existing suite failure, unrelated:** `scripts/lib/__tests__/lessonsIndexLocale.test.ts`
asserts a case-folding locale is installed. This container has only `C`, `C.utf8`, `POSIX`, so
it fails on a clean tree too — verified independently, not taken on report. It touches nothing
in this diff.

**Not run against real data**, per #1429's explicit out-of-scope note — the runner needs the
year-end snapshot archive, and R2 means a runner starts empty. Operator follow-up:
`npx tsx scripts/validate-vs-ceo-report.ts --cache-dir ./cache`, results to #1429.

## Note for review

`scripts/tsconfig.json` is not a clean gate and never was — it emits 23 errors on plain
`origin/main` (implicit `rootDir` vs. cross-package source imports, `import.meta` under its CJS
module setting). These files add 17 more of the same `TS6059 "not under rootDir"` class,
cascading from analytics-core **source** imports — following the existing `registryFreshness.ts`
precedent, since `classifyDistinguishedTier` is not exported from the analytics-core package
index and R16 warns off built `dist`. Zero real type errors: `tsc --noEmit --strict --types node`
on both new source files is clean, and nothing in CI or any npm script invokes that tsconfig.
Worth its own cleanup issue if you want the gate to mean something.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ChV9VodCpZ7t2LMLL5ft5n)_