### PR TITLE
fix(frontend): give the degraded district view a program-year selector (#1436)

### DIFF
--- a/frontend/src/hooks/__tests__/useDistrictRankHistoryYears.test.tsx
+++ b/frontend/src/hooks/__tests__/useDistrictRankHistoryYears.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * useDistrictRankHistoryYears (#1436)
+ *
+ * The degraded "limited data" view on DistrictDetailPage is only reachable for
+ * a district with NO `district-snapshot-index.json` entry (districts that DO
+ * have one self-heal to their newest data year via the page's auto-select
+ * effect — #1398). For such a district `index[id] ?? []` is empty, so a year
+ * selector fed from the snapshot index would render with nothing in it.
+ *
+ * Its rank history is the only record of the years it exists in:
+ * `v1/rank-history/{id}.json` is written for every district that ever appeared
+ * in any all-districts-rankings.json (data-pipeline.yml, "Building per-district
+ * rank history").
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnRankHistory: vi.fn(),
+}))
+
+import { fetchCdnRankHistory } from '../../services/cdn'
+import {
+  programYearsFromRankHistory,
+  useDistrictRankHistoryYears,
+} from '../useDistrictRankHistoryYears'
+
+const mockedFetch = vi.mocked(fetchCdnRankHistory)
+
+function point(date: string) {
+  return {
+    date,
+    aggregateScore: 100,
+    clubsRank: 1,
+    paymentsRank: 1,
+    distinguishedRank: 1,
+    totalDistricts: 128,
+    overallRank: 41,
+  }
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return React.createElement(QueryClientProvider, { client }, children)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('programYearsFromRankHistory (#1436)', () => {
+  it('derives the program years a district appears in, newest first', () => {
+    const years = programYearsFromRankHistory([
+      { date: '2024-12-31' },
+      { date: '2025-06-30' },
+      { date: '2026-01-15' },
+    ])
+
+    expect(years.map(py => py.label)).toEqual(['2025-2026', '2024-2025'])
+  })
+
+  it('returns an empty list for a district with no rank history', () => {
+    expect(programYearsFromRankHistory([])).toEqual([])
+  })
+
+  it('drops unparseable dates rather than minting a NaN-NaN year (#1353)', () => {
+    const years = programYearsFromRankHistory([
+      { date: 'not-a-date' },
+      { date: '2025-06-30' },
+    ])
+
+    expect(years.map(py => py.label)).toEqual(['2024-2025'])
+  })
+})
+
+describe('useDistrictRankHistoryYears (#1436)', () => {
+  it('does not fetch while disabled — the happy path adds no request', () => {
+    const { result } = renderHook(
+      () => useDistrictRankHistoryYears('44', false),
+      { wrapper }
+    )
+
+    expect(mockedFetch).not.toHaveBeenCalled()
+    expect(result.current.programYears).toEqual([])
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('returns the years the district appears in when enabled', async () => {
+    mockedFetch.mockResolvedValue({
+      districtId: '44',
+      districtName: '44',
+      history: [point('2024-12-31'), point('2025-06-30')],
+    })
+
+    const { result } = renderHook(
+      () => useDistrictRankHistoryYears('44', true),
+      { wrapper }
+    )
+
+    await waitFor(() =>
+      expect(result.current.programYears.map(py => py.label)).toEqual([
+        '2024-2025',
+      ])
+    )
+    expect(mockedFetch).toHaveBeenCalledWith('44')
+  })
+
+  it('degrades to an empty list when the rank history 404s', async () => {
+    mockedFetch.mockRejectedValue(new Error('404'))
+
+    const { result } = renderHook(
+      () => useDistrictRankHistoryYears('999', true),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.programYears).toEqual([])
+  })
+})

--- a/frontend/src/hooks/__tests__/useUrlProgramYear.test.ts
+++ b/frontend/src/hooks/__tests__/useUrlProgramYear.test.ts
@@ -42,6 +42,7 @@ vi.mock('../useDefaultProgramYear', () => ({
 
 // Must import after mock
 import { useUrlProgramYear } from '../useUrlProgramYear'
+import { getProgramYear } from '../../utils/programYear'
 import { snap } from '../../test-utils/snapshotDate'
 
 // Captures the live URL search string so tests can assert whether ?py= is
@@ -227,6 +228,88 @@ describe('useUrlProgramYear (#272)', () => {
 
       expect(result.current.selectedProgramYear.year).toBe(2024)
       expect(result.current.selectedDate).toBe('2025-01-15')
+    })
+  })
+
+  /**
+   * #1436 — `?py=` and `?date=` are read INDEPENDENTLY (see the reads above), so
+   * a `?date=` outside the selected program year leaves the page
+   * self-inconsistent. `searchIndex.ts` documents the same hazard and sets both
+   * together for exactly this reason.
+   *
+   * Two separate setter calls in one handler cannot do that: react-router's
+   * `setSearchParams` functional updater is handed the RENDER-TIME
+   * `searchParams` (react-router 7 `useSearchParams`), not the pending value —
+   * so the second call is computed from a stale base and silently discards the
+   * first call's key. Hence one setter that writes both keys in one navigation.
+   */
+  describe('setProgramYearAndDate (#1436)', () => {
+    it('writes both params in a single navigation', () => {
+      const { result } = renderHook(() => useUrlProgramYear(), {
+        wrapper: createWrapper(['/?py=2025&date=2026-06-30']),
+      })
+
+      act(() => {
+        result.current.setProgramYearAndDate(
+          getProgramYear(2024),
+          snap('2025-06-30')
+        )
+      })
+
+      expect(result.current.selectedProgramYear.year).toBe(2024)
+      expect(result.current.selectedDate).toBe('2025-06-30')
+      expect(location.search).toContain('py=2024')
+      expect(location.search).toContain('date=2025-06-30')
+    })
+
+    it('keeps ?py= when the date is cleared — the stale-base regression', () => {
+      // The naive `setSelectedProgramYear(py); setSelectedDate(undefined)`
+      // sequence loses `py=2024` here, because the second call rebuilds the
+      // query string from the pre-click params.
+      const { result } = renderHook(() => useUrlProgramYear(), {
+        wrapper: createWrapper(['/?py=2025&date=2026-06-30']),
+      })
+
+      act(() => {
+        result.current.setProgramYearAndDate(getProgramYear(2024), undefined)
+      })
+
+      expect(location.search).toContain('py=2024')
+      expect(location.search).not.toContain('date=')
+      expect(result.current.selectedDate).toBeUndefined()
+    })
+
+    it('never emits a ?date= outside the selected program year', () => {
+      const { result } = renderHook(() => useUrlProgramYear(), {
+        wrapper: createWrapper(['/?py=2025&date=2026-06-30']),
+      })
+
+      act(() => {
+        // 2026-06-30 belongs to PY 2025-2026, not to PY 2024-2025.
+        result.current.setProgramYearAndDate(
+          getProgramYear(2024),
+          snap('2026-06-30')
+        )
+      })
+
+      expect(location.search).toContain('py=2024')
+      expect(location.search).not.toContain('date=')
+    })
+
+    it('omits ?py= when the target year is the data-driven default', () => {
+      const { result } = renderHook(() => useUrlProgramYear(), {
+        wrapper: createWrapper(['/?py=2024&date=2025-06-30']),
+      })
+
+      act(() => {
+        result.current.setProgramYearAndDate(
+          getProgramYear(2025),
+          snap('2026-06-30')
+        )
+      })
+
+      expect(location.search).not.toContain('py=')
+      expect(location.search).toContain('date=2026-06-30')
     })
   })
 })

--- a/frontend/src/hooks/useDistrictRankHistoryYears.ts
+++ b/frontend/src/hooks/useDistrictRankHistoryYears.ts
@@ -1,0 +1,69 @@
+/**
+ * useDistrictRankHistoryYears — the program years a district appears in,
+ * derived from its RANK HISTORY rather than its snapshots (#1436).
+ *
+ * `useDistrictCachedDates` is the normal year source, and it is already
+ * per-district: it reads `district-snapshot-index.json`. But DistrictDetailPage's
+ * degraded "limited data" branch is only reachable for a district that has NO
+ * entry in that index — a district that DOES have one self-heals to its newest
+ * data year via the page's auto-select effect (#1398) and never degrades. For
+ * the degraded case `index[id] ?? []` is empty, so a selector fed from the
+ * snapshot index would render with nothing in it and fix nothing.
+ *
+ * The rank history is the record of where such a district actually appears:
+ * `v1/rank-history/{id}.json` is written for EVERY district that ever appeared
+ * in any `all-districts-rankings.json` (data-pipeline.yml, "Building
+ * per-district rank history"). That is exactly the population that can reach the
+ * degraded view with something to show — `GlobalRankingsTab`, already rendered
+ * there, reads the same file.
+ */
+
+import { useMemo } from 'react'
+import { useRankHistory } from './useRankHistory'
+import { getAvailableProgramYears } from '../utils/programYear'
+import type { ProgramYear } from '../utils/programYear'
+
+/**
+ * Pure: the distinct program years covered by a district's rank-history points,
+ * newest first. Unparseable dates are dropped by `getAvailableProgramYears`
+ * rather than minting a `NaN-NaN` year (#1353) — the history is CDN JSON and is
+ * not schema-validated on the way in.
+ */
+export function programYearsFromRankHistory(
+  history: ReadonlyArray<{ date: string }>
+): ProgramYear[] {
+  return getAvailableProgramYears(history.map(point => point.date))
+}
+
+export interface DistrictRankHistoryYears {
+  programYears: ProgramYear[]
+  isLoading: boolean
+}
+
+/**
+ * @param districtId - District whose rank history to read.
+ * @param enabled - Gate the request. Callers pass `true` only once the snapshot
+ *   index has resolved EMPTY for this district, so the happy path issues no
+ *   extra fetch.
+ */
+export function useDistrictRankHistoryYears(
+  districtId: string | undefined,
+  enabled: boolean
+): DistrictRankHistoryYears {
+  const districtIds = useMemo(
+    () => (enabled && districtId ? [districtId] : []),
+    [enabled, districtId]
+  )
+  const active = districtIds.length > 0
+
+  // No date bounds — the whole history is wanted, which is what makes the year
+  // list complete. `useRankHistory` is itself gated on a non-empty id list.
+  const { data, isLoading } = useRankHistory({ districtIds })
+
+  const programYears = useMemo(
+    () => programYearsFromRankHistory(data?.[0]?.history ?? []),
+    [data]
+  )
+
+  return { programYears, isLoading: active ? isLoading : false }
+}

--- a/frontend/src/hooks/useUrlProgramYear.ts
+++ b/frontend/src/hooks/useUrlProgramYear.ts
@@ -14,7 +14,7 @@
 import { useEffect, useCallback, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useProgramYear } from '../contexts/ProgramYearContext'
-import { getProgramYear } from '../utils/programYear'
+import { getProgramYear, isDateInProgramYear } from '../utils/programYear'
 import type { ProgramYear } from '../utils/programYear'
 import { useDefaultProgramYear } from './useDefaultProgramYear'
 import { toSnapshotDate, type SnapshotDate } from '../types/snapshotDate'
@@ -111,10 +111,53 @@ export function useUrlProgramYear() {
     [setSearchParams, setContextDate]
   )
 
+  /**
+   * Move the program year and the snapshot date TOGETHER, in one navigation
+   * (#1436).
+   *
+   * `?py=` and `?date=` are read independently above, so a `?date=` outside the
+   * selected program year leaves the page self-inconsistent — the hazard
+   * `searchIndex.ts` documents and sets both params to avoid. Calling
+   * `setSelectedProgramYear` and then `setSelectedDate` cannot avoid it:
+   * react-router's `setSearchParams` hands the functional updater the
+   * RENDER-TIME `searchParams`, not the pending value, so the second call is
+   * computed from a stale base and silently discards the first call's key.
+   *
+   * A `date` outside `py` is dropped rather than written — the inconsistent
+   * pair must not be reachable through this setter even by a caller mistake.
+   */
+  const setProgramYearAndDate = useCallback(
+    (py: ProgramYear, date: SnapshotDate | undefined) => {
+      const dateInYear =
+        date && isDateInProgramYear(date, py) ? date : undefined
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          if (py.year === defaultPY.year) {
+            next.delete('py')
+          } else {
+            next.set('py', py.year.toString())
+          }
+          if (!dateInYear) {
+            next.delete('date')
+          } else {
+            next.set('date', dateInYear)
+          }
+          return next
+        },
+        { replace: true }
+      )
+      setContextPY(py)
+      setContextDate(dateInYear)
+    },
+    [setSearchParams, setContextPY, setContextDate, defaultPY.year]
+  )
+
   return {
     selectedProgramYear,
     setSelectedProgramYear,
     selectedDate,
     setSelectedDate,
+    setProgramYearAndDate,
   }
 }

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -525,9 +525,9 @@ const DistrictDetailPageInner: React.FC = () => {
               </div>
             </div>
 
-            {/* #1436 — the way out. Without this the branch below returns
-                before DistrictDetailHeader, the page's only year control, so a
-                district viewable in another year was unreachable from its own
+            {/* #1436 — the way out. This branch returns before
+                DistrictDetailHeader, which was the page's only year control, so
+                a district viewable in another year was unreachable from its own
                 page. Rendered only when there IS another year to reach — but
                 the slot is reserved while the rank-history query is in flight,
                 so the selector does not late-insert and push the rankings

--- a/frontend/src/pages/DistrictDetailPage.tsx
+++ b/frontend/src/pages/DistrictDetailPage.tsx
@@ -15,13 +15,16 @@ import { useDistrictAnalytics } from '../hooks/useDistrictAnalytics'
 import { useAggregatedAnalytics } from '../hooks/useAggregatedAnalytics'
 import { usePerformanceTargets } from '../hooks/usePerformanceTargets'
 import { useDistrictCachedDates } from '../hooks/useDistrictData'
+import { useDistrictRankHistoryYears } from '../hooks/useDistrictRankHistoryYears'
 import { useUrlProgramYear } from '../hooks/useUrlProgramYear'
+import { ProgramYearSelector } from '../components/ProgramYearSelector'
 import {
   getAvailableProgramYears,
   filterDatesByProgramYear,
   getMostRecentDateInProgramYear,
   isDateInProgramYear,
 } from '../utils/programYear'
+import type { ProgramYear } from '../utils/programYear'
 import { DistrictOverview } from '../components/DistrictOverview'
 import { NotableDatesSection } from '../components/NotableDatesSection'
 import { LongestServingClubsLeaderboard } from '../components/LongestServingClubsLeaderboard'
@@ -67,6 +70,7 @@ const DistrictDetailPageInner: React.FC = () => {
     setSelectedProgramYear,
     selectedDate,
     setSelectedDate,
+    setProgramYearAndDate,
   } = useUrlProgramYear()
 
   // Fetch cached dates for date selector
@@ -82,6 +86,24 @@ const DistrictDetailPageInner: React.FC = () => {
   const availableProgramYears = React.useMemo(() => {
     return getAvailableProgramYears(allCachedDates)
   }, [allCachedDates])
+
+  // #1436 — the degraded "limited data" view's year source.
+  //
+  // `availableProgramYears` above is already per-district (it reads
+  // `district-snapshot-index.json`), which is precisely why it cannot feed the
+  // degraded selector: the branch below requires `!selectedDistrict`, and a
+  // district WITH an index entry self-heals to its newest data year via the
+  // effect that follows (#1398) and never degrades. The branch is reachable
+  // only when the index has no entry — `index[id] ?? []` empty — so a selector
+  // fed from it would render with nothing in it.
+  //
+  // The district's rank history is where it does appear. Gated on the index
+  // having RESOLVED empty, so the happy path issues no extra request.
+  const needsRankHistoryYears = !!cachedDatesData && allCachedDates.length === 0
+  const {
+    programYears: rankHistoryProgramYears,
+    isLoading: isLoadingRankHistoryYears,
+  } = useDistrictRankHistoryYears(districtId, needsRankHistoryYears)
 
   // Auto-select a valid program year if current selection is not in available list
   React.useEffect(() => {
@@ -369,6 +391,53 @@ const DistrictDetailPageInner: React.FC = () => {
     }
   }, [analytics, performanceTargets])
 
+  // ── Degraded "limited data" view: program-year controls (#1436) ────────────
+  //
+  // Snapshot years when the district has them, rank-history years when it does
+  // not. Declared unconditionally, above the early return — these are hooks.
+
+  const degradedDataYears =
+    availableProgramYears.length > 0
+      ? availableProgramYears
+      : rankHistoryProgramYears
+
+  // The selected year is offered alongside the data years even when it has
+  // none: a <select> whose value is absent from its options renders blank, and
+  // the user has to be able to see where they currently are. It is the ONLY
+  // year added — everything else in the list is a year this district really
+  // appears in.
+  const degradedYearOptions = React.useMemo(() => {
+    const hasSelected = degradedDataYears.some(
+      py => py.year === selectedProgramYear.year
+    )
+    const merged = hasSelected
+      ? degradedDataYears
+      : [...degradedDataYears, selectedProgramYear]
+    return [...merged].sort((a, b) => b.year - a.year)
+  }, [degradedDataYears, selectedProgramYear])
+
+  // The most recent year with data OTHER than the one being viewed — what the
+  // banner names so the user is not left guessing which year to try.
+  const degradedSuggestedYear = React.useMemo(
+    () =>
+      degradedDataYears.find(py => py.year !== selectedProgramYear.year) ??
+      null,
+    [degradedDataYears, selectedProgramYear]
+  )
+
+  // Move BOTH `?py=` and `?date=` in one navigation. `useUrlProgramYear` reads
+  // them independently, so a `?date=` left over from the previous year would
+  // leave the page self-inconsistent — the hazard `searchIndex.ts` documents.
+  // A district with no snapshots has no in-year date to offer, so the date is
+  // dropped rather than carried across.
+  const handleDegradedProgramYearChange = React.useCallback(
+    (py: ProgramYear) => {
+      const dateInYear = getMostRecentDateInProgramYear(allCachedDates, py)
+      setProgramYearAndDate(py, dateInYear ?? undefined)
+    },
+    [allCachedDates, setProgramYearAndDate]
+  )
+
   // If districts data has loaded but this district isn't in the tracked list,
   // show a limited page with Global Rankings (available for all districts)
   // instead of blank data. Only 6 districts have detailed per-district analytics.
@@ -414,7 +483,10 @@ const DistrictDetailPageInner: React.FC = () => {
             </div>
 
             {/* Limited data banner */}
-            <div className="bg-tm-happy-yellow bg-opacity-20 border border-tm-happy-yellow rounded-lg p-4 mb-6 flex items-start gap-3">
+            <div
+              data-testid="limited-data-banner"
+              className="bg-tm-happy-yellow bg-opacity-20 border border-tm-happy-yellow rounded-lg p-4 mb-6 flex items-start gap-3"
+            >
               <svg
                 className="w-5 h-5 text-tm-loyal-blue mt-0.5 flex-shrink-0"
                 fill="none"
@@ -432,13 +504,47 @@ const DistrictDetailPageInner: React.FC = () => {
                 <p className="text-sm font-medium text-tm-black">
                   This district has limited data available.
                 </p>
-                <p className="text-sm text-gray-600 mt-1">
-                  Detailed analytics (clubs, divisions, trends) are not yet
-                  tracked for this district. Global rankings are available
-                  below.
-                </p>
+                {/* #1436 — "not tracked in THIS year" and "not tracked at all"
+                    are different situations and must not read identically. The
+                    first names a year that does have data, so the user is not
+                    left guessing which year to try. */}
+                {degradedSuggestedYear ? (
+                  <p className="text-sm text-gray-600 mt-1">
+                    Detailed analytics (clubs, divisions, trends) are not
+                    tracked for this district in {selectedProgramYear.label}. It
+                    does appear in {degradedSuggestedYear.label} — switch
+                    program year below.
+                  </p>
+                ) : (
+                  <p className="text-sm text-gray-600 mt-1">
+                    Detailed analytics (clubs, divisions, trends) are not yet
+                    tracked for this district. Global rankings are available
+                    below.
+                  </p>
+                )}
               </div>
             </div>
+
+            {/* #1436 — the way out. Without this the branch below returns
+                before DistrictDetailHeader, the page's only year control, so a
+                district viewable in another year was unreachable from its own
+                page. Rendered only when there IS another year to reach — but
+                the slot is reserved while the rank-history query is in flight,
+                so the selector does not late-insert and push the rankings
+                below it down (the Lesson 107 shape). */}
+            {(isLoadingRankHistoryYears || degradedSuggestedYear) && (
+              <div
+                data-testid="degraded-program-year-selector"
+                className="mb-6 max-w-xs"
+              >
+                <ProgramYearSelector
+                  availableProgramYears={degradedYearOptions}
+                  selectedProgramYear={selectedProgramYear}
+                  onProgramYearChange={handleDegradedProgramYearChange}
+                  isLoading={isLoadingRankHistoryYears}
+                />
+              </div>
+            )}
 
             {/* Global Rankings tab for untracked districts */}
             <GlobalRankingsTab

--- a/frontend/src/pages/__tests__/DistrictDetailPage.degradedYearSelector.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.degradedYearSelector.test.tsx
@@ -340,6 +340,20 @@ function assertNoInconsistentUrl() {
   }
 }
 
+/**
+ * The selector's slot is reserved with a skeleton while the rank-history query
+ * is in flight (no late insert above GlobalRankingsTab), so the testid lands
+ * before the <select> does — wait for the control itself, not the wrapper.
+ */
+async function findYearSelect() {
+  return waitFor(() =>
+    within(screen.getByTestId('degraded-program-year-selector')).getByRole(
+      'combobox',
+      { name: /program year/i }
+    )
+  )
+}
+
 const LIMITED = /This district has limited data available/i
 
 describe('DistrictDetailPage — degraded view year selector (#1436)', () => {
@@ -353,9 +367,7 @@ describe('DistrictDetailPage — degraded view year selector (#1436)', () => {
     expect(selector).toBeInTheDocument()
 
     // D44's rank history covers PY 2024-2025 only.
-    const select = within(selector).getByRole('combobox', {
-      name: /program year/i,
-    })
+    const select = await findYearSelect()
     expect(
       within(select).getByRole('option', { name: /2024-2025/ })
     ).toBeInTheDocument()
@@ -377,11 +389,7 @@ describe('DistrictDetailPage — degraded view year selector (#1436)', () => {
     const client = renderAt('/district/44?py=2025&date=2026-06-30')
     await districtListLanded(client)
 
-    const selector = await screen.findByTestId('degraded-program-year-selector')
-    await user.selectOptions(
-      within(selector).getByRole('combobox', { name: /program year/i }),
-      '2024'
-    )
+    await user.selectOptions(await findYearSelect(), '2024')
 
     // D44 has no snapshot in ANY year, so there is no in-year date to offer —
     // `?date=` must be dropped, never left pointing at the old year.
@@ -403,11 +411,7 @@ describe('DistrictDetailPage — degraded view year selector (#1436)', () => {
 
     await waitFor(() => expect(screen.getByText(LIMITED)).toBeInTheDocument())
 
-    const selector = await screen.findByTestId('degraded-program-year-selector')
-    await user.selectOptions(
-      within(selector).getByRole('combobox', { name: /program year/i }),
-      '2024'
-    )
+    await user.selectOptions(await findYearSelect(), '2024')
 
     await waitFor(() =>
       expect(screen.getByTestId('district-detail-lede')).toBeInTheDocument()

--- a/frontend/src/pages/__tests__/DistrictDetailPage.degradedYearSelector.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.degradedYearSelector.test.tsx
@@ -1,0 +1,448 @@
+/**
+ * DistrictDetailPage (#1436) — the degraded "limited data" view must carry a
+ * program-year selector.
+ *
+ * `:383` returns early, BEFORE `DistrictDetailHeader` — the only component that
+ * receives `selectedProgramYear` / `setSelectedProgramYear` /
+ * `availableProgramYears`. So a district absent from the selected year's roster
+ * was stranded on the one year with nothing: `GlobalRankingsTab` (rendered
+ * inside the branch) has only a metric toggle, no year control.
+ *
+ * Two distinct year sources, both exercised here:
+ *   - a district WITH a snapshot-index entry → its snapshot years (the source
+ *     the page already reads via `useDistrictCachedDates`), and switching to a
+ *     year whose roster has it renders the full view;
+ *   - a district with NO index entry (the reported case, D44) → its
+ *     rank-history years, because `index['44'] ?? []` is empty.
+ *
+ * R22: this mounts a page, so it lives in `src/pages/__tests__/`.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import {
+  render,
+  screen,
+  cleanup,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  useLocation,
+  useSearchParams,
+} from 'react-router-dom'
+import DistrictDetailPage from '../DistrictDetailPage'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import {
+  fetchCdnRankings,
+  fetchCdnRankingsForDate,
+  fetchCdnRankHistory,
+  fetchCdnDates,
+} from '../../services/cdn'
+import { useDistrictCachedDates } from '../../hooks/useDistrictData'
+import type { CdnRankingsData, CdnRankHistoryData } from '../../services/cdn'
+import { snap } from '../../test-utils/snapshotDate'
+import type { SnapshotDate } from '../../types/snapshotDate'
+
+// ---------------------------------------------------------------------------
+// Environment shims (mirrors the DistrictDetailPage.pastYearDistrict harness)
+// ---------------------------------------------------------------------------
+
+const localStorageMock = {
+  getItem: vi.fn(() => null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+  length: 0,
+  key: vi.fn(() => null),
+}
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+})
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | null = null
+  readonly rootMargin: string = ''
+  readonly scrollMargin: string = ''
+  readonly thresholds: ReadonlyArray<number> = []
+  private readonly callback: (
+    entries: IntersectionObserverEntry[],
+    observer: IntersectionObserver
+  ) => void
+  constructor(
+    callback: (
+      entries: IntersectionObserverEntry[],
+      observer: IntersectionObserver
+    ) => void
+  ) {
+    this.callback = callback
+  }
+  observe(target: Element): void {
+    setTimeout(() => {
+      this.callback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        this
+      )
+    }, 0)
+  }
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+}
+Object.defineProperty(global, 'IntersectionObserver', {
+  value: MockIntersectionObserver,
+  writable: true,
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+type Row = CdnRankingsData['rankings'][number]
+
+function row(districtId: string): Row {
+  return {
+    districtId,
+    districtName: districtId,
+    region: '06',
+    paidClubs: 90,
+    paidClubBase: 88,
+    clubGrowthPercent: 2,
+    totalPayments: 2919,
+    paymentBase: 2754,
+    paymentGrowthPercent: 6,
+    activeClubs: 92,
+    distinguishedClubs: 38,
+    selectDistinguished: 4,
+    presidentsDistinguished: 14,
+    distinguishedPercent: 43,
+    clubsRank: 29,
+    paymentsRank: 20,
+    distinguishedRank: 71,
+    aggregateScore: 279,
+    overallRank: 33,
+  }
+}
+
+/** The CURRENT roster — neither D27 nor D44 is in it. */
+const CURRENT: CdnRankingsData = {
+  rankings: [row('61')],
+  asOfDate: '2026-08-02',
+  generatedAt: '2026-08-02T00:00:00Z',
+}
+
+const CURRENT_PINNED: CdnRankingsData = {
+  ...CURRENT,
+  snapshotDate: snap('2026-06-30'),
+}
+
+/** The 2024-2025 year-end roster — D27 and D44 were both districts then. */
+const PY_2024: CdnRankingsData = {
+  rankings: [row('61'), row('27'), row('44')],
+  snapshotDate: snap('2025-06-30'),
+  asOfDate: '2025-07-18',
+  generatedAt: '2025-07-18T00:00:00Z',
+}
+
+function historyPoint(date: string) {
+  return {
+    date,
+    aggregateScore: 279,
+    clubsRank: 29,
+    paymentsRank: 20,
+    distinguishedRank: 71,
+    totalDistricts: 128,
+    overallRank: 41,
+  }
+}
+
+/** D44 appears in the rankings for PY 2024-2025 only — and has no snapshot. */
+const D44_RANK_HISTORY: CdnRankHistoryData = {
+  districtId: '44',
+  districtName: '44',
+  history: [historyPoint('2024-12-31'), historyPoint('2025-06-30')],
+}
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../services/cdn', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../services/cdn')>()
+  return {
+    ...actual,
+    fetchCdnRankings: vi.fn(),
+    fetchCdnRankingsForDate: vi.fn(),
+    fetchCdnRankHistory: vi.fn(),
+    fetchCdnDates: vi.fn(),
+  }
+})
+
+vi.mock('../../hooks/useLatestAsOfDate', () => ({
+  useLatestAsOfDate: () => ({
+    asOfDate: undefined,
+    latestSnapshotDate: undefined,
+  }),
+  useGlobalFreshness: () => ({ asOfDate: undefined, isLatest: false }),
+}))
+
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(),
+}))
+
+vi.mock('../../hooks/useDistrictAnalytics', () => ({
+  useDistrictAnalytics: vi.fn(() => ({
+    data: {
+      allClubs: [],
+      distinguishedClubs: {
+        total: 0,
+        smedley: 0,
+        presidents: 0,
+        select: 0,
+        distinguished: 0,
+      },
+      totalMembership: 1000,
+      membershipChange: 0,
+      performanceTargets: null,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('../../hooks/useAggregatedAnalytics', () => ({
+  useAggregatedAnalytics: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    usedFallback: false,
+  })),
+}))
+
+vi.mock('../../hooks/usePerformanceTargets', () => ({
+  usePerformanceTargets: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+vi.mock('../../hooks/useCompetitiveAwards', () => ({
+  useCompetitiveAwards: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+const mockedLatest = vi.mocked(fetchCdnRankings)
+const mockedForDate = vi.mocked(fetchCdnRankingsForDate)
+const mockedRankHistory = vi.mocked(fetchCdnRankHistory)
+const mockedDates = vi.mocked(fetchCdnDates)
+
+/** D44 has no `district-snapshot-index.json` entry — the reported case. */
+const NO_SNAPSHOTS = {
+  data: { districtId: '44', dates: [], count: 0, dateRange: null },
+  isLoading: false,
+  error: null,
+} as unknown as ReturnType<typeof useDistrictCachedDates>
+
+/** D27 has snapshots in both years. */
+const DATES_LOADED = {
+  data: { dates: ['2026-06-30', '2025-06-30'] },
+  isLoading: false,
+  error: null,
+} as unknown as ReturnType<typeof useDistrictCachedDates>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorageMock.getItem.mockReturnValue(null)
+  vi.mocked(useDistrictCachedDates).mockReturnValue(NO_SNAPSHOTS)
+  mockedLatest.mockResolvedValue(CURRENT)
+  mockedForDate.mockImplementation((date: SnapshotDate) =>
+    Promise.resolve(date === '2025-06-30' ? PY_2024 : CURRENT_PINNED)
+  )
+  mockedRankHistory.mockResolvedValue(D44_RANK_HISTORY)
+  mockedDates.mockResolvedValue({
+    dates: ['2025-06-30', '2026-06-30'],
+    count: 2,
+    generatedAt: '2026-08-02T00:00:00Z',
+  })
+})
+afterEach(() => cleanup())
+
+// The URL is the artefact under test for the `?py=` / `?date=` consistency
+// criterion, so record EVERY search string the router commits — a transiently
+// inconsistent pair is as much a defect as a final one.
+const seenSearches: string[] = []
+
+function UrlProbe() {
+  const loc = useLocation()
+  const [sp] = useSearchParams()
+  React.useEffect(() => {
+    seenSearches.push(sp.toString())
+  }, [loc.key, sp])
+  return null
+}
+
+function renderAt(url: string) {
+  seenSearches.length = 0
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <ProgramYearProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <Routes>
+            <Route
+              path="/district/:districtId"
+              element={<DistrictDetailPage />}
+            />
+          </Routes>
+          <UrlProbe />
+        </MemoryRouter>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+  return client
+}
+
+async function districtListLanded(client: QueryClient) {
+  await waitFor(() =>
+    expect(
+      client
+        .getQueriesData({ queryKey: ['districts'] })
+        .some(([, data]) => data !== undefined)
+    ).toBe(true)
+  )
+}
+
+/** PY start year → [startDate, endDate], for the consistency assertion. */
+function programYearBounds(year: number) {
+  return [`${year}-07-01`, `${year + 1}-06-30`] as const
+}
+
+function assertNoInconsistentUrl() {
+  for (const search of seenSearches) {
+    const params = new URLSearchParams(search)
+    const py = params.get('py')
+    const date = params.get('date')
+    if (py === null || date === null) continue
+    const [start, end] = programYearBounds(parseInt(py, 10))
+    expect(
+      date >= start && date <= end,
+      `?date=${date} is outside ?py=${py} (${start}..${end}) in "${search}"`
+    ).toBe(true)
+  }
+}
+
+const LIMITED = /This district has limited data available/i
+
+describe('DistrictDetailPage — degraded view year selector (#1436)', () => {
+  it('offers the rank-history years for a district with no snapshot index entry', async () => {
+    const client = renderAt('/district/44?py=2025')
+    await districtListLanded(client)
+
+    await waitFor(() => expect(screen.getByText(LIMITED)).toBeInTheDocument())
+
+    const selector = await screen.findByTestId('degraded-program-year-selector')
+    expect(selector).toBeInTheDocument()
+
+    // D44's rank history covers PY 2024-2025 only.
+    const select = within(selector).getByRole('combobox', {
+      name: /program year/i,
+    })
+    expect(
+      within(select).getByRole('option', { name: /2024-2025/ })
+    ).toBeInTheDocument()
+  })
+
+  it('names a year that does have data instead of leaving the user to guess', async () => {
+    const client = renderAt('/district/44?py=2025')
+    await districtListLanded(client)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('limited-data-banner')).toHaveTextContent(
+        /2024-2025/
+      )
+    )
+  })
+
+  it('sets ?py= and ?date= consistently when the year changes', async () => {
+    const user = userEvent.setup()
+    const client = renderAt('/district/44?py=2025&date=2026-06-30')
+    await districtListLanded(client)
+
+    const selector = await screen.findByTestId('degraded-program-year-selector')
+    await user.selectOptions(
+      within(selector).getByRole('combobox', { name: /program year/i }),
+      '2024'
+    )
+
+    // D44 has no snapshot in ANY year, so there is no in-year date to offer —
+    // `?date=` must be dropped, never left pointing at the old year.
+    await waitFor(() => {
+      const last = seenSearches[seenSearches.length - 1] ?? ''
+      expect(new URLSearchParams(last).get('py')).toBe('2024')
+      expect(new URLSearchParams(last).get('date')).toBeNull()
+    })
+    assertNoInconsistentUrl()
+  })
+
+  it('reaches the full view by switching to a year whose roster has the district', async () => {
+    // D27 HAS snapshots in both years, so its year list comes from the snapshot
+    // index; the current year's roster simply omits it.
+    vi.mocked(useDistrictCachedDates).mockReturnValue(DATES_LOADED)
+    const user = userEvent.setup()
+    const client = renderAt('/district/27?py=2025&date=2026-06-30')
+    await districtListLanded(client)
+
+    await waitFor(() => expect(screen.getByText(LIMITED)).toBeInTheDocument())
+
+    const selector = await screen.findByTestId('degraded-program-year-selector')
+    await user.selectOptions(
+      within(selector).getByRole('combobox', { name: /program year/i }),
+      '2024'
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('district-detail-lede')).toBeInTheDocument()
+    )
+    expect(screen.queryByText(LIMITED)).not.toBeInTheDocument()
+    assertNoInconsistentUrl()
+  })
+
+  it('degrades gracefully for a district with no snapshots and no rank history', async () => {
+    mockedRankHistory.mockRejectedValue(new Error('404'))
+    const client = renderAt('/district/999?py=2025')
+    await districtListLanded(client)
+
+    await waitFor(() => expect(screen.getByText(LIMITED)).toBeInTheDocument())
+    expect(
+      screen.queryByTestId('degraded-program-year-selector')
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId('limited-data-banner')).toHaveTextContent(
+      /not yet tracked/i
+    )
+  })
+
+  it('leaves the happy path unchanged — no degraded chrome for a current district', async () => {
+    vi.mocked(useDistrictCachedDates).mockReturnValue(DATES_LOADED)
+    const client = renderAt('/district/61?py=2025&date=2026-06-30')
+    await districtListLanded(client)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('district-detail-lede')).toBeInTheDocument()
+    )
+    expect(screen.queryByText(LIMITED)).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('degraded-program-year-selector')
+    ).not.toBeInTheDocument()
+    // The rank-history fallback must not fire for a district that has snapshots.
+    expect(mockedRankHistory).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/__tests__/DistrictDetailPage.degradedYearSelector.test.tsx
+++ b/frontend/src/pages/__tests__/DistrictDetailPage.degradedYearSelector.test.tsx
@@ -326,16 +326,26 @@ function programYearBounds(year: number) {
   return [`${year}-07-01`, `${year + 1}-06-30`] as const
 }
 
+/**
+ * `?py=` is OMITTED when it equals the data-driven default (useUrlProgramYear),
+ * so an absent `py` is not "unasserted" — it means the default year, which for
+ * this harness's dates index (2025-06-30, 2026-06-30) is 2025-2026. Resolving it
+ * here rather than skipping keeps the check total.
+ */
+const HARNESS_DEFAULT_PY = 2025
+
 function assertNoInconsistentUrl() {
   for (const search of seenSearches) {
     const params = new URLSearchParams(search)
     const py = params.get('py')
     const date = params.get('date')
-    if (py === null || date === null) continue
-    const [start, end] = programYearBounds(parseInt(py, 10))
+    if (date === null) continue
+    const [start, end] = programYearBounds(
+      py === null ? HARNESS_DEFAULT_PY : parseInt(py, 10)
+    )
     expect(
       date >= start && date <= end,
-      `?date=${date} is outside ?py=${py} (${start}..${end}) in "${search}"`
+      `?date=${date} is outside ?py=${py ?? HARNESS_DEFAULT_PY} (${start}..${end}) in "${search}"`
     ).toBe(true)
   }
 }

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,6 +2,7 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `coupled-url-params-need-one-setter-not-two-calls.md` — Two setSearchParams calls in one handler silently drop the first key — coupled URL params need a single combined setter  (2026-08-22)
 - `a-centred-fixed-width-overlay-is-a-viewport-collision-bug-in-every-edge-column.md` — A fixed-width overlay centred on its trigger is off-screen wherever the trigger sits near a viewport edge — it is a property of the shared component, never of the card that reported it, and the measured correction cannot live in a Tailwind v4 translate utility  (2026-08-03)
 - `a-deliberately-shared-query-key-is-a-coupling-with-no-compiler.md` — Two hooks sharing a React Query key to avoid a duplicate fetch are coupled with nothing but a comment — narrowing one hook's key silently re-scopes or breaks the other, so decide explicitly and pay the fetch  (2026-08-03)
 - `a-docs-page-that-restates-the-code-needs-a-census-not-a-generator.md` — A docs page that restates behaviour spread across many mechanisms cannot be generated from any one of them — couple it with a census that fails when unclaimed code appears, and prove the census fires against a synthetic case the repo can never produce  (2026-08-03)

--- a/tasks/lessons/lessons/coupled-url-params-need-one-setter-not-two-calls.md
+++ b/tasks/lessons/lessons/coupled-url-params-need-one-setter-not-two-calls.md
@@ -1,0 +1,65 @@
+---
+date: 2026-08-22
+tier: lesson
+summary: Two setSearchParams calls in one handler silently drop the first key — coupled URL params need a single combined setter
+tags: [frontend, react-router, url-state, program-year]
+---
+
+# Coupled URL params need one setter, not two calls
+
+**Date:** 2026-08-22
+**Issue:** #1436 (frontend: the degraded district view drops the program-year selector)
+**Tags:** frontend, react-router, url-state, program-year
+
+## What happened
+
+`useUrlProgramYear` exposes `setSelectedProgramYear` (writes `?py=`) and
+`setSelectedDate` (writes `?date=`) as two independent setters, each doing its
+own `setSearchParams(prev => …)`. `searchIndex.ts` already documents why the two
+params are coupled: the hook **reads** them independently, so a `?date=` outside
+the selected program year leaves the page self-inconsistent. Omni-search
+therefore sets both when it routes to a historical district.
+
+The obvious way to honour that from a year selector is
+`setSelectedProgramYear(py); setSelectedDate(dateInNewYear)`. It does not work.
+react-router 7's `useSearchParams` hands the functional updater the
+**render-time** `searchParams` value captured in the `useCallback` closure — not
+the pending one:
+
+```js
+let setSearchParams = React.useCallback((nextInit, navigateOptions) => {
+  const newSearchParams = createSearchParams(
+    typeof nextInit === 'function' ? nextInit(new URLSearchParams(searchParams)) : nextInit
+  )
+  navigate('?' + newSearchParams, navigateOptions)
+}, [navigate, searchParams])
+```
+
+Both calls in one handler are computed from the same pre-click base, so the
+second navigation wins outright and the first call's key is discarded. Setting
+`py=2024` then clearing `date` lands on a URL with **no `py` at all** — silently
+back on the default year, which is exactly the state the selector existed to
+escape.
+
+## The fix
+
+One setter that writes both keys in a single `setSearchParams` call
+(`setProgramYearAndDate`), with the invariant enforced inside it: a date outside
+the target program year is dropped rather than written, so the inconsistent pair
+is not reachable through the API even by a caller mistake.
+
+## Rule
+
+When two URL params must agree, expose **one** setter that writes them in one
+navigation, and enforce the invariant inside it. Never compose the guarantee out
+of two independent setters — with a render-time-captured base, the second write
+silently reverts the first, and the bug is invisible in the hook's return value
+(which reflects the new location) while being wrong in the URL.
+
+## Warning
+
+The same shape applies to any pair of `useSearchParams`-backed setters called in
+one event handler, not just `py`/`date` — `useUrlState` consumers included.
+Assert on the committed **search string**, not on the hook's returned state: a
+test that only checks `result.current.selectedProgramYear` passes while the URL
+is wrong.


### PR DESCRIPTION
Fixes #1436.

## Problem

`DistrictDetailPage`'s degraded "limited data" branch renders a banner and
`GlobalRankingsTab`, then **early-returns before `DistrictDetailHeader`** — the
only component wired to `selectedProgramYear` / `setSelectedProgramYear` /
`availableProgramYears`. So the page's only year control exists solely on the
happy path, and a district absent from the selected year's roster is stranded on
the one year with nothing. `GlobalRankingsTab` has only a metric toggle
(`GlobalRankingsTab.tsx:237`), no year control of its own.

Reported against `ts.taverns.red/district/44` on PY 2025-2026.

## Built to the amended AC, not the original

The issue body's claim that `availableProgramYears` comes from a *global*
cached-date list is wrong, and the correction comment supersedes it. Verified
independently here:

- `DistrictDetailPage.tsx:73` → `useDistrictCachedDates(districtId || '')`
- `useDistrictData.ts:42-44` → `index[districtId] ?? []` from
  `district-snapshot-index.json`

The year list is already per-district and already comes from that index — so
**original AC #2 is already satisfied and cannot fix the reported case.** The
degraded branch requires `!selectedDistrict`, and a district that *has* an index
entry self-heals to its newest data year via the auto-select effect at `:86-100`
(#1398's fix), so it never reaches the branch. The branch is only reachable when
the district has **no** index entry — District 44 — for which `index['44'] ?? []`
is empty and an index-fed selector would render blank.

Year source therefore follows amended AC #2: the snapshot-index years when the
district has an entry, its **rank-history** years when it does not. Verified
that `v1/rank-history/{id}.json` is written for every district that ever appeared
in any `all-districts-rankings.json` (`data-pipeline.yml:1328-1390`, "Building
per-district rank history") — exactly the population that can reach this view
with something to show.

## Changes

- **`useDistrictRankHistoryYears`** (new) — the fallback year source. Gated on
  the snapshot index having **resolved empty**, so the happy path issues no extra
  request. A pure `programYearsFromRankHistory` carries the derivation so it can
  be unit-tested without a mount.
- **`useUrlProgramYear.setProgramYearAndDate`** (new) — moves `?py=` and `?date=`
  in **one** navigation. Two `setSearchParams` calls cannot: react-router 7 hands
  the functional updater the *render-time* params, so both are computed from the
  same pre-click base and the second silently discards the first's key —
  `setSelectedProgramYear(py)` followed by `setSelectedDate(undefined)` lands on
  a URL with **no `?py=` at all**. A date outside the target year is dropped
  rather than written, so the inconsistent pair `searchIndex.ts` documents is
  unreachable through the API.
- **The banner** now separates "not tracked in *this* year" from "not tracked at
  all" and names a year that does have data. The first line is unchanged, so
  existing assertions still hold.
- **The selector's slot is reserved** while the rank-history query is in flight,
  so it does not late-insert and push `GlobalRankingsTab` down (the Lesson 107
  shape).
- Revives `ProgramYearSelector`, which had no live consumer. Dark mode is covered
  by the existing `[data-theme='dark'] select` rule in `dark-mode.css` (R10), and
  its `!important` color beats the component's inline `--tm-black`.

## Tests

TDD: red commit `e525f2ca` (3 suites failing for the stated reasons), green
commit `f2cbb1d3`.

- `frontend/src/hooks/__tests__/useDistrictRankHistoryYears.test.tsx` — pure
  derivation, the disabled gate (no fetch on the happy path), and the 404 case.
- `frontend/src/hooks/__tests__/useUrlProgramYear.test.ts` — new
  `setProgramYearAndDate` block, asserting on the **committed search string**, not
  the hook's return value (which reflects the new location and would pass while
  the URL is wrong).
- `frontend/src/pages/__tests__/DistrictDetailPage.degradedYearSelector.test.tsx`
  — the page-level ACs, including a URL probe that records *every* search string
  the router commits, so a transiently inconsistent `?py=`/`?date=` pair fails
  too. R22 respected: page mount, so it lives in `src/pages/__tests__/`.

## Verification

| Gate | Result |
| --- | --- |
| `npm run pre-commit` (typecheck + lint + yaml lint) | exit 0 |
| `npm run typecheck:tests` | exit 0 |
| `npm run format:check` | exit 0 |
| `npm run test:no-page-mounts:check` (R22) | exit 0 |
| `npm run test:quarantine:check` | exit 0 |
| `npm run test:frontend` | exit 0 — **341 files, 4051 tests, all passing** |

Pre-existing `DistrictDetailPage` suites (`pastYearDistrict`, `integration`,
`rankingProgramYear`, `leanHub`, `redesign`) — 38/38 pass, no regressions.

## What could NOT be verified here

`cdn.taverns.red` egress is blocked in this environment. **This fix has not been
confirmed against live data or a preview channel** — no live District 44 page was
loaded, no real `v1/rank-history/44.json` was fetched, and the assumption that
D44's rank history covers the years it appears in was verified from the pipeline
source, not from the published artifact. Everything here is built against
fixtures and mocks. Full-DoD live verification on the PR preview channel is still
outstanding.

The issue's open question — whether District 44 appearing in the 2025-2026
rankings with no per-district snapshot is expected or a pipeline gap, and what
"District 44" means across the 2026-07-01 renumbering — is untouched by this PR
and still open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ChV9VodCpZ7t2LMLL5ft5n)_