### PR TITLE
fix(frontend): a club that moved districts no longer dead-ends on its old-district URL (#1441)

### DIFF
--- a/frontend/src/components/ClubHistoryTable.tsx
+++ b/frontend/src/components/ClubHistoryTable.tsx
@@ -49,18 +49,22 @@ function signedNet(value: number | null): string {
 export interface ClubHistoryTableProps {
   rows: ClubHistoryRow[]
   clubName: string
-  /** When both are provided (#1302), each year label becomes a deep link to
+  /** When provided (#1302), each year label becomes a deep link to
    *  ClubDetailPage focused on that program year (`?py=<startYear>`), so a user
    *  reading the multi-year table can jump into a single year. Omitted → plain
-   *  text (keeps the component usable outside a Router). */
-  districtId?: string | undefined
+   *  text (keeps the component usable outside a Router).
+   *
+   *  #1441 — the link is the district-agnostic `/club/:clubId` route, which
+   *  resolves the club's district from the club index. A row knows its program
+   *  year but not its district: districts were reformed on 2026-07-01 and
+   *  clubs moved between them, so the page's current district is not a fact
+   *  about the club's 2022 row. No `districtId` prop, by design. */
   clubId?: string | undefined
 }
 
 export function ClubHistoryTable({
   rows,
   clubName,
-  districtId,
   clubId,
 }: ClubHistoryTableProps) {
   const [sortField, setSortField] = useState<SortField>('year')
@@ -168,9 +172,9 @@ export function ClubHistoryTable({
           {sortedRows.map(row => (
             <tr key={row.startYear}>
               <th scope="row" className="club-history-td club-history-td--year">
-                {districtId && clubId ? (
+                {clubId ? (
                   <Link
-                    to={`/district/${districtId}/club/${clubId}?py=${row.startYear}`}
+                    to={`/club/${clubId}?py=${row.startYear}`}
                     className="club-history-year-link"
                   >
                     {row.label}

--- a/frontend/src/components/__tests__/ClubHistoryTable.test.tsx
+++ b/frontend/src/components/__tests__/ClubHistoryTable.test.tsx
@@ -111,27 +111,26 @@ describe('ClubHistoryTable (#1229)', () => {
   })
 })
 
-describe('ClubHistoryTable — per-year focus links (#1302)', () => {
-  it('links each program-year row to that year on the club detail page', () => {
+describe('ClubHistoryTable — per-year focus links (#1302, #1441)', () => {
+  it('links each program-year row to that year without asserting a district', () => {
     render(
       <MemoryRouter>
-        <ClubHistoryTable
-          rows={rows}
-          clubName="Test Club"
-          districtId="61"
-          clubId="00000606"
-        />
+        <ClubHistoryTable rows={rows} clubName="Test Club" clubId="00000606" />
       </MemoryRouter>
     )
-    // The year label becomes a deep link to ClubDetailPage focused on that PY,
-    // so a user reading the multi-year table can jump into a single year.
+    // The year label is a deep link to ClubDetailPage focused on that PY, so a
+    // user reading the multi-year table can jump into a single year (#1302).
+    // #1441: the route is district-agnostic. Districts were reformed on
+    // 2026-07-01 and clubs moved, so a row's program year and the page's
+    // district are independent facts — stamping today's district onto a 2022
+    // row asserts something the row does not know.
     const link = screen.getByRole('link', { name: '2023-2024' })
-    expect(link).toHaveAttribute('href', '/district/61/club/00000606?py=2023')
+    expect(link).toHaveAttribute('href', '/club/00000606?py=2023')
     const older = screen.getByRole('link', { name: '2022-2023' })
-    expect(older).toHaveAttribute('href', '/district/61/club/00000606?py=2022')
+    expect(older).toHaveAttribute('href', '/club/00000606?py=2022')
   })
 
-  it('renders plain year labels (no links) when district/club are absent', () => {
+  it('renders plain year labels (no links) when the club id is absent', () => {
     render(<ClubHistoryTable rows={rows} clubName="Test Club" />)
     expect(screen.queryByRole('link', { name: '2023-2024' })).toBeNull()
     expect(screen.getByText('2023-2024')).toBeInTheDocument()

--- a/frontend/src/pages/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from 'react'
 import { useParams, useNavigate, useLocation, Link } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { fetchCdnClubIndex } from '../services/cdn'
 import { useDistrictAnalytics, ClubTrend } from '../hooks/useDistrictAnalytics'
 import { useDistricts } from '../hooks/useDistricts'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
@@ -247,6 +249,45 @@ const ClubDetailPage: React.FC = () => {
     return analytics.allClubs.find(c => c.clubId === clubId) ?? null
   }, [analytics, clubId])
 
+  // ── Moved-club lookup (#1441) ─────────────────────────────────────────────
+  // The 2026-07-01 reformation moved clubs between districts, so every link
+  // made before July points at a club's OLD district. `config/club-index.json`
+  // maps every club to its CURRENT district and is rebuilt wholesale each
+  // pipeline run; `ClubRedirectPage` already consumes it through this same
+  // `fetchCdnClubIndex` helper and query key, so a warm cache is reused rather
+  // than refetched. `enabled` keeps the happy path (club present in this
+  // district) free of any extra CDN request.
+  const { data: clubIndex, isError: isClubIndexError } = useQuery({
+    queryKey: ['club-index'],
+    queryFn: fetchCdnClubIndex,
+    staleTime: 15 * 60 * 1000,
+    enabled: !!clubId && !club && !isLoading && !isError,
+  })
+
+  // Where the index says this club lives now — null unless the index both
+  // knows the club AND places it in a DIFFERENT district than the URL claims.
+  // Anything less (absent from the index, same district, fetch failed) stays
+  // null so the cautious "may have been removed" copy survives: we only assert
+  // a move the index actually substantiates.
+  const movedTo = useMemo(() => {
+    if (club || !clubId || !clubIndex) return null
+    // Same exact-key lookup form ClubRedirectPage uses. #1440 is replacing the
+    // club-id comparisons on this page with a shared normalizer — this is
+    // deliberately a single expression so that swap is a one-line change.
+    const entry = clubIndex.clubs[clubId]
+    if (!entry?.districtId || entry.districtId === districtId) return null
+    return entry
+  }, [club, clubId, clubIndex, districtId])
+
+  const movedToName = useMemo(() => {
+    if (!movedTo) return ''
+    const match = districtsData?.districts?.find(
+      d => d.id === movedTo.districtId
+    )
+    const raw = match?.name || movedTo.districtId
+    return /^\d+$/.test(raw) ? `District ${raw}` : raw
+  }, [movedTo, districtsData])
+
   // Find matching raw CSV record for per-goal progress (#242)
   const clubRawRecord = useMemo(() => {
     if (!districtStats || !clubId) return null
@@ -433,7 +474,54 @@ const ClubDetailPage: React.FC = () => {
     )
   }
 
-  // ── Club not found ───────────────────────────────────────────────────────
+  // ── Club absent from this district ───────────────────────────────────────
+  // #1441 — three distinct outcomes, and the copy must not overreach past what
+  // the club index actually substantiates:
+  //   1. index still in flight  → say nothing yet (a "removed" flash would be
+  //      a claim we are about to contradict)
+  //   2. index places the club elsewhere → it MOVED; name the district and
+  //      offer the link
+  //   3. anything else (absent from the index, index unreachable, index agrees
+  //      with this district) → the pre-existing cautious copy
+
+  // Unresolved = enabled, but neither settled to data nor to an error yet.
+  // Deliberately NOT `isFetching`: on the render where `enabled` flips true the
+  // query is still 'idle', which would leak one frame of "may have been
+  // removed" before the lookup even starts.
+  const isClubIndexUnresolved = !!clubId && !clubIndex && !isClubIndexError
+
+  if (!club && isClubIndexUnresolved) {
+    return (
+      <div className="min-h-screen">
+        <div className="container mx-auto px-4 py-8">
+          <LoadingSkeleton variant="card" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!club && movedTo) {
+    // The index is a CURRENT mapping, so the destination link deliberately
+    // drops the `?py=` this URL may carry: the club was genuinely in this
+    // district for older program years, and forwarding that year would land
+    // the visitor on a second dead end.
+    return (
+      <div className="min-h-screen">
+        <div className="container mx-auto px-4 py-8">
+          <EmptyState
+            title="Club Moved Districts"
+            message={`${movedTo.clubName || `Club ${clubId}`} is no longer in ${districtName} — it is now in ${movedToName}.`}
+            icon="search"
+            action={{
+              label: `View this club in ${movedToName}`,
+              onClick: () =>
+                navigate(`/district/${movedTo.districtId}/club/${clubId}`),
+            }}
+          />
+        </div>
+      </div>
+    )
+  }
 
   if (!club) {
     return (

--- a/frontend/src/pages/ClubHistoryPage.tsx
+++ b/frontend/src/pages/ClubHistoryPage.tsx
@@ -83,12 +83,7 @@ export default function ClubHistoryPage() {
           message={`No completed program years on file yet for ${heading}. History appears once a program year closes (June 30).`}
         />
       ) : (
-        <ClubHistoryTable
-          rows={rows}
-          clubName={heading}
-          districtId={districtId}
-          clubId={clubId}
-        />
+        <ClubHistoryTable rows={rows} clubName={heading} clubId={clubId} />
       )}
 
       <p className="club-history-page__back">

--- a/frontend/src/pages/__tests__/ClubDetailPage.movedClub.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.movedClub.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Moved-club tests for ClubDetailPage (#1441).
+ *
+ * The 2026-07-01 district reformation moved clubs between districts. A club is
+ * continuous across that move — same number, same charter — so every link made
+ * before July points at the club's OLD district. The not-found branch used to
+ * tell those visitors the club "may have been removed"; `config/club-index.json`
+ * (the same index `ClubRedirectPage` consumes) knows exactly which district the
+ * club is in now.
+ *
+ * R22: this is a full-page mount, so it lives in `src/pages/__tests__/`.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { screen, render, cleanup, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import { ProgramYearProvider } from '../../contexts/ProgramYearContext'
+import { DarkModeProvider } from '../../contexts/DarkModeContext'
+import ClubDetailPage from '../ClubDetailPage'
+import { fetchCdnClubIndex } from '../../services/cdn'
+
+Object.defineProperty(window, 'matchMedia', {
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+  writable: true,
+})
+
+vi.mock('../../hooks/useDistricts', () => ({
+  useDistricts: vi.fn(() => ({
+    data: {
+      districts: [
+        { id: '90', name: 'District 90' },
+        { id: '70', name: 'District 70' },
+      ],
+    },
+  })),
+}))
+
+vi.mock('../../hooks/useDistrictData', () => ({
+  useDistrictCachedDates: vi.fn(() => ({
+    data: {
+      districtId: '90',
+      dates: ['2026-08-01'],
+      count: 1,
+      dateRange: { startDate: '2026-08-01', endDate: '2026-08-01' },
+    },
+  })),
+}))
+
+vi.mock('../../services/cdn', () => ({
+  fetchCdnClubIndex: vi.fn(),
+  fetchCdnDates: vi.fn().mockResolvedValue({
+    dates: ['2026-08-01'],
+    count: 1,
+    generatedAt: '2026-08-02T00:00:00Z',
+  }),
+  fetchCdnRankings: vi
+    .fn()
+    .mockResolvedValue({ rankings: [], asOfDate: '2026-08-01' }),
+  fetchCdnManifest: vi
+    .fn()
+    .mockResolvedValue({ latestSnapshotDate: '2026-08-01' }),
+}))
+
+vi.mock('../../hooks/useMembershipData', () => ({
+  useDistrictStatistics: vi.fn(() => ({ data: null, isLoading: false })),
+}))
+
+// District 90's PY-2026 snapshot no longer contains club 00002274 — it moved.
+vi.mock('../../hooks/useDistrictAnalytics', () => ({
+  useDistrictAnalytics: vi.fn(() => ({
+    data: { districtId: '90', allClubs: [] },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+  ClubTrend: {},
+}))
+
+const mockedClubIndex = vi.mocked(fetchCdnClubIndex)
+
+const LocationProbe = () => {
+  const { pathname } = useLocation()
+  return <div data-testid="loc-path">{pathname}</div>
+}
+
+afterEach(() => cleanup())
+beforeEach(() => vi.clearAllMocks())
+
+function renderAt(url = '/district/90/club/00002274') {
+  // A fresh client per render — the club-index query key is shared app-wide,
+  // so a module-level client would leak one test's index into the next.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProgramYearProvider>
+        <DarkModeProvider>
+          <MemoryRouter initialEntries={[url]}>
+            <LocationProbe />
+            <Routes>
+              <Route
+                path="/district/:districtId/club/:clubId"
+                element={<ClubDetailPage />}
+              />
+              <Route
+                path="/district/:districtId"
+                element={<div>district landing</div>}
+              />
+            </Routes>
+          </MemoryRouter>
+        </DarkModeProvider>
+      </ProgramYearProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('ClubDetailPage — club moved districts (#1441)', () => {
+  it('does not claim the club may have been removed when the index knows its new district', async () => {
+    mockedClubIndex.mockResolvedValue({
+      clubs: {
+        '00002274': { districtId: '70', clubName: 'Riverside Toastmasters' },
+      },
+    })
+
+    renderAt()
+
+    expect(await screen.findByText(/now in District 70/i)).toBeInTheDocument()
+    expect(screen.queryByText(/may have been removed/i)).not.toBeInTheDocument()
+  })
+
+  it('links through to the club in its new district', async () => {
+    mockedClubIndex.mockResolvedValue({
+      clubs: {
+        '00002274': { districtId: '70', clubName: 'Riverside Toastmasters' },
+      },
+    })
+
+    renderAt()
+
+    const go = await screen.findByRole('button', { name: /District 70/i })
+    await userEvent.click(go)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('loc-path')).toHaveTextContent(
+        '/district/70/club/00002274'
+      )
+    )
+  })
+
+  it('keeps the cautious copy for a club absent from the index entirely', async () => {
+    mockedClubIndex.mockResolvedValue({ clubs: {} })
+
+    renderAt()
+
+    expect(
+      await screen.findByText(/may have been removed/i)
+    ).toBeInTheDocument()
+  })
+
+  it('keeps the cautious copy when the index still places the club in this district', async () => {
+    mockedClubIndex.mockResolvedValue({
+      clubs: {
+        '00002274': { districtId: '90', clubName: 'Riverside Toastmasters' },
+      },
+    })
+
+    renderAt()
+
+    expect(
+      await screen.findByText(/may have been removed/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/now in District/i)).not.toBeInTheDocument()
+  })
+
+  it('degrades to the cautious copy when the index itself cannot be fetched', async () => {
+    mockedClubIndex.mockRejectedValue(new Error('CDN club index fetch failed'))
+
+    renderAt()
+
+    expect(
+      await screen.findByText(/may have been removed/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/ClubDetailPage.programYear.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.programYear.test.tsx
@@ -50,6 +50,10 @@ vi.mock('../../hooks/useDistrictData', () => ({
 }))
 
 vi.mock('../../services/cdn', () => ({
+  // #1441 — the page's moved-club lookup imports this even when it never runs
+  // (it is `enabled` only while the club is absent); a module mock must still
+  // define the export or the import resolves to undefined and useQuery throws.
+  fetchCdnClubIndex: vi.fn().mockResolvedValue({ clubs: {} }),
   fetchCdnDates: vi.fn().mockResolvedValue({
     dates: ['2025-08-01', '2026-05-01', '2026-08-01'],
     count: 3,

--- a/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ClubDetailPage.test.tsx
@@ -88,6 +88,14 @@ const baseMockClub = {
   newMembers: 2,
 }
 
+// #1441 — the not-found branch now consults the club index before concluding
+// a club is gone. Only that one export is stubbed (partial mock): the page's
+// other CDN reads keep their existing behaviour in this file.
+vi.mock('../../services/cdn', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../services/cdn')>()),
+  fetchCdnClubIndex: vi.fn().mockResolvedValue({ clubs: {} }),
+}))
+
 vi.mock('../../hooks/useDistrictAnalytics', () => ({
   useDistrictAnalytics: vi.fn(() => ({
     data: {
@@ -278,10 +286,13 @@ describe('ClubDetailPage (#208)', () => {
     expect(screen.getAllByText('-5').length).toBeGreaterThanOrEqual(1)
   })
 
-  it('renders not found state for invalid club ID', () => {
+  // #1441 — now async: the page waits for the club index to settle before it
+  // will claim a club is gone, so an unknown id resolves to "Club Not Found"
+  // only once the index comes back without it.
+  it('renders not found state for invalid club ID', async () => {
     renderWithRoute('99999999')
 
-    expect(screen.getByText('Club Not Found')).toBeInTheDocument()
+    expect(await screen.findByText('Club Not Found')).toBeInTheDocument()
   })
 
   // #1104 — a transient CDN fetch reject must surface a distinct, retryable

--- a/tasks/lessons/INDEX.md
+++ b/tasks/lessons/INDEX.md
@@ -2,6 +2,7 @@
 # Lessons index
 
 ## lessons (manifest-pinned + session-judged)
+- `a-query-that-just-became-enabled-is-idle-not-fetching.md` — A TanStack Query that just became `enabled` reports idle, not fetching — gate deferred copy on "unresolved", not on isFetching  (2026-08-22)
 - `a-centred-fixed-width-overlay-is-a-viewport-collision-bug-in-every-edge-column.md` — A fixed-width overlay centred on its trigger is off-screen wherever the trigger sits near a viewport edge — it is a property of the shared component, never of the card that reported it, and the measured correction cannot live in a Tailwind v4 translate utility  (2026-08-03)
 - `a-deliberately-shared-query-key-is-a-coupling-with-no-compiler.md` — Two hooks sharing a React Query key to avoid a duplicate fetch are coupled with nothing but a comment — narrowing one hook's key silently re-scopes or breaks the other, so decide explicitly and pay the fetch  (2026-08-03)
 - `a-docs-page-that-restates-the-code-needs-a-census-not-a-generator.md` — A docs page that restates behaviour spread across many mechanisms cannot be generated from any one of them — couple it with a census that fails when unclaimed code appears, and prove the census fires against a synthetic case the repo can never produce  (2026-08-03)

--- a/tasks/lessons/lessons/a-query-that-just-became-enabled-is-idle-not-fetching.md
+++ b/tasks/lessons/lessons/a-query-that-just-became-enabled-is-idle-not-fetching.md
@@ -1,0 +1,58 @@
+---
+date: 2026-08-22
+tier: lesson
+summary: A TanStack Query that just became `enabled` reports idle, not fetching — gate deferred copy on "unresolved", not on isFetching
+tags: [frontend, react-query, tanstack-query, loading-states, ui-copy]
+---
+
+# A query that just became `enabled` is idle, not fetching
+
+**Date:** 2026-08-22
+**PR:** #1441 (moved-club redirect)
+
+## What happened
+
+`ClubDetailPage` had to stop telling visitors a club "may have been removed"
+before it had asked the club index where the club actually went. The lookup is a
+`useQuery` with `enabled` flipped on only when the club is missing from this
+district's snapshot — so the natural gate looked like:
+
+```tsx
+if (!club && isClubIndexFetching) return <Skeleton />
+if (!club && movedTo) return <MovedMessage />
+if (!club) return <MayHaveBeenRemoved />   // ← rendered for one frame
+```
+
+On the render where `enabled` flips from `false` to `true`, the query's status
+is `pending` but its **`fetchStatus` is still `'idle'`** — the fetch is kicked
+off from an effect, after that render commits. So `isFetching` is `false`, the
+first two guards both fall through, and the user gets one frame of the exact
+claim the whole change existed to prevent, immediately retracted.
+
+## The fix
+
+Gate on *unresolved* — the query has neither settled to data nor to an error —
+rather than on the in-flight flag:
+
+```tsx
+const isClubIndexUnresolved = !!clubId && !clubIndex && !isClubIndexError
+```
+
+That covers idle-before-fetch, in-flight, and retries in one predicate, and it
+falls through the moment the answer exists in either direction.
+
+## Rule
+
+When a deferred query decides *which claim to render* (not merely whether to
+show a spinner over content that is already correct), derive the "don't speak
+yet" gate from the absence of a settled result — `!data && !isError` — not from
+`isFetching` / `isLoading`. `fetchStatus` lags `enabled` by one render, and a
+gate that lags is a gate that flashes the wrong answer.
+
+## Warning
+
+The same one-frame gap exists for any `enabled`-gated query whose false branch
+is a *statement about the world* — "not found", "no access", "no results",
+"unsupported" — rather than an inert placeholder. The flash is invisible in
+JSDOM tests that `await findBy…`, so tests will not catch it; only reading the
+render order will.


### PR DESCRIPTION
Closes #1441.

## Problem

The 2026-07-01 reformation moved clubs between districts. A club is continuous
across that move — same number, same charter — only its parent changed. So every
club link created before July points at the club's **old** district, and those
dead-ended:

> **Club Not Found** — Club 00002274 was not found in District 90. It may have been removed…

The club was not removed. It is one district over, and `config/club-index.json`
— rebuilt wholesale every pipeline run, already consumed by `ClubRedirectPage` —
knows exactly which one. The not-found branch never asked it.

Second instance in the same area: `ClubHistoryTable` built every row's link as
`/district/${districtId}/club/${clubId}?py=${row.startYear}` — the page's
**current** district stamped onto every historical program year.

## Changes

**`frontend/src/pages/ClubDetailPage.tsx`** — the absent-club branch now
consults the club index first, through the existing `fetchCdnClubIndex` helper
and the same `['club-index']` query key `ClubRedirectPage` uses (no second fetch
path; a warm cache is reused). The query is `enabled` only while the club is
missing from this district, so the happy path costs no extra CDN request. Three
outcomes:

| index says | copy |
| --- | --- |
| not resolved yet | neutral skeleton — no "removed" flash we are about to retract |
| a **different** district | **Club Moved Districts** — "… is no longer in District 90 — it is now in District 70", with a link through |
| club absent / index unreachable / index agrees with this district | the pre-existing cautious "may have been removed" copy, unchanged |

**`frontend/src/components/ClubHistoryTable.tsx`** — rows now link to the
district-agnostic `/club/:clubId?py=<startYear>` route, which resolves the
district from the club index and preserves `?py=`. The `districtId` prop is
removed rather than left unused, so nothing can quietly re-stamp it;
`ClubHistoryPage` updated accordingly.

## In-place message, not an auto-redirect

The index is a **current** mapping. An auto-redirect would rewrite the URL the
visitor arrived on and, for a historical `?py=` view, forward a program year the
destination district may not have had the club in — bouncing them to a second
dead end with no explanation. The in-place message states one fact the index
substantiates and hands over one link. For the same reason the destination link
deliberately drops `?py=`.

The copy judgement is load-bearing: *"this club is now in District 70"* is only
rendered when the index actually says so and says a **different** district than
the URL. A club genuinely absent from the index, or an index we could not fetch,
still gets the old cautious copy.

## Coordination with sibling issues

- **#1440 (club-id normalizer)** — not landed as of `origin/main`, so
  `ClubDetailPage.tsx:247`/`:263` are untouched here and no fourth comparison was
  hand-rolled. The new index lookup is a single expression using the exact same
  key form `ClubRedirectPage` already uses (`clubIndex.clubs[clubId]`), so
  swapping in the shared normalizer is a one-line change at one call site.
- **#1437 (`useClubHistory` rewrite)** — not touched. Once it lands, history rows
  will legitimately span districts, which is exactly why the row links had to
  stop asserting the page's district. No change is needed there when it merges.
- **#1436 / PR #1444** — merged to `main` while this branch was open; `main` is
  merged in here as `1af89ac5`. The only conflict was the generated
  `tasks/lessons/INDEX.md` (both PRs add a lesson). Resolved by regenerating with
  `npm run lessons:index`, not by hand — both lessons are present in the result.
  No code file conflicted.
- `ClubRedirectPage.tsx` is unmodified — its redirect behaviour was already
  correct and is what the history-table links now lean on.

## Tests

TDD, red before green:

- `frontend/src/pages/__tests__/ClubDetailPage.movedClub.test.tsx` (new, 5 tests)
  — full-page mount, so it lives in `pages/__tests__/` per **R22**. Covers: the
  moved case does not render "may have been removed" and does name District 70;
  the link navigates to `/district/70/club/00002274`; and three
  graceful-degradation cases (absent from the index, index agrees with this
  district, index fetch rejects) that all keep the cautious copy.
- Two pre-existing tests adjusted for the now-async gate — **not** pinned:
  `ClubDetailPage.test.tsx`'s not-found case awaits the index settling (via a
  *partial* cdn mock, so every other CDN read in that file stays real), and
  `ClubDetailPage.programYear.test.tsx`'s module mock declares the new export.
- `ClubHistoryTable.test.tsx`'s link assertions now expect the district-agnostic
  href.

One lesson filed —
`tasks/lessons/lessons/a-query-that-just-became-enabled-is-idle-not-fetching.md`:
on the render where a TanStack query's `enabled` flips true its `fetchStatus` is
still `'idle'`, so gating the deferred "may have been removed" copy on
`isFetching` leaked one frame of exactly the claim this PR removes. The gate is
`!data && !isError` instead. `INDEX.md` regenerated.

**Exit codes, all re-run after the `main` merge:** `npm run pre-commit` → **0**
(typecheck + lint + yaml; 0 eslint errors), `npm run format:check` → **0**,
`npm run test:no-page-mounts:check` (R22 guard) → **0**, targeted suites
(`ClubDetailPage` ×3 + `ClubHistoryTable` + `ClubHistoryPage`) → **0**, 52/52.
The husky pre-push `vitest --run --project unit` gate ran on both pushes and
passed: **240 files / 3162 tests** on the post-merge push. CI runs the full unit
+ integration projects with coverage as the gate of record.

## Acceptance criteria

- [x] Failing test first: `/district/OLD/club/X` for a club the index places in
      District NEW does not render "may have been removed"
- [x] The not-found branch consults `config/club-index.json` via the existing
      helper — no second fetch path
- [x] A club genuinely absent from the index still degrades to the existing copy
- [x] `ClubHistoryTable` no longer stamps the page's district onto other years
- [x] Club-id lookup uses the same form as `ClubRedirectPage`; one-line swap when
      #1440's normalizer lands
- [x] R22 respected — the page mount is in `frontend/src/pages/__tests__/`

## Verification

Live verification on the PR preview channel is still outstanding — this is opened
as a draft. `cdn.taverns.red` and the Firebase preview host are both 403 at
CONNECT from this environment, so the work was built and tested against fixtures.
