### PR TITLE
fix(frontend): classify distinguished word forms by substring (#1431)

### DIFF
--- a/frontend/src/utils/__tests__/clubHistory.test.ts
+++ b/frontend/src/utils/__tests__/clubHistory.test.ts
@@ -68,6 +68,34 @@ describe('buildClubHistoryRow', () => {
     expect(row.tierLabel).toBe('Smedley Distinguished')
   })
 
+  it('renders P for a historical "Presidents Distinguished" year (#1431)', () => {
+    // Integration-level criterion, satisfied at the view-model level rather
+    // than by a page mount (R22). `buildClubHistoryRow` is what the per-club
+    // history table renders from, and historical snapshots carry the
+    // apostrophe-less dashboard word form
+    // (TOASTMASTERS_DASHBOARD_KNOWLEDGE.md:521). This used to fall through to
+    // null → an em-dash, silently understating the club's history.
+    const row = buildClubHistoryRow(
+      2019,
+      '2020-06-30',
+      makeClub({ distinguishedStatus: 'Presidents Distinguished' })
+    )
+    expect(row.hasData).toBe(true)
+    expect(row.tierCode).toBe('P')
+    expect(row.tierLabel).toBe("President's Distinguished")
+    expect(row.tierLabel).not.toBe('—')
+  })
+
+  it('exports the historical word-form tier to CSV as its display name (#1431)', () => {
+    const row = buildClubHistoryRow(
+      2019,
+      '2020-06-30',
+      makeClub({ distinguishedStatus: 'Presidents Distinguished' })
+    )
+    const csv = toClubHistoryCsvRows([row])
+    expect(csv[1]?.[2]).toBe("President's Distinguished")
+  })
+
   it('treats an absent club (missing year) as a no-data row, not a crash', () => {
     const row = buildClubHistoryRow(2021, '2022-06-30', undefined)
     expect(row.hasData).toBe(false)

--- a/frontend/src/utils/__tests__/distinguishedTier.test.ts
+++ b/frontend/src/utils/__tests__/distinguishedTier.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { distinguishedTierName, normalizeTierCode } from '../distinguishedTier'
+/* Imported from analytics-core's SOURCE, not its package root: the root
+   barrel does not re-export `classifyDistinguishedTier`, and the package's
+   `exports` map has no subpath entry. The shared-table test below is the
+   guard that keeps the frontend mirror and the analytics-core original from
+   diverging again (#1431). */
+import { classifyDistinguishedTier } from '../../../../packages/analytics-core/src/analytics/ClubEligibilityUtils'
 
 /* #795 (epic #821 Sprint 3) — domain helper for rendering the "Club
    Distinguished Status" code (`'' | D | S | P | M`) as a display name.
@@ -52,4 +58,82 @@ describe('normalizeTierCode (#1229)', () => {
   it('returns null for an unrecognised value rather than guessing', () => {
     expect(normalizeTierCode('Mystery')).toBeNull()
   })
+})
+
+describe('normalizeTierCode word forms (#1431)', () => {
+  it('maps the dashboard word form without an apostrophe to P', () => {
+    // TOASTMASTERS_DASHBOARD_KNOWLEDGE.md:521 documents the dashboard's
+    // distinguished status word forms — "Presidents Distinguished" has NO
+    // apostrophe. The exact-match map only held the apostrophe spelling, so
+    // every historical President's-Distinguished year rendered an em-dash.
+    expect(normalizeTierCode('Presidents Distinguished')).toBe('P')
+  })
+
+  it('still maps the apostrophe spelling to P', () => {
+    expect(normalizeTierCode("President's Distinguished")).toBe('P')
+  })
+
+  it('accepts a curly apostrophe in the word form', () => {
+    expect(normalizeTierCode('President\u2019s Distinguished')).toBe('P')
+  })
+
+  it('accepts lowercase letter codes', () => {
+    expect(normalizeTierCode('p')).toBe('P')
+    expect(normalizeTierCode(' d ')).toBe('D')
+  })
+
+  it('degrades an unanticipated distinguished word form to D', () => {
+    // Any spelling that says "distinguished" but names no higher tier is at
+    // least base Distinguished — matching analytics-core's final `return 'D'`.
+    expect(normalizeTierCode('Distinguished Club')).toBe('D')
+  })
+
+  it('treats "Not Distinguished" as no tier', () => {
+    expect(normalizeTierCode('Not Distinguished')).toBeNull()
+  })
+})
+
+/* The important one: `distinguishedTier.ts` mirrors analytics-core's
+   `classifyDistinguishedTier` because the frontend cannot import it (see the
+   import note at the top of this file). This table asserts the two agree on
+   every input, so a change to either side that is not made to the other fails
+   here instead of silently understating a club's history (#1431). */
+const SHARED_TIER_INPUTS: readonly (string | undefined)[] = [
+  undefined,
+  '',
+  '   ',
+  'D',
+  'S',
+  'P',
+  'M',
+  'd',
+  's',
+  'p',
+  'm',
+  ' P ',
+  'Distinguished',
+  'Select Distinguished',
+  "President's Distinguished",
+  'President\u2019s Distinguished',
+  'Presidents Distinguished',
+  'Smedley Distinguished',
+  'smedley distinguished',
+  '  SELECT DISTINGUISHED  ',
+  'Distinguished Club',
+  'Not Distinguished',
+  'not distinguished',
+  'Mystery',
+  'Z',
+  'President',
+]
+
+describe('normalizeTierCode agrees with classifyDistinguishedTier (#1431)', () => {
+  it.each(SHARED_TIER_INPUTS.map(input => [JSON.stringify(input), input]))(
+    'agrees on %s',
+    (_label, input) => {
+      expect(normalizeTierCode(input as string | undefined)).toBe(
+        classifyDistinguishedTier(input as string | undefined)
+      )
+    }
+  )
 })

--- a/frontend/src/utils/distinguishedTier.ts
+++ b/frontend/src/utils/distinguishedTier.ts
@@ -30,26 +30,37 @@ const LETTER_CODES: ReadonlySet<string> = new Set<ClubTierCode>([
 ])
 
 /**
- * Inverse of {@link TIER_NAMES} — historical snapshots sometimes carry the tier
- * as a word form instead of a letter code (`distinguishedStatus` may be either;
- * see `ClubStatisticsFile`). Kept beside the canonical code→name map so the two
- * directions can't drift apart (lesson 117).
- */
-const WORD_FORM_TO_CODE: Record<string, ClubTierCode> = {
-  distinguished: 'D',
-  'select distinguished': 'S',
-  "president's distinguished": 'P',
-  'smedley distinguished': 'M',
-}
-
-/**
  * Normalize a raw `distinguishedStatus` value to a canonical letter code.
- * Returns null for an absent, empty, or unrecognised value (→ em-dash, never a
- * guess). Accepts both live letter codes and historical word forms.
+ *
+ * Historical snapshots sometimes carry the tier as a word form instead of a
+ * letter code (`distinguishedStatus` may be either; see `ClubStatisticsFile`).
+ * The classification is **substring-based**, not an exact-match lookup: the
+ * dashboard's documented word form has no apostrophe ("Presidents
+ * Distinguished" — `TOASTMASTERS_DASHBOARD_KNOWLEDGE.md:521`), so a keyed map
+ * silently dropped every historical President's-Distinguished year (#1431).
+ *
+ * This mirrors `classifyDistinguishedTier` in analytics-core
+ * (`packages/analytics-core/src/analytics/ClubEligibilityUtils.ts`) line for
+ * line. It is a mirror rather than a delegation because that function is not
+ * re-exported from the package root and the package's `exports` map has no
+ * subpath entry. The shared-table test in `__tests__/distinguishedTier.test.ts`
+ * asserts the two agree on every input — lesson 117's real bite here was
+ * drifting from the *other implementation of the same rule*, not from the
+ * code→name map next door. Keep the two in lockstep.
+ *
+ * Returns null for an absent, empty, or non-distinguished value (→ em-dash).
  */
 export function normalizeTierCode(raw?: string): ClubTierCode | null {
   if (!raw) return null
-  const trimmed = raw.trim()
-  if (LETTER_CODES.has(trimmed)) return trimmed as ClubTierCode
-  return WORD_FORM_TO_CODE[trimmed.toLowerCase()] ?? null
+
+  const code = raw.trim().toUpperCase()
+  if (LETTER_CODES.has(code)) return code as ClubTierCode
+
+  const words = raw.toLowerCase()
+  if (!words.includes('distinguished')) return null
+  if (words.includes('not distinguished')) return null
+  if (words.includes('smedley')) return 'M'
+  if (words.includes('president')) return 'P'
+  if (words.includes('select')) return 'S'
+  return 'D'
 }


### PR DESCRIPTION
Fixes #1431. Found during the #1429 pre-flight audit; filed and fixed separately because it is a live defect unrelated to that sprint.

## Problem

`normalizeTierCode` looked the word form up in an **exact-match map** keyed with an
apostrophe — `"president's distinguished"` — but the dashboard's documented spelling has
none: `"Presidents Distinguished"` (`TOASTMASTERS_DASHBOARD_KNOWLEDGE.md:521`). The lookup
missed, returned `null`, and the per-club history table rendered an **em-dash** for every
historical President's-Distinguished year — in the one surface built to show club history.

It failed silently by design: the function documents `null` as "absent, empty, or
unrecognised value (→ em-dash, never a guess)", so a dropped row is indistinguishable from a
club that genuinely wasn't distinguished that year.

Two smaller divergences rode along: the letter-code check was case-sensitive, and an
unanticipated word form fell through to `null` instead of degrading to `D`.

## Fix

Deleted `WORD_FORM_TO_CODE` and mirrored analytics-core's substring rule
(`ClubEligibilityUtils.ts:129-146`) line for line. All three divergences go with it.

**Mirrored, not delegated** — and deliberately. The frontend does depend on
`@taverns-red/analytics-core`, but `classifyDistinguishedTier` is not re-exported from the
package root and `packages/analytics-core/package.json`'s `exports` map has only a `"."`
entry, so no subpath import exists. Delegating would have meant editing the analytics-core
barrel plus an R16 package rebuild — a much wider change for a one-function bug fix.

The guard against that mirror drifting is executable, not a comment: a **shared-table test**
runs 26 inputs through both implementations and asserts they agree. It imports the real
`classifyDistinguishedTier` from analytics-core **source** (not the gitignored `dist`), so a
stale build cannot defeat it. Change either implementation without the other and it fails.

That is the actual lesson here. The old code carried a comment invoking lesson 117 — "kept
beside the canonical code→name map so the two directions can't drift apart". They never
drifted from *each other*; they drifted from the **other implementation of the same rule**,
which a comment cannot catch and a test can.

## Tests

`distinguishedTier.test.ts`: `'Presidents Distinguished'` → `'P'` (the bug);
`"President's Distinguished"` → `'P'` (old spelling doesn't regress); curly-apostrophe
`'President’s Distinguished'` → `'P'`; `'p'` and `' d '` → `'P'`/`'D'` (the case-sensitivity
divergence); `'Distinguished Club'` → `'D'` (degrade rather than drop); `'Not Distinguished'`
→ `null` (negation guard survives the switch); plus the 26-input agreement table.

`clubHistory.test.ts`: `buildClubHistoryRow` with `'Presidents Distinguished'` yields
`tierCode: 'P'` / `tierLabel: "President's Distinguished"` and explicitly not `'—'`, and the
same row exports correctly through `toClubHistoryCsvRows`.

**Where the integration-level criterion went.** The issue asked for it "integration-level";
it is satisfied at the `clubHistory.ts` view-model level instead. R22 forbids a page mount in
the unit project, and `buildClubHistoryRow` is the complete view model behind that table
(`normalizeTierCode` has exactly one production consumer, `clubHistory.ts:87`). What this
does **not** cover is the JSX rendering of `tierCode`/`tierLabel` into a badge — a follow-up
test under `frontend/src/pages/__tests__/` would be needed for that. Flagging it as a
deliberate substitution, not an omission.

## Verification

| Check | Result |
| --- | --- |
| Red, before fix | `13 failed \| 36 passed (49)` — `expected null to be 'P'`, the right reason |
| Green, after fix | `49 passed (49)` |
| Full unit project | `239 files, 3152 passed` |
| Full integration project | `100 files, 883 passed` |
| analytics-core suite | `109 passed` (unchanged) |
| `npm run typecheck` / `typecheck:test` | exit 0 |
| `npm run test:no-page-mounts:check` | `✓ no unit-project test imports a page component` |
| `npx prettier --check` / `eslint` (3 files) | clean |

## Not verified

**Live-data prevalence.** How many archived rows actually carry the no-apostrophe form is
unknown — CDN egress is blocked from these sessions. The fix is correct either way; a single
`snapshots/{YYYY}-06-30/district_61.json` fetch would settle the impact number.

## Follow-up worth considering

A lesson is arguably warranted: *a comment saying "kept beside its inverse so they can't
drift" only guards drift between the two copies in front of you; a mirror of another module's
rule needs an executable agreement test.* Not filed here — it would also require regenerating
`tasks/lessons/INDEX.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ChV9VodCpZ7t2LMLL5ft5n)_